### PR TITLE
Add Secure flag to session cookie when served over HTTPS

### DIFF
--- a/web/src/controllers/sessionController.ts
+++ b/web/src/controllers/sessionController.ts
@@ -80,7 +80,10 @@ function setSessionCookie(value: string) {
   if (typeof document === 'undefined') {
     return
   }
-  document.cookie = `${SESSION_COOKIE}=${encodeURIComponent(value)}; Max-Age=${SESSION_MAX_AGE_SECONDS}; Path=/; SameSite=Lax`
+  const isSecureContext =
+    typeof window !== 'undefined' && window.location?.protocol === 'https:'
+  const secureAttribute = isSecureContext ? '; Secure' : ''
+  document.cookie = `${SESSION_COOKIE}=${encodeURIComponent(value)}; Max-Age=${SESSION_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${secureAttribute}`
 }
 
 function generateSessionId() {


### PR DESCRIPTION
## Summary
- append the Secure attribute to the session cookie when the app is served over HTTPS
- keep existing cookie attributes untouched for non-secure contexts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6aa7db290832192830902c0184cff