### PR TITLE
Propagate owner contact metadata during store setup

### DIFF
--- a/functions/src/callables.ts
+++ b/functions/src/callables.ts
@@ -4,6 +4,10 @@ import * as admin from 'firebase-admin';
 export const backfillMyStore = functions.https.onCall(async (_data, context) => {
   if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Sign in first.');
   const uid = context.auth.uid;
+  const token = context.auth.token as Record<string, unknown>;
+  const email = typeof token.email === 'string' ? (token.email as string) : null;
+  const phone = typeof token.phone_number === 'string' ? (token.phone_number as string) : null;
+  const firstSignupEmail = email;
   const db = admin.firestore();
   const storeId = uid;
 
@@ -16,14 +20,36 @@ export const backfillMyStore = functions.https.onCall(async (_data, context) => 
   const batch = db.batch();
   if (!storeSnap.exists) {
     batch.set(storeRef, {
-      id: storeId, ownerId: uid, createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      id: storeId,
+      ownerId: uid,
+      ownerEmail: email,
+      ownerPhone: phone,
+      firstSignupEmail,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
       updatedAt: admin.firestore.FieldValue.serverTimestamp(), plan: 'free', status: 'active',
     });
   }
   if (!memberSnap.exists) {
-    batch.set(memberRef, { uid, role: 'owner', createdAt: admin.firestore.FieldValue.serverTimestamp() });
+    batch.set(memberRef, {
+      uid,
+      role: 'owner',
+      email,
+      phone,
+      firstSignupEmail,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
   }
-  batch.set(mapRef, { uid, storeId, role: 'owner', createdAt: admin.firestore.FieldValue.serverTimestamp() });
+  batch.set(mapRef, {
+    uid,
+    storeId,
+    role: 'owner',
+    email,
+    phone,
+    firstSignupEmail,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
 
   await batch.commit();
   await admin.auth().setCustomUserClaims(uid, { storeId, role: 'owner' });

--- a/functions/src/onAuthCreate.ts
+++ b/functions/src/onAuthCreate.ts
@@ -9,6 +9,9 @@ export const onAuthCreate = functions.auth.user().onCreate(async (user) => {
   const db = getFirestore();
   const uid = user.uid;
   const storeId = uid; // simple 1:1 default
+  const ownerEmail = user.email ?? null;
+  const ownerPhone = user.phoneNumber ?? null;
+  const firstSignupEmail = ownerEmail;
 
   const storeRef = db.doc(`stores/${storeId}`);
   const memberRef = db.doc(`stores/${storeId}/members/${uid}`);
@@ -22,6 +25,9 @@ export const onAuthCreate = functions.auth.user().onCreate(async (user) => {
     batch.set(storeRef, {
       id: storeId,
       ownerId: uid,
+      ownerEmail,
+      ownerPhone,
+      firstSignupEmail,
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       plan: 'free',
@@ -33,7 +39,11 @@ export const onAuthCreate = functions.auth.user().onCreate(async (user) => {
     batch.set(memberRef, {
       uid,
       role: 'owner',
+      email: ownerEmail,
+      phone: ownerPhone,
+      firstSignupEmail,
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
     });
   }
 
@@ -41,7 +51,11 @@ export const onAuthCreate = functions.auth.user().onCreate(async (user) => {
     uid,
     storeId,
     role: 'owner',
+    email: ownerEmail,
+    phone: ownerPhone,
+    firstSignupEmail,
     createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
   });
 
   await batch.commit();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -325,7 +325,12 @@ export default function App() {
           sanitizedEmail,
           sanitizedPassword,
         )
-        await createMyFirstStore({ phone: sanitizedPhone })
+        await createMyFirstStore({
+          contact: {
+            phone: sanitizedPhone,
+            firstSignupEmail: sanitizedEmail,
+          },
+        })
         await persistSession(nextUser)
         try {
           await nextUser.getIdToken(true)


### PR DESCRIPTION
## Summary
- capture the phone and initial email in createMyFirstStore and pass them to initializeStore without clobbering existing metadata
- thread optional contact details through initializeStore and related helpers so owner and membership documents store phone/firstSignupEmail consistently
- update callable bootstrap paths to mirror the new schema when creating owner records

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68d7f1a1763c832182bfd32fca03417d