### PR TITLE
Simplify active store resolution

### DIFF
--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -1,6 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { httpsCallable } from 'firebase/functions'
-import { functions } from '../firebase'
 import { useAuthUser } from './useAuthUser'
 
 interface ActiveStoreState {
@@ -9,10 +7,6 @@ interface ActiveStoreState {
   isLoading: boolean
   error: string | null
   selectStore: (storeId: string) => void
-  needsStoreResolution: boolean
-  resolveStoreAccess: (storeCode: string) => Promise<{ ok: boolean; error: string | null }>
-  isResolvingStoreAccess: boolean
-  resolutionError: string | null
 }
 
 interface StoreClaims {
@@ -25,30 +19,10 @@ interface InternalStoreState {
   stores: string[]
   isLoading: boolean
   error: string | null
-  requiresManualEntry: boolean
-  isResolving: boolean
-  resolutionError: string | null
 }
 
 const ACTIVE_STORE_STORAGE_PREFIX = 'sedifex.activeStore.'
-const STORE_CODE_PATTERN = /^[A-Z]{6}$/
-const NO_STORE_MESSAGE =
-  'We could not find any stores linked to your account. Enter your store code to restore access.'
-
-type ResolveStoreAccessPayload = {
-  storeCode: string
-}
-
-type ResolveStoreAccessResponse = {
-  ok: boolean
-  storeId: string | null
-  claims?: StoreClaims
-}
-
-type StoreResolutionResult = {
-  ok: boolean
-  error: string | null
-}
+const NO_STORE_MESSAGE = 'We could not find any stores linked to your account.'
 
 function normalizeStoreList(claims: StoreClaims): string[] {
   if (!Array.isArray(claims.stores)) {
@@ -120,9 +94,6 @@ export function useActiveStore(): ActiveStoreState {
     stores: [],
     isLoading: Boolean(user),
     error: null,
-    requiresManualEntry: false,
-    isResolving: false,
-    resolutionError: null,
   })
 
   const selectStore = useCallback(
@@ -140,7 +111,6 @@ export function useActiveStore(): ActiveStoreState {
         return {
           ...prev,
           storeId,
-          resolutionError: null,
         }
       })
     },
@@ -156,9 +126,6 @@ export function useActiveStore(): ActiveStoreState {
         stores: [],
         isLoading: false,
         error: null,
-        requiresManualEntry: false,
-        isResolving: false,
-        resolutionError: null,
       })
       return
     }
@@ -167,7 +134,6 @@ export function useActiveStore(): ActiveStoreState {
       ...prev,
       isLoading: true,
       error: null,
-      resolutionError: null,
     }))
 
     const persistedStoreId = readPersistedStoreId(user.uid)
@@ -192,9 +158,6 @@ export function useActiveStore(): ActiveStoreState {
           stores,
           isLoading: false,
           error: stores.length === 0 ? NO_STORE_MESSAGE : null,
-          requiresManualEntry: stores.length === 0,
-          isResolving: false,
-          resolutionError: null,
         })
       })
       .catch(error => {
@@ -205,9 +168,6 @@ export function useActiveStore(): ActiveStoreState {
           stores: [],
           isLoading: false,
           error: 'We could not determine your store access. Some actions may fail.',
-          requiresManualEntry: false,
-          isResolving: false,
-          resolutionError: null,
         })
       })
 
@@ -216,97 +176,6 @@ export function useActiveStore(): ActiveStoreState {
     }
   }, [user])
 
