### PR TITLE
Enhance PWA offline support

### DIFF
--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,18 +1,295 @@
-const CACHE = 'sedifex-static-v1';
-self.addEventListener('install', (e) => {
-  e.waitUntil(caches.open(CACHE).then(c => c.addAll([
-    '/', '/index.html', '/manifest.webmanifest'
-  ])));
-});
-self.addEventListener('activate', (e) => self.clients.claim());
-self.addEventListener('fetch', (e) => {
-  const req = e.request;
-  if (req.method !== 'GET') return;
-  e.respondWith(
-    caches.match(req).then(cached => cached || fetch(req).then(resp => {
-      const copy = resp.clone();
-      caches.open(CACHE).then(c => c.put(req, copy));
-      return resp;
-    }).catch(() => cached))
-  );
-});
+const CACHE_NAME = 'sedifex-static-v2'
+const SYNC_TAG = 'sync-pending-requests'
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/products',
+  '/sell',
+  '/receive',
+  '/customers',
+  '/close-day',
+  '/settings',
+]
+
+const DB_NAME = 'sedifex-offline'
+const DB_VERSION = 1
+const STORE_NAME = 'pending'
+const MAX_RETRIES = 3
+
+let isProcessingQueue = false
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS)).catch(error => {
+      console.warn('[sw] Precaching failed', error)
+    })
+  )
+})
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    (async () => {
+      await self.clients.claim()
+      const keys = await caches.keys()
+      await Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+      await processQueue()
+    })()
+  )
+})
+
+self.addEventListener('fetch', event => {
+  const { request } = event
+  if (request.method !== 'GET') return
+
+  const url = new URL(request.url)
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      caches.match('/index.html').then(cached => cached || fetch(request).catch(() => cached))
+    )
+    return
+  }
+
+  if (url.origin !== self.location.origin) {
+    return
+  }
+
+  event.respondWith(
+    caches.match(request).then(cached => {
+      const fetchPromise = fetch(request)
+        .then(response => {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
+            return response
+          }
+          const copy = response.clone()
+          caches.open(CACHE_NAME).then(cache => cache.put(request, copy))
+          return response
+        })
+        .catch(() => cached)
+
+      return cached || fetchPromise
+    })
+  )
+})
+
+self.addEventListener('message', event => {
+  const data = event.data
+  if (!data || typeof data !== 'object') return
+
+  if (data.type === 'QUEUE_BACKGROUND_REQUEST' && data.payload) {
+    event.waitUntil(handleQueueRequest(data.payload))
+  }
+
+  if (data.type === 'PROCESS_QUEUE_NOW') {
+    event.waitUntil(processQueue())
+  }
+})
+
+self.addEventListener('sync', event => {
+  if (event.tag === SYNC_TAG) {
+    event.waitUntil(processQueue())
+  }
+})
+
+async function handleQueueRequest(payload) {
+  const entry = {
+    requestType: payload.requestType,
+    endpoint: payload.endpoint,
+    payload: payload.payload,
+    authToken: payload.authToken || null,
+    createdAt: payload.createdAt || Date.now(),
+    retries: 0,
+    updatedAt: Date.now(),
+  }
+
+  await addQueueEntry(entry)
+  await scheduleSync()
+}
+
+async function scheduleSync() {
+  if (self.registration && 'sync' in self.registration) {
+    try {
+      await self.registration.sync.register(SYNC_TAG)
+    } catch (error) {
+      console.warn('[sw] Unable to register background sync', error)
+      await processQueue()
+    }
+  } else {
+    await processQueue()
+  }
+}
+
+function openQueueDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+async function addQueueEntry(entry) {
+  const db = await openQueueDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    tx.oncomplete = () => {
+      db.close()
+      resolve(true)
+    }
+    tx.onabort = tx.onerror = () => {
+      const error = tx.error || new Error('Queue transaction failed')
+      db.close()
+      reject(error)
+    }
+    tx.objectStore(STORE_NAME).add(entry)
+  })
+}
+
+async function getQueueEntries() {
+  const db = await openQueueDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    const store = tx.objectStore(STORE_NAME)
+    const request = store.getAll()
+    request.onsuccess = () => {
+      db.close()
+      resolve(request.result || [])
+    }
+    request.onerror = () => {
+      db.close()
+      reject(request.error)
+    }
+  })
+}
+
+async function deleteQueueEntry(id) {
+  const db = await openQueueDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    tx.oncomplete = () => {
+      db.close()
+      resolve(true)
+    }
+    tx.onabort = tx.onerror = () => {
+      const error = tx.error || new Error('Queue delete failed')
+      db.close()
+      reject(error)
+    }
+    tx.objectStore(STORE_NAME).delete(id)
+  })
+}
+
+async function updateQueueEntry(id, updates) {
+  const db = await openQueueDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    const getRequest = store.get(id)
+    getRequest.onsuccess = () => {
+      const current = getRequest.result
+      if (!current) {
+        resolve(false)
+        return
+      }
+      const next = Object.assign({}, current, updates)
+      store.put(next)
+    }
+    tx.oncomplete = () => {
+      db.close()
+      resolve(true)
+    }
+    tx.onabort = tx.onerror = () => {
+      const error = tx.error || new Error('Queue update failed')
+      db.close()
+      reject(error)
+    }
+  })
+}
+
+async function processQueue() {
+  if (isProcessingQueue) return
+  isProcessingQueue = true
+  try {
+    const entries = await getQueueEntries()
+    if (!entries.length) {
+      return
+    }
+
+    const failures = []
+
+    for (const entry of entries) {
+      if (!entry || entry.id === undefined) continue
+      try {
+        await sendQueueEntry(entry)
+        await deleteQueueEntry(entry.id)
+        notifyClients({ type: 'QUEUE_REQUEST_COMPLETED', requestType: entry.requestType })
+      } catch (error) {
+        console.warn('[sw] Failed to send queued request', error)
+        const attempts = (entry.retries || 0) + 1
+        if (attempts >= MAX_RETRIES) {
+          await deleteQueueEntry(entry.id)
+          notifyClients({
+            type: 'QUEUE_REQUEST_FAILED',
+            requestType: entry.requestType,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          })
+        } else {
+          await updateQueueEntry(entry.id, { retries: attempts, updatedAt: Date.now() })
+          failures.push(entry.id)
+        }
+      }
+    }
+
+    if (failures.length) {
+      notifyClients({ type: 'QUEUE_PROCESSING_REQUIRED' })
+      if (self.registration && 'sync' in self.registration) {
+        try {
+          await self.registration.sync.register(SYNC_TAG)
+        } catch (error) {
+          console.warn('[sw] Unable to re-register sync after failure', error)
+        }
+      }
+    }
+  } finally {
+    isProcessingQueue = false
+  }
+}
+
+async function sendQueueEntry(entry) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (entry.authToken) {
+    headers['Authorization'] = `Bearer ${entry.authToken}`
+  }
+
+  const response = await fetch(entry.endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ data: entry.payload }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+
+  const result = await response.json().catch(() => ({}))
+  if (result && result.error) {
+    throw new Error(result.error.message || 'Callable function error')
+  }
+  return result
+}
+
+function notifyClients(message) {
+  self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
+    clients.forEach(client => {
+      client.postMessage(message)
+    })
+  }).catch(error => {
+    console.warn('[sw] Unable to notify clients', error)
+  })
+}

