### PR TITLE
Revamp authentication theme

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,7 +1,18 @@
 :root {
-  color: #0f172a;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #f5f4ff;
+  font-family: "Inter", "Plus Jakarta Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+  background-color: #030712;
+  --color-text-primary: #e2e8f0;
+  --color-text-secondary: #cbd5f5;
+  --color-text-muted: #94a3b8;
+  --color-border: rgba(148, 163, 184, 0.35);
+  --color-border-strong: rgba(99, 102, 241, 0.55);
+  --color-accent-start: #38bdf8;
+  --color-accent-end: #a855f7;
+  --color-accent-solid: #7c3aed;
+  --color-positive: #34d399;
+  --color-negative: #f87171;
+  --color-info: #38bdf8;
 }
 
 * {
@@ -13,260 +24,324 @@ body,
 #root {
   min-height: 100%;
   margin: 0;
-  background-color: #f5f4ff;
+  background-color: #030712;
 }
 
 body {
   display: flex;
+  color: var(--color-text-primary);
 }
 
 .app {
+  position: relative;
   flex: 1;
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(24px, 5vw, 64px);
-  background: radial-gradient(140% 140% at 0% 0%, rgba(67, 56, 202, 0.16) 0%, rgba(255, 255, 255, 0) 60%),
-    linear-gradient(160deg, rgba(79, 70, 229, 0.07) 0%, rgba(12, 74, 110, 0.05) 100%);
+  padding: clamp(24px, 5vw, 72px);
+  background:
+    radial-gradient(160% 160% at 12% 16%, rgba(56, 189, 248, 0.14) 0%, rgba(3, 7, 18, 0) 58%),
+    radial-gradient(140% 140% at 88% 12%, rgba(168, 85, 247, 0.16) 0%, rgba(3, 7, 18, 0) 60%),
+    radial-gradient(120% 120% at 50% 100%, rgba(59, 130, 246, 0.18) 0%, rgba(3, 7, 18, 0) 65%),
+    linear-gradient(180deg, #020617 0%, #0f172a 100%);
+  overflow: hidden;
+}
+
+.app::before,
+.app::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  inset: auto;
+  width: 420px;
+  height: 420px;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.7;
+  transform: translate(-40%, -20%);
+  background: radial-gradient(circle at 30% 30%, rgba(56, 189, 248, 0.6), rgba(2, 132, 199, 0));
+  mix-blend-mode: screen;
+}
+
+.app::after {
+  right: -220px;
+  bottom: -220px;
+  transform: translate(30%, 30%);
+  background: radial-gradient(circle at 70% 70%, rgba(168, 85, 247, 0.65), rgba(236, 72, 153, 0));
 }
 
 .app__card {
-  width: min(440px, 100%);
-  background: #ffffff;
-  border-radius: 28px;
-  padding: clamp(24px, 4vw, 40px);
-  box-shadow: 0 25px 60px -25px rgba(30, 64, 175, 0.35);
-  border: 1px solid rgba(79, 70, 229, 0.12);
+  position: relative;
+  width: min(460px, 100%);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.82), rgba(24, 33, 53, 0.82));
+  border-radius: 32px;
+  padding: clamp(28px, 4vw, 44px);
+  box-shadow: 0 30px 80px -30px rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  backdrop-filter: blur(26px);
+  -webkit-backdrop-filter: blur(26px);
+}
+
+.app__card::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  pointer-events: none;
 }
 
 .app__brand {
   display: flex;
   align-items: center;
-  gap: 16px;
-  margin-bottom: 18px;
+  gap: 18px;
+  margin-bottom: 20px;
 }
 
 .app__logo {
-  width: 52px;
-  height: 52px;
-  border-radius: 18px;
-  background: linear-gradient(135deg, #4338ca 0%, #6366f1 100%);
+  width: 58px;
+  height: 58px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, var(--color-accent-start) 0%, var(--color-accent-end) 100%);
   display: grid;
   place-items: center;
   color: #f8fafc;
-  font-weight: 600;
-  font-size: 20px;
-  letter-spacing: 0.06em;
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: 0.08em;
+  box-shadow: 0 16px 32px -16px rgba(79, 70, 229, 0.8);
 }
 
 .app__title {
-  font-size: clamp(28px, 3vw, 32px);
+  font-size: clamp(30px, 3vw, 36px);
   font-weight: 700;
   margin: 0;
+  color: var(--color-text-primary);
+  letter-spacing: -0.01em;
 }
 
 .app__tagline {
-  margin: 4px 0 0;
-  color: #475569;
+  margin: 6px 0 0;
+  color: var(--color-text-secondary);
   font-size: 15px;
 }
 
 .app__highlight {
-  color: #4338ca;
+  color: var(--color-accent-start);
   font-weight: 600;
 }
 
 .toggle-group {
   display: inline-flex;
-  padding: 4px;
-  border-radius: 14px;
-  background: #eef2ff;
-  border: 1px solid rgba(99, 102, 241, 0.2);
-  margin-top: 16px;
+  padding: 5px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  margin-top: 18px;
+  backdrop-filter: blur(16px);
 }
 
 .toggle-button {
   border: none;
   background: transparent;
-  color: #4338ca;
+  color: var(--color-text-muted);
   font-weight: 600;
   font-size: 14px;
-  padding: 10px 18px;
+  padding: 12px 20px;
   border-radius: 12px;
-  transition: background 150ms ease, color 150ms ease, box-shadow 150ms ease;
+  transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
   cursor: pointer;
 }
 
