### PR TITLE
Add receipt sharing and loyalty prompts to sell workflow

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { db } from '../firebase'
 
 import { useAuthUser } from '../hooks/useAuthUser'
 import { useToast } from '../components/ToastProvider'
+import { useActiveStore } from '../hooks/useActiveStore'
 
 
 type InventorySeverity = 'warning' | 'info' | 'critical'

--- a/web/src/pages/Sell.css
+++ b/web/src/pages/Sell.css
@@ -190,6 +190,78 @@
   color: #047857;
 }
 
+.sell-page__loyalty {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border: 1px dashed rgba(67, 56, 202, 0.35);
+  border-radius: 12px;
+  background: rgba(224, 231, 255, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sell-page__loyalty-title {
+  font-size: 14px;
+  color: #312e81;
+}
+
+.sell-page__loyalty-text {
+  font-size: 13px;
+  color: #4338ca;
+  margin: 0;
+}
+
+.sell-page__loyalty-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.sell-page__engagement {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid #bbf7d0;
+  border-radius: 16px;
+  background: #f0fdf4;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sell-page__engagement-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #065f46;
+  margin: 0;
+}
+
+.sell-page__engagement-text {
+  margin: 0;
+  font-size: 14px;
+  color: #047857;
+}
+
+.sell-page__engagement-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.sell-page__engagement-details {
+  font-size: 13px;
+  color: #14532d;
+}
+
+.sell-page__engagement-preview {
+  margin: 8px 0 0;
+  padding: 12px;
+  background: #dcfce7;
+  border-radius: 12px;
+  font-family: 'Courier New', Courier, monospace;
+  white-space: pre-wrap;
+}
+
 .receipt-print {
   display: none;
 }


### PR DESCRIPTION
## Summary
- add shareable receipt helpers to offer email and SMS options once a sale is recorded
- surface loyalty prompts when a customer is selected during checkout
- fix missing Dashboard import uncovered by the TypeScript build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d559ff20d88321aaa057ba8bd41241