### PR TITLE
Improve workspace styling and product layouts

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -1,0 +1,143 @@
+.shell {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #f8fafc;
+  min-height: 100vh;
+  color: #0f172a;
+}
+
+.shell__header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.shell__header-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 12px 18px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.shell__brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.shell__logo {
+  font-size: 24px;
+  font-weight: 800;
+  color: #4338ca;
+}
+
+.shell__tagline {
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.shell__nav {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
+}
+
+.shell__nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  color: #4338ca;
+  background-color: #eef2ff;
+  border: 1px solid transparent;
+  box-shadow: none;
+  transition: all 0.2s ease;
+  line-height: 1.4;
+}
+
+.shell__nav-link:is(:hover, :focus-visible) {
+  border-color: rgba(67, 56, 202, 0.25);
+  box-shadow: 0 6px 18px rgba(67, 56, 202, 0.1);
+}
+
+.shell__nav-link.is-active {
+  font-weight: 600;
+  color: #ffffff;
+  background-color: #4338ca;
+  border-color: #4338ca;
+  box-shadow: 0 6px 18px rgba(67, 56, 202, 0.18);
+}
+
+.shell__account {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  background: #eef2ff;
+  border-radius: 999px;
+}
+
+.shell__account-email {
+  font-size: 13px;
+  color: #4338ca;
+  font-weight: 600;
+}
+
+.shell__main {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+}
+
+.shell a {
+  color: inherit;
+}
+
+.shell input,
+.shell select,
+.shell textarea {
+  font: inherit;
+  color: inherit;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.shell input:focus,
+.shell select:focus,
+.shell textarea:focus {
+  border-color: #4338ca;
+  box-shadow: 0 0 0 3px rgba(67, 56, 202, 0.12);
+  outline: none;
+}
+
+.shell button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.shell button:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
+}
+
+.shell table {
+  width: 100%;
+}

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { signOut } from 'firebase/auth'
 import { auth } from '../firebase'
