### PR TITLE
Add lint script and sale integration test scaffolding

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -1,0 +1,79 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import react from 'eslint-plugin-react'
+import reactHooks from 'eslint-plugin-react-hooks'
+import jsxA11y from 'eslint-plugin-jsx-a11y'
+import tseslint from '@typescript-eslint/eslint-plugin'
+import tsParser from '@typescript-eslint/parser'
+import testingLibrary from 'eslint-plugin-testing-library'
+import jestDom from 'eslint-plugin-jest-dom'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  {
+    ignores: ['node_modules/**', 'dist/**', 'build/**', 'coverage/**'],
+  },
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.es2021,
+        ...globals.node,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+      react,
+      'react-hooks': reactHooks,
+      'jsx-a11y': jsxA11y,
+      'testing-library': testingLibrary,
+      'jest-dom': jestDom,
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...tseslint.configs.recommended.rules,
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      ...jsxA11y.configs.recommended.rules,
+      ...testingLibrary.configs.react.rules,
+      ...jestDom.configs.recommended.rules,
+      ...prettier.rules,
+      'react/react-in-jsx-scope': 'off',
+      'react/prop-types': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+  {
+    files: ['**/*.test.{ts,tsx}', 'src/test/**/*.ts'],
+    languageOptions: {
+      globals: {
+        vi: 'readonly',
+        describe: 'readonly',
+        test: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+      },
+    },
+  },
+]

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
+    "test": "vitest run"
   },
   "dependencies": {
     "firebase": "^10.13.0",
@@ -17,8 +19,23 @@
   "devDependencies": {
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.13",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^14.3.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-jest-dom": "^5.1.0",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-testing-library": "^6.2.1",
+    "globals": "^14.0.0",
+    "jsdom": "^24.0.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.5",
-    "@vitejs/plugin-react": "^4.3.1"
+    "vitest": "^1.6.0"
   }
 }

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactElement } from 'react'
+
+import Sell from './Sell'
+
+const mockUseAuthUser = vi.fn()
+vi.mock('../hooks/useAuthUser', () => ({
+  useAuthUser: () => mockUseAuthUser(),
+}))
+
+const mockUseActiveStore = vi.fn()
+vi.mock('../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+const mockQueueCallableRequest = vi.fn()
+vi.mock('../utils/offlineQueue', () => ({
+  queueCallableRequest: (...args: unknown[]) => mockQueueCallableRequest(...args),
+}))
+
+vi.mock('../firebase', () => ({
+  db: {},
+  functions: {},
+}))
+
+const mockCommitSale = vi.fn()
+vi.mock('firebase/functions', () => ({
+  httpsCallable: () => mockCommitSale,
+}))
+
+const productSnapshot = {
+  docs: [
+    {
+      id: 'product-1',
+      data: () => ({ id: 'product-1', name: 'Iced Coffee', price: 12, storeId: 'store-1' }),
+    },
+  ],
+}
+
+const customerSnapshot = {
+  docs: [
+    {
+      id: 'customer-1',
+      data: () => ({ id: 'customer-1', name: 'Ada Lovelace', phone: '+233200000000' }),
+    },
+  ],
+}
+
+const collection = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
+const query = vi.fn((collectionRef: { path: string }, ...clauses: unknown[]) => ({
+  type: 'query',
+  collection: collectionRef,
+  clauses,
+}))
+const where = vi.fn((...args: unknown[]) => ({ type: 'where', args }))
+const orderBy = vi.fn((field: string) => ({ type: 'orderBy', field }))
+const doc = vi.fn(() => ({ id: 'generated-sale-id' }))
+
+const onSnapshot = vi.fn((queryRef: { collection: { path: string } }, callback: (snap: unknown) => void) => {
+  if (queryRef.collection.path === 'products') {
+    callback(productSnapshot)
+  }
+  if (queryRef.collection.path === 'customers') {
+    callback(customerSnapshot)
+  }
+  return () => {
+    /* noop */
+  }
+})
+
+vi.mock('firebase/firestore', () => ({
+  collection: (...args: unknown[]) => collection(...args),
+  query: (...args: unknown[]) => query(...args as [any, ...unknown[]]),
+  where: (...args: unknown[]) => where(...args),
+  orderBy: (...args: unknown[]) => orderBy(...args as [string]),
+  doc: (...args: unknown[]) => doc(...args),
+  onSnapshot: (...args: unknown[]) => onSnapshot(...args as [any, any]),
+}))
+
+function renderWithProviders(ui: ReactElement) {
+  return render(ui, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+describe('Sell page', () => {
+  beforeEach(() => {
+    mockUseAuthUser.mockReset()
+    mockUseActiveStore.mockReset()
+    mockCommitSale.mockReset()
+    mockUseAuthUser.mockReturnValue({
+      uid: 'cashier-123',
+      email: 'cashier@example.com',
+    })
+    mockUseActiveStore.mockReturnValue({
+      storeId: 'store-1',
+      role: 'cashier',
+      isLoading: false,
+      error: null,
+    })
+    mockCommitSale.mockResolvedValue({
+      data: {
+        ok: true,
+        saleId: 'sale-42',
+      },
+    })
+    mockQueueCallableRequest.mockReset()
+    collection.mockClear()
+    query.mockClear()
+    where.mockClear()
+    orderBy.mockClear()
+    doc.mockClear()
+    onSnapshot.mockClear()
+  })
+
+  it('records a cash sale and shows a success message', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<Sell />)
+
+    const productButton = await screen.findByRole('button', { name: /iced coffee/i })
+    await user.click(productButton)
+
+    const cashInput = screen.getByLabelText(/cash received/i)
+    await user.clear(cashInput)
+    await user.type(cashInput, '15')
+
+    const recordButton = screen.getByRole('button', { name: /record sale/i })
+    await user.click(recordButton)
+
+    await waitFor(() => {
+      expect(mockCommitSale).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mockCommitSale).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storeId: 'store-1',
+        totals: expect.objectContaining({ total: 12 }),
+        payment: expect.objectContaining({ method: 'cash', amountPaid: 15, changeDue: 3 }),
+        items: [
+          expect.objectContaining({ productId: 'product-1', qty: 1, price: 12 }),
+        ],
+      }),
+    )
+
+    expect(await screen.findByText(/Sale recorded #sale-42/i)).toBeInTheDocument()
+  })
+})

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom/vitest'
+
+beforeEach(() => {
+  // Ensure print is stubbed so tests can observe invocations without touching the real browser API.
+  Object.defineProperty(window, 'print', {
+    value: vi.fn(),
+    configurable: true,
+    writable: true,
+  })
+})

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -15,7 +15,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "types": [
-      "vite/client"
+      "vite/client",
+      "vitest/globals"
     ]
   },
   "include": [

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,4 +3,10 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.ts',
+    css: true,
+  },
 })


### PR DESCRIPTION
## Summary
- add eslint/vitest scripts and supporting dev dependencies to the web workspace
- configure Vitest with a shared setup file that stubs browser globals for tests
- add a React Testing Library integration test that walks through recording a cash sale on the Sell page

## Testing
- `npm run lint` *(fails: required eslint plugins are not present because the sandbox cannot download new npm packages)*
- `npm run test` *(fails: vitest is not available because dependency installation is blocked by the sandbox proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d5780bed508321a419fa1db060d2eb