### PR TITLE
Increase opacity for cards and controls

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -111,10 +111,10 @@ body {
 }
 
 .info-card {
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.82), rgba(24, 33, 53, 0.78));
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(24, 33, 53, 0.9));
   border-radius: 28px;
   padding: clamp(20px, 3vw, 30px);
-  border: 1px solid rgba(148, 163, 184, 0.22);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: 0 24px 60px -32px rgba(15, 23, 42, 0.9);
   display: grid;
   gap: 14px;
@@ -202,11 +202,11 @@ body {
 .app__card {
   position: relative;
   width: min(520px, 100%);
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(24, 33, 53, 0.8));
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.96), rgba(24, 33, 53, 0.92));
   border-radius: 32px;
   padding: clamp(28px, 4vw, 44px);
   box-shadow: var(--shadow-card);
-  border: 1px solid rgba(148, 163, 184, 0.28);
+  border: 1px solid rgba(148, 163, 184, 0.4);
   backdrop-filter: blur(26px);
   -webkit-backdrop-filter: blur(26px);
 }
@@ -365,8 +365,8 @@ body {
   display: inline-flex;
   padding: 5px;
   border-radius: 16px;
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(99, 102, 241, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(99, 102, 241, 0.55);
   margin-top: 18px;
   backdrop-filter: blur(16px);
 }
@@ -389,9 +389,9 @@ body {
 }
 
 .toggle-button.is-active {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.22) 0%, rgba(168, 85, 247, 0.3) 100%);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.32) 0%, rgba(168, 85, 247, 0.42) 100%);
   color: var(--color-text-primary);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.3), 0 14px 28px -20px rgba(99, 102, 241, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.36), 0 14px 28px -20px rgba(99, 102, 241, 0.7);
   transform: translateY(-1px);
 }
 
@@ -419,8 +419,8 @@ body {
   gap: 8px;
   padding: 8px 14px;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.4);
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -486,9 +486,9 @@ input[type="email"],
 input[type="password"] {
   padding: 15px 18px;
   border-radius: 16px;
-  border: 1px solid var(--color-border);
+  border: 1px solid rgba(148, 163, 184, 0.45);
   font-size: 15px;
-  background: rgba(15, 23, 42, 0.65);
+  background: rgba(15, 23, 42, 0.88);
   color: var(--color-text-primary);
   transition: border 160ms ease, box-shadow 160ms ease, transform 160ms ease;
   backdrop-filter: blur(8px);
@@ -544,8 +544,8 @@ input[disabled] {
   display: flex;
   align-items: center;
   gap: 8px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.88);
 }
 
 .status--loading {
@@ -584,8 +584,8 @@ input[disabled] {
   width: 100%;
   padding: 14px 16px;
   border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(15, 23, 42, 0.82);
   font-weight: 600;
   font-size: 14px;
   color: var(--color-text-primary);


### PR DESCRIPTION
## Summary
- increase the opacity of info cards, primary cards, toggles, pills, status banners, secondary buttons, and auth inputs for a stronger fill
- adjust matching borders and gradients so the heavier backgrounds maintain contrast and hover treatments

## Testing
- npm run build *(fails: src/pages/Products.tsx:186:38 - error TS2345: Argument of type '{ id: string; }[]' is not assignable to parameter of type '{ updatedAt?: unknown; createdAt?: unknown; }[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c7508df48321bb199264ecabbfe2