### PR TITLE
Fix duplicate queue label helper in App

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,27 +29,8 @@ interface StatusState {
 
 type QueueRequestType = 'sale' | 'receipt'
 
-type QueueCompletionMessage = {
-  type: 'QUEUE_REQUEST_COMPLETED'
-  requestType?: unknown
-}
-
-type QueueFailureMessage = {
-  type: 'QUEUE_REQUEST_FAILED'
-  requestType?: unknown
-  error?: unknown
-}
-
-type ServiceWorkerMessage = QueueCompletionMessage | QueueFailureMessage | MessageEvent['data']
-
 function isQueueRequestType(value: unknown): value is QueueRequestType {
   return value === 'sale' || value === 'receipt'
-}
-
-function getQueueRequestLabel(requestType: QueueRequestType | null) {
-  if (requestType === 'sale') return 'sale'
-  if (requestType === 'receipt') return 'receipt'
-  return 'request'
 }
 
 const LOGIN_IMAGE_URL = 'https://i.imgur.com/fx9vne9.jpeg'
@@ -155,13 +136,10 @@ function isQueueFailedMessage(value: unknown): value is QueueFailedMessage {
 }
 
 function getQueueRequestLabel(requestType: unknown): string {
-  if (requestType === 'sale') {
-    return 'sale'
+  if (!isQueueRequestType(requestType)) {
+    return 'request'
   }
-  if (requestType === 'receipt') {
-    return 'stock receipt'
-  }
-  return 'request'
+  return requestType === 'receipt' ? 'stock receipt' : 'sale'
 }
 
 function normalizeQueueError(value: unknown): string | null {


### PR DESCRIPTION
## Summary
- remove the duplicate queue request helper definitions in `App.tsx`
- reuse the queue request type guard when formatting queue labels so compilation no longer fails

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173
- npm run build *(fails: missing `vitest/globals` type definition because the registry blocks installing the Vitest packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d57c5f8b048321a3a50a2cb3f380c4