### PR TITLE
feat: expand close day workflow

### DIFF
--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -1,14 +1,57 @@
-import React, { useEffect, useState } from 'react'
-import { collection, query, where, orderBy, onSnapshot, Timestamp } from 'firebase/firestore'
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  collection,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  Timestamp,
+  addDoc,
+  serverTimestamp,
+} from 'firebase/firestore'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
+import { useAuthUser } from '../hooks/useAuthUser'
 
-type Sale = { total: number; createdAt?: any; storeId: string }
+const DENOMINATIONS = [200, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1] as const
+
+type CashCountState = Record<string, string>
+
+function createInitialCashCountState(): CashCountState {
+  return DENOMINATIONS.reduce<CashCountState>((acc, denom) => {
+    acc[String(denom)] = ''
+    return acc
+  }, {})
+}
+
+function parseCurrency(input: string): number {
+  if (!input) return 0
+  const normalized = input.replace(/[^0-9.-]/g, '')
+  const value = Number.parseFloat(normalized)
+  return Number.isFinite(value) ? value : 0
+}
+
+function parseQuantity(input: string): number {
+  if (!input) return 0
+  const normalized = input.replace(/[^0-9]/g, '')
+  const value = Number.parseInt(normalized, 10)
+  return Number.isFinite(value) && value >= 0 ? value : 0
+}
 
 export default function CloseDay() {
   const { storeId: STORE_ID, isLoading: storeLoading, error: storeError } = useActiveStore()
+  const user = useAuthUser()
 
   const [total, setTotal] = useState(0)
+  const [cashCounts, setCashCounts] = useState<CashCountState>(() => createInitialCashCountState())
+  const [looseCash, setLooseCash] = useState('')
+  const [cardAndDigital, setCardAndDigital] = useState('')
+  const [cashRemoved, setCashRemoved] = useState('')
+  const [cashAdded, setCashAdded] = useState('')
+  const [notes, setNotes] = useState('')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitSuccess, setSubmitSuccess] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   useEffect(() => {
     if (!STORE_ID) return
@@ -26,16 +69,259 @@ export default function CloseDay() {
     })
   }, [STORE_ID])
 
