### PR TITLE
Simplify membership gate handling

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,7 +19,6 @@ import {
 import { AuthUserContext } from './hooks/useAuthUser'
 import { getOnboardingStatus, setOnboardingStatus } from './utils/onboarding'
 import { createMyFirstStore } from './controllers/storeController'
-import Gate from './pages/Gate' // ← new: self-serve bootstrap gate
 
 type AuthMode = 'login' | 'signup'
 
@@ -573,10 +572,7 @@ export default function App() {
 
   return (
     <AuthUserContext.Provider value={user}>
-      {/* Gate shows “Create my store” when user has no memberships */}
-      <Gate>
-        <Outlet />
-      </Gate>
+      <Outlet />
     </AuthUserContext.Provider>
   )
 }

--- a/web/src/pages/Gate.test.tsx
+++ b/web/src/pages/Gate.test.tsx
@@ -1,127 +1,41 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { FirebaseError } from 'firebase/app';
+import { render, screen } from '@testing-library/react';
 
 import Gate from './Gate';
 
-const mockUseAuthUser = vi.fn();
-vi.mock('../hooks/useAuthUser', () => ({
-  useAuthUser: () => mockUseAuthUser(),
-}));
-
-vi.mock('../firebase', () => ({
-  db: {},
-}));
-
-const mockCreateMyFirstStore = vi.fn();
-vi.mock('../controllers/storeController', () => ({
-  createMyFirstStore: (...args: unknown[]) => mockCreateMyFirstStore(...args),
-}));
-
-const collectionGroupMock = vi.fn();
-const queryMock = vi.fn((collectionRef: unknown, ...clauses: unknown[]) => ({
-  collectionRef,
-  clauses,
-}));
-const whereMock = vi.fn((...args: unknown[]) => ({ type: 'where', args }));
-const getDocsMock = vi.fn();
-
-vi.mock('firebase/firestore', () => ({
-  collectionGroup: (...args: Parameters<typeof collectionGroupMock>) =>
-    collectionGroupMock(...args),
-  query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
-  where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
-  getDocs: (...args: Parameters<typeof getDocsMock>) => getDocsMock(...args),
+const mockUseMemberships = vi.fn();
+vi.mock('../hooks/useMemberships', () => ({
+  useMemberships: () => mockUseMemberships(),
 }));
 
 describe('Gate', () => {
   beforeEach(() => {
-    mockUseAuthUser.mockReset();
-    mockCreateMyFirstStore.mockReset();
-    collectionGroupMock.mockReset();
-    queryMock.mockReset();
-    whereMock.mockReset();
-    getDocsMock.mockReset();
+    mockUseMemberships.mockReset();
   });
 
-  it('clears error state after a successful retry', async () => {
-    const membershipSnapshot = {
-      docs: [
-        {
-          id: 'membership-1',
-          data: () => ({
-            storeId: 'store-123',
-            uid: 'user-1',
-            role: 'owner',
-            displayName: 'Owner',
-          }),
-        },
-      ],
-    };
-
-    let currentUser: { uid: string; refresh?: string } | null = { uid: 'user-1' };
-    mockUseAuthUser.mockImplementation(() => currentUser);
-
-    getDocsMock.mockRejectedValueOnce(new Error('temporary failure'));
-    getDocsMock.mockResolvedValueOnce(membershipSnapshot);
-
-    const content = <div data-testid="app">App loaded</div>;
-    const { rerender } = render(<Gate>{content}</Gate>);
-
-    await waitFor(() => {
-      expect(screen.getByText(/temporary failure/i)).toBeInTheDocument();
-    });
-
-    currentUser = { uid: 'user-1', refresh: 'retry' };
-    rerender(<Gate>{content}</Gate>);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('app')).toBeInTheDocument();
-    });
-
-    expect(screen.queryByText(/temporary failure/i)).not.toBeInTheDocument();
-  });
-
-  it('shows bootstrap CTA when membership load is permission denied', async () => {
-    mockUseAuthUser.mockReturnValue({ uid: 'user-1' });
-    getDocsMock.mockRejectedValueOnce(
-      new FirebaseError('permission-denied', 'Missing or insufficient permissions.')
-    );
+  it('renders a loading state while memberships are loading', () => {
+    mockUseMemberships.mockReturnValue({ loading: true, error: null });
 
     render(<Gate />);
 
-    await waitFor(() => {
-      expect(screen.getByText(/create my store/i)).toBeInTheDocument();
-    });
-
-    expect(screen.getByText(/missing or insufficient permissions/i)).toBeInTheDocument();
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 
-  it('shows bootstrap CTA when membership load fails offline', async () => {
-    mockUseAuthUser.mockReturnValue({ uid: 'user-1' });
-    getDocsMock.mockRejectedValueOnce(
-      new FirebaseError('unavailable', 'Client is offline, please retry.')
-    );
+  it('renders an error message when memberships fail to load', () => {
+    const error = new Error('Failed to load memberships');
+    mockUseMemberships.mockReturnValue({ loading: false, error });
 
     render(<Gate />);
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /create my store/i })).toBeInTheDocument();
-    });
-
-    expect(screen.getByText(/client is offline/i)).toBeInTheDocument();
+    expect(screen.getByText(/failed to load memberships/i)).toBeInTheDocument();
   });
 
-  it('shows CTA with irrecoverable error message', async () => {
-    mockUseAuthUser.mockReturnValue({ uid: 'user-1' });
-    getDocsMock.mockRejectedValueOnce(new Error('unexpected failure'));
+  it('renders children once memberships load successfully', () => {
+    mockUseMemberships.mockReturnValue({ loading: false, error: null });
+    const child = <div data-testid="app">App</div>;
 
-    render(<Gate />);
+    render(<Gate>{child}</Gate>);
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /create my store/i })).toBeInTheDocument();
-    });
-
-    expect(screen.getByText(/unexpected failure/i)).toBeInTheDocument();
+    expect(screen.getByTestId('app')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/Gate.tsx
+++ b/web/src/pages/Gate.tsx
@@ -1,122 +1,32 @@
 // web/src/pages/Gate.tsx
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
-import { FirebaseError } from 'firebase/app';
+import type { ReactNode } from 'react';
 import { useMemberships } from '../hooks/useMemberships';
-import { createMyFirstStore } from '../controllers/storeController';
-
-function isRecoverableMembershipError(error: unknown) {
-  if (!error) return false;
-
-  if (error instanceof FirebaseError) {
-    if (error.code === 'permission-denied' || error.code === 'resource-exhausted') {
-      return true;
-    }
-
-    const message = error.message.toLowerCase();
-    return message.includes('offline') || message.includes('quota');
-  }
-
-  if (error instanceof Error) {
-    const message = error.message.toLowerCase();
-    return message.includes('offline') || message.includes('quota');
-  }
-
-  return false;
-}
 
 function toErrorMessage(error: unknown) {
-  if (!error) return null;
-  if (error instanceof Error) return error.message;
+  if (!error) return 'Something went wrong. Please try again.';
+  if (error instanceof Error) return error.message || 'Something went wrong. Please try again.';
   try {
     return JSON.stringify(error);
-  } catch (e) {
+  } catch (serializationError) {
     return String(error);
   }
 }
 
-export default function Gate({ children }: { children: ReactNode }) {
-  const { loading, memberships, error } = useMemberships();
-  const [busy, setBusy] = useState(false);
-  const [errMsg, setErrMsg] = useState<string | null>(null);
-  const autoCreateTriggered = useRef(false);
+export default function Gate({ children }: { children?: ReactNode }) {
+  const { loading, error } = useMemberships();
 
-  const attemptCreateStore = useCallback(async () => {
-    try {
-      setErrMsg(null);
-      setBusy(true);
-      await createMyFirstStore();
-      // reload to re-run membership query and mount the app
-      location.reload();
-    } catch (e) {
-      setErrMsg(toErrorMessage(e) || 'Failed to create store');
-    } finally {
-      setBusy(false);
-    }
-  }, []);
+  if (loading) {
+    return <div className="p-6">Loading…</div>;
+  }
 
-  useEffect(() => {
-    if (loading) return;
-    if (error && !isRecoverableMembershipError(error)) return;
-    if (memberships.length !== 0) return;
-    if (autoCreateTriggered.current) return;
-
-    autoCreateTriggered.current = true;
-    void attemptCreateStore();
-  }, [attemptCreateStore, error, loading, memberships]);
-
-  if (loading) return <div className="p-6">Loading…</div>;
-
-  const recoverableMembershipError = isRecoverableMembershipError(error) ? error : null;
-  const irrecoverableMembershipError = error && !recoverableMembershipError ? error : null;
-  const membershipErrorMessage = toErrorMessage(error);
-
-  const shouldAutoCreateStore =
-    memberships.length === 0 && (!error || isRecoverableMembershipError(error));
-
-  // No memberships → show self-serve bootstrap
-  if (memberships.length === 0 || error) {
+  if (error) {
     return (
       <div className="mx-auto max-w-md p-6 text-center">
-        <h1 className="text-2xl font-semibold mb-2">Let’s set up your workspace</h1>
-        <p className="text-sm text-gray-600 mb-6">
-          You don’t have a store yet. Create one now and you’ll be the owner.
-        </p>
-
-        {recoverableMembershipError && (
-          <div className="mb-3 text-sm text-amber-600">
-            We couldn’t confirm your memberships: {membershipErrorMessage}
-          </div>
-        )}
-
-        {irrecoverableMembershipError && (
-          <div className="mb-3 text-sm text-red-600">
-            Error loading memberships: {membershipErrorMessage}
-          </div>
-        )}
-
-        {errMsg && <div className="mb-3 text-sm text-red-600">{errMsg}</div>}
-
-        {shouldAutoCreateStore && !errMsg ? (
-          <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
-            <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-gray-300 border-t-gray-500" />
-            Creating your store…
-          </div>
-        ) : (
-          <button
-            className="px-4 py-2 rounded-xl bg-black text-white disabled:opacity-60"
-            disabled={busy}
-            onClick={() => {
-              autoCreateTriggered.current = true;
-              void attemptCreateStore();
-            }}
-          >
-            {busy ? 'Creating…' : 'Create my store'}
-          </button>
-        )}
+        <h1 className="text-2xl font-semibold mb-2">We couldn't load your workspace</h1>
+        <p className="text-sm text-red-600">{toErrorMessage(error)}</p>
       </div>
     );
   }
 
-  // Has at least one membership → render the app
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- render the authenticated app shell directly from `App` without the `Gate` bootstrap wrapper
- rewrite `Gate` to only handle membership loading state and surface errors when they occur
- update the Gate test suite to match the streamlined behavior

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d7abd9d25083219e4072757205ad36