### PR TITLE
Increase busy state table opacity

### DIFF
--- a/web/src/pages/Products.css
+++ b/web/src/pages/Products.css
@@ -5,8 +5,9 @@
 /* ensure table renders crisp by default on this page */
 .products-page .table { opacity: 1; filter: none; transition: opacity 160ms ease; }
 
-/* only dim during real operations on this page (when aria-busy is true) */
-.products-page[aria-busy="true"] .table { opacity: .45; pointer-events: none; }
+/* only dim during real operations on this page (when aria-busy is true)
+   keep opacity high enough so new/updated rows remain legible */
+.products-page[aria-busy="true"] .table { opacity: .8; pointer-events: none; }
 
 .products__form-card {
   position: relative;


### PR DESCRIPTION
## Summary
- raise the busy-state table opacity on the products page so saved rows stay visible while operations complete
- document the intent in the surrounding comment for future adjustments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d512791f8c8321b412c8d3d3ada489