### PR TITLE
Add toast notifications provider

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -497,3 +497,94 @@ input[disabled] {
     flex-direction: column;
   }
 }
+
+.toast-region {
+  position: fixed;
+  top: clamp(16px, 4vw, 28px);
+  right: clamp(16px, 4vw, 28px);
+  display: grid;
+  gap: 12px;
+  width: min(360px, calc(100vw - 32px));
+  z-index: 2000;
+  pointer-events: none;
+}
+
+.toast {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: 0 24px 56px -26px rgba(15, 23, 42, 0.85);
+  font-size: 14px;
+  font-weight: 500;
+  pointer-events: auto;
+  backdrop-filter: blur(18px);
+}
+
+.toast__indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--color-info);
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.15);
+}
+
+.toast--success .toast__indicator {
+  background: var(--color-positive);
+  box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.18);
+}
+
+.toast--error .toast__indicator {
+  background: var(--color-negative);
+  box-shadow: 0 0 0 4px rgba(248, 113, 113, 0.2);
+}
+
+.toast__message {
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.toast__dismiss {
+  border: none;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 18px;
+  cursor: pointer;
+  border-radius: 999px;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.toast__dismiss:hover,
+.toast__dismiss:focus-visible {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--color-text-primary);
+}
+
+.toast__dismiss:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.6);
+  outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+  .toast-region {
+    left: 16px;
+    right: 16px;
+    width: auto;
+  }
+
+  .toast {
+    grid-template-columns: auto 1fr;
+  }
+
+  .toast__dismiss {
+    justify-self: end;
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { Outlet } from 'react-router-dom'
 import { auth } from './firebase'
 import './App.css'
 import './pwa'
+import { useToast } from './components/ToastProvider'
 
 type AuthMode = 'login' | 'signup'
 
@@ -25,6 +26,7 @@ export default function App() {
   const [password, setPassword] = useState('')
   const [status, setStatus] = useState<StatusState>({ tone: 'idle', message: '' })
   const isLoading = status.tone === 'loading'
+  const { publish } = useToast()
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, nextUser => {
@@ -58,6 +60,19 @@ export default function App() {
 
     }
   }
+
+  useEffect(() => {
+    if (!status.message) {
+      return
+    }
+
+    if (status.tone === 'success' || status.tone === 'error') {
+      publish({
+        tone: status.tone,
+        message: status.message
+      })
+    }
+  }, [publish, status.message, status.tone])
 
   function handleModeChange(nextMode: AuthMode) {
     setMode(nextMode)

--- a/web/src/components/ToastProvider.tsx
+++ b/web/src/components/ToastProvider.tsx
@@ -1,0 +1,117 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react'
+
+type ToastTone = 'info' | 'success' | 'error'
+
+interface ToastOptions {
+  message: string
+  tone?: ToastTone
+  duration?: number
+}
+
+interface ToastEntry {
+  id: number
+  message: string
+  tone: ToastTone
+  duration: number
+}
+
+interface ToastContextValue {
+  publish: (options: ToastOptions) => number
+  dismiss: (id?: number) => void
+}
+
+const DEFAULT_DURATION = 5000
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined)
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastEntry[]>([])
+
+  const dismiss = useCallback((id?: number) => {
+    setToasts(current => {
+      if (typeof id === 'number') {
+        return current.filter(toast => toast.id !== id)
+      }
+
+      return []
+    })
+  }, [])
+
+  const publish = useCallback((options: ToastOptions) => {
+    const message = options.message.trim()
+    if (!message) {
+      return -1
+    }
+
+    const toast: ToastEntry = {
+      id: Date.now() + Math.floor(Math.random() * 1000),
+      message,
+      tone: options.tone ?? 'info',
+      duration: options.duration ?? DEFAULT_DURATION
+    }
+
+    setToasts(current => [...current, toast])
+    return toast.id
+  }, [])
+
+  const value = useMemo(() => ({ publish, dismiss }), [publish, dismiss])
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="toast-region" role="region" aria-live="polite" aria-label="Notifications">
+        {toasts.map(toast => (
+          <Toast key={toast.id} toast={toast} onDismiss={dismiss} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+
+  return context
+}
+
+interface ToastProps {
+  toast: ToastEntry
+  onDismiss: (id: number) => void
+}
+
+function Toast({ toast, onDismiss }: ToastProps) {
+  const role = toast.tone === 'error' ? 'alert' : 'status'
+  const ariaLive = toast.tone === 'error' ? 'assertive' : 'polite'
+
+  React.useEffect(() => {
+    if (toast.duration <= 0) {
+      return
+    }
+
+    const timer = window.setTimeout(() => onDismiss(toast.id), toast.duration)
+    return () => window.clearTimeout(timer)
+  }, [toast, onDismiss])
+
+  return (
+    <div
+      className={`toast toast--${toast.tone}`}
+      role={role}
+      aria-live={ariaLive}
+      aria-atomic="true"
+    >
+      <span className="toast__indicator" aria-hidden="true" />
+      <span className="toast__message">{toast.message}</span>
+      <button
+        type="button"
+        className="toast__dismiss"
+        onClick={() => onDismiss(toast.id)}
+        aria-label="Dismiss notification"
+      >
+        ×
+      </button>
+    </div>
+  )
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,6 +9,7 @@ import Sell from './pages/Sell'
 import Receive from './pages/Receive'
 import CloseDay from './pages/CloseDay'
 import Settings from './pages/Settings'
+import { ToastProvider } from './components/ToastProvider'
 
 const router = createHashRouter([
   {
@@ -27,6 +28,8 @@ const router = createHashRouter([
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <ToastProvider>
+      <RouterProvider router={router} />
+    </ToastProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- create a reusable toast provider and dismissible notification UI
- mount the toast system at the app root so any route can publish notifications
- trigger toast messages for authentication success and error states and style the overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d42feefb448321a70fae2f62f9b316