### PR TITLE
Add phone capture to signup and store creation

### DIFF
--- a/web/src/controllers/storeController.ts
+++ b/web/src/controllers/storeController.ts
@@ -4,18 +4,24 @@ import { httpsCallable } from 'firebase/functions';
 import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
 import { db, functions } from '../firebase';
 
-export async function createMyFirstStore() {
+type CreateMyFirstStoreOptions = {
+  phone: string;
+};
+
+export async function createMyFirstStore(options: CreateMyFirstStoreOptions) {
   const auth = getAuth();
   const user = auth.currentUser;
   if (!user) throw new Error('Not signed in');
 
   const storeId = user.uid;
+  const ownerPhone = options.phone;
 
   // 1) Create the store (id == uid)
   await setDoc(doc(db, 'stores', storeId), {
     storeId,
     ownerId: user.uid,
     ownerEmail: user.email ?? null,
+    ownerPhone,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
   }, { merge: true });
@@ -25,6 +31,7 @@ export async function createMyFirstStore() {
     uid: user.uid,
     role: 'owner',
     email: user.email ?? null,
+    phone: ownerPhone,
     displayName: user.displayName ?? null,
     photoURL: user.photoURL ?? null,
     createdAt: serverTimestamp(),


### PR DESCRIPTION
## Summary
- add phone and normalized phone state to the signup flow with validation and sanitization
- render a phone input and sanitize it before submitting while preventing submission without a phone number
- persist the captured phone number when creating the initial store record

## Testing
- npm --prefix web run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68d7efcb4d6883219c4c67c5bc63b7b4