### PR TITLE
Remove unused Firebase rules testing dependency

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,6 @@
     "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
-    "@firebase/rules-unit-testing": "^2.0.5",
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.13",
     "@typescript-eslint/eslint-plugin": "^6.21.0",


### PR DESCRIPTION
## Summary
- remove the unused @firebase/rules-unit-testing entry from the web package

## Testing
- npm install (fails: registry returned 403 for @testing-library/jest-dom)

------
https://chatgpt.com/codex/tasks/task_e_68d66c7c0f008321bb3810a7d165eec8