### PR TITLE
Relax store write rules for staging testing

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -76,40 +76,46 @@ service cloud.firestore {
 
     match /products/{id} {
       allow read: if inStore(resource.data.storeId);
-      allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);
-      allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
+      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
+      allow create: if inStore(request.resource.data.storeId);
+      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
     }
 
     match /customers/{id} {
       allow read: if inStore(resource.data.storeId);
-      allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);
-      allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
+      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
+      allow create: if inStore(request.resource.data.storeId);
+      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
     }
 
     match /sales/{id} {
       allow read: if inStore(resource.data.storeId);
       // cashiers/managers/owners: your existing inStore() covers who can create a sale
       allow create: if inStore(request.resource.data.storeId);
-      allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
+      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
+      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
     }
 
     match /expenses/{id} {
       allow read: if inStore(resource.data.storeId);
-      allow create: if hasRole(request.resource.data.storeId, ['owner','manager','cashier']);
-      allow update: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
-      allow delete: if hasRole(resource.data.storeId, ['owner','manager']);
+      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
+      allow create: if inStore(request.resource.data.storeId);
+      allow update: if inStore(resource.data.storeId) && storeIdUnchanged();
+      allow delete: if inStore(resource.data.storeId);
     }
 
     match /storeGoals/{id} {
       allow read: if inStore(resource.data.storeId);
-      allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);
-      allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
+      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
+      allow create: if inStore(request.resource.data.storeId);
+      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
     }
 
     match /closeouts/{id} {
       allow read: if inStore(resource.data.storeId);
-      allow create: if hasRole(request.resource.data.storeId, ['owner','manager']);
-      allow update, delete: if hasRole(resource.data.storeId, ['owner','manager']) && storeIdUnchanged();
+      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
+      allow create: if inStore(request.resource.data.storeId);
+      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
     }
 
     match /storeUsers/{membershipId} {


### PR DESCRIPTION
## Summary
- relax the store-scoped Firestore write rules to allow any member of a store to create, update, or delete documents during staging/testing
- document directly in the rules that this broader access is temporary and should be reverted before production hardening

## Testing
- `firebase deploy --only firestore:rules` *(fails: firebase CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c65dd07c8321b8b6ad7047d9b81e