### PR TITLE
Enhance navigation tabs and dashboard quick links

### DIFF
--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -1,22 +1,111 @@
 import React from 'react'
+import { NavLink } from 'react-router-dom'
+import { signOut } from 'firebase/auth'
+import { auth } from '../firebase'
+
+const NAV_ITEMS = [
+  { to: '/', label: 'Dashboard', end: true },
+  { to: '/products', label: 'Products' },
+  { to: '/sell', label: 'Sell' },
+  { to: '/receive', label: 'Receive' },
+  { to: '/close-day', label: 'Close Day' },
+  { to: '/settings', label: 'Settings' }
+]
+
+function linkStyle(isActive: boolean): React.CSSProperties {
+  return {
+    padding: '8px 14px',
+    borderRadius: 999,
+    textDecoration: 'none',
+    fontSize: 14,
+    fontWeight: isActive ? 600 : 500,
+    color: isActive ? '#fff' : '#4338CA',
+    backgroundColor: isActive ? '#4338CA' : '#EEF2FF',
+    border: `1px solid ${isActive ? '#4338CA' : 'transparent'}`,
+    boxShadow: isActive ? '0 6px 18px rgba(67, 56, 202, 0.18)' : 'none',
+    transition: 'all 0.2s ease',
+    lineHeight: 1.4
+  }
+}
 
 export default function Shell({ children }: { children: React.ReactNode }) {
+  const userEmail = auth.currentUser?.email ?? 'Account'
+
   return (
-    <div style={{fontFamily:'Inter, system-ui, Arial'}}>
-      <header style={{position:'sticky', top:0, background:'#fff', borderBottom:'1px solid #eee', zIndex:10}}>
-        <div style={{maxWidth:1000, margin:'0 auto', padding:'12px 16px', display:'flex', alignItems:'center', gap:16}}>
-          <div style={{fontSize:24, fontWeight:800, color:'#4338CA'}}>Sedifex</div>
-          <nav style={{display:'flex', gap:12}}>
-            <a href="#/">Dashboard</a>
-            <a href="#/products">Products</a>
-            <a href="#/sell">Sell</a>
-            <a href="#/receive">Receive</a>
-            <a href="#/close-day">Close Day</a>
-            <a href="#/settings">Settings</a>
+    <div style={{ fontFamily: 'Inter, system-ui, Arial', background: '#F8FAFC', minHeight: '100vh' }}>
+      <header style={{ position: 'sticky', top: 0, background: '#fff', borderBottom: '1px solid #E2E8F0', zIndex: 10 }}>
+        <div
+          style={{
+            maxWidth: 1100,
+            margin: '0 auto',
+            padding: '12px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 16,
+            flexWrap: 'wrap'
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{ fontSize: 24, fontWeight: 800, color: '#4338CA' }}>Sedifex</div>
+            <span style={{ fontSize: 13, color: '#64748B' }}>Sell faster. Count smarter.</span>
+          </div>
+
+          <nav
+            aria-label="Primary"
+            style={{
+              display: 'flex',
+              gap: 8,
+              flexWrap: 'wrap',
+              justifyContent: 'center',
+              alignItems: 'center',
+              flexGrow: 1
+            }}
+          >
+            {NAV_ITEMS.map(item => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                end={item.end}
+                style={({ isActive }) => linkStyle(isActive)}
+              >
+                {item.label}
+              </NavLink>
+            ))}
           </nav>
+
+          <div
+            style={{
+              marginLeft: 'auto',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: '#EEF2FF',
+              borderRadius: 999,
+              padding: '6px 10px'
+            }}
+          >
+            <span style={{ fontSize: 13, color: '#4338CA', fontWeight: 600 }}>{userEmail}</span>
+            <button
+              type="button"
+              onClick={() => signOut(auth)}
+              style={{
+                border: 'none',
+                background: '#4338CA',
+                color: '#fff',
+                fontSize: 13,
+                fontWeight: 600,
+                padding: '6px 10px',
+                borderRadius: 999,
+                cursor: 'pointer'
+              }}
+            >
+              Sign out
+            </button>
+          </div>
         </div>
       </header>
-      <main style={{maxWidth:1000, margin:'0 auto', padding:'16px'}}>{children}</main>
+
+      <main style={{ maxWidth: 1100, margin: '0 auto', padding: '24px 16px' }}>{children}</main>
     </div>
   )
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,9 +1,79 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
+
+const QUICK_LINKS = [
+  {
+    to: '/products',
+    title: 'Products',
+    description: 'Manage your catalogue, update prices, and keep stock levels accurate.'
+  },
+  {
+    to: '/sell',
+    title: 'Sell',
+    description: 'Ring up a customer, track the cart, and record a sale in seconds.'
+  },
+  {
+    to: '/receive',
+    title: 'Receive',
+    description: 'Log new inventory as it arrives so every aisle stays replenished.'
+  },
+  {
+    to: '/close-day',
+    title: 'Close Day',
+    description: 'Balance the till, review totals, and lock in a clean daily report.'
+  },
+  {
+    to: '/settings',
+    title: 'Settings',
+    description: 'Configure staff, taxes, and other controls that keep your shop running.'
+  }
+]
+
 export default function Dashboard() {
   return (
     <div>
-      <h2 style={{color:'#4338CA'}}>Dashboard</h2>
-      <p>Welcome to Sedifex. Use the nav to manage Products, Sell, Receive, and Close Day.</p>
+      <h2 style={{ color: '#4338CA', marginBottom: 8 }}>Dashboard</h2>
+      <p style={{ color: '#475569', marginBottom: 24 }}>
+        Welcome back! Choose what you’d like to work on — the most important Sedifex pages are just one tap away.
+      </p>
+
+      <section
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          gap: 16
+        }}
+        aria-label="Important pages"
+      >
+        {QUICK_LINKS.map(link => (
+          <Link
+            key={link.to}
+            to={link.to}
+            style={{
+              display: 'block',
+              background: '#fff',
+              borderRadius: 16,
+              padding: '20px 18px',
+              border: '1px solid #E2E8F0',
+              textDecoration: 'none',
+              color: '#0F172A',
+              boxShadow: '0 8px 24px rgba(15, 23, 42, 0.08)',
+              transition: 'transform 0.2s ease, box-shadow 0.2s ease'
+            }}
+          >
+            <div style={{ fontSize: 18, fontWeight: 700, color: '#1E293B', marginBottom: 8 }}>
+              {link.title}
+            </div>
+            <p style={{ fontSize: 14, lineHeight: 1.5, color: '#475569', margin: 0 }}>
+              {link.description}
+            </p>
+            <span style={{ display: 'inline-flex', alignItems: 'center', marginTop: 16, fontSize: 14, fontWeight: 600, color: '#4338CA' }}>
+              Open {link.title}
+              <span aria-hidden="true" style={{ marginLeft: 6 }}>→</span>
+            </span>
+          </Link>
+        ))}
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- gate the authenticated shell behind the router outlet and keep the login flow intact
- refresh the app header with NavLink-based tabs, user info, and a sign-out button
- add dashboard quick links that spotlight the key Sedifex pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40c8bd9108321b2b468662e49f474