### PR TITLE
Allow Gate auto-create to run on recoverable membership errors

### DIFF
--- a/web/src/pages/Gate.tsx
+++ b/web/src/pages/Gate.tsx
@@ -56,7 +56,7 @@ export default function Gate({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (loading) return;
-    if (error) return;
+    if (error && !isRecoverableMembershipError(error)) return;
     if (memberships.length !== 0) return;
     if (autoCreateTriggered.current) return;
 
@@ -70,7 +70,8 @@ export default function Gate({ children }: { children: ReactNode }) {
   const irrecoverableMembershipError = error && !recoverableMembershipError ? error : null;
   const membershipErrorMessage = toErrorMessage(error);
 
-  const shouldAutoCreateStore = !error && memberships.length === 0;
+  const shouldAutoCreateStore =
+    memberships.length === 0 && (!error || isRecoverableMembershipError(error));
 
   // No memberships → show self-serve bootstrap
   if (memberships.length === 0 || error) {


### PR DESCRIPTION
## Summary
- allow the Gate auto-create flow to proceed when membership errors are recoverable
- show the creating spinner instead of the manual button while auto-create runs after a recoverable membership error

## Testing
- npm --prefix web run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d799a8e19c8321b4687f922ef8312d