+  useEffect(() => {
+    const style = document.createElement('style')
+    style.textContent = `@media print { .no-print { display: none !important; } .print-summary { max-width: 100% !important; } }`
+    document.head.appendChild(style)
+    return () => {
+      document.head.removeChild(style)
+    }
+  }, [])
+
+  const looseCashTotal = useMemo(() => parseCurrency(looseCash), [looseCash])
+
+  const countedCash = useMemo(() => {
+    return DENOMINATIONS.reduce((sum, denom) => {
+      const count = parseQuantity(cashCounts[String(denom)])
+      return sum + denom * count
+    }, 0) + looseCashTotal
+  }, [cashCounts, looseCashTotal])
+
+  const cardTotal = useMemo(() => parseCurrency(cardAndDigital), [cardAndDigital])
+  const removedTotal = useMemo(() => parseCurrency(cashRemoved), [cashRemoved])
+  const addedTotal = useMemo(() => parseCurrency(cashAdded), [cashAdded])
+
+  const expectedCash = useMemo(() => {
+    const computed = total - cardTotal - removedTotal + addedTotal
+    return Number.isFinite(computed) ? computed : 0
+  }, [addedTotal, cardTotal, removedTotal, total])
+
+  const variance = useMemo(() => countedCash - expectedCash, [countedCash, expectedCash])
+
+  const handleCountChange = (denom: number, value: string) => {
+    setCashCounts(prev => ({ ...prev, [String(denom)]: value }))
+  }
+
+  const handlePrint = () => {
+    window.print()
+  }
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async event => {
+    event.preventDefault()
+    if (!STORE_ID) return
+
+    setSubmitError(null)
+    setSubmitSuccess(false)
+    setIsSubmitting(true)
+
+    try {
+      const start = new Date(); start.setHours(0, 0, 0, 0)
+      const closePayload = {
+        storeId: STORE_ID,
+        businessDay: Timestamp.fromDate(start),
+        salesTotal: total,
+        expectedCash,
+        countedCash,
+        variance,
+        looseCash: looseCashTotal,
+        cardAndDigital: cardTotal,
+        cashRemoved: removedTotal,
+        cashAdded: addedTotal,
+        denominations: DENOMINATIONS.map(denom => {
+          const quantity = parseQuantity(cashCounts[String(denom)])
+          return {
+            denomination: denom,
+            quantity,
+            subtotal: denom * quantity,
+          }
+        }),
+        notes: notes.trim() || null,
+        closedBy: user
+          ? {
+              uid: user.uid,
+              displayName: user.displayName || null,
+              email: user.email || null,
+            }
+          : null,
+        closedAt: serverTimestamp(),
+      }
+
+      await addDoc(collection(db, 'closeouts'), closePayload)
+      setSubmitSuccess(true)
+      setCashCounts(createInitialCashCountState())
+      setLooseCash('')
+      setCardAndDigital('')
+      setCashRemoved('')
+      setCashAdded('')
+      setNotes('')
+    } catch (error) {
+      console.error('[close-day] Failed to record closeout', error)
+      setSubmitError('We were unable to save the close day record. Please retry.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   if (storeLoading) return <div>Loading…</div>
   if (!STORE_ID) return <div>We were unable to determine your store access. Please sign out and back in.</div>
 
   return (
-    <div>
-      <h2 style={{color:'#4338CA'}}>Close Day</h2>
+    <div className="print-summary" style={{ maxWidth: 760 }}>
+      <h2 style={{ color: '#4338CA' }}>Close Day</h2>
       {storeError && <p style={{ color: '#b91c1c' }}>{storeError}</p>}
-      <p>Today’s sales total</p>
-      <div style={{fontSize:32, fontWeight:800}}>GHS {total.toFixed(2)}</div>
-      <p style={{marginTop:12}}>Next: cash count & variance sheet.</p>
+
+      <form onSubmit={handleSubmit}>
+        <section style={{ marginTop: 24 }}>
+          <h3 style={{ marginBottom: 8 }}>Sales Summary</h3>
+          <p style={{ marginBottom: 8 }}>Today’s sales total</p>
+          <div style={{ fontSize: 32, fontWeight: 800, marginBottom: 16 }}>GHS {total.toFixed(2)}</div>
+          <div style={{ display: 'grid', gap: 12, maxWidth: 420 }}>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span>Card &amp; digital payments</span>
+              <input
+                type="number"
+                inputMode="decimal"
+                step="0.01"
+                min="0"
+                value={cardAndDigital}
+                onChange={event => setCardAndDigital(event.target.value)}
+                placeholder="0.00"
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span>Cash removed (drops, payouts)</span>
+              <input
+                type="number"
+                inputMode="decimal"
+                step="0.01"
+                min="0"
+                value={cashRemoved}
+                onChange={event => setCashRemoved(event.target.value)}
+                placeholder="0.00"
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span>Cash added (float top-ups)</span>
+              <input
+                type="number"
+                inputMode="decimal"
+                step="0.01"
+                min="0"
+                value={cashAdded}
+                onChange={event => setCashAdded(event.target.value)}
+                placeholder="0.00"
+              />
+            </label>
+          </div>
+        </section>
+
+        <section style={{ marginTop: 32 }}>
+          <h3 style={{ marginBottom: 12 }}>Cash Count</h3>
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: 'left', borderBottom: '1px solid #d1d5db', padding: '6px 4px' }}>Denomination</th>
+                  <th style={{ textAlign: 'left', borderBottom: '1px solid #d1d5db', padding: '6px 4px' }}>Quantity</th>
+                  <th style={{ textAlign: 'right', borderBottom: '1px solid #d1d5db', padding: '6px 4px' }}>Subtotal</th>
+                </tr>
+              </thead>
+              <tbody>
+                {DENOMINATIONS.map(denom => {
+                  const key = String(denom)
+                  const quantity = parseQuantity(cashCounts[key])
+                  const subtotal = denom * quantity
+                  return (
+                    <tr key={key}>
+                      <td style={{ padding: '6px 4px' }}>GHS {denom.toFixed(denom % 1 === 0 ? 0 : 2)}</td>
+                      <td style={{ padding: '6px 4px' }}>
+                        <input
+                          type="number"
+                          inputMode="numeric"
+                          min="0"
+                          step="1"
+                          value={cashCounts[key]}
+                          onChange={event => handleCountChange(denom, event.target.value)}
+                          style={{ width: '100%' }}
+                        />
+                      </td>
+                      <td style={{ padding: '6px 4px', textAlign: 'right' }}>GHS {subtotal.toFixed(2)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td style={{ padding: '6px 4px' }}>Loose cash / coins</td>
+                  <td style={{ padding: '6px 4px' }} colSpan={2}>
+                    <input
+                      type="number"
+                      inputMode="decimal"
+                      step="0.01"
+                      min="0"
+                      value={looseCash}
+                      onChange={event => setLooseCash(event.target.value)}
+                      style={{ width: '100%' }}
+                      placeholder="0.00"
+                    />
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </section>
+
+        <section style={{ marginTop: 32 }}>
+          <h3 style={{ marginBottom: 8 }}>Variance</h3>
+          <div style={{ display: 'grid', gap: 6, maxWidth: 360 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span>Expected cash</span>
+              <strong>GHS {expectedCash.toFixed(2)}</strong>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span>Counted cash</span>
+              <strong>GHS {countedCash.toFixed(2)}</strong>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span>Variance</span>
+              <strong style={{ color: Math.abs(variance) > 0.009 ? '#b91c1c' : '#047857' }}>
+                GHS {variance.toFixed(2)}
+              </strong>
+            </div>
+          </div>
+        </section>
+
+        <section style={{ marginTop: 32 }}>
+          <h3 style={{ marginBottom: 8 }}>Notes</h3>
+          <textarea
+            value={notes}
+            onChange={event => setNotes(event.target.value)}
+            rows={4}
+            style={{ width: '100%', resize: 'vertical' }}
+            placeholder="Include context for discrepancies or reminders for the next shift."
+          />
+        </section>
+
+        {submitError && (
+          <p style={{ color: '#b91c1c', marginTop: 16 }}>{submitError}</p>
+        )}
+        {submitSuccess && (
+          <p style={{ color: '#047857', marginTop: 16 }}>Close day record saved successfully.</p>
+        )}
+
+        <div className="no-print" style={{ display: 'flex', gap: 12, marginTop: 24 }}>
+          <button type="button" onClick={handlePrint} style={{ padding: '10px 16px' }}>
+            Print summary
+          </button>
+          <button
+            type="submit"
+            style={{ padding: '10px 16px', background: '#4338CA', color: 'white', border: 'none' }}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Saving…' : 'Save close day record'}
+          </button>
+        </div>
+      </form>
     </div>
   )
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -6,7 +6,6 @@ import { db } from '../firebase'
 import { useAuthUser } from '../hooks/useAuthUser'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useToast } from '../components/ToastProvider'
-import { useActiveStore } from '../hooks/useActiveStore'
 
 
 type InventorySeverity = 'warning' | 'info' | 'critical'


### PR DESCRIPTION
## Summary
- add a cash-count worksheet, adjustment inputs, and printable summary to Close Day
- record the user, totals, and variance for each close day in Firestore
- clean up a duplicate Dashboard import uncovered by the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55ca4bb64832199f6e20c3dc7dd6f