### PR TITLE
Add store switcher UI and persist active store selection

### DIFF
--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -1,14 +1,17 @@
-import { useEffect, useState } from 'react'
-import type { IdTokenResult } from 'firebase/auth'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAuthUser } from './useAuthUser'
 
 type StoreRole = 'owner' | 'manager' | 'cashier' | string
 
+type StoreRoleMap = Record<string, StoreRole>
+
 interface ActiveStoreState {
   storeId: string | null
   role: StoreRole | null
+  stores: string[]
   isLoading: boolean
   error: string | null
+  selectStore: (storeId: string) => void
 }
 
 interface StoreClaims {
@@ -16,6 +19,17 @@ interface StoreClaims {
   activeStoreId?: unknown
   roleByStore?: unknown
 }
+
+interface InternalStoreState {
+  storeId: string | null
+  role: StoreRole | null
+  stores: string[]
+  rolesByStore: StoreRoleMap
+  isLoading: boolean
+  error: string | null
+}
+
+const ACTIVE_STORE_STORAGE_PREFIX = 'sedifex.activeStore.'
 
 function normalizeStoreList(claims: StoreClaims): string[] {
   if (!Array.isArray(claims.stores)) {
@@ -25,22 +39,75 @@ function normalizeStoreList(claims: StoreClaims): string[] {
   return claims.stores.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
 }
 
-function resolveRole(claims: StoreClaims, storeId: string | null): StoreRole | null {
-  if (!storeId || typeof claims.roleByStore !== 'object' || claims.roleByStore === null) {
+function normalizeRoleMap(claims: StoreClaims): StoreRoleMap {
+  if (typeof claims.roleByStore !== 'object' || claims.roleByStore === null) {
+    return {}
+  }
+
+  const roleEntries = Object.entries(claims.roleByStore as Record<string, unknown>)
+  return roleEntries.reduce<StoreRoleMap>((acc, [storeId, value]) => {
+    if (typeof value === 'string' && typeof storeId === 'string' && storeId.trim().length > 0) {
+      acc[storeId] = value as StoreRole
+    }
+    return acc
+  }, {})
+}
+
+function resolveRole(rolesByStore: StoreRoleMap, storeId: string | null): StoreRole | null {
+  if (!storeId) {
     return null
   }
 
-  const role = (claims.roleByStore as Record<string, unknown>)[storeId]
-  return typeof role === 'string' ? role : null
+  return rolesByStore[storeId] ?? null
 }
 
-function resolveStoreId(result: IdTokenResult, fallbackUid: string | null): string | null {
-  const claims: StoreClaims = result.claims as StoreClaims
-  const stores = normalizeStoreList(claims)
-  const activeClaim = typeof claims.activeStoreId === 'string' ? claims.activeStoreId : null
+function getStorageKey(uid: string) {
+  return `${ACTIVE_STORE_STORAGE_PREFIX}${uid}`
+}
 
+function readPersistedStoreId(uid: string | null): string | null {
+  if (!uid || typeof window === 'undefined' || !window?.localStorage) {
+    return null
+  }
+
+  try {
+    const stored = window.localStorage.getItem(getStorageKey(uid))
+    return typeof stored === 'string' && stored.trim().length > 0 ? stored : null
+  } catch (error) {
+    console.warn('[store] Failed to read persisted store preference', error)
+    return null
+  }
+}
+
+function persistStoreId(uid: string, storeId: string | null) {
+  if (typeof window === 'undefined' || !window?.localStorage) {
+    return
+  }
+
+  const key = getStorageKey(uid)
+  try {
+    if (storeId) {
+      window.localStorage.setItem(key, storeId)
+    } else {
+      window.localStorage.removeItem(key)
+    }
+  } catch (error) {
+    console.warn('[store] Failed to persist store preference', error)
+  }
+}
+
+function resolveStoreId(
+  stores: string[],
+  activeClaim: string | null,
+  persistedStoreId: string | null,
+  fallbackUid: string | null,
+): string | null {
   if (activeClaim && stores.includes(activeClaim)) {
     return activeClaim
+  }
+
+  if (persistedStoreId && stores.includes(persistedStoreId)) {
+    return persistedStoreId
   }
 
   if (stores.length > 0) {
@@ -52,31 +119,74 @@ function resolveStoreId(result: IdTokenResult, fallbackUid: string | null): stri
 
 export function useActiveStore(): ActiveStoreState {
   const user = useAuthUser()
-  const [state, setState] = useState<ActiveStoreState>({
+  const [state, setState] = useState<InternalStoreState>({
     storeId: null,
     role: null,
+    stores: [],
+    rolesByStore: {},
     isLoading: Boolean(user),
     error: null,
   })
+
+  const selectStore = useCallback(
+    (storeId: string) => {
+      if (!user) {
+        return
+      }
+
+      setState(prev => {
+        if (!prev.stores.includes(storeId)) {
+          return prev
+        }
+
+        persistStoreId(user.uid, storeId)
+        return {
+          ...prev,
+          storeId,
+          role: resolveRole(prev.rolesByStore, storeId),
+        }
+      })
+    },
+    [user],
+  )
 
   useEffect(() => {
     let cancelled = false
 
     if (!user) {
-      setState({ storeId: null, role: null, isLoading: false, error: null })
+      setState({ storeId: null, role: null, stores: [], rolesByStore: {}, isLoading: false, error: null })
       return
     }
 
     setState(prev => ({ ...prev, isLoading: true, error: null }))
 
+    const persistedStoreId = readPersistedStoreId(user.uid)
+
     user
       .getIdTokenResult()
       .then(result => {
         if (cancelled) return
-        const resolvedStoreId = resolveStoreId(result, user.uid)
         const claims: StoreClaims = result.claims as StoreClaims
-        const role = resolveRole(claims, resolvedStoreId)
-        setState({ storeId: resolvedStoreId, role, isLoading: false, error: null })
+        const stores = normalizeStoreList(claims)
+        const rolesByStore = normalizeRoleMap(claims)
+        const activeClaim = typeof claims.activeStoreId === 'string' ? claims.activeStoreId : null
+        const resolvedStoreId = resolveStoreId(stores, activeClaim, persistedStoreId, user.uid)
+        const role = resolveRole(rolesByStore, resolvedStoreId)
+
+        if (resolvedStoreId && stores.includes(resolvedStoreId)) {
+          persistStoreId(user.uid, resolvedStoreId)
+        } else if (stores.length === 0) {
+          persistStoreId(user.uid, null)
+        }
+
+        setState({
+          storeId: resolvedStoreId,
+          role,
+          stores,
+          rolesByStore,
+          isLoading: false,
+          error: null,
+        })
       })
       .catch(error => {
         console.warn('[store] Unable to resolve store from auth claims', error)
@@ -84,6 +194,8 @@ export function useActiveStore(): ActiveStoreState {
         setState({
           storeId: user.uid ?? null,
           role: null,
+          stores: [],
+          rolesByStore: {},
           isLoading: false,
           error: 'We could not determine your store access. Some actions may fail.',
         })
@@ -94,6 +206,16 @@ export function useActiveStore(): ActiveStoreState {
     }
   }, [user])
 
-  return state
+  return useMemo(
+    () => ({
+      storeId: state.storeId,
+      role: state.role,
+      stores: state.stores,
+      isLoading: state.isLoading,
+      error: state.error,
+      selectStore,
+    }),
+    [selectStore, state.error, state.isLoading, state.role, state.storeId, state.stores],
+  )
 }
 

--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -82,14 +82,76 @@
   box-shadow: 0 6px 18px rgba(67, 56, 202, 0.18);
 }
 
-.shell__account {
+.shell__controls {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.shell__store-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  background: #eef2ff;
+  border-radius: 999px;
+}
+
+.shell__store-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #4338ca;
+}
+
+.shell .shell__store-select {
+  min-width: 160px;
+  border: none;
+  background: transparent;
+  font-size: 14px;
+  font-weight: 600;
+  color: #312e81;
+  padding: 0;
+  margin: 0;
+  appearance: none;
+  cursor: pointer;
+}
+
+.shell .shell__store-select:focus {
+  border: none;
+  box-shadow: none;
+}
+
+.shell .shell__store-select:disabled {
+  cursor: not-allowed;
+  color: #94a3b8;
+}
+
+.shell__store-role {
+  font-size: 12px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.shell__account {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 6px 10px;
   background: #eef2ff;
   border-radius: 999px;
+}
+
+.shell__store-error {
+  width: 100%;
+  text-align: right;
+  font-size: 12px;
+  color: #b91c1c;
+  font-weight: 500;
 }
 
 .shell__account-email {

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -93,11 +93,14 @@ describe('Sell page', () => {
       uid: 'cashier-123',
       email: 'cashier@example.com',
     })
+    const selectStoreMock = vi.fn()
     mockUseActiveStore.mockReturnValue({
       storeId: 'store-1',
       role: 'cashier',
+      stores: ['store-1'],
       isLoading: false,
       error: null,
+      selectStore: selectStoreMock,
     })
     mockCommitSale.mockResolvedValue({
       data: {


### PR DESCRIPTION
## Summary
- extend the active store hook to expose available stores, persist the selection, and provide a setter
- add a header store switcher with role display and error messaging so managers can change locations
- refresh shell styling and update tests to use the expanded hook contract

## Testing
- `npm test` *(fails: vitest binary unavailable because npm install was blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d57b11d1bc83219c14d358e2eab7fe