### PR TITLE
Remove storeSettings rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -100,12 +100,6 @@ service cloud.firestore {
       allow delete: if hasRole(resource.data.storeId, ['owner','manager']);
     }
 
-    match /storeSettings/{id} {
-      allow read: if hasRole(resource.data.storeId, ['owner','manager']);
-      allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);
-      allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
-    }
-
     match /storeGoals/{id} {
       allow read: if inStore(resource.data.storeId);
       allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);


### PR DESCRIPTION
## Summary
- remove the storeSettings collection security rule block from the Firestore ruleset
- confirmed no other backend assets reference the storeSettings collection

## Testing
- firebase deploy --only firestore:rules *(fails: firebase CLI not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bc42d4d08321addf3954432aeecb