### PR TITLE
Add POS checkout enhancements with receipt printing and customers page

### DIFF
--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { to: '/products', label: 'Products' },
   { to: '/sell', label: 'Sell' },
   { to: '/receive', label: 'Receive' },
+  { to: '/customers', label: 'Customers' },
   { to: '/close-day', label: 'Close Day' },
   { to: '/settings', label: 'Settings' }
 ]

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,7 @@ import Products from './pages/Products'
 import Sell from './pages/Sell'
 import Receive from './pages/Receive'
 import CloseDay from './pages/CloseDay'
+import Customers from './pages/Customers'
 import Settings from './pages/Settings'
 import { ToastProvider } from './components/ToastProvider'
 
@@ -20,6 +21,7 @@ const router = createHashRouter([
       { path: 'products',  element: <Shell><Products /></Shell> },
       { path: 'sell',      element: <Shell><Sell /></Shell> },
       { path: 'receive',   element: <Shell><Receive /></Shell> },
+      { path: 'customers', element: <Shell><Customers /></Shell> },
       { path: 'close-day', element: <Shell><CloseDay /></Shell> },
       { path: 'settings',  element: <Shell><Settings /></Shell> },
     ],

--- a/web/src/pages/Customers.css
+++ b/web/src/pages/Customers.css
@@ -1,0 +1,55 @@
+.customers-page__grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 1080px) {
+  .customers-page__grid {
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  }
+}
+
+.customers-page__section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.customers-page__form {
+  display: grid;
+  gap: 16px;
+}
+
+.customers-page__form-row {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 640px) {
+  .customers-page__form-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.customers-page__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #eef2ff;
+  color: #4338ca;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 8px 16px;
+  min-width: 120px;
+  text-align: center;
+}
+
+.customers-page__message {
+  margin: 0;
+  font-size: 14px;
+}
+
+.customers-page__message--error {
+  color: #b91c1c;
+}

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -1,0 +1,236 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { addDoc, collection, deleteDoc, doc, onSnapshot, orderBy, query, serverTimestamp, where } from 'firebase/firestore'
+import { Timestamp } from 'firebase/firestore'
+import { Link } from 'react-router-dom'
+import { auth, db } from '../firebase'
+import './Customers.css'
+
+type Customer = {
+  id: string
+  name: string
+  phone?: string
+  email?: string
+  notes?: string
+  createdAt?: Timestamp | null
+}
+
+export default function Customers() {
+  const user = auth.currentUser
+  const STORE_ID = useMemo(() => user?.uid || null, [user?.uid])
+
+  const [customers, setCustomers] = useState<Customer[]>([])
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [email, setEmail] = useState('')
+  const [notes, setNotes] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!STORE_ID) return
+    const q = query(
+      collection(db, 'customers'),
+      where('storeId', '==', STORE_ID),
+      orderBy('name')
+    )
+    return onSnapshot(q, snap => {
+      const rows = snap.docs.map(docSnap => {
+        const data = docSnap.data() as Omit<Customer, 'id'>
+        return {
+          id: docSnap.id,
+          ...data,
+        }
+      })
+      setCustomers(rows)
+    })
+  }, [STORE_ID])
+
+  async function addCustomer(event: React.FormEvent) {
+    event.preventDefault()
+    if (!STORE_ID) return
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      setError('Customer name is required to save a record.')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      await addDoc(collection(db, 'customers'), {
+        storeId: STORE_ID,
+        name: trimmedName,
+        ...(phone.trim() ? { phone: phone.trim() } : {}),
+        ...(email.trim() ? { email: email.trim() } : {}),
+        ...(notes.trim() ? { notes: notes.trim() } : {}),
+        createdAt: serverTimestamp(),
+      })
+      setName('')
+      setPhone('')
+      setEmail('')
+      setNotes('')
+    } catch (err) {
+      console.error('[customers] Unable to save customer', err)
+      setError('We could not save this customer. Please try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function removeCustomer(id: string) {
+    if (!id) return
+    const confirmation = window.confirm('Remove this customer?')
+    if (!confirmation) return
+    setBusy(true)
+    try {
+      await deleteDoc(doc(db, 'customers', id))
+    } catch (err) {
+      console.error('[customers] Unable to delete customer', err)
+      setError('Unable to delete this customer right now.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!STORE_ID) {
+    return <div>Loading…</div>
+  }
+
+  return (
+    <div className="page customers-page">
+      <header className="page__header">
+        <div>
+          <h2 className="page__title">Customers</h2>
+          <p className="page__subtitle">
+            Keep a tidy record of your regulars and speed up checkout on the sales floor.
+          </p>
+        </div>
+        <span className="customers-page__badge" aria-live="polite">
+          {customers.length} saved
+        </span>
+      </header>
+
+      <div className="customers-page__grid">
+        <section className="card" aria-label="Add a customer">
+          <div className="customers-page__section-header">
+            <h3 className="card__title">New customer</h3>
+            <p className="card__subtitle">Capture contact details so you can reuse them during checkout.</p>
+          </div>
+
+          <form className="customers-page__form" onSubmit={addCustomer}>
+            <div className="field">
+              <label className="field__label" htmlFor="customer-name">Full name</label>
+              <input
+                id="customer-name"
+                value={name}
+                onChange={event => setName(event.target.value)}
+                placeholder="e.g. Ama Mensah"
+                disabled={busy}
+                required
+              />
+            </div>
+
+            <div className="customers-page__form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="customer-phone">Phone</label>
+                <input
+                  id="customer-phone"
+                  value={phone}
+                  onChange={event => setPhone(event.target.value)}
+                  placeholder="024 000 0000"
+                  disabled={busy}
+                />
+              </div>
+              <div className="field">
+                <label className="field__label" htmlFor="customer-email">Email</label>
+                <input
+                  id="customer-email"
+                  value={email}
+                  onChange={event => setEmail(event.target.value)}
+                  placeholder="ama@example.com"
+                  disabled={busy}
+                  type="email"
+                />
+              </div>
+            </div>
+
+            <div className="field">
+              <label className="field__label" htmlFor="customer-notes">Notes</label>
+              <textarea
+                id="customer-notes"
+                value={notes}
+                onChange={event => setNotes(event.target.value)}
+                placeholder="Birthday reminders, delivery addresses, favourite products…"
+                rows={3}
+                disabled={busy}
+              />
+            </div>
+
+            {error && <p className="customers-page__message customers-page__message--error">{error}</p>}
+
+            <button type="submit" className="button button--primary" disabled={busy}>
+              Save customer
+            </button>
+          </form>
+
+          <p className="field__hint">
+            Customers saved here appear in the checkout flow. Visit the <Link to="/sell">Sell page</Link> to try it out.
+          </p>
+        </section>
+
+        <section className="card" aria-label="Saved customers">
+          <div className="customers-page__section-header">
+            <h3 className="card__title">Customer list</h3>
+            <p className="card__subtitle">
+              Stay organised and keep sales staff informed with up-to-date contact information.
+            </p>
+          </div>
+
+          {customers.length ? (
+            <div className="table-wrapper">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Contact</th>
+                    <th scope="col">Notes</th>
+                    <th scope="col">Created</th>
+                    <th scope="col">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {customers.map(customer => {
+                    const createdAt = customer.createdAt?.toDate?.() ?? null
+                    const contactBits = [customer.phone, customer.email].filter(Boolean).join(' • ')
+                    return (
+                      <tr key={customer.id}>
+                        <td>{customer.name}</td>
+                        <td>{contactBits || '—'}</td>
+                        <td>{customer.notes || '—'}</td>
+                        <td>{createdAt ? createdAt.toLocaleString() : '—'}</td>
+                        <td>
+                          <button
+                            type="button"
+                            className="button button--danger button--small"
+                            onClick={() => removeCustomer(customer.id)}
+                            disabled={busy}
+                          >
+                            Remove
+                          </button>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="empty-state">
+              <h3 className="empty-state__title">No customers saved yet</h3>
+              <p>Add your first customer using the form and they will appear here.</p>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/Sell.css
+++ b/web/src/pages/Sell.css
@@ -102,6 +102,186 @@
   text-align: right;
 }
 
+.sell-page__form-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+@media (min-width: 960px) {
+  .sell-page__form-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: end;
+  }
+}
+
+.sell-page__field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sell-page__input,
+.sell-page__select {
+  padding: 10px 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  font-size: 15px;
+}
+
+.sell-page__input:focus,
+.sell-page__select:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 0 0 2px rgba(129, 140, 248, 0.35);
+}
+
+.sell-page__customers-link {
+  color: #4338ca;
+  font-weight: 600;
+}
+
+.sell-page__payment-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid #e2e8f0;
+}
+
+@media (min-width: 720px) {
+  .sell-page__payment-summary {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+.sell-page__summary-label {
+  display: block;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+  margin-bottom: 4px;
+}
+
+.sell-page__change {
+  color: #047857;
+}
+
+.sell-page__change.is-short {
+  color: #b91c1c;
+}
+
+.sell-page__message {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 16px 0 0;
+  font-size: 14px;
+}
+
+.sell-page__message--error {
+  color: #b91c1c;
+}
+
+.sell-page__message--success {
+  color: #047857;
+}
+
+.receipt-print {
+  display: none;
+}
+
+.receipt-print.is-ready {
+  display: block;
+  position: fixed;
+  inset: 0;
+  padding: 24px;
+  background: #ffffff;
+  color: #111827;
+  font-family: 'Courier New', Courier, monospace;
+  z-index: -1;
+}
+
+.receipt-print__inner {
+  max-width: 360px;
+  margin: 0 auto;
+}
+
+.receipt-print__title {
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.receipt-print__meta {
+  text-align: center;
+  margin: 0 0 16px;
+  font-size: 13px;
+}
+
+.receipt-print__section {
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.receipt-print__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  margin-bottom: 16px;
+}
+
+.receipt-print__table th,
+.receipt-print__table td {
+  padding: 6px 0;
+  text-align: left;
+  border-bottom: 1px dashed #d4d4d4;
+}
+
+.receipt-print__table th:last-child,
+.receipt-print__table td:last-child {
+  text-align: right;
+}
+
+.receipt-print__summary {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.receipt-print__summary div {
+  display: flex;
+  justify-content: space-between;
+}
+
+.receipt-print__footer {
+  text-align: center;
+  font-size: 13px;
+  margin: 0;
+}
+
+@media print {
+  body * {
+    visibility: hidden !important;
+  }
+
+  .receipt-print.is-ready,
+  .receipt-print.is-ready * {
+    visibility: visible !important;
+  }
+
+  .receipt-print.is-ready {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 999;
+  }
+}
+
 @media (max-width: 640px) {
   .sell-page__total {
     width: 100%;

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -1,19 +1,59 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { collection, query, where, orderBy, onSnapshot, doc, writeBatch, addDoc, serverTimestamp } from 'firebase/firestore'
+import {
+  collection,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  doc,
+  writeBatch,
+  addDoc,
+  serverTimestamp,
+} from 'firebase/firestore'
 import { db, auth } from '../firebase'
 import './Sell.css'
+import { Link } from 'react-router-dom'
 
 type Product = { id: string; name: string; price: number; stockCount?: number; storeId: string }
 type CartLine = { productId: string; name: string; price: number; qty: number }
+type Customer = { id: string; name: string; phone?: string; email?: string; notes?: string }
+type ReceiptData = {
+  saleId: string
+  createdAt: Date
+  items: CartLine[]
+  subtotal: number
+  payment: {
+    method: string
+    amountPaid: number
+    changeDue: number
+  }
+  customer?: {
+    name: string
+    phone?: string
+    email?: string
+  }
+}
 
 export default function Sell() {
   const user = auth.currentUser
   const STORE_ID = useMemo(() => user?.uid || null, [user?.uid])
 
   const [products, setProducts] = useState<Product[]>([])
+  const [customers, setCustomers] = useState<Customer[]>([])
   const [queryText, setQueryText] = useState('')
   const [cart, setCart] = useState<CartLine[]>([])
+  const [selectedCustomerId, setSelectedCustomerId] = useState('')
+  const [paymentMethod, setPaymentMethod] = useState<'cash' | 'mobile' | 'card'>('cash')
+  const [amountTendered, setAmountTendered] = useState('')
+  const [saleError, setSaleError] = useState<string | null>(null)
+  const [saleSuccess, setSaleSuccess] = useState<string | null>(null)
+  const [isRecording, setIsRecording] = useState(false)
+  const [receipt, setReceipt] = useState<ReceiptData | null>(null)
   const subtotal = cart.reduce((s, l) => s + l.price * l.qty, 0)
+  const selectedCustomer = customers.find(c => c.id === selectedCustomerId)
+  const amountPaid = paymentMethod === 'cash' ? Number(amountTendered || 0) : subtotal
+  const changeDue = Math.max(0, amountPaid - subtotal)
+  const isCashShort = paymentMethod === 'cash' && amountPaid < subtotal && subtotal > 0
 
   useEffect(() => {
     if (!STORE_ID) return
@@ -22,6 +62,28 @@ export default function Sell() {
       setProducts(snap.docs.map(d => ({ id:d.id, ...(d.data() as any) })))
     })
   }, [STORE_ID])
+
+  useEffect(() => {
+    if (!STORE_ID) return
+    const q = query(collection(db, 'customers'), where('storeId', '==', STORE_ID), orderBy('name'))
+    return onSnapshot(q, snap => {
+      setCustomers(snap.docs.map(docSnap => ({ id: docSnap.id, ...(docSnap.data() as Customer) })))
+    })
+  }, [STORE_ID])
+
+  useEffect(() => {
+    if (!receipt) return
+    const timeout = window.setTimeout(() => {
+      window.print()
+    }, 250)
+    return () => window.clearTimeout(timeout)
+  }, [receipt])
+
+  useEffect(() => {
+    if (paymentMethod !== 'cash') {
+      setAmountTendered('')
+    }
+  }, [paymentMethod])
 
   function addToCart(p: Product) {
     setCart(cs => {
@@ -37,24 +99,73 @@ export default function Sell() {
   }
   async function recordSale() {
     if (!STORE_ID || cart.length === 0) return
-    // 1) write a sale with items array
-    const saleRef = await addDoc(collection(db, 'sales'), {
-      storeId: STORE_ID,
-      createdAt: serverTimestamp(),
-      items: cart,
-      total: subtotal
-    })
-    // 2) decrement stock with a batch
-    const batch = writeBatch(db)
-    cart.forEach(line => {
-      const pRef = doc(db,'products', line.productId)
-      const p = products.find(x=>x.id===line.productId)
-      const next = Math.max(0, (p?.stockCount || 0) - line.qty)
-      batch.update(pRef, { stockCount: next })
-    })
-    await batch.commit()
-    setCart([])
-    alert(`Sale recorded #${saleRef.id}`)
+    if (isCashShort) {
+      setSaleError('Cash received is less than the total due.')
+      return
+    }
+    setSaleError(null)
+    setSaleSuccess(null)
+    setReceipt(null)
+    setIsRecording(true)
+    try {
+      const salePayload: Record<string, unknown> = {
+        storeId: STORE_ID,
+        createdAt: serverTimestamp(),
+        items: cart,
+        total: subtotal,
+        payment: {
+          method: paymentMethod,
+          amountPaid,
+          changeDue,
+        },
+      }
+      if (selectedCustomer) {
+        salePayload.customer = {
+          id: selectedCustomer.id,
+          name: selectedCustomer.name,
+          ...(selectedCustomer.phone ? { phone: selectedCustomer.phone } : {}),
+          ...(selectedCustomer.email ? { email: selectedCustomer.email } : {}),
+        }
+      }
+      const saleRef = await addDoc(collection(db, 'sales'), salePayload)
+      const batch = writeBatch(db)
+      cart.forEach(line => {
+        const pRef = doc(db,'products', line.productId)
+        const p = products.find(x=>x.id===line.productId)
+        const next = Math.max(0, (p?.stockCount || 0) - line.qty)
+        batch.update(pRef, { stockCount: next })
+      })
+      await batch.commit()
+
+      const receiptItems = cart.map(line => ({ ...line }))
+      setReceipt({
+        saleId: saleRef.id,
+        createdAt: new Date(),
+        items: receiptItems,
+        subtotal,
+        payment: {
+          method: paymentMethod,
+          amountPaid,
+          changeDue,
+        },
+        customer: selectedCustomer
+          ? {
+              name: selectedCustomer.name,
+              phone: selectedCustomer.phone,
+              email: selectedCustomer.email,
+            }
+          : undefined,
+      })
+      setCart([])
+      setSelectedCustomerId('')
+      setAmountTendered('')
+      setSaleSuccess(`Sale recorded #${saleRef.id}. Receipt sent to printer.`)
+    } catch (err) {
+      console.error('[sell] Unable to record sale', err)
+      setSaleError('We were unable to record this sale. Please try again.')
+    } finally {
+      setIsRecording(false)
+    }
   }
 
   if (!STORE_ID) return <div>Loading…</div>
@@ -160,13 +271,94 @@ export default function Sell() {
                 <strong>GHS {subtotal.toFixed(2)}</strong>
               </div>
 
+              <div className="sell-page__form-grid">
+                <div className="sell-page__field-group">
+                  <label className="field__label" htmlFor="sell-customer">Customer</label>
+                  <select
+                    id="sell-customer"
+                    value={selectedCustomerId}
+                    onChange={event => setSelectedCustomerId(event.target.value)}
+                    className="sell-page__select"
+                  >
+                    <option value="">Walk-in customer</option>
+                    {customers.map(customer => (
+                      <option key={customer.id} value={customer.id}>
+                        {customer.name}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="field__hint">
+                    Need to add someone new? Manage records on the{' '}
+                    <Link to="/customers" className="sell-page__customers-link">Customers page</Link>.
+                  </p>
+                </div>
+
+                <div className="sell-page__field-group">
+                  <label className="field__label" htmlFor="sell-payment-method">Payment method</label>
+                  <select
+                    id="sell-payment-method"
+                    value={paymentMethod}
+                    onChange={event => setPaymentMethod(event.target.value as 'cash' | 'mobile' | 'card')}
+                    className="sell-page__select"
+                  >
+                    <option value="cash">Cash</option>
+                    <option value="mobile">Mobile money</option>
+                    <option value="card">Card</option>
+                  </select>
+                </div>
+
+                {paymentMethod === 'cash' && (
+                  <div className="sell-page__field-group">
+                    <label className="field__label" htmlFor="sell-amount-tendered">Cash received</label>
+                    <input
+                      id="sell-amount-tendered"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={amountTendered}
+                      onChange={event => setAmountTendered(event.target.value)}
+                      className="sell-page__input"
+                    />
+                  </div>
+                )}
+              </div>
+
+              <div className="sell-page__payment-summary" aria-live="polite">
+                <div>
+                  <span className="sell-page__summary-label">Amount due</span>
+                  <strong>GHS {subtotal.toFixed(2)}</strong>
+                </div>
+                <div>
+                  <span className="sell-page__summary-label">Paid</span>
+                  <strong>GHS {amountPaid.toFixed(2)}</strong>
+                </div>
+                <div className={`sell-page__change${isCashShort ? ' is-short' : ''}`}>
+                  <span className="sell-page__summary-label">{isCashShort ? 'Short' : 'Change due'}</span>
+                  <strong>GHS {changeDue.toFixed(2)}</strong>
+                </div>
+              </div>
+
+              {saleError && <p className="sell-page__message sell-page__message--error">{saleError}</p>}
+              {saleSuccess && (
+                <div className="sell-page__message sell-page__message--success">
+                  <span>{saleSuccess}</span>
+                  <button
+                    type="button"
+                    className="button button--small"
+                    onClick={() => window.print()}
+                  >
+                    Print again
+                  </button>
+                </div>
+              )}
+
               <button
                 type="button"
                 className="button button--primary button--block"
                 onClick={recordSale}
-                disabled={cart.length === 0}
+                disabled={cart.length === 0 || isRecording}
               >
-                Record sale
+                {isRecording ? 'Saving…' : 'Record sale'}
               </button>
             </>
           ) : (
@@ -176,6 +368,64 @@ export default function Sell() {
             </div>
           )}
         </section>
+      </div>
+
+      <div className={`receipt-print${receipt ? ' is-ready' : ''}`} aria-hidden={receipt ? 'false' : 'true'}>
+        {receipt && (
+          <div className="receipt-print__inner">
+            <h2 className="receipt-print__title">Sedifex POS</h2>
+            <p className="receipt-print__meta">
+              {user?.email ?? 'sales@sedifex.app'}
+              <br />
+              {receipt.createdAt.toLocaleString()}
+            </p>
+
+            {receipt.customer && (
+              <div className="receipt-print__section">
+                <strong>Customer:</strong>
+                <div>{receipt.customer.name}</div>
+                {receipt.customer.phone && <div>{receipt.customer.phone}</div>}
+                {receipt.customer.email && <div>{receipt.customer.email}</div>}
+              </div>
+            )}
+
+            <table className="receipt-print__table">
+              <thead>
+                <tr>
+                  <th>Item</th>
+                  <th>Qty</th>
+                  <th>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {receipt.items.map(line => (
+                  <tr key={line.productId}>
+                    <td>{line.name}</td>
+                    <td>{line.qty}</td>
+                    <td>GHS {(line.qty * line.price).toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            <div className="receipt-print__summary">
+              <div>
+                <span>Subtotal</span>
+                <strong>GHS {receipt.subtotal.toFixed(2)}</strong>
+              </div>
+              <div>
+                <span>Paid ({receipt.payment.method})</span>
+                <strong>GHS {receipt.payment.amountPaid.toFixed(2)}</strong>
+              </div>
+              <div>
+                <span>Change</span>
+                <strong>GHS {receipt.payment.changeDue.toFixed(2)}</strong>
+              </div>
+            </div>
+
+            <p className="receipt-print__footer">Sale #{receipt.saleId} — Thank you for shopping with us!</p>
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add a customer management page to capture shopper contact details for reuse at checkout
- extend the sell workflow with payment handling, change calculation, and automatic receipt printing
- update navigation and routing to surface the new customer tools in the workspace

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d517bebbec832181f41cf5e7e2ccaa