### PR TITLE
Add role-based access control across app

### DIFF
--- a/web/src/components/AccessDenied.tsx
+++ b/web/src/components/AccessDenied.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import type { StoreRole } from '../hooks/useActiveStore'
+import type { AppFeature } from '../utils/permissions'
+import { formatRoleLabel, getFeatureLabel } from '../utils/permissions'
+
+interface AccessDeniedProps {
+  feature: AppFeature
+  role: StoreRole | null
+}
+
+export function AccessDenied({ feature, role }: AccessDeniedProps) {
+  const featureLabel = getFeatureLabel(feature)
+  const roleLabel = formatRoleLabel(role)
+  const subtitleId = 'access-denied-subtitle'
+
+  return (
+    <div className="page" role="region" aria-labelledby="access-denied-title" aria-describedby={subtitleId}>
+      <header className="page__header">
+        <div>
+          <h1 className="page__title" id="access-denied-title">
+            Access restricted
+          </h1>
+          <p className="page__subtitle" id={subtitleId}>
+            The {featureLabel} workspace isn’t available for {roleLabel}. If you need this access, contact a store owner to
+            adjust your permissions.
+          </p>
+        </div>
+      </header>
+
+      <section className="card" role="status" aria-live="polite">
+        <p style={{ margin: 0, color: '#475569' }}>
+          Try switching to another store or reaching out to an owner who can upgrade your permissions.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAuthUser } from './useAuthUser'
 
-type StoreRole = 'owner' | 'manager' | 'cashier' | string
+export type StoreRole = 'owner' | 'manager' | 'cashier' | string
 
 type StoreRoleMap = Record<string, StoreRole>
 

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -5,17 +5,21 @@ import { auth } from '../firebase'
 import { useAuthUser } from '../hooks/useAuthUser'
 import { useConnectivityStatus } from '../hooks/useConnectivityStatus'
 import { useActiveStore } from '../hooks/useActiveStore'
+import type { AppFeature } from '../utils/permissions'
+import { canAccessFeature } from '../utils/permissions'
 import './Shell.css'
 import './Workspace.css'
 
-const NAV_ITEMS = [
-  { to: '/', label: 'Dashboard', end: true },
-  { to: '/products', label: 'Products' },
-  { to: '/sell', label: 'Sell' },
-  { to: '/receive', label: 'Receive' },
-  { to: '/customers', label: 'Customers' },
-  { to: '/close-day', label: 'Close Day' },
-  { to: '/settings', label: 'Settings' }
+type NavItem = { to: string; label: string; end?: boolean; feature: AppFeature }
+
+const NAV_ITEMS: NavItem[] = [
+  { to: '/', label: 'Dashboard', end: true, feature: 'dashboard' },
+  { to: '/products', label: 'Products', feature: 'products' },
+  { to: '/sell', label: 'Sell', feature: 'sell' },
+  { to: '/receive', label: 'Receive', feature: 'receive' },
+  { to: '/customers', label: 'Customers', feature: 'customers' },
+  { to: '/close-day', label: 'Close Day', feature: 'close-day' },
+  { to: '/settings', label: 'Settings', feature: 'settings' },
 ]
 
 function navLinkClass(isActive: boolean) {
@@ -136,6 +140,14 @@ export default function Shell({ children }: { children: React.ReactNode }) {
     }
   }
 
+  const visibleNavItems = useMemo(() => {
+    if (storeLoading) {
+      return NAV_ITEMS
+    }
+
+    return NAV_ITEMS.filter(item => canAccessFeature(storeRole, item.feature))
+  }, [storeLoading, storeRole])
+
   return (
     <div className="shell">
       <header className="shell__header">
@@ -146,7 +158,7 @@ export default function Shell({ children }: { children: React.ReactNode }) {
           </div>
 
           <nav className="shell__nav" aria-label="Primary">
-            {NAV_ITEMS.map(item => (
+            {visibleNavItems.map(item => (
               <NavLink
                 key={item.to}
                 to={item.to}

--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -12,6 +12,8 @@ import {
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useAuthUser } from '../hooks/useAuthUser'
+import { AccessDenied } from '../components/AccessDenied'
+import { canAccessFeature } from '../utils/permissions'
 
 const DENOMINATIONS = [200, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1] as const
 
@@ -39,7 +41,7 @@ function parseQuantity(input: string): number {
 }
 
 export default function CloseDay() {
-  const { storeId: STORE_ID, isLoading: storeLoading, error: storeError } = useActiveStore()
+  const { storeId: STORE_ID, role, isLoading: storeLoading, error: storeError } = useActiveStore()
   const user = useAuthUser()
 
   const [total, setTotal] = useState(0)
@@ -52,9 +54,10 @@ export default function CloseDay() {
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submitSuccess, setSubmitSuccess] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const hasAccess = canAccessFeature(role, 'close-day')
 
   useEffect(() => {
-    if (!STORE_ID) return
+    if (!STORE_ID || !hasAccess) return
     const start = new Date(); start.setHours(0,0,0,0)
     const q = query(
       collection(db,'sales'),
@@ -67,7 +70,7 @@ export default function CloseDay() {
       snap.forEach(d => sum += (d.data().total || 0))
       setTotal(sum)
     })
-  }, [STORE_ID])
+  }, [STORE_ID, hasAccess])
 
   useEffect(() => {
     const style = document.createElement('style')
@@ -108,7 +111,7 @@ export default function CloseDay() {
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async event => {
     event.preventDefault()
-    if (!STORE_ID) return
+    if (!STORE_ID || !hasAccess) return
 
     setSubmitError(null)
     setSubmitSuccess(false)
@@ -160,6 +163,10 @@ export default function CloseDay() {
     } finally {
       setIsSubmitting(false)
     }
+  }
+
+  if (!storeLoading && !hasAccess) {
+    return <AccessDenied feature="close-day" role={role ?? null} />
   }
 
   if (storeLoading) return <div>Loading…</div>

--- a/web/src/utils/permissions.ts
+++ b/web/src/utils/permissions.ts
@@ -1,0 +1,72 @@
+import type { StoreRole } from '../hooks/useActiveStore'
+
+export type AppFeature =
+  | 'dashboard'
+  | 'products'
+  | 'sell'
+  | 'receive'
+  | 'customers'
+  | 'close-day'
+  | 'settings'
+
+const FEATURE_LABELS: Record<AppFeature, string> = {
+  'dashboard': 'Dashboard',
+  'products': 'Products',
+  'sell': 'Sell',
+  'receive': 'Receive',
+  'customers': 'Customers',
+  'close-day': 'Close Day',
+  'settings': 'Settings',
+}
+
+const FEATURE_PERMISSIONS: Record<AppFeature, ReadonlyArray<StoreRole>> = {
+  'dashboard': ['owner', 'manager', 'cashier'],
+  'products': ['owner', 'manager'],
+  'sell': ['owner', 'manager', 'cashier'],
+  'receive': ['owner', 'manager', 'cashier'],
+  'customers': ['owner', 'manager'],
+  'close-day': ['owner', 'manager'],
+  'settings': ['owner'],
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  owner: 'Owner',
+  manager: 'Manager',
+  cashier: 'Cashier',
+}
+
+function normalizeRole(role: StoreRole | null): string | null {
+  if (typeof role !== 'string') {
+    return null
+  }
+
+  const normalized = role.trim().toLowerCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+export function canAccessFeature(role: StoreRole | null, feature: AppFeature): boolean {
+  const normalizedRole = normalizeRole(role)
+  if (!normalizedRole) {
+    return false
+  }
+
+  const allowedRoles = FEATURE_PERMISSIONS[feature]
+  if (!allowedRoles) {
+    return false
+  }
+
+  return allowedRoles.some(allowedRole => normalizeRole(allowedRole) === normalizedRole)
+}
+
+export function getFeatureLabel(feature: AppFeature): string {
+  return FEATURE_LABELS[feature] ?? feature
+}
+
+export function formatRoleLabel(role: StoreRole | null): string {
+  const normalizedRole = normalizeRole(role)
+  if (!normalizedRole) {
+    return 'your assigned role'
+  }
+
+  return ROLE_LABELS[normalizedRole] ?? role ?? 'your assigned role'
+}


### PR DESCRIPTION
## Summary
- add a reusable permissions helper and access denied view for RBAC messaging
- hide navigation and dashboard quick links a user cannot open based on their store role
- guard each feature page with role checks so owners, managers, and cashiers only see allowed workspaces

## Testing
- npm run lint *(fails: missing @eslint/js package in environment)*
- npm run test *(fails: vitest binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d57cb7a9f083219cfdc38a7e96df10