### PR TITLE
Add marketing feature cards to the landing page

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -102,6 +102,108 @@ body {
   z-index: 1;
 }
 
+.app__features {
+  width: min(1280px, 100%);
+  display: grid;
+  gap: clamp(24px, 5vw, 40px);
+  z-index: 1;
+}
+
+.app__features-header {
+  max-width: 720px;
+  display: grid;
+  gap: 12px;
+}
+
+.app__features-header h2 {
+  margin: 0;
+  font-size: clamp(22px, 4vw, 32px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.app__features-header p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.app__features-grid {
+  display: grid;
+  gap: clamp(16px, 4vw, 28px);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 26px);
+  padding: clamp(20px, 3vw, 28px);
+  border-radius: 24px;
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.94), rgba(17, 24, 39, 0.88));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  text-decoration: none;
+  color: var(--color-text-primary);
+  box-shadow: 0 26px 60px -36px rgba(15, 23, 42, 0.85);
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.feature-card:hover,
+.feature-card:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(99, 102, 241, 0.55);
+  box-shadow: 0 28px 68px -30px rgba(37, 99, 235, 0.6);
+}
+
+.feature-card:focus-visible {
+  outline: 2px solid rgba(191, 219, 254, 0.85);
+  outline-offset: 3px;
+}
+
+.feature-card__body {
+  display: grid;
+  gap: 10px;
+}
+
+.feature-card__body h3 {
+  margin: 0;
+  font-size: clamp(18px, 3vw, 22px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.feature-card__body p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.feature-card__cta {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: rgba(148, 163, 184, 0.9);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-transform: uppercase;
+}
+
+.feature-card__cta::after {
+  content: '→';
+  font-size: 16px;
+  color: var(--color-accent-start);
+  transition: transform 180ms ease;
+}
+
+.feature-card:hover .feature-card__cta::after,
+.feature-card:focus-visible .feature-card__cta::after {
+  transform: translateX(3px);
+}
+
 .app__info-grid {
   width: min(1280px, 100%);
   display: grid;
@@ -190,6 +292,16 @@ body {
     grid-template-columns: minmax(0, 520px) minmax(0, 1fr);
     align-items: center;
     gap: clamp(32px, 6vw, 72px);
+  }
+
+  .app__features {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .app__features-header {
+    max-width: none;
+    padding-right: clamp(10px, 4vw, 40px);
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -382,6 +382,34 @@ export default function App() {
   }
 
   if (!user) {
+    const PAGE_FEATURES = [
+      {
+        path: '/products',
+        name: 'Products',
+        description: 'Spot low inventory, sync counts, and keep every SKU accurate across locations.',
+      },
+      {
+        path: '/sell',
+        name: 'Sell',
+        description: 'Ring up sales with guided workflows that keep the floor moving and customers happy.',
+      },
+      {
+        path: '/receive',
+        name: 'Receive',
+        description: 'Check in purchase orders, reconcile deliveries, and put new stock to work immediately.',
+      },
+      {
+        path: '/customers',
+        name: 'Customers',
+        description: 'Understand top shoppers, loyalty trends, and service follow-ups without exporting data.',
+      },
+      {
+        path: '/close-day',
+        name: 'Close Day',
+        description: 'Tie out cash, settle registers, and share end-of-day reports with finance in one view.',
+      },
+    ] as const
+
     return (
       <main className="app" style={appStyle}>
         <div className="app__layout">
@@ -586,6 +614,36 @@ export default function App() {
             </div>
           </aside>
         </div>
+
+        <section className="app__features" aria-label="Sedifex workspace pages">
+          <header className="app__features-header">
+            <h2>Explore the workspace</h2>
+            <p>
+              Every Sedifex page is built to keep retail operations synchronized—from the sales
+              floor to finance.
+            </p>
+          </header>
+
+          <div className="app__features-grid" role="list">
+            {PAGE_FEATURES.map(feature => (
+              <Link
+                key={feature.path}
+                className="feature-card"
+                to={feature.path}
+                role="listitem"
+                aria-label={`Open the ${feature.name} page`}
+              >
+                <div className="feature-card__body">
+                  <h3>{feature.name}</h3>
+                  <p>{feature.description}</p>
+                </div>
+                <span className="feature-card__cta" aria-hidden="true">
+                  Visit {feature.name}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </section>
 
         <section className="app__info-grid" aria-label="Sedifex company information">
           <article className="info-card">

--- a/web/src/hooks/useEnsureOnboarded.ts
+++ b/web/src/hooks/useEnsureOnboarded.ts
@@ -1,4 +1,5 @@
 // web/src/hooks/useEnsureOnboarded.ts
+import React from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { getAuth, onIdTokenChanged } from 'firebase/auth';
 import { functions } from '../firebase';


### PR DESCRIPTION
## Summary
- introduce a feature list in the unauthenticated landing view so visitors can browse each workspace page
- add styled feature cards and responsive layout rules that align with the existing hero and info sections
- import React in useEnsureOnboarded to prevent runtime and type errors during builds

## Testing
- npm run build *(fails: existing type error in src/pages/Products.tsx when calling saveCachedProducts)*

------
https://chatgpt.com/codex/tasks/task_e_68d80a67313c8321a3a431b9e749f321