### PR TITLE
Update memberships hook to use useAuthUser

### DIFF
--- a/web/src/hooks/useMemberships.ts
+++ b/web/src/hooks/useMemberships.ts
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 import { collectionGroup, getDocs, query, where } from 'firebase/firestore';
 import { db } from '../firebase';           // your initialized Firestore
-import { useAuth } from './useAuth';        // your auth hook that exposes { user }
+import { useAuthUser } from './useAuthUser';
 
 export type Membership = {
   storeId: string;
@@ -13,7 +13,7 @@ export type Membership = {
 };
 
 export function useMemberships() {
-  const { user } = useAuth();
+  const user = useAuthUser();
   const [loading, setLoading] = useState(true);
   const [memberships, setMemberships] = useState<Membership[]>([]);
   const [error, setError] = useState<unknown>(null);


### PR DESCRIPTION
## Summary
- replace the auth hook import in `useMemberships` to use `useAuthUser`
- update the hook to call `useAuthUser` instead of destructuring a user object

## Testing
- npm run build *(fails: pre-existing TypeScript errors in various pages and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d6993f7e3483218850f5f551198568