### PR TITLE
Expand auth layout width

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -92,7 +92,7 @@ body {
 
 .app__layout {
   position: relative;
-  width: min(1100px, 100%);
+  width: min(1280px, 100%);
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   justify-items: center;
@@ -102,7 +102,7 @@ body {
 
 @media (min-width: 960px) {
   .app__layout {
-    grid-template-columns: minmax(0, 460px) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 520px) minmax(0, 1fr);
     align-items: center;
     gap: clamp(32px, 6vw, 72px);
   }
@@ -116,7 +116,7 @@ body {
 
 .app__card {
   position: relative;
-  width: min(460px, 100%);
+  width: min(520px, 100%);
   background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(24, 33, 53, 0.8));
   border-radius: 32px;
   padding: clamp(28px, 4vw, 44px);
@@ -139,7 +139,7 @@ body {
   position: relative;
   display: grid;
   place-items: center;
-  width: min(520px, 100%);
+  width: min(620px, 100%);
   border-radius: 32px;
   overflow: hidden;
   border: 1px solid rgba(148, 163, 184, 0.28);
@@ -207,7 +207,7 @@ body {
   .app__visual {
     order: 0;
     min-height: 100%;
-    max-width: 520px;
+    max-width: 620px;
   }
 }
 


### PR DESCRIPTION
## Summary
- widen the authentication layout container to allow more breathing room on large screens
- increase the card and hero image widths so the grid fills the expanded layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d51289295c83219a97e20165351307