--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -140,3 +140,28 @@
 .shell table {
   width: 100%;
 }
+
+.shell__offline-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px clamp(18px, 4vw, 48px);
+  background: #fef3c7;
+  color: #92400e;
+  border-bottom: 1px solid rgba(234, 179, 8, 0.3);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.shell__offline-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #f97316;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.2);
+}
+
+.shell__offline-text {
+  flex: 1;
+}

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { signOut } from 'firebase/auth'
 import { auth } from '../firebase'
@@ -23,6 +23,21 @@ function navLinkClass(isActive: boolean) {
 export default function Shell({ children }: { children: React.ReactNode }) {
   const user = useAuthUser()
   const userEmail = user?.email ?? 'Account'
+  const [isOffline, setIsOffline] = useState(!navigator.onLine)
+
+  useEffect(() => {
+    function handleNetworkChange() {
+      setIsOffline(!navigator.onLine)
+    }
+
+    window.addEventListener('online', handleNetworkChange)
+    window.addEventListener('offline', handleNetworkChange)
+
+    return () => {
+      window.removeEventListener('online', handleNetworkChange)
+      window.removeEventListener('offline', handleNetworkChange)
+    }
+  }, [])
 
   return (
     <div className="shell">
@@ -58,6 +73,13 @@ export default function Shell({ children }: { children: React.ReactNode }) {
           </div>
         </div>
       </header>
+
+      {isOffline && (
+        <div className="shell__offline-banner" role="status" aria-live="polite">
+          <span className="shell__offline-dot" aria-hidden="true" />
+          <span className="shell__offline-text">You’re offline. We’ll sync pending work when the connection returns.</span>
+        </div>
+      )}
 
       <main className="shell__main">{children}</main>
     </div>

--- a/web/src/pwa.ts
+++ b/web/src/pwa.ts
@@ -1,6 +1,21 @@
-// Simple service worker registration
+import { triggerQueueProcessing } from './utils/offlineQueue'
+
+// Simple service worker registration with offline queue support hooks
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js')
+  })
+
+  window.addEventListener('online', () => {
+    triggerQueueProcessing()
+  })
+
+  navigator.serviceWorker.addEventListener('message', event => {
+    const data = event.data
+    if (!data || typeof data !== 'object') return
+
+    if (data.type === 'QUEUE_PROCESSING_REQUIRED' && navigator.onLine) {
+      triggerQueueProcessing()
+    }
   })
 }

--- a/web/src/utils/offlineQueue.ts
+++ b/web/src/utils/offlineQueue.ts
@@ -1,0 +1,106 @@
+import { auth } from '../firebase'
+
+const FUNCTIONS_REGION = import.meta.env.VITE_FB_FUNCTIONS_REGION ?? 'us-central1'
+const PROJECT_ID = import.meta.env.VITE_FB_PROJECT_ID
+
+const SYNC_TAG = 'sync-pending-requests'
+
+type QueueRequestType = 'sale' | 'receipt'
+
+type QueueMessage = {
+  type: 'QUEUE_BACKGROUND_REQUEST'
+  payload: {
+    requestType: QueueRequestType
+    endpoint: string
+    payload: unknown
+    authToken: string | null
+    createdAt: number
+  }
+}
+
+type ProcessMessage = { type: 'PROCESS_QUEUE_NOW' }
+
+function getController(registration: ServiceWorkerRegistration) {
+  return registration.active ?? registration.waiting ?? registration.installing ?? null
+}
+
+export function getCallableEndpoint(functionName: string) {
+  if (!PROJECT_ID) {
+    throw new Error('Missing Firebase project configuration')
+  }
+  return `https://${FUNCTIONS_REGION}-${PROJECT_ID}.cloudfunctions.net/${functionName}`
+}
+
+export async function queueCallableRequest(
+  functionName: string,
+  payload: unknown,
+  requestType: QueueRequestType
+) {
+  if (!('serviceWorker' in navigator)) {
+    return false
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.ready
+    const controller = getController(registration)
+    if (!controller) {
+      return false
+    }
+
+    let authToken: string | null = null
+    try {
+      authToken = await auth.currentUser?.getIdToken() ?? null
+    } catch (error) {
+      console.warn('[offline-queue] Unable to read auth token for queued request', error)
+    }
+
+    const message: QueueMessage = {
+      type: 'QUEUE_BACKGROUND_REQUEST',
+      payload: {
+        requestType,
+        endpoint: getCallableEndpoint(functionName),
+        payload,
+        authToken,
+        createdAt: Date.now(),
+      },
+    }
+
+    controller.postMessage(message)
+
+    const syncManager = (registration as ServiceWorkerRegistration & { sync?: { register(tag: string): Promise<void> } }).sync
+    if (syncManager) {
+      try {
+        await syncManager.register(SYNC_TAG)
+      } catch (error) {
+        console.warn('[offline-queue] Background sync registration failed', error)
+        controller.postMessage({ type: 'PROCESS_QUEUE_NOW' } satisfies ProcessMessage)
+      }
+    } else {
+      controller.postMessage({ type: 'PROCESS_QUEUE_NOW' } satisfies ProcessMessage)
+    }
+
+    return true
+  } catch (error) {
+    console.error('[offline-queue] Failed to queue request for background processing', error)
+    return false
+  }
+}
+
+export async function triggerQueueProcessing() {
+  if (!('serviceWorker' in navigator)) return
+  try {
+    const registration = await navigator.serviceWorker.ready
+    const controller = getController(registration)
+    controller?.postMessage({ type: 'PROCESS_QUEUE_NOW' } satisfies ProcessMessage)
+    const syncManager = (registration as ServiceWorkerRegistration & { sync?: { register(tag: string): Promise<void> } }).sync
+    if (syncManager) {
+      try {
+        await syncManager.register(SYNC_TAG)
+      } catch (error) {
+        console.warn('[offline-queue] Unable to schedule sync on demand', error)
+      }
+    }
+  } catch (error) {
+    console.warn('[offline-queue] Unable to trigger queue processing', error)
+  }
+}


### PR DESCRIPTION
## Summary
- extend the service worker to precache core workspace routes, manage an IndexedDB-backed request queue, and process writes through background sync
- add a shared helper so sales and stock receipts can queue Firebase callable payloads when offline and retry automatically when back online
- surface connectivity state in the shell with an offline banner and hook the PWA bootstrap to trigger pending syncs when connectivity returns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55e113d2c8321866bce0b11c10591