### PR TITLE
Relax store bootstrap Firestore rule constraints

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -33,8 +33,8 @@ service cloud.firestore {
     match /stores/{storeId} {
       // Self-bootstrap: create /stores/{uid} once, if no membership doc exists yet
       allow create: if isAuthed()
-        && storeId == request.auth.uid
-        && !exists(/databases/$(database)/documents/stores/$(request.auth.uid)/members/$(request.auth.uid));
+        && request.resource.data.ownerId == request.auth.uid
+        && !exists(/databases/$(database)/documents/stores/$(storeId)/members/$(request.auth.uid));
 
       // Owners & managers can update/delete store metadata
       allow update, delete: if hasRole(storeId, ['owner','manager']);
@@ -48,10 +48,11 @@ service cloud.firestore {
         // Self-bootstrap owner membership:
         // allow creating /stores/{uid}/members/{uid} with role 'owner' once.
         allow create: if isAuthed()
-          && storeId == request.auth.uid
           && memberId == request.auth.uid
+          && request.resource.data.uid == request.auth.uid
+          && request.resource.data.storeId == storeId
           && request.resource.data.role == 'owner'
-          && !exists(/databases/$(database)/documents/stores/$(request.auth.uid)/members/$(request.auth.uid));
+          && !exists(/databases/$(database)/documents/stores/$(storeId)/members/$(request.auth.uid));
 
         // Read: anyone in the store can read members; always allow a user to read their own membership
         allow read: if inStore(storeId)


### PR DESCRIPTION
## Summary
- allow creating stores when the authenticated caller is the owner and lacks an existing membership for that store id
- require owner membership creation requests to match the caller's uid, storeId, and role without restricting the store id itself

## Testing
- firebase deploy --only firestore:rules *(fails: firebase CLI unavailable in the environment due to npm 403 when installing firebase-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68d8261255e083218ed752b6d2a769f1