### PR TITLE
Ensure store creation syncs owner metadata

### DIFF
--- a/web/src/controllers/storeController.ts
+++ b/web/src/controllers/storeController.ts
@@ -20,8 +20,7 @@ export async function createMyFirstStore() {
     updatedAt: serverTimestamp(),
   }, { merge: true });
 
-  // 2) Create the owner membership (members/{uid})
-  await setDoc(doc(db, 'stores', storeId, 'members', user.uid), {
+  const ownerMetadata = {
     storeId,
     uid: user.uid,
     role: 'owner',
@@ -30,7 +29,17 @@ export async function createMyFirstStore() {
     photoURL: user.photoURL ?? null,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
-  }, { merge: true });
+  };
+
+  // 2) Create the owner membership (members/{uid})
+  await setDoc(doc(db, 'stores', storeId, 'members', user.uid), ownerMetadata, { merge: true });
+
+  // 3) Store owner lookup (storeUsers/{storeId}_{uid})
+  await setDoc(doc(db, 'storeUsers', `${storeId}_${user.uid}`), ownerMetadata, { merge: true });
+
+  // 4) Ensure backend initialization + refreshed claims
+  const initializeStore = httpsCallable(functions, 'initializeStore');
+  await initializeStore();
 
   // Optional: if any legacy code still checks custom claims, refresh token
   await user.getIdToken(true);


### PR DESCRIPTION
## Summary
- create a reusable owner metadata payload during store creation and persist it to the `storeUsers` lookup
- call the `initializeStore` callable function before refreshing ID tokens so custom claims are updated
- mirror the updated store creation workflow in the hooks helper to keep both modules aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a6880f70832190ff24b0116b94d5