### PR TITLE
Clear membership hook errors on retry

### DIFF
--- a/web/src/hooks/useMemberships.ts
+++ b/web/src/hooks/useMemberships.ts
@@ -22,8 +22,13 @@ export function useMemberships() {
     let cancelled = false;
     (async () => {
       try {
+        if (!cancelled) setError(null);
         if (!user) {
-          if (!cancelled) { setMemberships([]); setLoading(false); }
+          if (!cancelled) {
+            setMemberships([]);
+            setError(null);
+            setLoading(false);
+          }
           return;
         }
         // members docs should include 'uid' and 'storeId' fields (write them when creating)
@@ -43,6 +48,7 @@ export function useMemberships() {
           };
         });
         setMemberships(rows);
+        setError(null);
         setLoading(false);
       } catch (e) {
         if (!cancelled) { setError(e); setLoading(false); }

--- a/web/src/pages/Gate.test.tsx
+++ b/web/src/pages/Gate.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import Gate from './Gate';
+
+const mockUseAuthUser = vi.fn();
+vi.mock('../hooks/useAuthUser', () => ({
+  useAuthUser: () => mockUseAuthUser(),
+}));
+
+vi.mock('../firebase', () => ({
+  db: {},
+}));
+
+const mockCreateMyFirstStore = vi.fn();
+vi.mock('../controllers/storeController', () => ({
+  createMyFirstStore: (...args: unknown[]) => mockCreateMyFirstStore(...args),
+}));
+
+const collectionGroupMock = vi.fn();
+const queryMock = vi.fn((collectionRef: unknown, ...clauses: unknown[]) => ({
+  collectionRef,
+  clauses,
+}));
+const whereMock = vi.fn((...args: unknown[]) => ({ type: 'where', args }));
+const getDocsMock = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  collectionGroup: (...args: Parameters<typeof collectionGroupMock>) =>
+    collectionGroupMock(...args),
+  query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
+  where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
+  getDocs: (...args: Parameters<typeof getDocsMock>) => getDocsMock(...args),
+}));
+
+describe('Gate', () => {
+  beforeEach(() => {
+    mockUseAuthUser.mockReset();
+    mockCreateMyFirstStore.mockReset();
+    collectionGroupMock.mockReset();
+    queryMock.mockReset();
+    whereMock.mockReset();
+    getDocsMock.mockReset();
+  });
+
+  it('clears error state after a successful retry', async () => {
+    const membershipSnapshot = {
+      docs: [
+        {
+          id: 'membership-1',
+          data: () => ({
+            storeId: 'store-123',
+            uid: 'user-1',
+            role: 'owner',
+            displayName: 'Owner',
+          }),
+        },
+      ],
+    };
+
+    let currentUser: { uid: string; refresh?: string } | null = { uid: 'user-1' };
+    mockUseAuthUser.mockImplementation(() => currentUser);
+
+    getDocsMock.mockRejectedValueOnce(new Error('temporary failure'));
+    getDocsMock.mockResolvedValueOnce(membershipSnapshot);
+
+    const content = <div data-testid="app">App loaded</div>;
+    const { rerender } = render(<Gate>{content}</Gate>);
+
+    await waitFor(() => {
+      expect(screen.getByText(/temporary failure/i)).toBeInTheDocument();
+    });
+
+    currentUser = { uid: 'user-1', refresh: 'retry' };
+    rerender(<Gate>{content}</Gate>);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('app')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/temporary failure/i)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, beforeAll, afterAll } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -10,6 +10,19 @@ const mockUseAuthUser = vi.fn()
 vi.mock('../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
 }))
+
+const originalCreateObjectURL = globalThis.URL.createObjectURL
+const originalRevokeObjectURL = globalThis.URL.revokeObjectURL
+
+beforeAll(() => {
+  ;(globalThis.URL as any).createObjectURL = vi.fn(() => 'blob:mock-url')
+  ;(globalThis.URL as any).revokeObjectURL = vi.fn()
+})
+
+afterAll(() => {
+  ;(globalThis.URL as any).createObjectURL = originalCreateObjectURL
+  ;(globalThis.URL as any).revokeObjectURL = originalRevokeObjectURL
+})
 
 const mockUseActiveStore = vi.fn()
 vi.mock('../hooks/useActiveStore', () => ({


### PR DESCRIPTION
## Summary
- clear the memberships hook error state before refetching and after successful responses
- add a Gate test that covers recovering from a failed memberships load
- stub URL.createObjectURL in Sell tests to keep the Vitest suite green

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d6bed80f288321841a460d0e37465a