### PR TITLE
Restrict storeUsers to store owners

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -117,6 +117,13 @@ service cloud.firestore {
       allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
     }
 
+    match /storeUsers/{membershipId} {
+      allow read: if hasRole(resource.data.storeId, ['owner']);
+      allow create: if hasRole(request.resource.data.storeId, ['owner']);
+      allow update: if hasRole(resource.data.storeId, ['owner']) && storeIdUnchanged();
+      allow delete: if hasRole(resource.data.storeId, ['owner']);
+    }
+
     /* ---------- User-scoped sessions ---------- */
 
     match /sessions/{id} {


### PR DESCRIPTION
## Summary
- add security rules for the storeUsers collection mirroring owner-only access
- enforce storeId immutability on storeUsers updates and permit owner reads

## Testing
- `npx vitest run tests/firestore.rules.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d6b6e111c48321a39f84f04dd27087