### PR TITLE
Remove settings page references from web client

### DIFF
--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -17,7 +17,6 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/receive', label: 'Receive' },
   { to: '/customers', label: 'Customers' },
   { to: '/close-day', label: 'Close Day' },
-  { to: '/settings', label: 'Settings' },
 ]
 
 function navLinkClass(isActive: boolean) {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,7 +9,6 @@ import Sell from './pages/Sell'
 import Receive from './pages/Receive'
 import CloseDay from './pages/CloseDay'
 import Customers from './pages/Customers'
-import Settings from './pages/Settings'
 import Onboarding from './pages/Onboarding'
 import { ToastProvider } from './components/ToastProvider'
 
@@ -24,7 +23,6 @@ const router = createHashRouter([
       { path: 'receive',   element: <Shell><Receive /></Shell> },
       { path: 'customers', element: <Shell><Customers /></Shell> },
       { path: 'close-day', element: <Shell><CloseDay /></Shell> },
-      { path: 'settings',  element: <Shell><Settings /></Shell> },
       { path: 'onboarding', element: <Shell><Onboarding /></Shell> },
     ],
   },

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -94,9 +94,9 @@ const QUICK_LINKS: Array<{
     description: 'Balance the till, review totals, and lock in a clean daily report.',
   },
   {
-    to: '/settings',
-    title: 'Settings',
-    description: 'Configure staff, taxes, and other controls that keep your shop running.',
+    to: '/customers',
+    title: 'Customers',
+    description: 'Look up purchase history, reward loyal shoppers, and keep profiles up to date.',
   },
 ]
 

--- a/web/src/pages/Onboarding.test.tsx
+++ b/web/src/pages/Onboarding.test.tsx
@@ -55,6 +55,6 @@ describe('Onboarding page', () => {
 
     expect(screen.getByRole('heading', { name: /welcome to sedifex/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /confirm your owner account/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /open staff access settings/i })).toBeInTheDocument()
+    expect(screen.getByText(/need to update access later/i)).toBeInTheDocument()
   })
 })

--- a/web/src/pages/Onboarding.tsx
+++ b/web/src/pages/Onboarding.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { useAuthUser } from '../hooks/useAuthUser'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { getOnboardingStatus, setOnboardingStatus, type OnboardingStatus } from '../utils/onboarding'
 import './Onboarding.css'
-
-const STAFF_ACCESS_PATH = '/settings?panel=staff'
 
 export default function Onboarding() {
   const user = useAuthUser()
@@ -78,7 +76,7 @@ export default function Onboarding() {
         </header>
         <p>
           You&apos;re signed in as the store owner. We recommend keeping this login private and using it only for
-          high-impact settings like payouts, data exports, and staff access. Add a recovery email in case you ever
+          high-impact controls like payouts, data exports, and staff access. Add a recovery email in case you ever
           need to reset your password.
         </p>
         <ul className="onboarding-card__list">
@@ -102,11 +100,11 @@ export default function Onboarding() {
         <ul className="onboarding-card__list">
           <li>Managers can run inventory and day-close workflows.</li>
           <li>Cashiers can sell, receive stock, and view customer history.</li>
-          <li>Owners always retain full settings and billing access.</li>
+          <li>Owners always retain full admin and billing access.</li>
         </ul>
-        <Link className="primary-button onboarding-card__cta" to={STAFF_ACCESS_PATH}>
-          Open staff access settings
-        </Link>
+        <p className="onboarding-card__cta">
+          Need to update access later? Your Sedifex account manager can help tailor roles for your team.
+        </p>
       </section>
 
       <section className="card onboarding-card" aria-labelledby="onboarding-step-3">
@@ -117,8 +115,8 @@ export default function Onboarding() {
           </h2>
         </header>
         <p>
-          Once you&apos;ve added your teammates, you&apos;re ready to jump into the dashboard. You can always return to
-          staff access from Settings to make changes later.
+          Once you&apos;ve added your teammates, you&apos;re ready to jump into the dashboard. You can always revisit
+          staff access later to make changes.
         </p>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- remove the defunct settings route from the router and navigation shell
- swap the dashboard quick link to point at the customers workspace
- refresh onboarding copy and expectations to avoid linking to the removed settings page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d7b7de38148321aa671795f22e2f13