+import './Shell.css'
+import './Workspace.css'
 
 const NAV_ITEMS = [
   { to: '/', label: 'Dashboard', end: true },
@@ -12,92 +14,41 @@ const NAV_ITEMS = [
   { to: '/settings', label: 'Settings' }
 ]
 
-function linkStyle(isActive: boolean): React.CSSProperties {
-  return {
-    padding: '8px 14px',
-    borderRadius: 999,
-    textDecoration: 'none',
-    fontSize: 14,
-    fontWeight: isActive ? 600 : 500,
-    color: isActive ? '#fff' : '#4338CA',
-    backgroundColor: isActive ? '#4338CA' : '#EEF2FF',
-    border: `1px solid ${isActive ? '#4338CA' : 'transparent'}`,
-    boxShadow: isActive ? '0 6px 18px rgba(67, 56, 202, 0.18)' : 'none',
-    transition: 'all 0.2s ease',
-    lineHeight: 1.4
-  }
+function navLinkClass(isActive: boolean) {
+  return `shell__nav-link${isActive ? ' is-active' : ''}`
 }
 
 export default function Shell({ children }: { children: React.ReactNode }) {
   const userEmail = auth.currentUser?.email ?? 'Account'
 
   return (
-    <div style={{ fontFamily: 'Inter, system-ui, Arial', background: '#F8FAFC', minHeight: '100vh' }}>
-      <header style={{ position: 'sticky', top: 0, background: '#fff', borderBottom: '1px solid #E2E8F0', zIndex: 10 }}>
-        <div
-          style={{
-            maxWidth: 1100,
-            margin: '0 auto',
-            padding: '12px 16px',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 16,
-            flexWrap: 'wrap'
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <div style={{ fontSize: 24, fontWeight: 800, color: '#4338CA' }}>Sedifex</div>
-            <span style={{ fontSize: 13, color: '#64748B' }}>Sell faster. Count smarter.</span>
+    <div className="shell">
+      <header className="shell__header">
+        <div className="shell__header-inner">
+          <div className="shell__brand">
+            <div className="shell__logo">Sedifex</div>
+            <span className="shell__tagline">Sell faster. Count smarter.</span>
           </div>
 
-          <nav
-            aria-label="Primary"
-            style={{
-              display: 'flex',
-              gap: 8,
-              flexWrap: 'wrap',
-              justifyContent: 'center',
-              alignItems: 'center',
-              flexGrow: 1
-            }}
-          >
+          <nav className="shell__nav" aria-label="Primary">
             {NAV_ITEMS.map(item => (
               <NavLink
                 key={item.to}
                 to={item.to}
                 end={item.end}
-                style={({ isActive }) => linkStyle(isActive)}
+                className={({ isActive }) => navLinkClass(isActive)}
               >
                 {item.label}
               </NavLink>
             ))}
           </nav>
 
-          <div
-            style={{
-              marginLeft: 'auto',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              background: '#EEF2FF',
-              borderRadius: 999,
-              padding: '6px 10px'
-            }}
-          >
-            <span style={{ fontSize: 13, color: '#4338CA', fontWeight: 600 }}>{userEmail}</span>
+          <div className="shell__account">
+            <span className="shell__account-email">{userEmail}</span>
             <button
               type="button"
+              className="button button--primary button--small"
               onClick={() => signOut(auth)}
-              style={{
-                border: 'none',
-                background: '#4338CA',
-                color: '#fff',
-                fontSize: 13,
-                fontWeight: 600,
-                padding: '6px 10px',
-                borderRadius: 999,
-                cursor: 'pointer'
-              }}
             >
               Sign out
             </button>
@@ -105,7 +56,7 @@ export default function Shell({ children }: { children: React.ReactNode }) {
         </div>
       </header>
 
-      <main style={{ maxWidth: 1100, margin: '0 auto', padding: '24px 16px' }}>{children}</main>
+      <main className="shell__main">{children}</main>
     </div>
   )
 }

--- a/web/src/layout/Workspace.css
+++ b/web/src/layout/Workspace.css
@@ -1,0 +1,302 @@
+.page {
+  display: grid;
+  gap: 24px;
+}
+
+.page__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.page__title {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 30px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #1e293b;
+}
+
+.page__subtitle {
+  margin: 4px 0 0;
+  color: #64748b;
+  font-size: 15px;
+  max-width: 56ch;
+}
+
+.page__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 24px 60px -40px rgba(15, 23, 42, 0.45);
+  padding: 20px clamp(20px, 4vw, 28px);
+  display: grid;
+  gap: 18px;
+}
+
+.card--flush {
+  padding: 0;
+}
+
+.card__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.card__subtitle {
+  margin: 0;
+  color: #64748b;
+  font-size: 14px;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+}
+
+.field__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #475569;
+}
+
+.field__hint {
+  font-size: 13px;
+  color: #94a3b8;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-weight: 600;
+  line-height: 1.2;
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease, border-color 0.18s ease;
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #4338ca, #4f46e5);
+  color: #ffffff;
+  box-shadow: 0 18px 40px -24px rgba(67, 56, 202, 0.6);
+}
+
+.button--primary:is(:hover, :focus-visible) {
+  box-shadow: 0 20px 44px -22px rgba(67, 56, 202, 0.8);
+}
+
+.button--secondary {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  box-shadow: 0 18px 40px -24px rgba(37, 99, 235, 0.6);
+}
+
+.button--success {
+  background: linear-gradient(135deg, #059669, #047857);
+  color: #ffffff;
+  box-shadow: 0 18px 40px -24px rgba(5, 150, 105, 0.55);
+}
+
+.button--neutral {
+  background: #eef2ff;
+  color: #4338ca;
+  border-color: rgba(67, 56, 202, 0.18);
+}
+
+.button--outline {
+  background: #ffffff;
+  color: #4338ca;
+  border-color: #cbd5f5;
+}
+
+.button--ghost {
+  background: transparent;
+  color: #4338ca;
+}
+
+.button--danger {
+  background: #fef2f2;
+  color: #b91c1c;
+  border-color: #fecaca;
+}
+
+.button--small {
+  padding: 6px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+}
+
+.button--block {
+  width: 100%;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 18px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.table thead {
+  background: #f1f5f9;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.table th,
+.table td {
+  padding: 14px 18px;
+  text-align: left;
+}
+
+.table th:last-child,
+.table td:last-child {
+  text-align: right;
+}
+
+.table tbody tr {
+  border-bottom: 1px solid #e2e8f0;
+  transition: background-color 0.2s ease;
+}
+
+.table tbody tr:is(:hover, :focus-within) {
+  background: #f8fafc;
+}
+
+.table input,
+.table select {
+  width: 100%;
+  padding: 8px 10px;
+}
+
+.input--align-right {
+  text-align: right;
+}
+
+.input--inline {
+  width: 72px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.badge--ok {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.badge--low {
+  background: #fef3c7;
+  color: #c2410c;
+}
+
+.badge--out {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.empty-state {
+  padding: 48px 24px;
+  text-align: center;
+  color: #64748b;
+  display: grid;
+  gap: 12px;
+}
+
+.empty-state__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.feedback {
+  font-size: 14px;
+  color: #047857;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  z-index: 50;
+}
+
+.modal {
+  background: #ffffff;
+  border-radius: 20px;
+  width: min(480px, 100%);
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 30px 80px -40px rgba(15, 23, 42, 0.5);
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.modal__message {
+  margin: 0;
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.modal__error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .table {
+    min-width: auto;
+  }
+
+  .shell__account {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/web/src/pages/Products.css
+++ b/web/src/pages/Products.css
@@ -1,0 +1,164 @@
+.products-page {
+  position: relative;
+}
+
+.products__form-card {
+  position: relative;
+}
+
+.products__form {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 720px) {
+  .products__form {
+    grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+    align-items: end;
+  }
+
+  .products__form-actions {
+    justify-self: end;
+  }
+}
+
+.products__form-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.products__scan-input {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.products__scan-input input {
+  flex: 1;
+}
+
+.products__controls {
+  display: grid;
+  gap: 20px;
+}
+
+@media (min-width: 768px) {
+  .products__controls {
+    grid-template-columns: 2fr 1fr;
+    align-items: end;
+  }
+}
+
+.products__filters {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.products__export-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.products__table-header {
+  padding: 20px clamp(20px, 4vw, 28px) 0;
+}
+
+.products__table {
+  width: 100%;
+}
+
+.products__row.is-editing {
+  background: rgba(238, 242, 255, 0.55);
+}
+
+.products__row.is-editing input {
+  background: #ffffff;
+}
+
+.products__price {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.products__name {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.products__name-text {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.products__meta {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.products__stock {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+@media (min-width: 820px) {
+  .products__stock {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+  }
+}
+
+.products__stock-count {
+  font-size: 13px;
+  color: #475569;
+  font-weight: 500;
+}
+
+.products__barcode {
+  font-family: 'Fira Code', 'Roboto Mono', Menlo, monospace;
+  font-size: 13px;
+  color: #1e293b;
+}
+
+.products__action-group {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.products__price-column,
+.products__actions-column {
+  text-align: right;
+}
+
+.products__modal {
+  position: relative;
+}
+
+.products__video {
+  width: 100%;
+  border-radius: 16px;
+  background: #000;
+  aspect-ratio: 3 / 2;
+}
+
+@media (max-width: 640px) {
+  .products__form {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .products__form-actions {
+    justify-content: flex-start;
+  }
+
+  .products__export-actions {
+    justify-content: flex-start;
+  }
+}

--- a/web/src/pages/Receive.css
+++ b/web/src/pages/Receive.css
@@ -1,0 +1,30 @@
+.receive-page__card {
+  max-width: 720px;
+}
+
+.receive-page__form {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 720px) {
+  .receive-page__form {
+    grid-template-columns: 2fr 1fr auto;
+    align-items: end;
+  }
+
+  .receive-page__actions {
+    justify-self: end;
+  }
+}
+
+.receive-page__actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+@media (max-width: 640px) {
+  .receive-page__form {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { collection, query, where, orderBy, onSnapshot, doc, updateDoc } from 'firebase/firestore'
 import { db, auth } from '../firebase'
+import './Receive.css'
 
 type Product = { id: string; name: string; stockCount?: number; storeId: string }
 
@@ -28,16 +29,54 @@ export default function Receive() {
   if (!STORE_ID) return <div>Loading…</div>
 
   return (
-    <div>
-      <h2 style={{color:'#4338CA'}}>Receive Stock</h2>
-      <div style={{display:'flex', gap:8}}>
-        <select value={selected} onChange={e=>setSelected(e.target.value)} style={{padding:8}}>
-          <option value="">Select product…</option>
-          {products.map(p=><option key={p.id} value={p.id}>{p.name} (Stock {p.stockCount ?? 0})</option>)}
-        </select>
-        <input type="number" min={1} placeholder="Qty" value={qty} onChange={e=>setQty(e.target.value)} style={{padding:8, width:120}} />
-        <button onClick={receive} style={{padding:'8px 12px', background:'#4338CA', color:'#fff', border:0, borderRadius:8}}>Add Stock</button>
-      </div>
+    <div className="page receive-page">
+      <header className="page__header">
+        <div>
+          <h2 className="page__title">Receive stock</h2>
+          <p className="page__subtitle">Log deliveries against your Firestore inventory so shelves stay replenished.</p>
+        </div>
+      </header>
+
+      <section className="card receive-page__card">
+        <div className="receive-page__form">
+          <div className="field">
+            <label className="field__label" htmlFor="receive-product">Product</label>
+            <select
+              id="receive-product"
+              value={selected}
+              onChange={e => setSelected(e.target.value)}
+            >
+              <option value="">Select product…</option>
+              {products.map(p => (
+                <option key={p.id} value={p.id}>
+                  {p.name} (Stock {p.stockCount ?? 0})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="field">
+            <label className="field__label" htmlFor="receive-qty">Quantity received</label>
+            <input
+              id="receive-qty"
+              type="number"
+              min={1}
+              placeholder="0"
+              value={qty}
+              onChange={e => setQty(e.target.value)}
+            />
+          </div>
+          <div className="receive-page__actions">
+            <button
+              type="button"
+              className="button button--primary"
+              onClick={receive}
+              disabled={!selected || !qty}
+            >
+              Add stock
+            </button>
+          </div>
+        </div>
+      </section>
     </div>
   )
 }

--- a/web/src/pages/Sell.css
+++ b/web/src/pages/Sell.css
@@ -1,0 +1,110 @@
+.sell-page__total {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  background: #eef2ff;
+  border-radius: 16px;
+  padding: 12px 16px;
+  min-width: 160px;
+}
+
+.sell-page__total-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6366f1;
+  font-weight: 600;
+}
+
+.sell-page__total-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: #312e81;
+}
+
+.sell-page__grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .sell-page__grid {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  }
+}
+
+.sell-page__section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sell-page__catalog-list {
+  display: grid;
+  gap: 12px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.sell-page__product {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  border-radius: 14px;
+  padding: 14px 16px;
+  text-align: left;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.sell-page__product:hover,
+.sell-page__product:focus-visible {
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow: 0 18px 40px -26px rgba(99, 102, 241, 0.6);
+  transform: translateY(-1px);
+}
+
+.sell-page__product-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.sell-page__product-meta {
+  display: block;
+  font-size: 13px;
+  color: #64748b;
+  margin-top: 4px;
+}
+
+.sell-page__product-action {
+  font-weight: 600;
+  color: #4338ca;
+}
+
+.sell-page__summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 16px;
+  font-size: 16px;
+}
+
+.sell-page__summary strong {
+  font-size: 20px;
+  color: #111827;
+}
+
+.sell-page__numeric {
+  text-align: right;
+}
+
+@media (max-width: 640px) {
+  .sell-page__total {
+    width: 100%;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the application shell with dedicated CSS and shared workspace primitives for inputs, buttons, tables, and cards
- redesign the products view with responsive sections, filtered export actions, stock badges, and an upgraded barcode modal
- refresh sell and receive screens to match the new workspace styling and improve readability on different screen sizes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4307b137c8321bd07234661301990