### PR TITLE
Add PDF receipt sharing for sales

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -10,6 +10,7 @@ import { AccessDenied } from '../components/AccessDenied'
 import { canAccessFeature } from '../utils/permissions'
 import './Products.css'
 import { loadCachedProducts, saveCachedProducts, PRODUCT_CACHE_LIMIT } from '../utils/offlineCache'
+import { buildSimplePdf } from '../utils/pdf'
 
 type FirestoreDate = ReturnType<typeof serverTimestamp> | Timestamp | Date | number | null
 
@@ -23,78 +24,6 @@ type Product = {
   minStock?: number
   createdAt?: FirestoreDate
   updatedAt?: FirestoreDate
-}
-
-/* ---------------- PDF helpers ---------------- */
-
-function escapePdfText(text: string) {
-  return text
-    .replace(/\\/g, '\\\\')
-    .replace(/\(/g, '\\(')
-    .replace(/\)/g, '\\)')
-    .replace(/\r/g, ' ')
-    .replace(/\n/g, ' ')
-}
-
-function buildSimplePdf(title: string, lines: string[]): Uint8Array {
-  const encoder = new TextEncoder()
-  const header = '%PDF-1.4\n'
-
-  let content = 'BT\n'
-  content += '/F1 18 Tf\n'
-  content += '72 760 Td\n'
-  content += `(${escapePdfText(title)}) Tj\n`
-  content += '/F1 11 Tf\n'
-  content += '0 -20 Td\n'
-
-  lines.forEach((line, index) => {
-    content += `(${escapePdfText(line)}) Tj\n`
-    if (index < lines.length - 1) {
-      content += '0 -16 Td\n'
-    }
-  })
-
-  content += 'ET\n'
-
-  const contentBytes = encoder.encode(content)
-
-  const objects: string[] = []
-  const offsets: number[] = [0]
-
-  objects.push('1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n')
-  objects.push('2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n')
-  objects.push('3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n')
-  objects.push(`4 0 obj\n<< /Length ${contentBytes.length} >>\nstream\n${content}\nendstream\nendobj\n`)
-  objects.push('5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n')
-
-  let currentOffset = header.length
-  const encodedObjects = objects.map(obj => {
-    offsets.push(currentOffset)
-    const bytes = encoder.encode(obj)
-    currentOffset += bytes.length
-    return bytes
-  })
-
-  const xrefOffset = currentOffset
-  let xref = `xref\n0 ${objects.length + 1}\n`
-  xref += '0000000000 65535 f \n'
-  for (let i = 1; i < offsets.length; i++) {
-    xref += offsets[i].toString().padStart(10, '0') + ' 00000 n \n'
-  }
-
-  const trailer = `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`
-
-  const parts: Uint8Array[] = [encoder.encode(header), ...encodedObjects, encoder.encode(xref), encoder.encode(trailer)]
-
-  const totalLength = parts.reduce((sum, part) => sum + part.length, 0)
-  const result = new Uint8Array(totalLength)
-  let offset = 0
-  parts.forEach(part => {
-    result.set(part, offset)
-    offset += part.length
-  })
-
-  return result
 }
 
 /* ---------------- Scanner modal (isolates hooks) ---------------- */

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
   collection,
   query,
@@ -26,6 +26,7 @@ import {
 } from '../utils/offlineCache'
 import { AccessDenied } from '../components/AccessDenied'
 import { canAccessFeature } from '../utils/permissions'
+import { buildSimplePdf } from '../utils/pdf'
 
 type Product = { id: string; name: string; price: number; stockCount?: number; storeId: string }
 type CartLine = { productId: string; name: string; price: number; qty: number }
@@ -45,6 +46,15 @@ type ReceiptData = {
     phone?: string
     email?: string
   }
