### PR TITLE
Link auth sidebar benefits to feature routes

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -274,6 +274,25 @@ body {
   color: rgba(226, 232, 240, 0.8);
 }
 
+.app__visual-link {
+  color: rgba(224, 231, 255, 0.92);
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  transition: color 160ms ease, border-color 160ms ease;
+}
+
+.app__visual-link:hover,
+.app__visual-link:focus-visible {
+  color: rgba(224, 231, 255, 1);
+  border-color: rgba(99, 102, 241, 0.6);
+}
+
+.app__visual-link:focus-visible {
+  outline: 2px solid rgba(191, 219, 254, 0.75);
+  outline-offset: 2px;
+}
+
 .app__visual-pill {
   display: inline-flex;
   align-items: center;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,7 @@ import {
   signInWithEmailAndPassword,
 } from 'firebase/auth'
 import { FirebaseError } from 'firebase/app'
-import { Outlet } from 'react-router-dom'
+import { Link, Outlet } from 'react-router-dom'
 import { auth } from './firebase'
 import './App.css'
 import './pwa'
@@ -228,8 +228,21 @@ export default function App() {
               <span className="app__visual-pill">Operations snapshot</span>
               <h2>Stay synced from the floor to finance</h2>
               <p>
-                Live sales, inventory alerts, and smart counts help your whole team stay aligned
-                from any device.
+                <Link className="app__visual-link" to="/sell">
+                  Live sales
+                </Link>
+                ,
+                {' '}
+                <Link className="app__visual-link" to="/products">
+                  inventory alerts
+                </Link>
+                , and
+                {' '}
+                <Link className="app__visual-link" to="/close-day">
+                  smart counts
+                </Link>
+                {' '}
+                help your whole team stay aligned from any device.
               </p>
             </div>
           </aside>


### PR DESCRIPTION
## Summary
- convert the operations snapshot benefits into navigable links that point to the Sell, Products, and Close Day workspaces
- style the sidebar links so they remain legible while providing hover and focus feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55fbbc0e48321b29e61744f233470