### PR TITLE
Add WhatsApp share link and update caching types

### DIFF
--- a/web/src/controllers/storeController.ts
+++ b/web/src/controllers/storeController.ts
@@ -1,7 +1,8 @@
 // web/src/controllers/storeController.ts
 import { getAuth } from 'firebase/auth';
+import { httpsCallable } from 'firebase/functions';
 import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
-import { db } from '../firebase';
+import { db, functions } from '../firebase';
 
 export async function createMyFirstStore() {
   const auth = getAuth();
@@ -33,4 +34,30 @@ export async function createMyFirstStore() {
 
   // Optional: if any legacy code still checks custom claims, refresh token
   await user.getIdToken(true);
+}
+
+type ManageStaffAccountPayload = {
+  storeId: string;
+  email: string;
+  role: string;
+  password?: string;
+};
+
+type ManageStaffAccountResult = {
+  ok: boolean;
+  storeId: string;
+  role: string;
+  email: string;
+  uid: string;
+  created: boolean;
+  claims?: unknown;
+};
+
+export async function manageStaffAccount(payload: ManageStaffAccountPayload) {
+  const callable = httpsCallable<ManageStaffAccountPayload, ManageStaffAccountResult>(
+    functions,
+    'manageStaffAccount',
+  );
+  const response = await callable(payload);
+  return response.data;
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -52,6 +52,8 @@ type ProductRecord = {
   price?: number
   stockCount?: number
   minStock?: number
+  createdAt?: unknown
+  updatedAt?: unknown
 }
 
 type CustomerRecord = {

--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -10,7 +10,14 @@ import { AccessDenied } from '../components/AccessDenied'
 import { canAccessFeature } from '../utils/permissions'
 import { loadCachedProducts, saveCachedProducts, PRODUCT_CACHE_LIMIT } from '../utils/offlineCache'
 
-type Product = { id: string; name: string; stockCount?: number; storeId: string }
+type Product = {
+  id: string
+  name: string
+  stockCount?: number
+  storeId: string
+  createdAt?: unknown
+  updatedAt?: unknown
+}
 
 function isOfflineError(error: unknown) {
   if (!navigator.onLine) return true

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -29,10 +29,18 @@ const mockSaveCachedCustomers = vi.fn(async () => {})
 vi.mock('../utils/offlineCache', () => ({
   PRODUCT_CACHE_LIMIT: 200,
   CUSTOMER_CACHE_LIMIT: 200,
-  loadCachedProducts: (...args: unknown[]) => mockLoadCachedProducts(...args),
-  saveCachedProducts: (...args: unknown[]) => mockSaveCachedProducts(...args),
-  loadCachedCustomers: (...args: unknown[]) => mockLoadCachedCustomers(...args),
-  saveCachedCustomers: (...args: unknown[]) => mockSaveCachedCustomers(...args),
+  loadCachedProducts: (
+    ...args: Parameters<typeof mockLoadCachedProducts>
+  ) => mockLoadCachedProducts(...args),
+  saveCachedProducts: (
+    ...args: Parameters<typeof mockSaveCachedProducts>
+  ) => mockSaveCachedProducts(...args),
+  loadCachedCustomers: (
+    ...args: Parameters<typeof mockLoadCachedCustomers>
+  ) => mockLoadCachedCustomers(...args),
+  saveCachedCustomers: (
+    ...args: Parameters<typeof mockSaveCachedCustomers>
+  ) => mockSaveCachedCustomers(...args),
 }))
 
 vi.mock('../firebase', () => ({
@@ -63,18 +71,18 @@ const customerSnapshot = {
   ],
 }
 
-const collection = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
-const query = vi.fn((collectionRef: { path: string }, ...clauses: unknown[]) => ({
+const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
+const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[]) => ({
   type: 'query',
   collection: collectionRef,
   clauses,
 }))
-const where = vi.fn((...args: unknown[]) => ({ type: 'where', args }))
-const orderBy = vi.fn((field: string, direction?: string) => ({ type: 'orderBy', field, direction }))
-const doc = vi.fn(() => ({ id: 'generated-sale-id' }))
-const limit = vi.fn((value: number) => ({ type: 'limit', value }))
+const whereMock = vi.fn((...args: unknown[]) => ({ type: 'where', args }))
+const orderByMock = vi.fn((field: string, direction?: string) => ({ type: 'orderBy', field, direction }))
+const docMock = vi.fn(() => ({ id: 'generated-sale-id' }))
+const limitMock = vi.fn((value: number) => ({ type: 'limit', value }))
 
-const onSnapshot = vi.fn((queryRef: { collection: { path: string } }, callback: (snap: unknown) => void) => {
+const onSnapshotMock = vi.fn((queryRef: { collection: { path: string } }, callback: (snap: unknown) => void) => {
   queueMicrotask(() => {
     if (queryRef.collection.path === 'products') {
       callback(productSnapshot)
@@ -89,13 +97,27 @@ const onSnapshot = vi.fn((queryRef: { collection: { path: string } }, callback: 
 })
 
 vi.mock('firebase/firestore', () => ({
-  collection: (...args: unknown[]) => collection(...args),
-  query: (...args: unknown[]) => query(...args as [any, ...unknown[]]),
-  where: (...args: unknown[]) => where(...args),
-  orderBy: (...args: unknown[]) => orderBy(...args as [string, string?]),
-  limit: (...args: unknown[]) => limit(...args as [number]),
-  doc: (...args: unknown[]) => doc(...args),
-  onSnapshot: (...args: unknown[]) => onSnapshot(...args as [any, any]),
+  collection: (
+    ...args: Parameters<typeof collectionMock>
+  ) => collectionMock(...args),
+  query: (
+    ...args: Parameters<typeof queryMock>
+  ) => queryMock(...args),
+  where: (
+    ...args: Parameters<typeof whereMock>
+  ) => whereMock(...args),
+  orderBy: (
+    ...args: Parameters<typeof orderByMock>
+  ) => orderByMock(...args),
+  limit: (
+    ...args: Parameters<typeof limitMock>
+  ) => limitMock(...args),
+  doc: (
+    ...args: Parameters<typeof docMock>
+  ) => docMock(...args),
+  onSnapshot: (
+    ...args: Parameters<typeof onSnapshotMock>
+  ) => onSnapshotMock(...args),
 }))
 
 function renderWithProviders(ui: ReactElement) {
@@ -135,13 +157,13 @@ describe('Sell page', () => {
     mockLoadCachedCustomers.mockResolvedValue([])
     mockSaveCachedProducts.mockResolvedValue(undefined)
     mockSaveCachedCustomers.mockResolvedValue(undefined)
-    collection.mockClear()
-    query.mockClear()
-    where.mockClear()
-    orderBy.mockClear()
-    limit.mockClear()
-    doc.mockClear()
-    onSnapshot.mockClear()
+    collectionMock.mockClear()
+    queryMock.mockClear()
+    whereMock.mockClear()
+    orderByMock.mockClear()
+    limitMock.mockClear()
+    docMock.mockClear()
+    onSnapshotMock.mockClear()
   })
 
   it('records a cash sale and shows a success message', async () => {

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -28,9 +28,25 @@ import { AccessDenied } from '../components/AccessDenied'
 import { canAccessFeature } from '../utils/permissions'
 import { buildSimplePdf } from '../utils/pdf'
 
-type Product = { id: string; name: string; price: number; stockCount?: number; storeId: string }
+type Product = {
+  id: string
+  name: string
+  price: number
+  stockCount?: number
+  storeId: string
+  createdAt?: unknown
+  updatedAt?: unknown
+}
 type CartLine = { productId: string; name: string; price: number; qty: number }
-type Customer = { id: string; name: string; phone?: string; email?: string; notes?: string }
+type Customer = {
+  id: string
+  name: string
+  phone?: string
+  email?: string
+  notes?: string
+  createdAt?: unknown
+  updatedAt?: unknown
+}
 type ReceiptData = {
   saleId: string
   createdAt: Date
@@ -52,6 +68,7 @@ type ReceiptSharePayload = {
   message: string
   emailHref: string
   smsHref: string
+  whatsappHref: string
   pdfBlob: Blob
   pdfUrl: string
   pdfFileName: string
@@ -270,10 +287,12 @@ export default function Sell() {
     const encodedBody = encodeURIComponent(message)
     const emailHref = `mailto:${receipt.customer?.email ?? ''}?subject=${encodedSubject}&body=${encodedBody}`
     const smsHref = `sms:${receipt.customer?.phone ?? ''}?body=${encodedBody}`
+    const whatsappHref = `https://wa.me/?text=${encodedBody}`
 
     const pdfLines = lines.slice(1)
     const pdfBytes = buildSimplePdf('Sedifex POS', pdfLines)
-    const pdfBlob = new Blob([pdfBytes], { type: 'application/pdf' })
+    const pdfBuffer = pdfBytes.slice().buffer
+    const pdfBlob = new Blob([pdfBuffer], { type: 'application/pdf' })
     const pdfUrl = URL.createObjectURL(pdfBlob)
     const pdfFileName = `receipt-${receipt.saleId}.pdf`
 
@@ -281,7 +300,7 @@ export default function Sell() {
       if (prev?.pdfUrl) {
         URL.revokeObjectURL(prev.pdfUrl)
       }
-      return { message, emailHref, smsHref, pdfBlob, pdfUrl, pdfFileName }
+      return { message, emailHref, smsHref, whatsappHref, pdfBlob, pdfUrl, pdfFileName }
     })
 
     return () => {


### PR DESCRIPTION
## Summary
- add WhatsApp sharing URL to the receipt share payload and ensure generated PDFs are compatible with stricter Blob typing
- extend cached product and customer types plus sales handling so new IndexedDB helpers satisfy TypeScript constraints
- provide a typed controller helper for the manageStaffAccount Cloud Function and update Sell page tests to use typed mocks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d69b4d2d64832194c569e9c47544b8