-  const resolveStoreAccess = useCallback(
-    async (rawCode: string): Promise<StoreResolutionResult> => {
-      if (!user) {
-        setState(prev => ({
-          ...prev,
-          resolutionError: 'Sign in again to restore store access.',
-        }))
-        return { ok: false, error: 'Sign in again to restore store access.' }
-      }
-
-      const normalizedCode = typeof rawCode === 'string' ? rawCode.trim().toUpperCase() : ''
-      if (!STORE_CODE_PATTERN.test(normalizedCode)) {
-        setState(prev => ({
-          ...prev,
-          resolutionError: 'Store codes must be exactly six letters.',
-        }))
-        return { ok: false, error: 'Store codes must be exactly six letters.' }
-      }
-
-      setState(prev => ({ ...prev, isResolving: true, resolutionError: null }))
-
-      try {
-        const callable = httpsCallable<ResolveStoreAccessPayload, ResolveStoreAccessResponse>(
-          functions,
-          'resolveStoreAccess',
-        )
-        await callable({ storeCode: normalizedCode })
-
-        const tokenResult = await user.getIdTokenResult(true)
-        const claims: StoreClaims = tokenResult.claims as StoreClaims
-        const stores = normalizeStoreList(claims)
-        const activeClaim =
-          typeof claims.activeStoreId === 'string' && stores.includes(claims.activeStoreId)
-            ? claims.activeStoreId
-            : null
-        const persistedStoreId = readPersistedStoreId(user.uid)
-        const resolvedStoreId = resolveStoreId(
-          stores,
-          activeClaim ?? (stores.includes(normalizedCode) ? normalizedCode : null),
-          stores.includes(normalizedCode) ? normalizedCode : persistedStoreId,
-        )
-
-        if (resolvedStoreId && stores.includes(resolvedStoreId)) {
-          persistStoreId(user.uid, resolvedStoreId)
-        } else {
-          persistStoreId(user.uid, null)
-        }
-
-        setState({
-          storeId: resolvedStoreId,
-          stores,
-          isLoading: false,
-          error: stores.length === 0 ? NO_STORE_MESSAGE : null,
-          requiresManualEntry: stores.length === 0,
-          isResolving: false,
-          resolutionError: stores.length === 0 ? 'We could not link that store code.' : null,
-        })
-
-        const success = stores.length > 0
-        return {
-          ok: success,
-          error: success ? null : 'We could not link that store code.',
-        }
-      } catch (error) {
-        console.warn('[store] Unable to resolve store manually', error)
-        const message = (() => {
-          if (error && typeof error === 'object' && 'code' in error) {
-            const code = String((error as { code?: unknown }).code ?? '')
-            if (code.endsWith('/not-found')) {
-              return 'We could not find a store with that code.'
-            }
-            if (code.endsWith('/permission-denied')) {
-              return 'You do not have access to that store.'
-            }
-            if (code.endsWith('/already-exists')) {
-              return 'That store is already linked to another account.'
-            }
-          }
-          if (error instanceof Error && error.message) {
-            return error.message
-          }
-          return 'We could not verify that store code. Try again.'
-        })()
-
-        setState(prev => ({ ...prev, isResolving: false, resolutionError: message }))
-        return { ok: false, error: message }
-      }
-    },
-    [user],
-  )
-
   return useMemo(
     () => ({
       storeId: state.storeId,
@@ -314,22 +183,7 @@ export function useActiveStore(): ActiveStoreState {
       isLoading: state.isLoading,
       error: state.error,
       selectStore,
-      needsStoreResolution: state.requiresManualEntry,
-      resolveStoreAccess,
-      isResolvingStoreAccess: state.isResolving,
-      resolutionError: state.resolutionError,
     }),
-    [
-      resolveStoreAccess,
-      selectStore,
-      state.error,
-      state.isLoading,
-      state.isResolving,
-      state.resolutionError,
-      state.requiresManualEntry,
-      state.storeId,
-      state.stores,
-    ],
+    [selectStore, state.error, state.isLoading, state.storeId, state.stores],
   )
 }
-

--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -121,6 +121,10 @@
   cursor: pointer;
 }
 
+.shell .shell__store-select[data-readonly] {
+  cursor: default;
+}
+
 .shell .shell__store-select:focus {
   border: none;
   box-shadow: none;
@@ -152,39 +156,6 @@
   font-size: 12px;
   color: #b91c1c;
   font-weight: 500;
-}
-
-.shell__store-recovery {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: flex-end;
-}
-
-.shell__store-recovery-label {
-  font-size: 12px;
-  color: #1f2937;
-  font-weight: 600;
-}
-
-.shell__store-recovery-controls {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.shell__store-recovery-input {
-  width: 120px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.shell__store-recovery-error {
-  font-size: 12px;
-  color: #b91c1c;
-  font-weight: 500;
-  text-align: right;
 }
 
 .shell__account-email {

--- a/web/src/pages/Onboarding.test.tsx
+++ b/web/src/pages/Onboarding.test.tsx
@@ -41,10 +41,6 @@ describe('Onboarding page', () => {
       isLoading: false,
       error: null,
       selectStore: vi.fn(),
-      resolveStoreAccess: vi.fn().mockResolvedValue({ ok: false, error: null }),
-      needsStoreResolution: false,
-      isResolvingStoreAccess: false,
-      resolutionError: null,
     })
 
     mockGetOnboardingStatus.mockReturnValue('pending')

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -153,10 +153,6 @@ describe('Sell page', () => {
       isLoading: false,
       error: null,
       selectStore: selectStoreMock,
-      resolveStoreAccess: vi.fn().mockResolvedValue({ ok: false, error: null }),
-      needsStoreResolution: false,
-      isResolvingStoreAccess: false,
-      resolutionError: null,
     })
     mockCommitSale.mockResolvedValue({
       data: {

--- a/web/src/pages/__tests__/Products.test.tsx
+++ b/web/src/pages/__tests__/Products.test.tsx
@@ -89,10 +89,6 @@ describe('Products page', () => {
       isLoading: false,
       error: null,
       selectStore: vi.fn(),
-      resolveStoreAccess: vi.fn().mockResolvedValue({ ok: false, error: null }),
-      needsStoreResolution: false,
-      isResolvingStoreAccess: false,
-      resolutionError: null,
     })
 
     mockLoadCachedProducts.mockResolvedValue([])
@@ -112,10 +108,6 @@ describe('Products page', () => {
       isLoading: true,
       error: null,
       selectStore: vi.fn(),
-      resolveStoreAccess: vi.fn().mockResolvedValue({ ok: false, error: null }),
-      needsStoreResolution: false,
-      isResolvingStoreAccess: false,
-      resolutionError: null,
     })
 
     render(


### PR DESCRIPTION
## Summary
- remove manual store recovery logic from the active store hook and default to the single claimed store
- simplify the shell header to display the resolved store identifier without a switcher
- update affected unit tests to align with the automatic store selection flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8366c33f4832193f3ad03032bed8d