### PR TITLE
Add Firestore access rules for customers collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -72,6 +72,14 @@ service cloud.firestore {
       allow delete: if hasRole(resource.data.storeId, ['owner','manager']);
     }
 
+    match /customers/{id} {
+      allow read: if inStore(resource.data.storeId);
+      allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);
+      allow update: if hasRole(resource.data.storeId, ['owner','manager'])
+                    && request.resource.data.storeId == resource.data.storeId;
+      allow delete: if hasRole(resource.data.storeId, ['owner','manager']);
+    }
+
     match /cashSessions/{id} {
       allow read: if inStore(resource.data.storeId);
       allow write: if hasRole(request.resource.data.storeId, ['owner','manager','cashier']);


### PR DESCRIPTION
## Summary
- add Firestore security rules for the customers collection mirroring store-based access controls

## Testing
- not run (Firebase CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d68851c90c8321ad2cf4d39e7fde62