### PR TITLE
Add receipt audit trail to receiving workflow

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -64,3 +64,90 @@ export const commitSale = functions.https.onCall(async (data, context) => {
 
   return { ok: true, saleId }
 })
+
+export const receiveStock = functions.https.onCall(async (data, context) => {
+  const { storeId, productId, qty, supplier, reference, unitCost } = data || {}
+  if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Login required')
+  const claims = context.auth.token as any
+  if (!claims?.stores?.includes?.(storeId)) {
+    throw new functions.https.HttpsError('permission-denied', 'No store access')
+  }
+
+  const productIdStr = typeof productId === 'string' ? productId : null
+  if (!productIdStr) {
+    throw new functions.https.HttpsError('invalid-argument', 'A product must be selected')
+  }
+
+  const amount = Number(qty)
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new functions.https.HttpsError('invalid-argument', 'Quantity must be greater than zero')
+  }
+
+  const normalizedSupplier = typeof supplier === 'string' ? supplier.trim() : ''
+  if (!normalizedSupplier) {
+    throw new functions.https.HttpsError('invalid-argument', 'Supplier is required')
+  }
+
+  const normalizedReference = typeof reference === 'string' ? reference.trim() : ''
+  if (!normalizedReference) {
+    throw new functions.https.HttpsError('invalid-argument', 'Reference number is required')
+  }
+
+  let normalizedUnitCost: number | null = null
+  if (unitCost !== undefined && unitCost !== null && unitCost !== '') {
+    const parsedCost = Number(unitCost)
+    if (!Number.isFinite(parsedCost) || parsedCost < 0) {
+      throw new functions.https.HttpsError('invalid-argument', 'Cost must be zero or greater when provided')
+    }
+    normalizedUnitCost = parsedCost
+  }
+
+  const productRef = db.collection('products').doc(productIdStr)
+  const receiptRef = db.collection('receipts').doc()
+  const ledgerRef = db.collection('ledger').doc()
+
+  await db.runTransaction(async (tx) => {
+    const pSnap = await tx.get(productRef)
+    if (!pSnap.exists || pSnap.get('storeId') !== storeId) {
+      throw new functions.https.HttpsError('failed-precondition', 'Bad product')
+    }
+
+    const currentStock = Number(pSnap.get('stockCount') || 0)
+    const nextStock = currentStock + amount
+    const timestamp = admin.firestore.FieldValue.serverTimestamp()
+
+    tx.update(productRef, {
+      stockCount: nextStock,
+      updatedAt: timestamp,
+      lastReceivedAt: timestamp,
+      lastReceivedQty: amount,
+      lastReceivedCost: normalizedUnitCost
+    })
+
+    const totalCost =
+      normalizedUnitCost === null ? null : Math.round((normalizedUnitCost * amount + Number.EPSILON) * 100) / 100
+
+    tx.set(receiptRef, {
+      storeId,
+      productId: productIdStr,
+      qty: amount,
+      supplier: normalizedSupplier,
+      reference: normalizedReference,
+      unitCost: normalizedUnitCost,
+      totalCost,
+      receivedBy: context.auth?.uid ?? null,
+      createdAt: timestamp
+    })
+
+    tx.set(ledgerRef, {
+      storeId,
+      productId: productIdStr,
+      qtyChange: amount,
+      type: 'receipt',
+      refId: receiptRef.id,
+      createdAt: timestamp
+    })
+  })
+
+  return { ok: true, receiptId: receiptRef.id }
+})

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { collection, doc, onSnapshot, query, setDoc, where, type Timestamp } fro
 import { db } from '../firebase'
 
 import { useAuthUser } from '../hooks/useAuthUser'
+import { useActiveStore } from '../hooks/useActiveStore'
 import { useToast } from '../components/ToastProvider'
 
 


### PR DESCRIPTION
## Summary
- add a receiveStock callable function that validates input, updates inventory, and records a receipt + ledger entry
- extend the Receive page UI to capture supplier, reference, and cost details and invoke the backend function
- fix the Dashboard import so the active store hook is available during builds

## Testing
- npm run build (functions)
- npm run build (web)


------
https://chatgpt.com/codex/tasks/task_e_68d55b14ab74832191791e744427bebe