+}
+
+type ReceiptSharePayload = {
+  message: string
+  emailHref: string
+  smsHref: string
+  pdfBlob: Blob
+  pdfUrl: string
+  pdfFileName: string
 }
 
 type CommitSalePayload = {
@@ -108,6 +118,7 @@ export default function Sell() {
   const [saleSuccess, setSaleSuccess] = useState<string | null>(null)
   const [isRecording, setIsRecording] = useState(false)
   const [receipt, setReceipt] = useState<ReceiptData | null>(null)
+  const [receiptSharePayload, setReceiptSharePayload] = useState<ReceiptSharePayload | null>(null)
   const subtotal = cart.reduce((s, l) => s + l.price * l.qty, 0)
   const selectedCustomer = customers.find(c => c.id === selectedCustomerId)
   const amountPaid = paymentMethod === 'cash' ? Number(amountTendered || 0) : subtotal
@@ -209,6 +220,102 @@ export default function Sell() {
   }, [hasAccess, receipt])
 
   useEffect(() => {
+    if (!receipt) {
+      setReceiptSharePayload(prev => {
+        if (prev?.pdfUrl) {
+          URL.revokeObjectURL(prev.pdfUrl)
+        }
+        return null
+      })
+      return
+    }
+
+    const contactLine = user?.email ?? 'sales@sedifex.app'
+
+    const lines: string[] = []
+    lines.push('Sedifex POS')
+    lines.push(contactLine)
+    lines.push(receipt.createdAt.toLocaleString())
+
+    if (receipt.customer) {
+      lines.push('')
+      lines.push('Customer:')
+      lines.push(`  ${receipt.customer.name}`)
+      if (receipt.customer.phone) {
+        lines.push(`  ${receipt.customer.phone}`)
+      }
+      if (receipt.customer.email) {
+        lines.push(`  ${receipt.customer.email}`)
+      }
+    }
+
+    lines.push('')
+    lines.push('Items:')
+    receipt.items.forEach(line => {
+      lines.push(`  • ${line.qty} × ${line.name} — GHS ${(line.qty * line.price).toFixed(2)}`)
+    })
+
+    lines.push('')
+    lines.push(`Subtotal: GHS ${receipt.subtotal.toFixed(2)}`)
+    lines.push(`Paid (${receipt.payment.method}): GHS ${receipt.payment.amountPaid.toFixed(2)}`)
+    lines.push(`Change: GHS ${receipt.payment.changeDue.toFixed(2)}`)
+    lines.push('')
+    lines.push(`Sale #${receipt.saleId}`)
+    lines.push('Thank you for shopping with us!')
+
+    const message = lines.join('\n')
+    const emailSubject = `Receipt for sale #${receipt.saleId}`
+    const encodedSubject = encodeURIComponent(emailSubject)
+    const encodedBody = encodeURIComponent(message)
+    const emailHref = `mailto:${receipt.customer?.email ?? ''}?subject=${encodedSubject}&body=${encodedBody}`
+    const smsHref = `sms:${receipt.customer?.phone ?? ''}?body=${encodedBody}`
+
+    const pdfLines = lines.slice(1)
+    const pdfBytes = buildSimplePdf('Sedifex POS', pdfLines)
+    const pdfBlob = new Blob([pdfBytes], { type: 'application/pdf' })
+    const pdfUrl = URL.createObjectURL(pdfBlob)
+    const pdfFileName = `receipt-${receipt.saleId}.pdf`
+
+    setReceiptSharePayload(prev => {
+      if (prev?.pdfUrl) {
+        URL.revokeObjectURL(prev.pdfUrl)
+      }
+      return { message, emailHref, smsHref, pdfBlob, pdfUrl, pdfFileName }
+    })
+
+    return () => {
+      URL.revokeObjectURL(pdfUrl)
+    }
+  }, [receipt, user?.email])
+
+  const handleDownloadPdf = useCallback(() => {
+    setReceiptSharePayload(prev => {
+      if (!prev) return prev
+
+      const url = prev.pdfUrl || URL.createObjectURL(prev.pdfBlob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = prev.pdfFileName
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+
+      URL.revokeObjectURL(url)
+      const refreshedUrl = URL.createObjectURL(prev.pdfBlob)
+      return { ...prev, pdfUrl: refreshedUrl }
+    })
+  }, [])
+
+  useEffect(() => {
+    const url = receiptSharePayload?.pdfUrl
+    return () => {
+      if (url) {
+        URL.revokeObjectURL(url)
+      }
+    }
+  }, [receiptSharePayload?.pdfUrl])
+
+  useEffect(() => {
     if (paymentMethod !== 'cash') {
       setAmountTendered('')
     }
@@ -217,44 +324,6 @@ export default function Sell() {
   if (!storeLoading && !hasAccess) {
     return <AccessDenied feature="sell" role={role ?? null} />
   }
-
-  const receiptSharePayload = useMemo(() => {
-    if (!receipt) return null
-
-    const lines: string[] = []
-    lines.push(`Sale #${receipt.saleId}`)
-    lines.push(receipt.createdAt.toLocaleString())
-
-    if (receipt.customer) {
-      lines.push('')
-      lines.push(`Customer: ${receipt.customer.name}`)
-      if (receipt.customer.phone) {
-        lines.push(`Phone: ${receipt.customer.phone}`)
-      }
-      if (receipt.customer.email) {
-        lines.push(`Email: ${receipt.customer.email}`)
-      }
-    }
-
-    lines.push('')
-    receipt.items.forEach(line => {
-      lines.push(`${line.qty} × ${line.name} — GHS ${(line.qty * line.price).toFixed(2)}`)
-    })
-
-    lines.push('')
-    lines.push(`Subtotal: GHS ${receipt.subtotal.toFixed(2)}`)
-    lines.push(`Paid (${receipt.payment.method}): GHS ${receipt.payment.amountPaid.toFixed(2)}`)
-    lines.push(`Change due: GHS ${receipt.payment.changeDue.toFixed(2)}`)
-    lines.push('')
-    lines.push('Thank you for shopping with us!')
-
-    const message = lines.join('\n')
-    const emailSubject = `Receipt for sale #${receipt.saleId}`
-    const emailHref = `mailto:${receipt.customer?.email ?? ''}?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(message)}`
-    const smsHref = `sms:${receipt.customer?.phone ?? ''}?body=${encodeURIComponent(message)}`
-
-    return { message, emailHref, smsHref }
-  }, [receipt])
 
   function addToCart(p: Product) {
     setCart(cs => {
@@ -598,6 +667,13 @@ export default function Sell() {
                     Email or text the receipt so your customer has a digital copy right away.
                   </p>
                   <div className="sell-page__engagement-actions">
+                    <button
+                      type="button"
+                      className="button button--ghost button--small"
+                      onClick={handleDownloadPdf}
+                    >
+                      Download PDF
+                    </button>
                     <a
                       className="button button--ghost button--small"
                       href={receiptSharePayload.emailHref}

--- a/web/src/utils/pdf.ts
+++ b/web/src/utils/pdf.ts
@@ -1,0 +1,69 @@
+function escapePdfText(text: string) {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/\r/g, ' ')
+    .replace(/\n/g, ' ')
+}
+
+export function buildSimplePdf(title: string, lines: string[]): Uint8Array {
+  const encoder = new TextEncoder()
+  const header = '%PDF-1.4\n'
+
+  let content = 'BT\n'
+  content += '/F1 18 Tf\n'
+  content += '72 760 Td\n'
+  content += `(${escapePdfText(title)}) Tj\n`
+  content += '/F1 11 Tf\n'
+  content += '0 -20 Td\n'
+
+  lines.forEach((line, index) => {
+    content += `(${escapePdfText(line)}) Tj\n`
+    if (index < lines.length - 1) {
+      content += '0 -16 Td\n'
+    }
+  })
+
+  content += 'ET\n'
+
+  const contentBytes = encoder.encode(content)
+
+  const objects: string[] = []
+  const offsets: number[] = [0]
+
+  objects.push('1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n')
+  objects.push('2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n')
+  objects.push('3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n')
+  objects.push(`4 0 obj\n<< /Length ${contentBytes.length} >>\nstream\n${content}\nendstream\nendobj\n`)
+  objects.push('5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n')
+
+  let currentOffset = header.length
+  const encodedObjects = objects.map(obj => {
+    offsets.push(currentOffset)
+    const bytes = encoder.encode(obj)
+    currentOffset += bytes.length
+    return bytes
+  })
+
+  const xrefOffset = currentOffset
+  let xref = `xref\n0 ${objects.length + 1}\n`
+  xref += '0000000000 65535 f \n'
+  for (let i = 1; i < offsets.length; i++) {
+    xref += offsets[i].toString().padStart(10, '0') + ' 00000 n \n'
+  }
+
+  const trailer = `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`
+
+  const parts: Uint8Array[] = [encoder.encode(header), ...encodedObjects, encoder.encode(xref), encoder.encode(trailer)]
+
+  const totalLength = parts.reduce((sum, part) => sum + part.length, 0)
+  const result = new Uint8Array(totalLength)
+  let offset = 0
+  parts.forEach(part => {
+    result.set(part, offset)
+    offset += part.length
+  })
+
+  return result
+}


### PR DESCRIPTION
## Summary
- extract the simple PDF builder used for product exports into a shared utility
- generate a PDF version of the sale receipt data after a successful sale and expose download metadata
- add a receipt share button that downloads the PDF while keeping email and SMS previews in sync

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@firebase%2frules-unit-testing)*

------
https://chatgpt.com/codex/tasks/task_e_68d59cf957d4832184259ecd2617ab8f