### PR TITLE
Allow members to read membership docs by uid

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -54,7 +54,8 @@ service cloud.firestore {
           && !exists(/databases/$(database)/documents/stores/$(request.auth.uid)/members/$(request.auth.uid));
 
         // Read: anyone in the store can read members; always allow a user to read their own membership
-        allow read: if inStore(storeId) || (isAuthed() && memberId == request.auth.uid);
+        allow read: if inStore(storeId)
+          || (isAuthed() && (memberId == request.auth.uid || resource.data.uid == request.auth.uid));
 
         // Updates:
         // - Owners can manage roles (add/remove/modify any member)


### PR DESCRIPTION
## Summary
- extend the members read rule to allow access when the membership document uid matches the signed-in user

## Testing
- not run (environment lacks firebase CLI access)


------
https://chatgpt.com/codex/tasks/task_e_68d6f35e02e483218afb99a2232acc25