### PR TITLE
Fix toast auto-dismiss timer to avoid hook mismatch

### DIFF
--- a/web/src/components/ToastProvider.tsx
+++ b/web/src/components/ToastProvider.tsx
@@ -51,8 +51,13 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     }
 
     setToasts(current => [...current, toast])
+
+    if (toast.duration > 0 && typeof window !== 'undefined') {
+      window.setTimeout(() => dismiss(toast.id), toast.duration)
+    }
+
     return toast.id
-  }, [])
+  }, [dismiss])
 
   const value = useMemo(() => ({ publish, dismiss }), [publish, dismiss])
 
@@ -85,15 +90,6 @@ interface ToastProps {
 function Toast({ toast, onDismiss }: ToastProps) {
   const role = toast.tone === 'error' ? 'alert' : 'status'
   const ariaLive = toast.tone === 'error' ? 'assertive' : 'polite'
-
-  React.useEffect(() => {
-    if (toast.duration <= 0) {
-      return
-    }
-
-    const timer = window.setTimeout(() => onDismiss(toast.id), toast.duration)
-    return () => window.clearTimeout(timer)
-  }, [toast, onDismiss])
 
   return (
     <div


### PR DESCRIPTION
## Summary
- move toast auto-dismiss scheduling into the publish function to avoid per-toast effects
- remove the toast component hook so React does not see inconsistent hook counts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5620968e883218ee6b496dea37d75