### PR TITLE
Require custom store codes during signup

### DIFF
--- a/functions/src/callables.ts
+++ b/functions/src/callables.ts
@@ -1,58 +1,171 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 
-export const backfillMyStore = functions.https.onCall(async (_data, context) => {
+const STORE_CODE_PATTERN = /^[A-Z]{6}$/;
+
+function normalizeStoreCode(value: unknown) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const trimmed = value.trim().toUpperCase();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (!STORE_CODE_PATTERN.test(trimmed)) {
+    throw new functions.https.HttpsError('invalid-argument', 'Store code must be exactly six letters.');
+  }
+
+  return trimmed;
+}
+
+function normalizeContact(data: unknown) {
+  if (!data || typeof data !== 'object') {
+    return { phone: null as string | null, firstSignupEmail: null as string | null };
+  }
+
+  const contact = data as Record<string, unknown>;
+  const rawPhone = typeof contact.phone === 'string' ? contact.phone.trim() : '';
+  const phone = rawPhone ? rawPhone : null;
+  const rawFirstSignupEmail =
+    typeof contact.firstSignupEmail === 'string' ? contact.firstSignupEmail.trim().toLowerCase() : '';
+  const firstSignupEmail = rawFirstSignupEmail ? rawFirstSignupEmail : null;
+  return { phone, firstSignupEmail };
+}
+
+export const backfillMyStore = functions.https.onCall(async (data, context) => {
   if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Sign in first.');
   const uid = context.auth.uid;
   const token = context.auth.token as Record<string, unknown>;
   const email = typeof token.email === 'string' ? (token.email as string) : null;
   const phone = typeof token.phone_number === 'string' ? (token.phone_number as string) : null;
-  const firstSignupEmail = email;
+
+  const payload = data ?? {};
+  const storeId = normalizeStoreCode((payload as Record<string, unknown>).storeCode);
+  if (!storeId) {
+    throw new functions.https.HttpsError('invalid-argument', 'A valid store code is required.');
+  }
+
+  const { phone: contactPhone, firstSignupEmail: contactFirstSignupEmail } = normalizeContact(
+    (payload as Record<string, unknown>).contact,
+  );
+  const resolvedPhone = contactPhone ?? phone;
+  const resolvedFirstSignupEmail = contactFirstSignupEmail ?? email;
   const db = admin.firestore();
-  const storeId = uid;
 
   const storeRef = db.doc(`stores/${storeId}`);
   const memberRef = db.doc(`stores/${storeId}/members/${uid}`);
   const mapRef = db.doc(`storeUsers/${storeId}_${uid}`);
 
-  const [storeSnap, memberSnap] = await db.getAll(storeRef, memberRef);
+  const [storeSnap, memberSnap, mapSnap] = await db.getAll(storeRef, memberRef, mapRef);
+  if (storeSnap.exists) {
+    const ownerId = storeSnap.get('ownerId');
+    if (ownerId && ownerId !== uid) {
+      throw new functions.https.HttpsError('already-exists', 'That store code is already in use.');
+    }
+  }
+
+  const timestamp = admin.firestore.FieldValue.serverTimestamp();
 
   const batch = db.batch();
-  if (!storeSnap.exists) {
-    batch.set(storeRef, {
+  batch.set(
+    storeRef,
+    {
+      storeId,
       id: storeId,
       ownerId: uid,
       ownerEmail: email,
-      ownerPhone: phone,
-      firstSignupEmail,
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(), plan: 'free', status: 'active',
-    });
-  }
+      ownerPhone: resolvedPhone ?? null,
+      firstSignupEmail: resolvedFirstSignupEmail ?? null,
+      updatedAt: timestamp,
+      ...(storeSnap.exists
+        ? {}
+        : { createdAt: timestamp, plan: 'free', status: 'active' }),
+    },
+    { merge: true },
+  );
+
   if (!memberSnap.exists) {
-    batch.set(memberRef, {
+    batch.set(
+      memberRef,
+      {
+        uid,
+        role: 'owner',
+        email,
+        phone: resolvedPhone ?? null,
+        firstSignupEmail: resolvedFirstSignupEmail ?? null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+      { merge: true },
+    );
+  } else {
+    batch.set(
+      memberRef,
+      {
+        phone: resolvedPhone ?? null,
+        firstSignupEmail: resolvedFirstSignupEmail ?? null,
+        updatedAt: timestamp,
+      },
+      { merge: true },
+    );
+  }
+
+  batch.set(
+    mapRef,
+    {
       uid,
+      storeId,
       role: 'owner',
       email,
-      phone,
-      firstSignupEmail,
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    });
-  }
-  batch.set(mapRef, {
-    uid,
-    storeId,
-    role: 'owner',
-    email,
-    phone,
-    firstSignupEmail,
-    createdAt: admin.firestore.FieldValue.serverTimestamp(),
-    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-  });
+      phone: resolvedPhone ?? null,
+      firstSignupEmail: resolvedFirstSignupEmail ?? null,
+      updatedAt: timestamp,
+      ...(mapSnap.exists ? {} : { createdAt: timestamp }),
+    },
+    { merge: true },
+  );
 
   await batch.commit();
-  await admin.auth().setCustomUserClaims(uid, { storeId, role: 'owner' });
 
-  return { ok: true, storeId };
+  const membershipsSnapshot = await db.collection('storeUsers').where('uid', '==', uid).get();
+  const stores = Array.from(
+    new Set(
+      membershipsSnapshot.docs
+        .map(doc => doc.get('storeId'))
+        .filter((value): value is string => typeof value === 'string' && value.length > 0),
+    ),
+  );
+  const roleByStore = membershipsSnapshot.docs.reduce<Record<string, string>>((acc, doc) => {
+    const membershipStoreId = doc.get('storeId');
+    const membershipRole = doc.get('role');
+    if (typeof membershipStoreId === 'string' && typeof membershipRole === 'string') {
+      acc[membershipStoreId] = membershipRole;
+    }
+    return acc;
+  }, {});
+
+  const existingClaims = await admin
+    .auth()
+    .getUser(uid)
+    .then(result => (result.customClaims ?? {}) as Record<string, unknown>)
+    .catch(() => ({} as Record<string, unknown>));
+
+  const activeStoreId = stores.includes(storeId)
+    ? storeId
+    : (typeof existingClaims.activeStoreId === 'string' && stores.includes(existingClaims.activeStoreId)
+        ? (existingClaims.activeStoreId as string)
+        : stores[0] ?? null);
+
+  const nextClaims = {
+    ...existingClaims,
+    stores,
+    activeStoreId,
+    roleByStore,
+  };
+
+  await admin.auth().setCustomUserClaims(uid, nextClaims);
+
+  return { ok: true, storeId, claims: nextClaims };
 });

--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -70,7 +70,6 @@ function resolveStoreId(
   stores: string[],
   activeClaim: string | null,
   persistedStoreId: string | null,
-  fallbackUid: string | null,
 ): string | null {
   if (activeClaim && stores.includes(activeClaim)) {
     return activeClaim
@@ -84,7 +83,7 @@ function resolveStoreId(
     return stores[0]
   }
 
-  return fallbackUid ?? null
+  return null
 }
 
 export function useActiveStore(): ActiveStoreState {
@@ -136,7 +135,7 @@ export function useActiveStore(): ActiveStoreState {
         const claims: StoreClaims = result.claims as StoreClaims
         const stores = normalizeStoreList(claims)
         const activeClaim = typeof claims.activeStoreId === 'string' ? claims.activeStoreId : null
-        const resolvedStoreId = resolveStoreId(stores, activeClaim, persistedStoreId, user.uid)
+        const resolvedStoreId = resolveStoreId(stores, activeClaim, persistedStoreId)
 
         if (resolvedStoreId && stores.includes(resolvedStoreId)) {
           persistStoreId(user.uid, resolvedStoreId)
@@ -155,7 +154,7 @@ export function useActiveStore(): ActiveStoreState {
         console.warn('[store] Unable to resolve store from auth claims', error)
         if (cancelled) return
         setState({
-          storeId: user.uid ?? null,
+          storeId: null,
           stores: [],
           isLoading: false,
           error: 'We could not determine your store access. Some actions may fail.',

--- a/web/src/hooks/useEnsureOnboarded.ts
+++ b/web/src/hooks/useEnsureOnboarded.ts
@@ -1,29 +1,26 @@
 // web/src/hooks/useEnsureOnboarded.ts
 import React from 'react';
-import { httpsCallable } from 'firebase/functions';
 import { getAuth, onIdTokenChanged } from 'firebase/auth';
-import { functions } from '../firebase';
 
 export function useEnsureOnboarded() {
   // Call once after login or when token changes
   React.useEffect(() => {
     const auth = getAuth();
 
-    const unsub = onIdTokenChanged(auth, async (user) => {
+    const unsub = onIdTokenChanged(auth, async user => {
       if (!user) return;
-      // Try to read claims
-      const token = await user.getIdTokenResult();
-      const hasStore = !!token.claims?.storeId;
 
-      if (!hasStore) {
-        try {
-          const backfill = httpsCallable(functions, 'backfillMyStore');
-          await backfill({});
-          // Force refresh claims
+      try {
+        const token = await user.getIdTokenResult();
+        const stores = Array.isArray(token.claims?.stores)
+          ? token.claims.stores.filter((value): value is string => typeof value === 'string' && value.length > 0)
+          : [];
+
+        if (stores.length === 0) {
           await user.getIdToken(true);
-        } catch (e) {
-          console.error('[onboarding] backfill failed', e);
         }
+      } catch (error) {
+        console.error('[onboarding] Unable to refresh store claims', error);
       }
     });
 

--- a/web/src/pages/Onboarding.test.tsx
+++ b/web/src/pages/Onboarding.test.tsx
@@ -31,13 +31,13 @@ describe('Onboarding page', () => {
     mockSetOnboardingStatus.mockReset()
 
     mockUseAuthUser.mockReturnValue({
-      uid: 'store-123',
+      uid: 'user-123',
       email: 'owner@example.com',
     })
 
     mockUseActiveStore.mockReturnValue({
-      storeId: 'store-123',
-      stores: ['store-123'],
+      storeId: 'ORBITX',
+      stores: ['ORBITX'],
       isLoading: false,
       error: null,
       selectStore: vi.fn(),
@@ -56,5 +56,6 @@ describe('Onboarding page', () => {
     expect(screen.getByRole('heading', { name: /welcome to sedifex/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /confirm your owner account/i })).toBeInTheDocument()
     expect(screen.getByText(/need to update access later/i)).toBeInTheDocument()
+    expect(screen.getByText(/let's secure your store \(ORBITX\)/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- add store-code state and validation to the signup form so only six-letter codes are accepted and sent to the backend
- update store creation logic and Firebase functions to create stores, memberships, and claims under the chosen code instead of the UID
- refresh onboarding helpers and tests to rely on manual codes instead of UID fallbacks

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d8192c5c988321a19ce477e838c6fd