### PR TITLE
Move dashboard access guard into component

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -826,6 +826,10 @@ export default function Dashboard() {
     },
   ]
 
+  if (!storeLoading && !hasAccess) {
+    return <AccessDenied feature="dashboard" role={role ?? null} />
+  }
+
   if (storeLoading) {
     return <div>Loading…</div>
   }
@@ -1424,6 +1428,4 @@ function Sparkline({
     </svg>
   )
 }
-  if (!storeLoading && !hasAccess) {
-    return <AccessDenied feature="dashboard" role={role ?? null} />
-  }
+


### PR DESCRIPTION
## Summary
- relocate the access guard into the Dashboard component ahead of the loading and store checks
- remove the stray module-scope return left after the Sparkline helper

## Testing
- npm run build *(fails: missing dependencies because npm install is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d66e9ad8a8832190304c16f9ea33ed