### PR TITLE
Add products management page

### DIFF
--- a/web/src/pages/Products.css
+++ b/web/src/pages/Products.css
@@ -1,0 +1,208 @@
+.products-page {
+  gap: 24px;
+}
+
+.products-page__card {
+  margin-bottom: 24px;
+}
+
+.products-page__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.products-page__search {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+}
+
+.products-page__search input {
+  padding: 8px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  min-width: 220px;
+}
+
+.products-page__filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.products-page__warning {
+  margin-top: 8px;
+  color: #b45309;
+}
+
+.products-page__receive-link {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 16px;
+  border-radius: 8px;
+  background-color: #1f2937;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.products-page__receive-link:hover {
+  background-color: #111827;
+}
+
+.products-page__table-wrapper {
+  overflow-x: auto;
+}
+
+.products-page__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.products-page__table th,
+.products-page__table td {
+  padding: 12px;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+  vertical-align: top;
+}
+
+.products-page__product-name {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.products-page__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  background-color: #e5e7eb;
+  color: #374151;
+}
+
+.products-page__badge--alert {
+  background-color: #fef3c7;
+  color: #b45309;
+}
+
+.products-page__actions {
+  text-align: right;
+}
+
+.products-page__edit-button {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  background-color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.products-page__edit-button:hover {
+  background-color: #f9fafb;
+}
+
+.products-page__loading,
+.products-page__empty,
+.products-page__error {
+  margin: 16px 0;
+  font-size: 14px;
+}
+
+.products-page__error {
+  color: #b91c1c;
+}
+
+.products-page__form {
+  display: grid;
+  gap: 16px;
+  max-width: 520px;
+}
+
+.products-page__submit {
+  align-self: start;
+  padding: 10px 18px;
+  border-radius: 6px;
+  background-color: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+}
+
+.products-page__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.products-page__status {
+  font-size: 14px;
+}
+
+.products-page__status--success {
+  color: #047857;
+}
+
+.products-page__status--error {
+  color: #b91c1c;
+}
+
+.products-page__dialog {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(17, 24, 39, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 40;
+}
+
+.products-page__dialog-content {
+  background-color: #fff;
+  padding: 24px;
+  border-radius: 12px;
+  width: min(480px, 100%);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+}
+
+.products-page__dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.products-page__cancel {
+  padding: 10px 18px;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  cursor: pointer;
+}
+
+.products-page__cancel:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .products-page__toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .products-page__actions {
+    text-align: left;
+  }
+}

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -1,0 +1,640 @@
+import React, { FormEvent, useEffect, useMemo, useState } from 'react'
+import {
+  addDoc,
+  collection,
+  doc,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  updateDoc,
+  where,
+} from 'firebase/firestore'
+import { FirebaseError } from 'firebase/app'
+import { Link } from 'react-router-dom'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import {
+  PRODUCT_CACHE_LIMIT,
+  loadCachedProducts,
+  saveCachedProducts,
+} from '../utils/offlineCache'
+import './Products.css'
+
+interface ReceiptDetails {
+  qty?: number | null
+  supplier?: string | null
+  receivedAt?: unknown
+}
+
+export type ProductRecord = {
+  id: string
+  name: string
+  sku?: string | null
+  stockCount?: number | null
+  reorderThreshold?: number | null
+  lastReceipt?: ReceiptDetails | null
+  createdAt?: unknown
+  updatedAt?: unknown
+  __optimistic?: boolean
+}
+
+type StatusTone = 'success' | 'error'
+
+interface StatusState {
+  tone: StatusTone
+  message: string
+}
+
+const DEFAULT_CREATE_FORM = {
+  name: '',
+  sku: '',
+  reorderThreshold: '',
+  initialStock: '',
+}
+
+const DEFAULT_EDIT_FORM = {
+  name: '',
+  sku: '',
+  reorderThreshold: '',
+}
+
+function toDate(value: unknown): Date | null {
+  if (!value) return null
+  if (value instanceof Date) return value
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value)
+    return Number.isNaN(parsed) ? null : new Date(parsed)
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? new Date(value) : null
+  }
+  if (typeof value === 'object') {
+    const anyValue = value as { toDate?: () => Date; toMillis?: () => number; seconds?: number; nanoseconds?: number }
+    if (typeof anyValue.toDate === 'function') {
+      try {
+        return anyValue.toDate() ?? null
+      } catch (error) {
+        console.warn('[products] Failed to convert timestamp via toDate', error)
+      }
+    }
+    if (typeof anyValue.toMillis === 'function') {
+      try {
+        const millis = anyValue.toMillis()
+        return Number.isFinite(millis) ? new Date(millis) : null
+      } catch (error) {
+        console.warn('[products] Failed to convert timestamp via toMillis', error)
+      }
+    }
+    if (typeof anyValue.seconds === 'number') {
+      const millis = anyValue.seconds * 1000 + Math.round((anyValue.nanoseconds ?? 0) / 1_000_000)
+      return Number.isFinite(millis) ? new Date(millis) : null
+    }
+  }
+  return null
+}
+
+function formatReceiptDetails(receipt: ReceiptDetails | null | undefined): string {
+  if (!receipt) return 'No receipts recorded'
+  const qty = typeof receipt.qty === 'number' ? receipt.qty : null
+  const supplier = typeof receipt.supplier === 'string' ? receipt.supplier : null
+  const receivedAt = toDate(receipt.receivedAt)
+  const parts: string[] = []
+  if (qty !== null) {
+    parts.push(`${qty} received`)
+  }
+  if (supplier) {
+    parts.push(`from ${supplier}`)
+  }
+  if (receivedAt) {
+    parts.push(`on ${receivedAt.toLocaleDateString()} ${receivedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`)
+  }
+  if (!parts.length) {
+    return 'Last receipt details unavailable'
+  }
+  return parts.join(' ')
+}
+
+function sortProducts(products: ProductRecord[]): ProductRecord[] {
+  return [...products].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+}
+
+function isOfflineError(error: unknown) {
+  if (!navigator.onLine) return true
+  if (error instanceof FirebaseError) {
+    return error.code === 'unavailable' || error.code === 'internal'
+  }
+  if (error instanceof TypeError) {
+    const message = error.message.toLowerCase()
+    return message.includes('network') || message.includes('fetch')
+  }
+  return false
+}
+
+export default function Products() {
+  const { storeId: STORE_ID, isLoading: storeLoading, error: storeError } = useActiveStore()
+
+  const [products, setProducts] = useState<ProductRecord[]>([])
+  const [isLoadingProducts, setIsLoadingProducts] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [filterText, setFilterText] = useState('')
+  const [showLowStockOnly, setShowLowStockOnly] = useState(false)
+  const [createForm, setCreateForm] = useState(DEFAULT_CREATE_FORM)
+  const [createStatus, setCreateStatus] = useState<StatusState | null>(null)
+  const [isCreating, setIsCreating] = useState(false)
+  const [editForm, setEditForm] = useState(DEFAULT_EDIT_FORM)
+  const [editStatus, setEditStatus] = useState<StatusState | null>(null)
+  const [editingProductId, setEditingProductId] = useState<string | null>(null)
+  const [isUpdating, setIsUpdating] = useState(false)
+
+  useEffect(() => {
+    if (!STORE_ID) return
+
+    let cancelled = false
+    setIsLoadingProducts(true)
+    setLoadError(null)
+
+    loadCachedProducts<Omit<ProductRecord, '__optimistic'>>(STORE_ID)
+      .then(cached => {
+        if (!cancelled && cached.length) {
+          setProducts(prev => {
+            const optimistic = prev.filter(item => item.__optimistic)
+            const sanitized = cached.map(item => ({ ...item, __optimistic: false }))
+            return sortProducts([...sanitized, ...optimistic])
+          })
+          setIsLoadingProducts(false)
+        }
+      })
+      .catch(error => {
+        console.warn('[products] Failed to load cached products', error)
+      })
+
+    const q = query(
+      collection(db, 'products'),
+      where('storeId', '==', STORE_ID),
+      orderBy('updatedAt', 'desc'),
+      orderBy('createdAt', 'desc'),
+      limit(PRODUCT_CACHE_LIMIT),
+    )
+
+    const unsubscribe = onSnapshot(
+      q,
+      snapshot => {
+        if (cancelled) return
+        const rows = snapshot.docs.map(docSnap => ({ id: docSnap.id, ...(docSnap.data() as Record<string, unknown>) }))
+        saveCachedProducts(STORE_ID, rows).catch(error => {
+          console.warn('[products] Failed to cache products', error)
+        })
+        setProducts(prev => {
+          const optimistic = prev.filter(product => product.__optimistic)
+          const merged = rows.map(row => ({
+            ...(row as ProductRecord),
+            __optimistic: false,
+          }))
+          const optimisticRemainders = optimistic.filter(item => !rows.some(row => row.id === item.id))
+          return sortProducts([...merged, ...optimisticRemainders])
+        })
+        setIsLoadingProducts(false)
+      },
+      error => {
+        if (cancelled) return
+        console.error('[products] Failed to subscribe to products', error)
+        setLoadError('Unable to load products right now. Please try again shortly.')
+        setIsLoadingProducts(false)
+      },
+    )
+
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [STORE_ID])
+
+  useEffect(() => {
+    if (!editingProductId) {
+      setEditForm(DEFAULT_EDIT_FORM)
+      return
+    }
+    const product = products.find(item => item.id === editingProductId)
+    if (!product) return
+    setEditForm({
+      name: product.name ?? '',
+      sku: product.sku ?? '',
+      reorderThreshold:
+        typeof product.reorderThreshold === 'number' && Number.isFinite(product.reorderThreshold)
+          ? String(product.reorderThreshold)
+          : '',
+    })
+  }, [editingProductId, products])
+
+  const filteredProducts = useMemo(() => {
+    const normalizedQuery = filterText.trim().toLowerCase()
+    return sortProducts(
+      products.filter(product => {
+        const stockCount = typeof product.stockCount === 'number' ? product.stockCount : 0
+        const reorder = typeof product.reorderThreshold === 'number' ? product.reorderThreshold : null
+        const matchesLowStock = !showLowStockOnly || (reorder !== null && stockCount <= reorder)
+        if (!matchesLowStock) return false
+        if (!normalizedQuery) return true
+        const haystack = `${product.name ?? ''} ${product.sku ?? ''}`.toLowerCase()
+        return haystack.includes(normalizedQuery)
+      }),
+    )
+  }, [filterText, products, showLowStockOnly])
+
+  function handleCreateFieldChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = event.target
+    setCreateForm(prev => ({ ...prev, [name]: value }))
+  }
+
+  function handleEditFieldChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = event.target
+    setEditForm(prev => ({ ...prev, [name]: value }))
+  }
+
+  function resetCreateForm() {
+    setCreateForm(DEFAULT_CREATE_FORM)
+  }
+
+  function validateNumbers(value: string, allowZero = true) {
+    if (!value.trim()) return null
+    const parsed = Number(value)
+    if (!Number.isFinite(parsed)) return null
+    if (parsed < 0) return null
+    if (!allowZero && parsed === 0) return null
+    return parsed
+  }
+
+  async function handleCreateProduct(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!STORE_ID) {
+      setCreateStatus({ tone: 'error', message: 'Store access is not ready. Please refresh and try again.' })
+      return
+    }
+    const name = createForm.name.trim()
+    const sku = createForm.sku.trim()
+    const reorderThreshold = validateNumbers(createForm.reorderThreshold)
+    const initialStock = validateNumbers(createForm.initialStock)
+
+    if (!name) {
+      setCreateStatus({ tone: 'error', message: 'Name your product so the team recognises it on the shelf.' })
+      return
+    }
+    if (createForm.reorderThreshold && reorderThreshold === null) {
+      setCreateStatus({ tone: 'error', message: 'Enter a valid reorder point that is zero or greater.' })
+      return
+    }
+    if (createForm.initialStock && initialStock === null) {
+      setCreateStatus({ tone: 'error', message: 'Enter a valid opening stock that is zero or greater.' })
+      return
+    }
+
+    const optimisticProduct: ProductRecord = {
+      id: `optimistic-${Date.now()}`,
+      name,
+      sku: sku || null,
+      reorderThreshold: reorderThreshold ?? null,
+      stockCount: initialStock ?? 0,
+      lastReceipt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      __optimistic: true,
+    }
+
+    setIsCreating(true)
+    setCreateStatus(null)
+    setProducts(prev => sortProducts([optimisticProduct, ...prev]))
+
+    try {
+      const ref = await addDoc(collection(db, 'products'), {
+        storeId: STORE_ID,
+        name,
+        sku: sku || null,
+        reorderThreshold: reorderThreshold ?? null,
+        stockCount: initialStock ?? 0,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      })
+
+      setProducts(prev =>
+        prev.map(product =>
+          product.id === optimisticProduct.id
+            ? { ...product, id: ref.id, __optimistic: false }
+            : product,
+        ),
+      )
+      setCreateStatus({ tone: 'success', message: 'Product created successfully.' })
+      resetCreateForm()
+    } catch (error) {
+      console.error('[products] Failed to create product', error)
+      if (isOfflineError(error)) {
+        setProducts(prev =>
+          prev.map(product =>
+            product.id === optimisticProduct.id ? { ...product, __optimistic: true } : product,
+          ),
+        )
+        setCreateStatus({
+          tone: 'success',
+          message: 'Offline — product saved locally and will sync when you reconnect.',
+        })
+        return
+      }
+      setProducts(prev => prev.filter(product => product.id !== optimisticProduct.id))
+      setCreateStatus({ tone: 'error', message: 'Unable to create product. Please try again.' })
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  async function handleUpdateProduct(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!STORE_ID || !editingProductId) {
+      setEditStatus({ tone: 'error', message: 'Store access is not ready. Please refresh and try again.' })
+      return
+    }
+    const name = editForm.name.trim()
+    const sku = editForm.sku.trim()
+    const reorderThreshold = validateNumbers(editForm.reorderThreshold)
+
+    if (!name) {
+      setEditStatus({ tone: 'error', message: 'Name your product so staff know what to pick.' })
+      return
+    }
+    if (editForm.reorderThreshold && reorderThreshold === null) {
+      setEditStatus({ tone: 'error', message: 'Enter a valid reorder point that is zero or greater.' })
+      return
+    }
+
+    const previous = products.find(product => product.id === editingProductId)
+    if (!previous) {
+      setEditStatus({ tone: 'error', message: 'We could not find this product to update.' })
+      return
+    }
+
+    const updatedValues: Partial<ProductRecord> = {
+      name,
+      sku: sku || null,
+      reorderThreshold: reorderThreshold ?? null,
+      updatedAt: new Date(),
+    }
+
+    setIsUpdating(true)
+    setEditStatus(null)
+    setProducts(prev =>
+      sortProducts(
+        prev.map(product =>
+          product.id === editingProductId ? { ...product, ...updatedValues, __optimistic: true } : product,
+        ),
+      ),
+    )
+
+    try {
+      await updateDoc(doc(collection(db, 'products'), editingProductId), {
+        name,
+        sku: sku || null,
+        reorderThreshold: reorderThreshold ?? null,
+        updatedAt: serverTimestamp(),
+      })
+      setEditStatus({ tone: 'success', message: 'Product details updated.' })
+      setProducts(prev =>
+        prev.map(product =>
+          product.id === editingProductId ? { ...product, __optimistic: false } : product,
+        ),
+      )
+      setEditingProductId(null)
+    } catch (error) {
+      console.error('[products] Failed to update product', error)
+      setProducts(prev =>
+        prev.map(product =>
+          product.id === editingProductId ? previous : product,
+        ),
+      )
+      if (isOfflineError(error)) {
+        setEditStatus({
+          tone: 'success',
+          message: 'Offline — product edits saved and will sync when you reconnect.',
+        })
+        setEditingProductId(null)
+        return
+      }
+      setEditStatus({ tone: 'error', message: 'Unable to update product. Please try again.' })
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  function renderStatus(status: StatusState | null) {
+    if (!status) return null
+    return (
+      <div className={`products-page__status products-page__status--${status.tone}`} role="status">
+        {status.message}
+      </div>
+    )
+  }
+
+  if (storeLoading) {
+    return <div>Loading…</div>
+  }
+
+  if (!STORE_ID) {
+    return <div>We were unable to determine your store access. Please sign out and back in.</div>
+  }
+
+  return (
+    <div className="page products-page">
+      <header className="page__header">
+        <div>
+          <h2 className="page__title">Products</h2>
+          <p className="page__subtitle">
+            Review inventory, monitor low stock alerts, and keep your catalogue tidy.
+          </p>
+          {storeError ? <p className="products-page__warning">{storeError}</p> : null}
+        </div>
+        <Link to="/receive" className="products-page__receive-link">
+          Receive stock
+        </Link>
+      </header>
+
+      <section className="card products-page__card">
+        <div className="products-page__toolbar">
+          <label className="products-page__search">
+            <span className="products-page__search-label">Search</span>
+            <input
+              type="search"
+              placeholder="Search by product or SKU"
+              value={filterText}
+              onChange={event => setFilterText(event.target.value)}
+            />
+          </label>
+          <label className="products-page__filter">
+            <input
+              type="checkbox"
+              checked={showLowStockOnly}
+              onChange={event => setShowLowStockOnly(event.target.checked)}
+            />
+            <span>Show low stock only</span>
+          </label>
+        </div>
+        {loadError ? <div className="products-page__error">{loadError}</div> : null}
+        {isLoadingProducts ? <div className="products-page__loading">Loading products…</div> : null}
+        {!isLoadingProducts && filteredProducts.length === 0 ? (
+          <div className="products-page__empty" role="status">
+            No products found. Add your first item so you can track inventory.
+          </div>
+        ) : null}
+        {filteredProducts.length > 0 ? (
+          <div className="products-page__table-wrapper">
+            <table className="products-page__table">
+              <thead>
+                <tr>
+                  <th scope="col">Product</th>
+                  <th scope="col">SKU</th>
+                  <th scope="col">On hand</th>
+                  <th scope="col">Reorder point</th>
+                  <th scope="col">Last receipt</th>
+                  <th scope="col" className="products-page__actions">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredProducts.map(product => {
+                  const stockCount = typeof product.stockCount === 'number' ? product.stockCount : 0
+                  const reorderThreshold =
+                    typeof product.reorderThreshold === 'number' ? product.reorderThreshold : null
+                  const isLowStock = reorderThreshold !== null && stockCount <= reorderThreshold
+                  return (
+                    <tr key={product.id} data-testid={`product-row-${product.id}`}>
+                      <th scope="row">
+                        <div className="products-page__product-name">
+                          {product.name}
+                          {product.__optimistic ? (
+                            <span className="products-page__badge">Syncing…</span>
+                          ) : null}
+                          {isLowStock ? (
+                            <span className="products-page__badge products-page__badge--alert">Low stock</span>
+                          ) : null}
+                        </div>
+                      </th>
+                      <td>{product.sku || '—'}</td>
+                      <td>{stockCount}</td>
+                      <td>{reorderThreshold ?? '—'}</td>
+                      <td>{formatReceiptDetails(product.lastReceipt)}</td>
+                      <td className="products-page__actions">
+                        <button
+                          type="button"
+                          className="products-page__edit-button"
+                          onClick={() => setEditingProductId(product.id)}
+                        >
+                          Edit
+                        </button>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="card products-page__card">
+        <h3 className="card__title">Add product</h3>
+        <p className="card__subtitle">
+          Capture items you stock so sales and receipts stay accurate.
+        </p>
+        <form className="products-page__form" onSubmit={handleCreateProduct}>
+          <label className="field">
+            <span className="field__label">Name</span>
+            <input
+              name="name"
+              value={createForm.name}
+              onChange={handleCreateFieldChange}
+              placeholder="e.g. House Blend Coffee"
+              required
+            />
+          </label>
+          <label className="field">
+            <span className="field__label">SKU</span>
+            <input
+              name="sku"
+              value={createForm.sku}
+              onChange={handleCreateFieldChange}
+              placeholder="Optional stock keeping unit"
+            />
+          </label>
+          <label className="field">
+            <span className="field__label">Reorder point</span>
+            <input
+              name="reorderThreshold"
+              value={createForm.reorderThreshold}
+              onChange={handleCreateFieldChange}
+              placeholder="Alert when stock drops to…"
+              inputMode="numeric"
+            />
+          </label>
+          <label className="field">
+            <span className="field__label">Opening stock</span>
+            <input
+              name="initialStock"
+              value={createForm.initialStock}
+              onChange={handleCreateFieldChange}
+              placeholder="Quantity currently on hand"
+              inputMode="numeric"
+            />
+          </label>
+          <button type="submit" className="products-page__submit" disabled={isCreating}>
+            {isCreating ? 'Saving…' : 'Add product'}
+          </button>
+          {renderStatus(createStatus)}
+        </form>
+      </section>
+
+      {editingProductId ? (
+        <div className="products-page__dialog" role="dialog" aria-modal="true">
+          <div className="products-page__dialog-content">
+            <h3>Edit product</h3>
+            <form className="products-page__form" onSubmit={handleUpdateProduct}>
+              <label className="field">
+                <span className="field__label">Name</span>
+                <input
+                  name="name"
+                  value={editForm.name}
+                  onChange={handleEditFieldChange}
+                  required
+                />
+              </label>
+              <label className="field">
+                <span className="field__label">SKU</span>
+                <input name="sku" value={editForm.sku} onChange={handleEditFieldChange} />
+              </label>
+              <label className="field">
+                <span className="field__label">Reorder point</span>
+                <input
+                  name="reorderThreshold"
+                  value={editForm.reorderThreshold}
+                  onChange={handleEditFieldChange}
+                  inputMode="numeric"
+                />
+              </label>
+              <div className="products-page__dialog-actions">
+                <button
+                  type="button"
+                  className="products-page__cancel"
+                  onClick={() => setEditingProductId(null)}
+                  disabled={isUpdating}
+                >
+                  Cancel
+                </button>
+                <button type="submit" className="products-page__submit" disabled={isUpdating}>
+                  {isUpdating ? 'Saving…' : 'Save changes'}
+                </button>
+              </div>
+              {renderStatus(editStatus)}
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+

--- a/web/src/pages/__tests__/Products.test.tsx
+++ b/web/src/pages/__tests__/Products.test.tsx
@@ -1,0 +1,262 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { render, screen, waitFor, act, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import Products from '../Products'
+
+const mockUseActiveStore = vi.fn()
+vi.mock('../../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+const mockLoadCachedProducts = vi.fn(async () => [] as unknown[])
+const mockSaveCachedProducts = vi.fn(async () => {})
+
+vi.mock('../../utils/offlineCache', () => ({
+  PRODUCT_CACHE_LIMIT: 200,
+  loadCachedProducts: (...args: Parameters<typeof mockLoadCachedProducts>) =>
+    mockLoadCachedProducts(...args),
+  saveCachedProducts: (...args: Parameters<typeof mockSaveCachedProducts>) =>
+    mockSaveCachedProducts(...args),
+}))
+
+vi.mock('../../firebase', () => ({
+  db: {},
+}))
+
+const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
+const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[]) => ({
+  collection: collectionRef,
+  clauses,
+}))
+const whereMock = vi.fn((...args: unknown[]) => ({ type: 'where', args }))
+const orderByMock = vi.fn((field: string, direction?: string) => ({ type: 'orderBy', field, direction }))
+const limitMock = vi.fn((value: number) => ({ type: 'limit', value }))
+const onSnapshotMock = vi.fn(
+  (
+    queryRef: { collection: { path: string } },
+    onNext: (snapshot: { docs: { id: string; data: () => Record<string, unknown> }[] }) => void,
+  ) => {
+    queueMicrotask(() => {
+      onNext({ docs: [] })
+    })
+    return () => {}
+  },
+)
+const addDocMock = vi.fn()
+const updateDocMock = vi.fn(async () => {})
+const serverTimestampMock = vi.fn(() => 'server-timestamp')
+const docMock = vi.fn((collectionRef: { path: string }, id: string) => ({
+  type: 'doc',
+  path: `${collectionRef.path}/${id}`,
+}))
+
+vi.mock('firebase/firestore', () => ({
+  collection: (...args: Parameters<typeof collectionMock>) => collectionMock(...args),
+  query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
+  where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
+  orderBy: (...args: Parameters<typeof orderByMock>) => orderByMock(...args),
+  limit: (...args: Parameters<typeof limitMock>) => limitMock(...args),
+  onSnapshot: (
+    ...args: Parameters<typeof onSnapshotMock>
+  ) => onSnapshotMock(...args),
+  addDoc: (...args: Parameters<typeof addDocMock>) => addDocMock(...args),
+  updateDoc: (...args: Parameters<typeof updateDocMock>) => updateDocMock(...args),
+  serverTimestamp: (...args: Parameters<typeof serverTimestampMock>) => serverTimestampMock(...args),
+  doc: (...args: Parameters<typeof docMock>) => docMock(...args),
+}))
+
+describe('Products page', () => {
+  beforeEach(() => {
+    mockUseActiveStore.mockReset()
+    mockLoadCachedProducts.mockReset()
+    mockSaveCachedProducts.mockReset()
+    collectionMock.mockClear()
+    queryMock.mockClear()
+    whereMock.mockClear()
+    orderByMock.mockClear()
+    limitMock.mockClear()
+    onSnapshotMock.mockClear()
+    addDocMock.mockClear()
+    updateDocMock.mockClear()
+    serverTimestampMock.mockClear()
+    docMock.mockClear()
+
+    mockUseActiveStore.mockReturnValue({
+      storeId: 'store-1',
+      stores: ['store-1'],
+      isLoading: false,
+      error: null,
+      selectStore: vi.fn(),
+    })
+
+    mockLoadCachedProducts.mockResolvedValue([])
+    mockSaveCachedProducts.mockResolvedValue(undefined)
+    onSnapshotMock.mockImplementation((queryRef, onNext) => {
+      queueMicrotask(() => {
+        onNext({ docs: [] })
+      })
+      return () => {}
+    })
+  })
+
+  it('renders store loading state', () => {
+    mockUseActiveStore.mockReturnValue({
+      storeId: null,
+      stores: [],
+      isLoading: true,
+      error: null,
+      selectStore: vi.fn(),
+    })
+
+    render(
+      <MemoryRouter>
+        <Products />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no products are available', async () => {
+    let snapshotHandler: ((snap: { docs: { id: string; data: () => Record<string, unknown> }[] }) => void) | null = null
+    onSnapshotMock.mockImplementation((queryRef, onNext) => {
+      snapshotHandler = onNext
+      return () => {}
+    })
+
+    render(
+      <MemoryRouter>
+        <Products />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(onSnapshotMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      snapshotHandler?.({ docs: [] })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/no products found/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders inventory details from the subscription', async () => {
+    let snapshotHandler: ((snap: { docs: { id: string; data: () => Record<string, unknown> }[] }) => void) | null = null
+    onSnapshotMock.mockImplementation((queryRef, onNext) => {
+      snapshotHandler = onNext
+      return () => {}
+    })
+
+    render(
+      <MemoryRouter>
+        <Products />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(onSnapshotMock).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      snapshotHandler?.({
+        docs: [
+          {
+            id: 'product-1',
+            data: () => ({
+              name: 'Iced Coffee',
+              sku: 'COF-01',
+              stockCount: 2,
+              reorderThreshold: 5,
+              lastReceipt: { qty: 12, supplier: 'ACME' },
+            }),
+          },
+        ],
+      })
+    })
+
+    const productRow = await screen.findByTestId('product-row-product-1')
+    expect(productRow).toHaveTextContent('Iced Coffee')
+    expect(within(productRow).getByText(/low stock/i)).toBeInTheDocument()
+    expect(mockSaveCachedProducts).toHaveBeenCalled()
+  })
+
+  it('optimistically renders a newly created product', async () => {
+    const user = userEvent.setup()
+    let snapshotHandler: ((snap: { docs: { id: string; data: () => Record<string, unknown> }[] }) => void) | null = null
+    onSnapshotMock.mockImplementation((queryRef, onNext) => {
+      snapshotHandler = onNext
+      return () => {}
+    })
+
+    let resolveAddDoc: ((value: { id: string }) => void) | null = null
+    addDocMock.mockImplementation(async (...args: unknown[]) => {
+      return new Promise<{ id: string }>(resolve => {
+        resolveAddDoc = resolve
+      })
+    })
+
+    render(
+      <MemoryRouter>
+        <Products />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(onSnapshotMock).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      snapshotHandler?.({ docs: [] })
+    })
+
+    await user.type(screen.getByLabelText('Name'), 'New Blend')
+    await user.type(screen.getByLabelText('SKU'), 'NB-01')
+    await user.type(screen.getByLabelText('Reorder point'), '4')
+    await user.type(screen.getByLabelText('Opening stock'), '10')
+
+    await user.click(screen.getByRole('button', { name: /add product/i }))
+
+    expect(addDocMock).toHaveBeenCalled()
+    expect(addDocMock).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'products' }),
+      expect.objectContaining({
+        storeId: 'store-1',
+        name: 'New Blend',
+        sku: 'NB-01',
+        reorderThreshold: 4,
+        stockCount: 10,
+      }),
+    )
+    expect(screen.getByText('Syncing…')).toBeInTheDocument()
+
+    await act(async () => {
+      resolveAddDoc?.({ id: 'product-2' })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Product created successfully.')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      snapshotHandler?.({
+        docs: [
+          {
+            id: 'product-2',
+            data: () => ({
+              name: 'New Blend',
+              sku: 'NB-01',
+              stockCount: 10,
+              reorderThreshold: 4,
+            }),
+          },
+        ],
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Syncing…')).not.toBeInTheDocument()
+      expect(screen.getByText('New Blend')).toBeInTheDocument()
+    })
+  })
+})
+


### PR DESCRIPTION
## Summary
- add a products management page with offline-aware Firestore subscription and editing forms
- style the products experience with a dedicated stylesheet
- cover the new page with Vitest tests that mock Firestore and offline caching

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7b6ebda3883218fbc061e31227342