### PR TITLE
Allow provisional owner access to onboarding

### DIFF
--- a/web/src/pages/Onboarding.css
+++ b/web/src/pages/Onboarding.css
@@ -19,6 +19,17 @@
   font-size: 0.875rem;
 }
 
+.onboarding-page__provisional-banner {
+  background: #fff7ed;
+  border-color: #fed7aa;
+  color: #9a3412;
+  gap: 0.5rem;
+}
+
+.onboarding-page__provisional-banner p {
+  margin: 0;
+}
+
 .onboarding-card {
   display: flex;
   flex-direction: column;

--- a/web/src/pages/Onboarding.test.tsx
+++ b/web/src/pages/Onboarding.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { render, screen } from '@testing-library/react'
+
+import Onboarding from './Onboarding'
+
+const mockUseAuthUser = vi.fn()
+vi.mock('../hooks/useAuthUser', () => ({
+  useAuthUser: () => mockUseAuthUser(),
+}))
+
+const mockUseActiveStore = vi.fn()
+vi.mock('../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+const mockGetOnboardingStatus = vi.fn()
+const mockSetOnboardingStatus = vi.fn()
+vi.mock('../utils/onboarding', () => ({
+  getOnboardingStatus: (...args: Parameters<typeof mockGetOnboardingStatus>) =>
+    mockGetOnboardingStatus(...args),
+  setOnboardingStatus: (...args: Parameters<typeof mockSetOnboardingStatus>) =>
+    mockSetOnboardingStatus(...args),
+}))
+
+describe('Onboarding page', () => {
+  beforeEach(() => {
+    mockUseAuthUser.mockReset()
+    mockUseActiveStore.mockReset()
+    mockGetOnboardingStatus.mockReset()
+    mockSetOnboardingStatus.mockReset()
+
+    mockUseAuthUser.mockReturnValue({
+      uid: 'store-123',
+      email: 'owner@example.com',
+    })
+
+    mockUseActiveStore.mockReturnValue({
+      role: null,
+      storeId: 'store-123',
+      stores: ['store-123'],
+      isLoading: false,
+      error: null,
+      selectStore: vi.fn(),
+    })
+
+    mockGetOnboardingStatus.mockReturnValue('pending')
+  })
+
+  it('renders onboarding content while owner permissions are finalizing', () => {
+    render(
+      <MemoryRouter>
+        <Onboarding />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('heading', { name: /welcome to sedifex/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /confirm your owner account/i })).toBeInTheDocument()
+    expect(screen.getByText(/we're finalizing your owner permissions/i)).toBeInTheDocument()
+    expect(screen.queryByText(/access restricted/i)).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Onboarding.tsx
+++ b/web/src/pages/Onboarding.tsx
@@ -19,7 +19,16 @@ export default function Onboarding() {
     setStatus(getOnboardingStatus(user?.uid ?? null))
   }, [user?.uid])
 
+  const userId = user?.uid ?? null
   const hasAccess = useMemo(() => canAccessFeature(role, 'onboarding'), [role])
+  const hasProvisionalAccess = useMemo(() => {
+    if (!userId || !storeId) {
+      return false
+    }
+
+    return role === null && storeId === userId
+  }, [role, storeId, userId])
+  const canViewOnboarding = hasAccess || hasProvisionalAccess
   const hasCompleted = status === 'completed'
 
   function handleComplete() {
@@ -54,7 +63,7 @@ export default function Onboarding() {
     )
   }
 
-  if (!hasAccess) {
+  if (!canViewOnboarding) {
     return <AccessDenied feature="onboarding" role={role} />
   }
 
@@ -75,6 +84,20 @@ export default function Onboarding() {
           </span>
         )}
       </header>
+
+      {hasProvisionalAccess && (
+        <section
+          className="card onboarding-page__provisional-banner"
+          role="status"
+          aria-live="polite"
+          aria-label="Owner permissions are finalizing"
+        >
+          <p>
+            We&apos;re finalizing your owner permissions for store {storeId}. You can continue onboarding while we finish
+            setting things up.
+          </p>
+        </section>
+      )}
 
       <section className="card onboarding-card" aria-labelledby="onboarding-step-1">
         <header className="onboarding-card__header">


### PR DESCRIPTION
## Summary
- allow provisional owner access to the onboarding workspace while owner claims finish loading
- show a temporary banner explaining that owner permissions are finalizing but keep onboarding steps visible
- cover the provisional access branch with a new Vitest case

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6da4009dc8321b27d7073b93964fc