### PR TITLE
Add login page illustration panel

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -71,6 +71,24 @@ body {
   background: radial-gradient(circle at 70% 70%, rgba(168, 85, 247, 0.65), rgba(236, 72, 153, 0));
 }
 
+.app__layout {
+  position: relative;
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(28px, 6vw, 48px);
+  z-index: 1;
+}
+
+@media (min-width: 960px) {
+  .app__layout {
+    flex-direction: row;
+    align-items: stretch;
+    justify-content: space-between;
+  }
+}
+
 .app__card {
   position: relative;
   width: min(460px, 100%);
@@ -90,6 +108,40 @@ body {
   border-radius: 30px;
   border: 1px solid rgba(255, 255, 255, 0.04);
   pointer-events: none;
+}
+
+.app__visual {
+  display: none;
+}
+
+@media (min-width: 960px) {
+  .app__visual {
+    position: relative;
+    display: block;
+    flex: 1;
+    max-width: 480px;
+    border-radius: 32px;
+    overflow: hidden;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    box-shadow: 0 30px 80px -32px rgba(15, 23, 42, 0.85);
+  }
+
+  .app__visual img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transform: scale(1.02);
+  }
+
+  .app__visual::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(15, 23, 42, 0.25) 0%, rgba(15, 23, 42, 0.55) 100%);
+    mix-blend-mode: multiply;
+    pointer-events: none;
+  }
 }
 
 .app__brand {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,8 @@ interface StatusState {
   message: string
 }
 
+const LOGIN_IMAGE_URL = 'https://i.imgur.com/fx9vne9.jpeg'
+
 export default function App() {
   const [user, setUser] = useState<User | null>(null)
   const [isAuthReady, setIsAuthReady] = useState(false)
@@ -74,16 +76,16 @@ export default function App() {
 
   if (!user) {
     return (
-
       <main className="app">
-        <div className="app__card">
-          <div className="app__brand">
-            <span className="app__logo">Sx</span>
-            <div>
-              <h1 className="app__title">Sedifex</h1>
-              <p className="app__tagline">
-                Sell faster. <span className="app__highlight">Count smarter.</span>
-              </p>
+        <div className="app__layout">
+          <div className="app__card">
+            <div className="app__brand">
+              <span className="app__logo">Sx</span>
+              <div>
+                <h1 className="app__title">Sedifex</h1>
+                <p className="app__tagline">
+                  Sell faster. <span className="app__highlight">Count smarter.</span>
+                </p>
             </div>
           </div>
 
@@ -161,9 +163,16 @@ export default function App() {
               {status.message}
             </p>
           )}
+          </div>
+          <aside className="app__visual">
+            <img
+              src={LOGIN_IMAGE_URL}
+              alt="Team members organizing inventory packages in a warehouse"
+              loading="lazy"
+            />
+          </aside>
         </div>
       </main>
-
     )
   }
 


### PR DESCRIPTION
## Summary
- wrap the unauthenticated view in a responsive layout that can host supporting visuals
- render a warehouse-themed illustration beside the login card on wider screens
- style the new illustration panel so it complements the existing glassmorphism aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4289b185c8321a9dda2bd943547d5