+.toggle-button:hover,
+.toggle-button:focus-visible {
+  color: var(--color-text-primary);
+}
+
 .toggle-button.is-active {
-  background: #4338ca;
-  color: #f8fafc;
-  box-shadow: 0 12px 25px -16px rgba(67, 56, 202, 0.7);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.22) 0%, rgba(168, 85, 247, 0.3) 100%);
+  color: var(--color-text-primary);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.3), 0 14px 28px -20px rgba(99, 102, 241, 0.7);
+  transform: translateY(-1px);
 }
 
 .toggle-button:focus-visible {
-  outline: 2px solid #4338ca;
+  outline: 2px solid rgba(56, 189, 248, 0.6);
   outline-offset: 2px;
 }
 
 .form {
-  margin-top: 28px;
+  margin-top: 32px;
   display: grid;
-  gap: 18px;
+  gap: 20px;
 }
 
 .form__field {
   display: grid;
-  gap: 8px;
+  gap: 10px;
 }
 
 .form__hint {
-  color: #64748b;
-  font-size: 13px;
+  color: var(--color-text-muted);
+  font-size: 14px;
 }
 
 label {
   font-weight: 600;
-  color: #1f2937;
+  color: var(--color-text-secondary);
   font-size: 14px;
 }
 
 input[type="email"],
 input[type="password"] {
-  padding: 14px 16px;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 15px 18px;
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
   font-size: 15px;
-  transition: border 150ms ease, box-shadow 150ms ease;
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--color-text-primary);
+  transition: border 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  backdrop-filter: blur(8px);
+}
+
+input::placeholder {
+  color: rgba(148, 163, 184, 0.6);
 }
 
 input[type="email"]:focus-visible,
 input[type="password"]:focus-visible {
   outline: none;
-  border-color: #4338ca;
-  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.16);
+  border-color: var(--color-border-strong);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.25);
+  transform: translateY(-1px);
 }
 
 input[disabled] {
-  background-color: #f8fafc;
-  color: #94a3b8;
+  background-color: rgba(15, 23, 42, 0.35);
+  color: rgba(148, 163, 184, 0.6);
 }
 
 .primary-button {
   width: 100%;
   border: none;
-  border-radius: 14px;
-  padding: 14px 18px;
+  border-radius: 16px;
+  padding: 16px 18px;
   font-weight: 600;
   font-size: 15px;
-  background: linear-gradient(135deg, #4338ca 0%, #6366f1 100%);
+  background: linear-gradient(135deg, var(--color-accent-start) 0%, var(--color-accent-end) 100%);
   color: #f8fafc;
   cursor: pointer;
-  transition: transform 150ms ease, box-shadow 150ms ease, filter 150ms ease;
+  transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease;
+  box-shadow: 0 18px 34px -18px rgba(79, 70, 229, 0.75);
 }
 
 .primary-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 16px 32px -20px rgba(99, 102, 241, 0.7);
+  transform: translateY(-2px);
+  box-shadow: 0 22px 40px -18px rgba(99, 102, 241, 0.85);
 }
 
 .primary-button:disabled {
   cursor: wait;
-  filter: grayscale(0.2) brightness(0.96);
+  filter: grayscale(0.2) brightness(0.92);
 }
 
 .status {
-  margin-top: 12px;
-  padding: 12px 14px;
-  border-radius: 12px;
+  margin-top: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
   font-size: 14px;
   font-weight: 500;
   display: flex;
   align-items: center;
   gap: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.6);
 }
 
 .status--loading {
-  color: #4338ca;
-  background: rgba(99, 102, 241, 0.12);
+  color: var(--color-info);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.25);
 }
 
 .status--success {
-  color: #047857;
-  background: rgba(16, 185, 129, 0.12);
+  color: var(--color-positive);
+  box-shadow: inset 0 0 0 1px rgba(52, 211, 153, 0.28);
 }
 
 .status--error {
-  color: #b91c1c;
-  background: rgba(248, 113, 113, 0.16);
+  color: var(--color-negative);
+  box-shadow: inset 0 0 0 1px rgba(248, 113, 113, 0.28);
 }
 
 .link-button {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  color: #4338ca;
+  gap: 8px;
+  color: var(--color-accent-start);
   font-weight: 600;
   text-decoration: none;
-  margin-top: 18px;
-  transition: color 150ms ease;
+  margin-top: 20px;
+  transition: color 160ms ease, transform 160ms ease;
 }
 
 .link-button:hover {
-  color: #312e81;
+  color: var(--color-accent-end);
+  transform: translateX(2px);
 }
 
 .secondary-button {
-  margin-top: 16px;
+  margin-top: 18px;
   width: 100%;
-  padding: 12px 16px;
-  border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.7);
-  background: #ffffff;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(15, 23, 42, 0.55);
   font-weight: 600;
   font-size: 14px;
