### PR TITLE
Enforce storeId integrity in Firestore updates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -15,7 +15,9 @@ service cloud.firestore {
 
     match /products/{id} {
       allow read: if inStore(resource.data.storeId);
-      allow create, update: if hasRole(request.resource.data.storeId, ['owner','manager']);
+      allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);
+      allow update: if hasRole(resource.data.storeId, ['owner','manager'])
+                     && request.resource.data.storeId == resource.data.storeId;
       allow delete: if hasRole(resource.data.storeId, ['owner']);
     }
 
@@ -27,7 +29,9 @@ service cloud.firestore {
     match /sales/{id} {
       allow read: if inStore(resource.data.storeId);
       allow create: if hasRole(request.resource.data.storeId, ['owner','manager','cashier']);
-      allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']);
+      allow update: if hasRole(resource.data.storeId, ['owner','manager'])
+                    && request.resource.data.storeId == resource.data.storeId;
+      allow delete: if hasRole(resource.data.storeId, ['owner','manager']);
     }
 
     match /saleItems/{id} {
@@ -38,7 +42,9 @@ service cloud.firestore {
     match /expenses/{id} {
       allow read: if inStore(resource.data.storeId);
       allow create: if hasRole(request.resource.data.storeId, ['owner','manager','cashier']);
-      allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']);
+      allow update: if hasRole(resource.data.storeId, ['owner','manager'])
+                    && request.resource.data.storeId == resource.data.storeId;
+      allow delete: if hasRole(resource.data.storeId, ['owner','manager']);
     }
 
     match /cashSessions/{id} {

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^2.0.5",
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/web/tests/firestore.rules.test.ts
+++ b/web/tests/firestore.rules.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import {
+  deleteField,
+  doc,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
+import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
+
+const PROJECT_ID = 'sedifexbiz-security-tests';
+const STORE_ID = 'store-123';
+const OTHER_STORE_ID = 'store-456';
+
+let testEnv: RulesTestEnvironment;
+
+async function seedDocument(collection: string, data: Record<string, unknown>) {
+  await testEnv.withSecurityRulesDisabled(async (context) => {
+    await setDoc(doc(context.firestore(), `${collection}/doc`), data);
+  });
+}
+
+describe('Firestore security rules - store isolation', () => {
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: PROJECT_ID,
+      firestore: {
+        rules: readFileSync(
+          new URL('../../firestore.rules', import.meta.url),
+          'utf8',
+        ),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await testEnv.cleanup();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  const userClaims = {
+    stores: [STORE_ID],
+    roleByStore: {
+      [STORE_ID]: 'manager',
+    },
+  } as const;
+
+  const collections = ['products', 'sales', 'expenses'] as const;
+
+  test.each(collections)('prevents changing storeId on %s update', async (collection) => {
+    await seedDocument(collection, { storeId: STORE_ID, name: 'Original' });
+
+    const db = testEnv.authenticatedContext('user', userClaims).firestore();
+    const ref = doc(db, `${collection}/doc`);
+
+    await assertFails(
+      updateDoc(ref, {
+        storeId: OTHER_STORE_ID,
+      }),
+    );
+  });
+
+  test.each(collections)('prevents removing storeId on %s update', async (collection) => {
+    await seedDocument(collection, { storeId: STORE_ID, name: 'Original' });
+
+    const db = testEnv.authenticatedContext('user', userClaims).firestore();
+    const ref = doc(db, `${collection}/doc`);
+
+    await assertFails(
+      updateDoc(ref, {
+        storeId: deleteField(),
+      }),
+    );
+  });
+
+  test.each(collections)('allows updating other fields for %s', async (collection) => {
+    await seedDocument(collection, { storeId: STORE_ID, name: 'Original' });
+
+    const db = testEnv.authenticatedContext('user', userClaims).firestore();
+    const ref = doc(db, `${collection}/doc`);
+
+    await assertSucceeds(
+      updateDoc(ref, {
+        name: 'Updated',
+      }),
+    );
+  });
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -20,6 +20,7 @@
     ]
   },
   "include": [
-    "src"
+    "src",
+    "tests"
   ]
 }


### PR DESCRIPTION
## Summary
- prevent product, sale, and expense updates from changing the stored storeId
- add Firestore security rule tests that ensure storeId values cannot be removed or reassigned
- include test configuration updates so Vitest picks up the new Firestore rule tests

## Testing
- npm test *(fails: Vitest CLI unavailable in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d580551bd4832194fba53c343031e4