### PR TITLE
Improve service worker registration and precache

### DIFF
--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,15 +1,10 @@
 const CACHE_NAME = 'sedifex-static-v2'
 const SYNC_TAG = 'sync-pending-requests'
+const BASE_URL = new URL('./', self.location).pathname
 const PRECACHE_URLS = [
-  '/',
-  '/index.html',
-  '/manifest.webmanifest',
-  '/products',
-  '/sell',
-  '/receive',
-  '/customers',
-  '/close-day',
-  '/settings',
+  `${BASE_URL}index.html`,
+  `${BASE_URL}manifest.webmanifest`,
+  `${BASE_URL}heartbeat.json`,
 ]
 
 const DB_NAME = 'sedifex-offline'
@@ -40,13 +35,16 @@ self.addEventListener('activate', event => {
   )
 })
 
+const HEARTBEAT_PATH = `${BASE_URL}heartbeat.json`
+const OFFLINE_FALLBACK = `${BASE_URL}index.html`
+
 self.addEventListener('fetch', event => {
   const { request } = event
   if (request.method !== 'GET') return
 
   const url = new URL(request.url)
 
-  if (url.pathname === '/heartbeat.json') {
+  if (url.pathname === HEARTBEAT_PATH) {
     event.respondWith(
       fetch(new Request(request, { cache: 'no-store' }))
     )
@@ -55,7 +53,7 @@ self.addEventListener('fetch', event => {
 
   if (request.mode === 'navigate') {
     event.respondWith(
-      caches.match('/index.html').then(cached => cached || fetch(request).catch(() => cached))
+      caches.match(OFFLINE_FALLBACK).then(cached => cached || fetch(request).catch(() => cached))
     )
     return
   }

--- a/web/src/pwa.ts
+++ b/web/src/pwa.ts
@@ -2,8 +2,13 @@ import { triggerQueueProcessing } from './utils/offlineQueue'
 
 // Simple service worker registration with offline queue support hooks
 if ('serviceWorker' in navigator) {
+  const baseUrl = import.meta.env.BASE_URL.endsWith('/')
+    ? import.meta.env.BASE_URL
+    : `${import.meta.env.BASE_URL}/`
+
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js')
+    const swUrl = `${baseUrl}sw.js`
+    navigator.serviceWorker.register(swUrl, { scope: baseUrl })
   })
 
   window.addEventListener('online', () => {


### PR DESCRIPTION
## Summary
- register the service worker using Vite's `BASE_URL` so deployments under a sub-path continue to work
- scope precached assets to known static files using the service worker's base URL to avoid install-time 404s

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d576f4fea0832180e2f69d3e873cc7