### PR TITLE
Call store bootstrap during signup

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import {
 } from './controllers/sessionController'
 import { AuthUserContext } from './hooks/useAuthUser'
 import { getOnboardingStatus, setOnboardingStatus } from './utils/onboarding'
+import { createMyFirstStore } from './controllers/storeController'
 import Gate from './pages/Gate' // ← new: self-serve bootstrap gate
 
 type AuthMode = 'login' | 'signup'
@@ -291,6 +292,7 @@ export default function App() {
           sanitizedEmail,
           sanitizedPassword,
         )
+        await createMyFirstStore()
         await persistSession(nextUser)
         try {
           await nextUser.getIdToken(true)


### PR DESCRIPTION
## Summary
- import the store bootstrap helper into the main app shell
- invoke createMyFirstStore immediately after a new account is created so the store and membership records exist before onboarding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6fad7893c83219001c3537f4c94e6