### PR TITLE
Fix Gate component ReactNode typing

### DIFF
--- a/web/src/pages/Gate.tsx
+++ b/web/src/pages/Gate.tsx
@@ -1,9 +1,9 @@
 // web/src/pages/Gate.tsx
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useMemberships } from '../hooks/useMemberships';
 import { createMyFirstStore } from '../controllers/storeController';
 
-export default function Gate({ children }: { children: React.ReactNode }) {
+export default function Gate({ children }: { children: ReactNode }) {
   const { loading, memberships, error } = useMemberships();
   const [busy, setBusy] = useState(false);
   const [errMsg, setErrMsg] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- import the ReactNode type in Gate and use it for the children prop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d69f866fd88321abde885f4ab4849c