### PR TITLE
Fail fast when Firebase env vars are missing

### DIFF
--- a/web/src/firebase.ts
+++ b/web/src/firebase.ts
@@ -4,12 +4,31 @@ import { initializeFirestore, enableIndexedDbPersistence } from 'firebase/firest
 import { getFunctions } from 'firebase/functions'
 import { getStorage } from 'firebase/storage'
 
+type FirebaseEnvKey =
+  | 'VITE_FB_API_KEY'
+  | 'VITE_FB_AUTH_DOMAIN'
+  | 'VITE_FB_PROJECT_ID'
+  | 'VITE_FB_STORAGE_BUCKET'
+  | 'VITE_FB_APP_ID'
+
+function requireFirebaseEnv(key: FirebaseEnvKey): string {
+  const value = import.meta.env[key]
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value
+  }
+
+  throw new Error(
+    `[firebase] Missing required environment variable "${key}". ` +
+      'Ensure the value is defined in your deployment configuration.'
+  )
+}
+
 const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FB_API_KEY,
-  authDomain: import.meta.env.VITE_FB_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FB_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FB_STORAGE_BUCKET,
-  appId: import.meta.env.VITE_FB_APP_ID,
+  apiKey: requireFirebaseEnv('VITE_FB_API_KEY'),
+  authDomain: requireFirebaseEnv('VITE_FB_AUTH_DOMAIN'),
+  projectId: requireFirebaseEnv('VITE_FB_PROJECT_ID'),
+  storageBucket: requireFirebaseEnv('VITE_FB_STORAGE_BUCKET'),
+  appId: requireFirebaseEnv('VITE_FB_APP_ID'),
 }
 
 export const app = initializeApp(firebaseConfig)


### PR DESCRIPTION
## Summary
- validate required Firebase configuration variables before initializing the client SDK so deployments fail fast when misconfigured

## Testing
- npm run build *(fails: Duplicate function implementation in App.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d57785acc48321ba1b5dd400fad0dd