### PR TITLE
Ensure exported files trigger reliably

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -338,13 +338,27 @@ export default function Products() {
   }, [items, searchTerm, stockFilter])
 
   const exportFile = useCallback((content: BlobPart, type: string, filename: string) => {
+    if (typeof window === 'undefined') return
+
     const blob = new Blob([content], { type })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url
     link.download = filename
+    link.rel = 'noopener'
+    document.body.appendChild(link)
     link.click()
-    URL.revokeObjectURL(url)
+
+    const revoke = () => {
+      document.body.removeChild(link)
+      URL.revokeObjectURL(url)
+    }
+
+    if ('requestAnimationFrame' in window) {
+      window.requestAnimationFrame(revoke)
+    } else {
+      setTimeout(revoke, 0)
+    }
   }, [])
 
   const handleDownloadCsv = useCallback(() => {


### PR DESCRIPTION
## Summary
- update the `exportFile` helper on the products page to append a temporary anchor before invoking the download
- revoke object URLs after the browser handles the click so Firefox/Safari users can download reports consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4597ffcc88321bf1c745829d44940