-  color: #1f2937;
+  color: var(--color-text-primary);
   cursor: pointer;
-  transition: border 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+  transition: border 160ms ease, transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
 .secondary-button:hover {
-  transform: translateY(-1px);
-  border-color: #4338ca;
-  box-shadow: 0 12px 32px -24px rgba(30, 64, 175, 0.45);
+  transform: translateY(-2px);
+  border-color: rgba(99, 102, 241, 0.6);
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: 0 16px 36px -24px rgba(30, 64, 175, 0.5);
 }
 
 .secondary-button:focus-visible {
-  outline: 2px solid #4338ca;
+  outline: 2px solid rgba(56, 189, 248, 0.5);
   outline-offset: 2px;
 }
 
 .app__feature-list {
-  margin: 24px 0 0;
+  margin: 26px 0 0;
   padding: 0 0 0 20px;
-  color: #475569;
+  color: var(--color-text-muted);
   font-size: 14px;
   line-height: 1.6;
 }
 
 .app__feature-list li::marker {
-  color: #4338ca;
+  color: var(--color-accent-start);
 }
 
 .app__footer {
-  margin-top: 32px;
+  margin-top: 36px;
   font-size: 13px;
-  color: #64748b;
+  color: rgba(148, 163, 184, 0.7);
   text-align: center;
 }
 
 @media (max-width: 640px) {
   .app__card {
-    border-radius: 22px;
-    padding: 24px;
+    border-radius: 26px;
+    padding: 26px;
   }
 
   .app {
-    padding: 24px;
+    padding: 26px;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the authentication layout with a darker glassmorphism palette and layered gradient backdrop
- update interactive controls and typography to use accent color variables and smoother hover/focus transitions
- polish status, button, and link styling for better contrast in the new theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4196969e883218293ca5822ca3182