### PR TITLE
Add sidebar navigation to settings page

### DIFF
--- a/web/src/pages/Settings.css
+++ b/web/src/pages/Settings.css
@@ -1,3 +1,104 @@
+.settings-layout {
+  display: grid;
+  gap: 24px;
+}
+
+.settings-sidebar {
+  display: block;
+}
+
+.settings-sidebar__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.settings-sidebar__list-item {
+  flex: 0 0 auto;
+  min-width: 220px;
+}
+
+.settings-sidebar__item {
+  width: 100%;
+  display: grid;
+  gap: 6px;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  color: #0f172a;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.settings-sidebar__item:hover,
+.settings-sidebar__item:focus-visible {
+  border-color: #6366f1;
+}
+
+.settings-sidebar__item--active {
+  border-color: #6366f1;
+  background: #eef2ff;
+  color: #312e81;
+}
+
+.settings-sidebar__item-label {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.settings-sidebar__item-description {
+  font-size: 13px;
+  color: #64748b;
+}
+
+.settings-content {
+  display: grid;
+  gap: 24px;
+  min-width: 0;
+}
+
+.settings-panel {
+  display: grid;
+  gap: 24px;
+}
+
+.settings-placeholder {
+  display: grid;
+  gap: 12px;
+  color: #475569;
+}
+
+.settings-placeholder__description {
+  margin: 0;
+  font-size: 14px;
+  color: #64748b;
+}
+
+@media (min-width: 960px) {
+  .settings-layout {
+    grid-template-columns: 280px 1fr;
+    align-items: start;
+  }
+
+  .settings-sidebar__list {
+    flex-direction: column;
+    gap: 16px;
+    overflow: visible;
+  }
+
+  .settings-sidebar__list-item {
+    flex: none;
+    min-width: 0;
+  }
+}
+
 .settings-page__grid {
   display: grid;
   gap: 24px;


### PR DESCRIPTION
## Summary
- refactor the settings page to render within a sidebar layout and track the active admin panel in component state
- keep the existing tax, branch, payment, and role configuration inside the store configuration panel while adding overview, password, and role placeholders
- add responsive sidebar and placeholder styles to support the new layout classes

## Testing
- npm --prefix web run lint *(fails: missing @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d6670c363483218ad13972588d81d5