### PR TITLE
Allow cashiers to create products and customers

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -76,13 +76,13 @@ service cloud.firestore {
 
     match /products/{id} {
       allow read: if inStore(resource.data.storeId);
-      allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);
+      allow create: if hasRole(request.resource.data.storeId, ['owner','manager','cashier']);
       allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
     }
 
     match /customers/{id} {
       allow read: if inStore(resource.data.storeId);
-      allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);
+      allow create: if hasRole(request.resource.data.storeId, ['owner','manager','cashier']);
       allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
     }
 


### PR DESCRIPTION
## Summary
- allow the cashier role to create product and customer documents in Firestore rules

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7c5835dec8321ba11a5f973b11a3d