### PR TITLE
Refactor functions for single-tenant session model

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,122 +8,61 @@ service cloud.firestore {
       return request.auth != null;
     }
 
-    // Members live at: stores/{storeId}/members/{uid}
-    function memberDoc(storeId) {
-      return get(/databases/$(database)/documents/stores/$(storeId)/members/$(request.auth.uid));
+    function hasAnyRole(roles) {
+      return isAuthed() && roles.hasAny([request.auth.token.role]);
     }
 
-    function inStore(storeId) {
-      return isAuthed() && memberDoc(storeId).exists();
+    function ownerOrSelf(uid) {
+      return hasAnyRole(['owner']) || (isAuthed() && request.auth.uid == uid);
     }
 
-    function hasRole(storeId, roles) {
-      return inStore(storeId) && roles.hasAny([memberDoc(storeId).data.role]);
+    /* ---------- Team members & roles ---------- */
+
+    match /teamMembers/{uid} {
+      allow read: if ownerOrSelf(uid);
+      allow create, update, delete: if hasAnyRole(['owner']);
     }
 
-    // ❗ fixed
-    function storeIdUnchanged() {
-      return !request.resource.data.diff(resource.data).changedKeys().hasAny(['storeId']);
+    /* ---------- Business resources (single-tenant) ---------- */
+
+    function staffAccess() {
+      return hasAnyRole(['owner', 'staff']);
     }
-
-    /* ---------- Store bootstrap & management ---------- */
-
-    // Allow a signed-in user to create their FIRST store with id == their uid,
-    // exactly once, and read/update it if they’re in the store.
-    match /stores/{storeId} {
-      // Self-bootstrap: create /stores/{uid} once, if no membership doc exists yet
-      allow create: if isAuthed()
-        && request.resource.data.ownerId == request.auth.uid
-        && !exists(/databases/$(database)/documents/stores/$(storeId)/members/$(request.auth.uid));
-
-      // Owners & managers can update/delete store metadata
-      allow update, delete: if hasRole(storeId, ['owner','manager']);
-
-      // Anyone in the store can read store metadata
-      allow read: if inStore(storeId);
-
-      // Members subcollection
-      match /members/{memberId} {
-
-        // Self-bootstrap owner membership:
-        // allow creating /stores/{uid}/members/{uid} with role 'owner' once.
-        allow create: if isAuthed()
-          && memberId == request.auth.uid
-          && request.resource.data.uid == request.auth.uid
-          && request.resource.data.storeId == storeId
-          && request.resource.data.role == 'owner'
-          && !exists(/databases/$(database)/documents/stores/$(storeId)/members/$(request.auth.uid));
-
-        // Read: anyone in the store can read members; always allow a user to read their own membership
-        allow read: if inStore(storeId)
-          || (isAuthed() && (memberId == request.auth.uid || resource.data.uid == request.auth.uid));
-
-        // Updates:
-        // - Owners can manage roles (add/remove/modify any member)
-        // - Optionally allow users to update a safe subset of their own profile fields (displayName, photoURL)
-        allow update: if hasRole(storeId, ['owner'])
-          || (
-            isAuthed() && memberId == request.auth.uid &&
-            // Only allow self-updates to non-privileged fields
-            request.resource.data.diff(resource.data).changedKeys().hasOnly(['displayName','photoURL'])
-          );
-
-        // Deletions: owners only
-        allow delete: if hasRole(storeId, ['owner']);
-      }
-    }
-
-    /* ---------- Store-scoped collections (top-level, keyed by storeId) ---------- */
 
     match /products/{id} {
-      allow read: if inStore(resource.data.storeId);
-      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
-      allow create: if inStore(request.resource.data.storeId);
-      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
+      allow read, create, update, delete: if staffAccess();
     }
 
     match /customers/{id} {
-      allow read: if inStore(resource.data.storeId);
-      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
-      allow create: if inStore(request.resource.data.storeId);
-      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
+      allow read, create, update, delete: if staffAccess();
     }
 
     match /sales/{id} {
-      allow read: if inStore(resource.data.storeId);
-      // cashiers/managers/owners: your existing inStore() covers who can create a sale
-      allow create: if inStore(request.resource.data.storeId);
-      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
-      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
+      allow read, create, update, delete: if staffAccess();
     }
 
     match /expenses/{id} {
-      allow read: if inStore(resource.data.storeId);
-      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
-      allow create: if inStore(request.resource.data.storeId);
-      allow update: if inStore(resource.data.storeId) && storeIdUnchanged();
-      allow delete: if inStore(resource.data.storeId);
+      allow read, create, update, delete: if staffAccess();
     }
 
     match /storeGoals/{id} {
-      allow read: if inStore(resource.data.storeId);
-      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
-      allow create: if inStore(request.resource.data.storeId);
-      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
+      allow read, create, update, delete: if staffAccess();
     }
 
     match /closeouts/{id} {
-      allow read: if inStore(resource.data.storeId);
-      // TEMP: Relaxed for staging/testing so any store member can write; revert to role checks before production hardening.
-      allow create: if inStore(request.resource.data.storeId);
-      allow update, delete: if inStore(resource.data.storeId) && storeIdUnchanged();
+      allow read, create, update, delete: if staffAccess();
     }
 
-    match /storeUsers/{membershipId} {
-      allow read: if hasRole(resource.data.storeId, ['owner']);
-      allow create: if hasRole(request.resource.data.storeId, ['owner']);
-      allow update: if hasRole(resource.data.storeId, ['owner']) && storeIdUnchanged();
-      allow delete: if hasRole(resource.data.storeId, ['owner']);
+    match /receipts/{id} {
+      allow read, create, update, delete: if staffAccess();
+    }
+
+    match /ledger/{id} {
+      allow read, create, update, delete: if staffAccess();
+    }
+
+    match /saleItems/{id} {
+      allow read, create, update, delete: if staffAccess();
     }
 
     /* ---------- User-scoped sessions ---------- */

--- a/functions/src/callables.ts
+++ b/functions/src/callables.ts
@@ -1,171 +1,116 @@
-import * as functions from 'firebase-functions';
-import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions'
+import * as admin from 'firebase-admin'
 
-const STORE_CODE_PATTERN = /^[A-Z]{6}$/;
+if (!admin.apps.length) admin.initializeApp()
 
-function normalizeStoreCode(value: unknown) {
-  if (typeof value !== 'string') {
-    return '';
-  }
+const db = admin.firestore()
 
-  const trimmed = value.trim().toUpperCase();
-  if (!trimmed) {
-    return '';
-  }
+const VALID_ROLES = new Set(['owner', 'staff'])
 
-  if (!STORE_CODE_PATTERN.test(trimmed)) {
-    throw new functions.https.HttpsError('invalid-argument', 'Store code must be exactly six letters.');
-  }
-
-  return trimmed;
+type ContactPayload = {
+  phone?: unknown
+  firstSignupEmail?: unknown
 }
 
-function normalizeContact(data: unknown) {
-  if (!data || typeof data !== 'object') {
-    return { phone: null as string | null, firstSignupEmail: null as string | null };
+type BackfillPayload = {
+  contact?: ContactPayload
+}
+
+function normalizeContact(contact: ContactPayload | undefined) {
+  let hasPhone = false
+  let hasFirstSignupEmail = false
+  let phone: string | null | undefined
+  let firstSignupEmail: string | null | undefined
+
+  if (contact && typeof contact === 'object') {
+    if ('phone' in contact) {
+      hasPhone = true
+      const raw = contact.phone
+      if (raw === null || raw === undefined || raw === '') {
+        phone = null
+      } else if (typeof raw === 'string') {
+        const trimmed = raw.trim()
+        phone = trimmed ? trimmed : null
+      } else {
+        throw new functions.https.HttpsError('invalid-argument', 'Phone must be a string when provided')
+      }
+    }
+
+    if ('firstSignupEmail' in contact) {
+      hasFirstSignupEmail = true
+      const raw = contact.firstSignupEmail
+      if (raw === null || raw === undefined || raw === '') {
+        firstSignupEmail = null
+      } else if (typeof raw === 'string') {
+        const trimmed = raw.trim().toLowerCase()
+        firstSignupEmail = trimmed ? trimmed : null
+      } else {
+        throw new functions.https.HttpsError(
+          'invalid-argument',
+          'First signup email must be a string when provided',
+        )
+      }
+    }
   }
 
-  const contact = data as Record<string, unknown>;
-  const rawPhone = typeof contact.phone === 'string' ? contact.phone.trim() : '';
-  const phone = rawPhone ? rawPhone : null;
-  const rawFirstSignupEmail =
-    typeof contact.firstSignupEmail === 'string' ? contact.firstSignupEmail.trim().toLowerCase() : '';
-  const firstSignupEmail = rawFirstSignupEmail ? rawFirstSignupEmail : null;
-  return { phone, firstSignupEmail };
+  return { phone, hasPhone, firstSignupEmail, hasFirstSignupEmail }
+}
+
+async function applyRoleClaim(uid: string, role: string) {
+  const userRecord = await admin
+    .auth()
+    .getUser(uid)
+    .catch(() => null)
+  const existingClaims = (userRecord?.customClaims ?? {}) as Record<string, unknown>
+  const nextClaims: Record<string, unknown> = { ...existingClaims }
+  if (VALID_ROLES.has(role)) {
+    nextClaims.role = role
+  } else {
+    delete nextClaims.role
+  }
+  delete nextClaims.stores
+  delete nextClaims.activeStoreId
+  delete nextClaims.storeId
+  delete nextClaims.roleByStore
+  await admin.auth().setCustomUserClaims(uid, nextClaims)
+  return nextClaims
 }
 
 export const backfillMyStore = functions.https.onCall(async (data, context) => {
-  if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Sign in first.');
-  const uid = context.auth.uid;
-  const token = context.auth.token as Record<string, unknown>;
-  const email = typeof token.email === 'string' ? (token.email as string) : null;
-  const phone = typeof token.phone_number === 'string' ? (token.phone_number as string) : null;
+  if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Sign in first.')
 
-  const payload = data ?? {};
-  const storeId = normalizeStoreCode((payload as Record<string, unknown>).storeCode);
-  if (!storeId) {
-    throw new functions.https.HttpsError('invalid-argument', 'A valid store code is required.');
+  const uid = context.auth.uid
+  const token = context.auth.token as Record<string, unknown>
+  const email = typeof token.email === 'string' ? (token.email as string) : null
+  const phone = typeof token.phone_number === 'string' ? (token.phone_number as string) : null
+
+  const payload = (data ?? {}) as BackfillPayload
+  const contact = normalizeContact(payload.contact)
+  const resolvedPhone = contact.hasPhone ? contact.phone ?? null : phone ?? null
+  const resolvedFirstSignupEmail = contact.hasFirstSignupEmail
+    ? contact.firstSignupEmail ?? null
+    : email?.toLowerCase() ?? null
+
+  const memberRef = db.collection('teamMembers').doc(uid)
+  const memberSnap = await memberRef.get()
+  const timestamp = admin.firestore.FieldValue.serverTimestamp()
+
+  const memberData: admin.firestore.DocumentData = {
+    uid,
+    email,
+    role: 'owner',
+    phone: resolvedPhone,
+    firstSignupEmail: resolvedFirstSignupEmail,
+    invitedBy: uid,
+    updatedAt: timestamp,
   }
-
-  const { phone: contactPhone, firstSignupEmail: contactFirstSignupEmail } = normalizeContact(
-    (payload as Record<string, unknown>).contact,
-  );
-  const resolvedPhone = contactPhone ?? phone;
-  const resolvedFirstSignupEmail = contactFirstSignupEmail ?? email;
-  const db = admin.firestore();
-
-  const storeRef = db.doc(`stores/${storeId}`);
-  const memberRef = db.doc(`stores/${storeId}/members/${uid}`);
-  const mapRef = db.doc(`storeUsers/${storeId}_${uid}`);
-
-  const [storeSnap, memberSnap, mapSnap] = await db.getAll(storeRef, memberRef, mapRef);
-  if (storeSnap.exists) {
-    const ownerId = storeSnap.get('ownerId');
-    if (ownerId && ownerId !== uid) {
-      throw new functions.https.HttpsError('already-exists', 'That store code is already in use.');
-    }
-  }
-
-  const timestamp = admin.firestore.FieldValue.serverTimestamp();
-
-  const batch = db.batch();
-  batch.set(
-    storeRef,
-    {
-      storeId,
-      id: storeId,
-      ownerId: uid,
-      ownerEmail: email,
-      ownerPhone: resolvedPhone ?? null,
-      firstSignupEmail: resolvedFirstSignupEmail ?? null,
-      updatedAt: timestamp,
-      ...(storeSnap.exists
-        ? {}
-        : { createdAt: timestamp, plan: 'free', status: 'active' }),
-    },
-    { merge: true },
-  );
 
   if (!memberSnap.exists) {
-    batch.set(
-      memberRef,
-      {
-        uid,
-        role: 'owner',
-        email,
-        phone: resolvedPhone ?? null,
-        firstSignupEmail: resolvedFirstSignupEmail ?? null,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      },
-      { merge: true },
-    );
-  } else {
-    batch.set(
-      memberRef,
-      {
-        phone: resolvedPhone ?? null,
-        firstSignupEmail: resolvedFirstSignupEmail ?? null,
-        updatedAt: timestamp,
-      },
-      { merge: true },
-    );
+    memberData.createdAt = timestamp
   }
 
-  batch.set(
-    mapRef,
-    {
-      uid,
-      storeId,
-      role: 'owner',
-      email,
-      phone: resolvedPhone ?? null,
-      firstSignupEmail: resolvedFirstSignupEmail ?? null,
-      updatedAt: timestamp,
-      ...(mapSnap.exists ? {} : { createdAt: timestamp }),
-    },
-    { merge: true },
-  );
+  await memberRef.set(memberData, { merge: true })
+  const claims = await applyRoleClaim(uid, 'owner')
 
-  await batch.commit();
-
-  const membershipsSnapshot = await db.collection('storeUsers').where('uid', '==', uid).get();
-  const stores = Array.from(
-    new Set(
-      membershipsSnapshot.docs
-        .map(doc => doc.get('storeId'))
-        .filter((value): value is string => typeof value === 'string' && value.length > 0),
-    ),
-  );
-  const roleByStore = membershipsSnapshot.docs.reduce<Record<string, string>>((acc, doc) => {
-    const membershipStoreId = doc.get('storeId');
-    const membershipRole = doc.get('role');
-    if (typeof membershipStoreId === 'string' && typeof membershipRole === 'string') {
-      acc[membershipStoreId] = membershipRole;
-    }
-    return acc;
-  }, {});
-
-  const existingClaims = await admin
-    .auth()
-    .getUser(uid)
-    .then(result => (result.customClaims ?? {}) as Record<string, unknown>)
-    .catch(() => ({} as Record<string, unknown>));
-
-  const activeStoreId = stores.includes(storeId)
-    ? storeId
-    : (typeof existingClaims.activeStoreId === 'string' && stores.includes(existingClaims.activeStoreId)
-        ? (existingClaims.activeStoreId as string)
-        : stores[0] ?? null);
-
-  const nextClaims = {
-    ...existingClaims,
-    stores,
-    activeStoreId,
-    roleByStore,
-  };
-
-  await admin.auth().setCustomUserClaims(uid, nextClaims);
-
-  return { ok: true, storeId, claims: nextClaims };
-});
+  return { ok: true, claims }
+})

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,244 +4,111 @@ import * as admin from 'firebase-admin'
 admin.initializeApp()
 const db = admin.firestore()
 
-// -----------------------------
-// Types
-// -----------------------------
-type StoreUserDoc = {
-  storeId: string
-  uid: string
-  role: string
-  email?: string
-}
-
-type StoreClaims = {
-  stores: string[]
-  activeStoreId: string | null
-  roleByStore: Record<string, string>
-}
-
-type OwnerBootstrapMetadata = {
-  ownerEmail?: string | null
-  ownerPhone?: string | null
-  firstSignupEmail?: string | null
-  membershipPhone?: string | null
+type ContactPayload = {
+  phone?: unknown
+  firstSignupEmail?: unknown
 }
 
 type InitializeStorePayload = {
-  storeCode?: unknown
-  contact?: {
-    phone?: unknown
-    firstSignupEmail?: unknown
-  }
+  contact?: ContactPayload
 }
 
 type ResolveStoreAccessPayload = {
-  storeCode?: unknown
+  contact?: ContactPayload
 }
 
 type ManageStaffPayload = {
-  storeId?: unknown
   email?: unknown
   role?: unknown
   password?: unknown
 }
 
-// -----------------------------
-// Constants & helpers
-// -----------------------------
-const STORE_CODE_PATTERN = /^[A-Z]{6}$/
+const VALID_ROLES = new Set(['owner', 'staff'])
 
-function genStoreCode(): string {
-  const A = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-  return Array.from({ length: 6 }, () => A[Math.floor(Math.random() * A.length)]).join('')
+function normalizeContactPayload(contact: ContactPayload | undefined) {
+  let hasPhone = false
+  let hasFirstSignupEmail = false
+  let phone: string | null | undefined
+  let firstSignupEmail: string | null | undefined
+
+  if (contact && typeof contact === 'object') {
+    if ('phone' in contact) {
+      hasPhone = true
+      const raw = contact.phone
+      if (raw === null || raw === undefined || raw === '') {
+        phone = null
+      } else if (typeof raw === 'string') {
+        const trimmed = raw.trim()
+        phone = trimmed ? trimmed : null
+      } else {
+        throw new functions.https.HttpsError('invalid-argument', 'Phone must be a string when provided')
+      }
+    }
+
+    if ('firstSignupEmail' in contact) {
+      hasFirstSignupEmail = true
+      const raw = contact.firstSignupEmail
+      if (raw === null || raw === undefined || raw === '') {
+        firstSignupEmail = null
+      } else if (typeof raw === 'string') {
+        const trimmed = raw.trim().toLowerCase()
+        firstSignupEmail = trimmed ? trimmed : null
+      } else {
+        throw new functions.https.HttpsError(
+          'invalid-argument',
+          'First signup email must be a string when provided',
+        )
+      }
+    }
+  }
+
+  return { phone, hasPhone, firstSignupEmail, hasFirstSignupEmail }
 }
 
-async function listStoreMemberships(uid: string) {
-  const snapshot = await db.collection('storeUsers').where('uid', '==', uid).get()
-  return snapshot.docs
-    .map(doc => ({ id: doc.id, ...(doc.data() as StoreUserDoc) }))
-    .filter(doc => typeof doc.storeId === 'string' && typeof doc.role === 'string')
+function getRoleFromToken(token: Record<string, unknown> | undefined) {
+  const role = typeof token?.role === 'string' ? (token.role as string) : null
+  return role && VALID_ROLES.has(role) ? role : null
 }
 
-async function applyStoreClaims(uid: string, preferredActiveStoreId?: string | null): Promise<StoreClaims> {
-  const [memberships, userRecord] = await Promise.all([
-    listStoreMemberships(uid),
-    admin.auth().getUser(uid).catch(() => null),
-  ])
+function assertAuthenticated(context: functions.https.CallableContext) {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'Login required')
+  }
+}
 
-  const stores = Array.from(new Set(memberships.map(m => m.storeId).filter(Boolean)))
+function assertOwnerAccess(context: functions.https.CallableContext) {
+  assertAuthenticated(context)
+  const role = getRoleFromToken(context.auth!.token as Record<string, unknown>)
+  if (role !== 'owner') {
+    throw new functions.https.HttpsError('permission-denied', 'Owner access required')
+  }
+}
 
-  const roleByStore = memberships.reduce<Record<string, string>>((acc, m) => {
-    if (m.storeId && m.role) acc[m.storeId] = m.role
-    return acc
-  }, {})
+function assertStaffAccess(context: functions.https.CallableContext) {
+  assertAuthenticated(context)
+  const role = getRoleFromToken(context.auth!.token as Record<string, unknown>)
+  if (!role) {
+    throw new functions.https.HttpsError('permission-denied', 'Staff access required')
+  }
+}
 
+async function updateUserClaims(uid: string, role: string) {
+  const userRecord = await admin
+    .auth()
+    .getUser(uid)
+    .catch(() => null)
   const existingClaims = (userRecord?.customClaims ?? {}) as Record<string, unknown>
-  const preferredActive =
-    typeof preferredActiveStoreId === 'string' && stores.includes(preferredActiveStoreId)
-      ? preferredActiveStoreId
-      : null
-  const existingActiveClaim =
-    typeof existingClaims.activeStoreId === 'string' && stores.includes(existingClaims.activeStoreId as string)
-      ? (existingClaims.activeStoreId as string)
-      : null
-
-  let activeStoreId: string | null = preferredActive ?? existingActiveClaim
-  if (!activeStoreId) activeStoreId = stores.length > 0 ? stores[0] : null
-
-  const nextClaims = { ...existingClaims, stores, activeStoreId, roleByStore }
+  const nextClaims: Record<string, unknown> = { ...existingClaims }
+  nextClaims.role = role
+  delete nextClaims.stores
+  delete nextClaims.activeStoreId
+  delete nextClaims.storeId
+  delete nextClaims.roleByStore
   await admin.auth().setCustomUserClaims(uid, nextClaims)
-
-  return { stores, activeStoreId, roleByStore }
-}
-
-async function upsertStoreMembership(
-  storeId: string,
-  uid: string,
-  email: string | null,
-  role: string,
-  invitedBy: string | null,
-  contact: { phone?: string | null; firstSignupEmail?: string | null } = {},
-) {
-  const membershipRef = db.collection('storeUsers').doc(`${storeId}_${uid}`)
-  const storeMemberRef = db.collection('stores').doc(storeId).collection('members').doc(uid)
-
-  const [membershipSnap, storeMemberSnap] = await Promise.all([membershipRef.get(), storeMemberRef.get()])
-  const timestamp = admin.firestore.FieldValue.serverTimestamp()
-
-  const baseData = {
-    storeId,
-    uid,
-    email: email ?? null,
-    role,
-    invitedBy,
-    phone: contact.phone ?? null,
-    firstSignupEmail: contact.firstSignupEmail ?? null,
-    updatedAt: timestamp,
-  }
-
-  const membershipData = { ...baseData, ...(membershipSnap.exists ? {} : { createdAt: timestamp }) }
-  const storeMemberData = { ...baseData, ...(storeMemberSnap.exists ? {} : { createdAt: timestamp }) }
-
-  await Promise.all([
-    membershipRef.set(membershipData, { merge: true }),
-    storeMemberRef.set(storeMemberData, { merge: true }),
-  ])
-
-  return membershipData
-}
-
-async function ensureDefaultStoreForUser(
-  uid: string,
-  metadata: OwnerBootstrapMetadata = {},
-  preferredStoreId?: string | null,
-) {
-  const storeId = typeof preferredStoreId === 'string' ? preferredStoreId.trim() : ''
-  if (!storeId) return
-
-  const storeRef = db.collection('stores').doc(storeId)
-
-  await db.runTransaction(async tx => {
-    const storeSnap = await tx.get(storeRef)
-    const timestamp = admin.firestore.FieldValue.serverTimestamp()
-
-    const storeData: admin.firestore.DocumentData = {
-      storeId,
-      id: storeId,
-      ownerId: storeSnap.exists && storeSnap.get('ownerId') ? storeSnap.get('ownerId') : uid,
-      updatedAt: timestamp,
-    }
-
-    if (storeSnap.exists) {
-      const existingOwnerId = storeSnap.get('ownerId')
-      if (existingOwnerId && existingOwnerId !== uid) {
-        throw new functions.https.HttpsError('already-exists', 'Store code already assigned to another account')
-      }
-    } else {
-      storeData.createdAt = timestamp
-    }
-
-    if (metadata.ownerEmail !== undefined) storeData.ownerEmail = metadata.ownerEmail
-    if (metadata.ownerPhone !== undefined) storeData.ownerPhone = metadata.ownerPhone
-
-    const existingFirstSignupEmail = storeSnap.exists ? storeSnap.get('firstSignupEmail') : undefined
-    if (existingFirstSignupEmail === undefined || existingFirstSignupEmail === null) {
-      if (metadata.firstSignupEmail !== undefined) {
-        storeData.firstSignupEmail = metadata.firstSignupEmail
-      } else if (!storeSnap.exists && metadata.ownerEmail !== undefined) {
-        storeData.firstSignupEmail = metadata.ownerEmail
-      }
-    }
-
-    tx.set(storeRef, storeData, { merge: true })
-  })
-
-  await upsertStoreMembership(
-    storeId,
-    uid,
-    metadata.ownerEmail ?? null,
-    'owner',
-    null,
-    {
-      phone: metadata.membershipPhone ?? metadata.ownerPhone ?? null,
-      firstSignupEmail:
-        metadata.firstSignupEmail !== undefined ? metadata.firstSignupEmail : metadata.ownerEmail ?? null,
-    },
-  )
-}
-
-async function refreshUserClaims(
-  uid: string,
-  metadata: OwnerBootstrapMetadata = {},
-  preferredStoreId?: string | null,
-) {
-  await ensureDefaultStoreForUser(uid, metadata, preferredStoreId)
-  return applyStoreClaims(uid, preferredStoreId)
-}
-
-function normalizeStoreCode(value: unknown) {
-  if (typeof value !== 'string') return ''
-  const trimmed = value.trim().toUpperCase()
-  if (!trimmed) return ''
-  if (!STORE_CODE_PATTERN.test(trimmed)) {
-    throw new functions.https.HttpsError('invalid-argument', 'Store code must be exactly six letters.')
-  }
-  return trimmed
-}
-
-function normalizeInitializeStorePayload(
-  data: InitializeStorePayload | null | undefined,
-  { requireStoreCode }: { requireStoreCode: boolean },
-) {
-  const contact = data?.contact ?? {}
-  const rawPhone = typeof contact.phone === 'string' ? contact.phone.trim() : ''
-  const phone = rawPhone ? rawPhone : null
-  const rawFirstSignupEmail =
-    typeof contact.firstSignupEmail === 'string' ? contact.firstSignupEmail.trim().toLowerCase() : ''
-  const firstSignupEmail = rawFirstSignupEmail ? rawFirstSignupEmail : null
-  const storeCode = normalizeStoreCode(data?.storeCode)
-
-  if (requireStoreCode && !storeCode) {
-    throw new functions.https.HttpsError('invalid-argument', 'A valid store code is required.')
-  }
-
-  return { phone, firstSignupEmail, storeCode }
-}
-
-function assertOwnerAccess(context: functions.https.CallableContext, storeId: string) {
-  if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Login required')
-
-  const claims = context.auth.token as Record<string, unknown>
-  const stores = Array.isArray(claims.stores) ? claims.stores : []
-  if (!stores.includes(storeId)) throw new functions.https.HttpsError('permission-denied', 'No store access')
-
-  const roleByStore = (claims.roleByStore ?? {}) as Record<string, unknown>
-  const role = typeof roleByStore[storeId] === 'string' ? (roleByStore[storeId] as string) : null
-  if (role !== 'owner') throw new functions.https.HttpsError('permission-denied', 'Owner access required')
+  return nextClaims
 }
 
 function normalizeManageStaffPayload(data: ManageStaffPayload) {
-  const storeId = typeof data.storeId === 'string' ? data.storeId.trim() : ''
   const email = typeof data.email === 'string' ? data.email.trim().toLowerCase() : ''
   const role = typeof data.role === 'string' ? data.role.trim() : ''
   const passwordRaw = data.password
@@ -254,11 +121,13 @@ function normalizeManageStaffPayload(data: ManageStaffPayload) {
     throw new functions.https.HttpsError('invalid-argument', 'Password must be a string when provided')
   }
 
-  if (!storeId) throw new functions.https.HttpsError('invalid-argument', 'A valid storeId is required')
   if (!email) throw new functions.https.HttpsError('invalid-argument', 'A valid email is required')
   if (!role) throw new functions.https.HttpsError('invalid-argument', 'A role is required')
+  if (!VALID_ROLES.has(role)) {
+    throw new functions.https.HttpsError('invalid-argument', 'Unsupported role requested')
+  }
 
-  return { storeId, email, role, password }
+  return { email, role, password }
 }
 
 async function ensureAuthUser(email: string, password?: string) {
@@ -281,172 +150,138 @@ async function ensureAuthUser(email: string, password?: string) {
   }
 }
 
-// -----------------------------
-// Auth trigger: create default store on sign-up
-// -----------------------------
 export const handleUserCreate = functions.auth.user().onCreate(async user => {
   const uid = user.uid
-  const email = user.email ?? null
-  const storeCode = genStoreCode() // create a default store id like "ABCDEF"
-
-  await refreshUserClaims(
-    uid,
-    {
-      ownerEmail: email,
-      ownerPhone: user.phoneNumber ?? null,
-      firstSignupEmail: email,
-      membershipPhone: user.phoneNumber ?? null,
-    },
-    storeCode, // pass it so Firestore docs are actually written
-  )
-})
-
-// -----------------------------
-// Callable: initializeStore
-// -----------------------------
-export const initializeStore = functions.https.onCall(async (data, context) => {
-  if (!context.auth) {
-    throw new functions.https.HttpsError('unauthenticated', 'Login required')
-  }
-
-  const uid = context.auth.uid
-  const email = typeof context.auth.token.email === 'string' ? context.auth.token.email : null
-
-  const { phone, firstSignupEmail, storeCode } = normalizeInitializeStorePayload(
-    (data ?? {}) as InitializeStorePayload,
-    { requireStoreCode: true },
-  )
-
-  const claims = await refreshUserClaims(
-    uid,
-    {
-      ownerEmail: email,
-      ownerPhone: phone,
-      firstSignupEmail: firstSignupEmail ?? email ?? null,
-      membershipPhone: phone,
-    },
-    storeCode,
-  )
-
-  return { ok: true, claims, storeId: storeCode ?? null }
-})
-
-// -----------------------------
-// Callable: resolveStoreAccess
-// -----------------------------
-export const resolveStoreAccess = functions.https.onCall(async (data, context) => {
-  if (!context.auth) {
-    throw new functions.https.HttpsError('unauthenticated', 'Login required')
-  }
-
-  const uid = context.auth.uid
-  const email = typeof context.auth.token.email === 'string' ? context.auth.token.email : null
-  const phone = typeof context.auth.token.phone_number === 'string' ? context.auth.token.phone_number : null
-
-  const payload = (data ?? {}) as ResolveStoreAccessPayload
-  const storeCode = normalizeStoreCode(payload.storeCode)
-  if (!storeCode) throw new functions.https.HttpsError('invalid-argument', 'A valid store code is required.')
-
-  const storeRef = db.collection('stores').doc(storeCode)
-  const membershipRef = db.collection('storeUsers').doc(`${storeCode}_${uid}`)
-  const storeMemberRef = storeRef.collection('members').doc(uid)
-
-  const [storeSnap, membershipSnap, storeMemberSnap] = await Promise.all([
-    storeRef.get(),
-    membershipRef.get(),
-    storeMemberRef.get(),
-  ])
-
-  if (!storeSnap.exists) throw new functions.https.HttpsError('not-found', 'No store matches the provided code.')
-
   const timestamp = admin.firestore.FieldValue.serverTimestamp()
-  const ownerId = storeSnap.get('ownerId')
+  await db
+    .collection('teamMembers')
+    .doc(uid)
+    .set(
+      {
+        uid,
+        email: user.email ?? null,
+        phone: user.phoneNumber ?? null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+      { merge: true },
+    )
+})
 
-  const resolveExistingString = (value: unknown): string | null => {
-    if (typeof value === 'string') {
-      const trimmed = value.trim()
-      return trimmed ? trimmed : null
-    }
-    return null
-  }
+export const initializeStore = functions.https.onCall(async (data, context) => {
+  assertAuthenticated(context)
 
-  const existingRole =
-    resolveExistingString(membershipSnap.get('role')) ??
-    resolveExistingString(storeMemberSnap.get('role')) ??
-    null
+  const uid = context.auth!.uid
+  const token = context.auth!.token as Record<string, unknown>
+  const email = typeof token.email === 'string' ? (token.email as string) : null
+  const tokenPhone = typeof token.phone_number === 'string' ? (token.phone_number as string) : null
 
-  let role = existingRole ?? 'staff'
-  if (!existingRole && resolveExistingString(ownerId) === uid) role = 'owner'
+  const payload = (data ?? {}) as InitializeStorePayload
+  const contact = normalizeContactPayload(payload.contact)
+  const resolvedPhone = contact.hasPhone ? contact.phone ?? null : tokenPhone ?? null
+  const resolvedFirstSignupEmail = contact.hasFirstSignupEmail
+    ? contact.firstSignupEmail ?? null
+    : email?.toLowerCase() ?? null
 
-  const existingPhone =
-    resolveExistingString(membershipSnap.get('phone')) ??
-    resolveExistingString(storeMemberSnap.get('phone')) ??
-    null
-  const membershipPhone = existingPhone ?? (phone ?? null)
+  const memberRef = db.collection('teamMembers').doc(uid)
+  const memberSnap = await memberRef.get()
+  const timestamp = admin.firestore.FieldValue.serverTimestamp()
 
-  const existingFirstSignupEmail =
-    resolveExistingString(membershipSnap.get('firstSignupEmail')) ??
-    resolveExistingString(storeMemberSnap.get('firstSignupEmail')) ??
-    null
-  const membershipFirstSignupEmail = existingFirstSignupEmail ?? (email ? email.toLowerCase() : null)
-
-  const invitedBy = resolveExistingString(membershipSnap.get('invitedBy'))
-
-  const baseMembership = {
-    storeId: storeCode,
+  const memberData: admin.firestore.DocumentData = {
     uid,
-    email: email ?? null,
-    role,
-    invitedBy,
-    phone: membershipPhone,
-    firstSignupEmail: membershipFirstSignupEmail,
+    email,
+    role: 'owner',
+    phone: resolvedPhone,
+    firstSignupEmail: resolvedFirstSignupEmail,
+    invitedBy: uid,
     updatedAt: timestamp,
   }
 
-  const membershipData = { ...baseMembership, ...(membershipSnap.exists ? {} : { createdAt: timestamp }) }
-  const storeMemberData = { ...baseMembership, ...(storeMemberSnap.exists ? {} : { createdAt: timestamp }) }
+  if (!memberSnap.exists) {
+    memberData.createdAt = timestamp
+  }
 
-  await Promise.all([
-    membershipRef.set(membershipData, { merge: true }),
-    storeMemberRef.set(storeMemberData, { merge: true }),
-  ])
+  await memberRef.set(memberData, { merge: true })
+  const claims = await updateUserClaims(uid, 'owner')
 
-  const claims = await applyStoreClaims(uid, storeCode)
-  return { ok: true, storeId: storeCode, claims }
+  return { ok: true, claims }
 })
 
-// -----------------------------
-// Callable: manageStaffAccount
-// -----------------------------
-export const manageStaffAccount = functions.https.onCall(async (data, context) => {
-  const { storeId, email, role, password } = normalizeManageStaffPayload(data as ManageStaffPayload)
-  assertOwnerAccess(context, storeId)
+export const resolveStoreAccess = functions.https.onCall(async (data, context) => {
+  assertAuthenticated(context)
 
+  const uid = context.auth!.uid
+  const token = context.auth!.token as Record<string, unknown>
+  const email = typeof token.email === 'string' ? (token.email as string) : null
+  const tokenPhone = typeof token.phone_number === 'string' ? (token.phone_number as string) : null
+
+  const memberRef = db.collection('teamMembers').doc(uid)
+  const memberSnap = await memberRef.get()
+  if (!memberSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'No team membership found for this account')
+  }
+
+  const memberData = memberSnap.data() ?? {}
+  const roleRaw = typeof memberData.role === 'string' ? (memberData.role as string) : ''
+  if (!VALID_ROLES.has(roleRaw)) {
+    throw new functions.https.HttpsError('failed-precondition', 'This account does not have workspace access yet')
+  }
+
+  const payload = (data ?? {}) as ResolveStoreAccessPayload
+  const contact = normalizeContactPayload(payload.contact)
+  const resolvedPhone = contact.hasPhone ? contact.phone ?? null : tokenPhone ?? null
+  const resolvedFirstSignupEmail = contact.hasFirstSignupEmail
+    ? contact.firstSignupEmail ?? null
+    : email?.toLowerCase() ?? null
+
+  const updates: admin.firestore.DocumentData = { updatedAt: admin.firestore.FieldValue.serverTimestamp() }
+  if (contact.hasPhone) {
+    updates.phone = resolvedPhone
+  }
+  if (contact.hasFirstSignupEmail) {
+    updates.firstSignupEmail = resolvedFirstSignupEmail
+  }
+  if (Object.keys(updates).length > 1) {
+    await memberRef.set(updates, { merge: true })
+  }
+
+  const claims = await updateUserClaims(uid, roleRaw)
+  return { ok: true, role: roleRaw, claims }
+})
+
+export const manageStaffAccount = functions.https.onCall(async (data, context) => {
+  assertOwnerAccess(context)
+
+  const { email, role, password } = normalizeManageStaffPayload(data as ManageStaffPayload)
   const invitedBy = context.auth?.uid ?? null
   const { record, created } = await ensureAuthUser(email, password)
 
-  await upsertStoreMembership(storeId, record.uid, email, role, invitedBy)
-  const claims = await applyStoreClaims(record.uid)
+  const memberRef = db.collection('teamMembers').doc(record.uid)
+  const memberSnap = await memberRef.get()
+  const timestamp = admin.firestore.FieldValue.serverTimestamp()
 
-  return {
-    ok: true,
-    storeId,
-    role,
-    email,
+  const memberData: admin.firestore.DocumentData = {
     uid: record.uid,
-    created,
-    claims,
+    email,
+    role,
+    invitedBy,
+    updatedAt: timestamp,
   }
+
+  if (!memberSnap.exists) {
+    memberData.createdAt = timestamp
+  }
+
+  await memberRef.set(memberData, { merge: true })
+  const claims = await updateUserClaims(record.uid, role)
+
+  return { ok: true, role, email, uid: record.uid, created, claims }
 })
 
-// -----------------------------
-// Callable: commitSale
-// -----------------------------
 export const commitSale = functions.https.onCall(async (data, context) => {
-  const { storeId, branchId, items, totals, cashierId, saleId: saleIdRaw, payment, customer } = data || {}
-  if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Login required')
-  const claims = context.auth.token as any
-  if (!claims?.stores?.includes?.(storeId)) throw new functions.https.HttpsError('permission-denied', 'No store access')
+  assertStaffAccess(context)
+
+  const { branchId, items, totals, cashierId, saleId: saleIdRaw, payment, customer } = data || {}
 
   const saleId = typeof saleIdRaw === 'string' ? saleIdRaw.trim() : ''
   if (!saleId) throw new functions.https.HttpsError('invalid-argument', 'A valid saleId is required')
@@ -469,8 +304,9 @@ export const commitSale = functions.https.onCall(async (data, context) => {
         })
       : []
 
+    const timestamp = admin.firestore.FieldValue.serverTimestamp()
+
     tx.set(saleRef, {
-      storeId,
       branchId: branchId ?? null,
       cashierId,
       total: totals?.total ?? 0,
@@ -478,7 +314,8 @@ export const commitSale = functions.https.onCall(async (data, context) => {
       payment: payment ?? null,
       customer: customer ?? null,
       items: normalizedItems,
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdBy: context.auth?.uid ?? null,
+      createdAt: timestamp,
     })
 
     for (const it of normalizedItems) {
@@ -487,32 +324,30 @@ export const commitSale = functions.https.onCall(async (data, context) => {
       }
       const itemId = db.collection('_').doc().id
       tx.set(saleItemsRef.doc(itemId), {
-        storeId,
         saleId,
         productId: it.productId,
         qty: it.qty,
         price: it.price,
         taxRate: it.taxRate,
+        createdAt: timestamp,
       })
 
       const pRef = db.collection('products').doc(it.productId)
       const pSnap = await tx.get(pRef)
-      if (!pSnap.exists || pSnap.get('storeId') !== storeId) {
+      if (!pSnap.exists) {
         throw new functions.https.HttpsError('failed-precondition', 'Bad product')
       }
-      const curr = pSnap.get('stockCount') || 0
+      const curr = Number(pSnap.get('stockCount') || 0)
       const next = curr - Math.abs(it.qty || 0)
-      tx.update(pRef, { stockCount: next, updatedAt: admin.firestore.FieldValue.serverTimestamp() })
+      tx.update(pRef, { stockCount: next, updatedAt: timestamp })
 
       const ledgerId = db.collection('_').doc().id
       tx.set(db.collection('ledger').doc(ledgerId), {
-        storeId,
-        branchId,
         productId: it.productId,
         qtyChange: -Math.abs(it.qty || 0),
         type: 'sale',
         refId: saleId,
-        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        createdAt: timestamp,
       })
     }
   })
@@ -520,16 +355,10 @@ export const commitSale = functions.https.onCall(async (data, context) => {
   return { ok: true, saleId }
 })
 
-// -----------------------------
-// Callable: receiveStock
-// -----------------------------
 export const receiveStock = functions.https.onCall(async (data, context) => {
-  const { storeId, productId, qty, supplier, reference, unitCost } = data || {}
-  if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Login required')
-  const claims = context.auth.token as any
-  if (!claims?.stores?.includes?.(storeId)) {
-    throw new functions.https.HttpsError('permission-denied', 'No store access')
-  }
+  assertStaffAccess(context)
+
+  const { productId, qty, supplier, reference, unitCost } = data || {}
 
   const productIdStr = typeof productId === 'string' ? productId : null
   if (!productIdStr) throw new functions.https.HttpsError('invalid-argument', 'A product must be selected')
@@ -560,7 +389,7 @@ export const receiveStock = functions.https.onCall(async (data, context) => {
 
   await db.runTransaction(async tx => {
     const pSnap = await tx.get(productRef)
-    if (!pSnap.exists || pSnap.get('storeId') !== storeId) {
+    if (!pSnap.exists) {
       throw new functions.https.HttpsError('failed-precondition', 'Bad product')
     }
 
@@ -580,7 +409,6 @@ export const receiveStock = functions.https.onCall(async (data, context) => {
       normalizedUnitCost === null ? null : Math.round((normalizedUnitCost * amount + Number.EPSILON) * 100) / 100
 
     tx.set(receiptRef, {
-      storeId,
       productId: productIdStr,
       qty: amount,
       supplier: normalizedSupplier,
@@ -592,7 +420,6 @@ export const receiveStock = functions.https.onCall(async (data, context) => {
     })
 
     tx.set(ledgerRef, {
-      storeId,
       productId: productIdStr,
       qtyChange: amount,
       type: 'receipt',

--- a/functions/src/onAuthCreate.ts
+++ b/functions/src/onAuthCreate.ts
@@ -1,65 +1,25 @@
-import * as functions from 'firebase-functions';
-import { getFirestore } from 'firebase-admin/firestore';
-import { getAuth } from 'firebase-admin/auth';
-import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions'
+import { getFirestore } from 'firebase-admin/firestore'
+import * as admin from 'firebase-admin'
 
-if (!admin.apps.length) admin.initializeApp();
+if (!admin.apps.length) admin.initializeApp()
 
-export const onAuthCreate = functions.auth.user().onCreate(async (user) => {
-  const db = getFirestore();
-  const uid = user.uid;
-  const storeId = uid; // simple 1:1 default
-  const ownerEmail = user.email ?? null;
-  const ownerPhone = user.phoneNumber ?? null;
-  const firstSignupEmail = ownerEmail;
+export const onAuthCreate = functions.auth.user().onCreate(async user => {
+  const db = getFirestore()
+  const uid = user.uid
+  const timestamp = admin.firestore.FieldValue.serverTimestamp()
 
-  const storeRef = db.doc(`stores/${storeId}`);
-  const memberRef = db.doc(`stores/${storeId}/members/${uid}`);
-  const mapRef = db.doc(`storeUsers/${storeId}_${uid}`);
-
-  // Idempotent: only create if not already there
-  const [storeSnap, memberSnap] = await db.getAll(storeRef, memberRef);
-  const batch = db.batch();
-
-  if (!storeSnap.exists) {
-    batch.set(storeRef, {
-      id: storeId,
-      ownerId: uid,
-      ownerEmail,
-      ownerPhone,
-      firstSignupEmail,
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-      plan: 'free',
-      status: 'active',
-    });
-  }
-
-  if (!memberSnap.exists) {
-    batch.set(memberRef, {
-      uid,
-      role: 'owner',
-      email: ownerEmail,
-      phone: ownerPhone,
-      firstSignupEmail,
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    });
-  }
-
-  batch.set(mapRef, {
-    uid,
-    storeId,
-    role: 'owner',
-    email: ownerEmail,
-    phone: ownerPhone,
-    firstSignupEmail,
-    createdAt: admin.firestore.FieldValue.serverTimestamp(),
-    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-  });
-
-  await batch.commit();
-
-  // Set custom claims (storeId, role)
-  await getAuth().setCustomUserClaims(uid, { storeId, role: 'owner' });
-});
+  await db
+    .collection('teamMembers')
+    .doc(uid)
+    .set(
+      {
+        uid,
+        email: user.email ?? null,
+        phone: user.phoneNumber ?? null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+      { merge: true },
+    )
+})

--- a/functions/test/commitSale.test.js
+++ b/functions/test/commitSale.test.js
@@ -165,7 +165,7 @@ Module._load = function patchedLoad(request, parent, isMain) {
 
 async function run() {
   currentDb = new MockFirestore({
-    'products/prod-1': { storeId: 'store-1', stockCount: 5 },
+    'products/prod-1': { stockCount: 5 },
   })
 
   delete require.cache[require.resolve('../lib/index.js')]
@@ -174,12 +174,11 @@ async function run() {
   const context = {
     auth: {
       uid: 'cashier-1',
-      token: { stores: ['store-1'] },
+      token: { role: 'staff' },
     },
   }
 
   const payload = {
-    storeId: 'store-1',
     branchId: 'branch-1',
     cashierId: 'cashier-1',
     saleId: 'sale-123',
@@ -195,7 +194,7 @@ async function run() {
 
   const saleDoc = currentDb.getDoc('sales/sale-123')
   assert.ok(saleDoc)
-  assert.strictEqual(saleDoc.storeId, 'store-1')
+  assert.strictEqual(saleDoc.branchId, 'branch-1')
 
   const saleItems = currentDb.listCollection('saleItems')
   assert.strictEqual(saleItems.length, 1)

--- a/web/tests/firestore.rules.test.ts
+++ b/web/tests/firestore.rules.test.ts
@@ -1,396 +1,55 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest'
 
-const STORE_ID = 'store-123';
-const OTHER_STORE_ID = 'store-456';
-
-const managerClaims = {
-  stores: [STORE_ID],
-  roleByStore: {
-    [STORE_ID]: 'manager',
-  },
-} as const;
-
-const ownerClaims = {
-  stores: [STORE_ID],
-  roleByStore: {
-    [STORE_ID]: 'owner',
-  },
-} as const;
-
-const outsiderOwnerClaims = {
-  stores: [OTHER_STORE_ID],
-  roleByStore: {
-    [OTHER_STORE_ID]: 'owner',
-  },
-} as const;
-
-type Claims = {
-  stores: readonly string[];
-  roleByStore: Record<string, string>;
-};
+type Role = 'owner' | 'staff' | undefined
 
 type AuthContext = {
-  token: Claims;
-};
-
-const managerAuth: AuthContext = { token: managerClaims };
-const ownerAuth: AuthContext = { token: ownerClaims };
-const outsiderOwnerAuth: AuthContext = { token: outsiderOwnerClaims };
-
-const DELETE_FIELD = Symbol('deleteField');
-const deleteField = () => DELETE_FIELD;
-
-type StoreDoc = {
-  storeId: string;
-  [key: string]: unknown;
-};
-
-type StoreUserDoc = {
-  storeId: string;
-  uid: string;
-  role: string;
-};
-
-type ProductDoc = StoreDoc & {
-  price: number;
-  stockCount?: number;
-};
-
-type UpdateData = Record<string, unknown | typeof DELETE_FIELD>;
-
-type Collection = 'products' | 'sales' | 'expenses';
-
-function hasRole(storeId: string, allowed: readonly string[], auth: AuthContext | null): boolean {
-  if (!auth) {
-    return false;
+  uid: string
+  token: {
+    role?: Role
   }
+} | null
 
-  const { stores, roleByStore } = auth.token;
-  if (!stores.includes(storeId)) {
-    return false;
-  }
-
-  const role = roleByStore[storeId];
-  return allowed.includes(role);
+function isAuthed(auth: AuthContext): auth is { uid: string; token: { role?: Role } } {
+  return auth !== null
 }
 
-function getMergedValue<T>(existing: T | undefined, update: UpdateData, key: string): unknown {
-  if (Object.prototype.hasOwnProperty.call(update, key)) {
-    const value = update[key];
-    if (value === DELETE_FIELD) {
-      return undefined;
-    }
-    return value;
-  }
-
-  return existing;
+function hasAnyRole(roles: readonly Role[], auth: AuthContext) {
+  return isAuthed(auth) && roles.includes((auth.token.role ?? undefined) as Role)
 }
 
-function canUpdateProduct(resource: ProductDoc, update: UpdateData, auth: AuthContext | null): boolean {
-  if (!hasRole(resource.storeId, ['owner', 'manager'], auth)) {
-    return false;
-  }
-
-  const storeIdValue = getMergedValue(resource.storeId, update, 'storeId');
-  if (storeIdValue !== resource.storeId) {
-    return false;
-  }
-
-  const priceValue = getMergedValue(resource.price, update, 'price');
-  if (typeof priceValue !== 'number') {
-    return false;
-  }
-
-  const stockValue = getMergedValue(resource.stockCount, update, 'stockCount');
-  if (stockValue !== undefined) {
-    if (typeof stockValue !== 'number' || stockValue < 0) {
-      return false;
-    }
-  }
-
-  return true;
+function ownerOrSelf(uid: string, auth: AuthContext) {
+  return hasAnyRole(['owner'], auth) || (isAuthed(auth) && auth.uid === uid)
 }
 
-function canUpdateStoreDoc(resource: StoreDoc, update: UpdateData, auth: AuthContext | null): boolean {
-  if (!hasRole(resource.storeId, ['owner', 'manager'], auth)) {
-    return false;
-  }
-
-  const storeIdValue = getMergedValue(resource.storeId, update, 'storeId');
-  return storeIdValue === resource.storeId;
+function staffAccess(auth: AuthContext) {
+  return hasAnyRole(['owner', 'staff'], auth)
 }
 
-function canUpdate(collection: Collection, resource: StoreDoc, update: UpdateData, auth: AuthContext | null): boolean {
-  if (collection === 'products') {
-    return canUpdateProduct(resource as ProductDoc, update, auth);
-  }
+describe('Firestore security rules helpers (single tenant)', () => {
+  const ownerAuth: AuthContext = { uid: 'owner-1', token: { role: 'owner' } }
+  const staffAuth: AuthContext = { uid: 'staff-1', token: { role: 'staff' } }
+  const outsiderAuth: AuthContext = { uid: 'outsider-1', token: {} }
 
-  return canUpdateStoreDoc(resource, update, auth);
-}
+  test('owner can manage team members', () => {
+    expect(ownerOrSelf('team-1', ownerAuth)).toBe(true)
+    expect(hasAnyRole(['owner'], ownerAuth)).toBe(true)
+  })
 
-function canReadStoreUser(resource: StoreUserDoc, auth: AuthContext | null): boolean {
-  return hasRole(resource.storeId, ['owner'], auth);
-}
+  test('staff cannot write team member documents', () => {
+    expect(hasAnyRole(['owner'], staffAuth)).toBe(false)
+  })
 
-function canCreateStoreUser(request: StoreUserDoc, auth: AuthContext | null): boolean {
-  return hasRole(request.storeId, ['owner'], auth);
-}
+  test('users can read their own team member document', () => {
+    expect(ownerOrSelf('staff-1', staffAuth)).toBe(true)
+    expect(ownerOrSelf('staff-1', outsiderAuth)).toBe(false)
+  })
 
-function canUpdateStoreUser(resource: StoreUserDoc, update: UpdateData, auth: AuthContext | null): boolean {
-  if (!hasRole(resource.storeId, ['owner'], auth)) {
-    return false;
-  }
+  test('owner and staff can access business resources', () => {
+    expect(staffAccess(ownerAuth)).toBe(true)
+    expect(staffAccess(staffAuth)).toBe(true)
+  })
 
-  const storeIdValue = getMergedValue(resource.storeId, update, 'storeId');
-  return storeIdValue === resource.storeId;
-}
-
-function canDeleteStoreUser(resource: StoreUserDoc, auth: AuthContext | null): boolean {
-  return hasRole(resource.storeId, ['owner'], auth);
-}
-
-function canCreateProduct(request: Partial<ProductDoc> & StoreDoc, auth: AuthContext | null): boolean {
-  if (!hasRole(request.storeId, ['owner', 'manager'], auth)) {
-    return false;
-  }
-
-  if (typeof request.price !== 'number') {
-    return false;
-  }
-
-  if (Object.prototype.hasOwnProperty.call(request, 'stockCount')) {
-    const stock = request.stockCount;
-    if (stock !== undefined) {
-      if (typeof stock !== 'number' || stock < 0) {
-        return false;
-      }
-    }
-  }
-
-  return true;
-}
-
-describe('Firestore security rules - store isolation', () => {
-  const collections: readonly Collection[] = ['products', 'sales', 'expenses'];
-
-  test.each(collections)('prevents changing storeId on %s update', (collection) => {
-    const resource: StoreDoc =
-      collection === 'products'
-        ? { storeId: STORE_ID, name: 'Original', price: 100, stockCount: 3 }
-        : { storeId: STORE_ID, name: 'Original' };
-
-    expect(
-      canUpdate(
-        collection,
-        resource,
-        {
-          storeId: OTHER_STORE_ID,
-        },
-        managerAuth,
-      ),
-    ).toBe(false);
-  });
-
-  test.each(collections)('prevents removing storeId on %s update', (collection) => {
-    const resource: StoreDoc =
-      collection === 'products'
-        ? { storeId: STORE_ID, name: 'Original', price: 100, stockCount: 3 }
-        : { storeId: STORE_ID, name: 'Original' };
-
-    expect(
-      canUpdate(
-        collection,
-        resource,
-        {
-          storeId: deleteField(),
-        },
-        managerAuth,
-      ),
-    ).toBe(false);
-  });
-
-  test.each(collections)('allows updating other fields for %s', (collection) => {
-    const resource: StoreDoc =
-      collection === 'products'
-        ? { storeId: STORE_ID, name: 'Original', price: 100, stockCount: 3 }
-        : { storeId: STORE_ID, name: 'Original' };
-
-    expect(
-      canUpdate(
-        collection,
-        resource,
-        {
-          name: 'Updated',
-        },
-        managerAuth,
-      ),
-    ).toBe(true);
-  });
-});
-
-describe('Firestore security rules - product field validation', () => {
-  const validProduct: ProductDoc = {
-    storeId: STORE_ID,
-    name: 'Product',
-    price: 199,
-    stockCount: 3,
-  };
-
-  test('allows creating a product with numeric price and stock', () => {
-    expect(canCreateProduct(validProduct, managerAuth)).toBe(true);
-  });
-
-  test('allows creating a product without stockCount', () => {
-    expect(
-      canCreateProduct(
-        {
-          storeId: STORE_ID,
-          name: 'Product',
-          price: 50,
-        },
-        managerAuth,
-      ),
-    ).toBe(true);
-  });
-
-  test('rejects creating a product with non-numeric price', () => {
-    expect(
-      canCreateProduct(
-        {
-          storeId: STORE_ID,
-          name: 'Invalid',
-          price: 'not-a-number' as unknown as number,
-        },
-        managerAuth,
-      ),
-    ).toBe(false);
-  });
-
-  test('rejects creating a product with negative stock', () => {
-    expect(
-      canCreateProduct(
-        {
-          storeId: STORE_ID,
-          name: 'Invalid',
-          price: 100,
-          stockCount: -1,
-        },
-        managerAuth,
-      ),
-    ).toBe(false);
-  });
-
-  test('rejects creating a product with non-numeric stock', () => {
-    expect(
-      canCreateProduct(
-        {
-          storeId: STORE_ID,
-          name: 'Invalid',
-          price: 100,
-          stockCount: 'many' as unknown as number,
-        },
-        managerAuth,
-      ),
-    ).toBe(false);
-  });
-
-  test('allows updating a product without touching price or stock', () => {
-    expect(
-      canUpdateProduct(validProduct, {
-        name: 'Updated name',
-      }, managerAuth),
-    ).toBe(true);
-  });
-
-  test('rejects updating a product with a non-numeric price', () => {
-    expect(
-      canUpdateProduct(validProduct, {
-        price: 'not-a-number' as unknown as number,
-      }, managerAuth),
-    ).toBe(false);
-  });
-
-  test('allows updating a product with a numeric price', () => {
-    expect(
-      canUpdateProduct(validProduct, {
-        price: 250,
-      }, managerAuth),
-    ).toBe(true);
-  });
-
-  test('rejects updating a product with negative stock', () => {
-    expect(
-      canUpdateProduct(validProduct, {
-        stockCount: -5,
-      }, managerAuth),
-    ).toBe(false);
-  });
-
-  test('rejects removing price from a product', () => {
-    expect(
-      canUpdateProduct(validProduct, {
-        price: deleteField(),
-      }, managerAuth),
-    ).toBe(false);
-  });
-
-  test('allows updating a product with valid stock count', () => {
-    expect(
-      canUpdateProduct(validProduct, {
-        stockCount: 0,
-      }, managerAuth),
-    ).toBe(true);
-  });
-});
-
-describe('Firestore security rules - storeUsers', () => {
-  const membership: StoreUserDoc = { storeId: STORE_ID, uid: 'staff-1', role: 'cashier' };
-
-  test('allows an owner to read memberships for their store', () => {
-    expect(canReadStoreUser(membership, ownerAuth)).toBe(true);
-  });
-
-  test('prevents non-owners from reading memberships', () => {
-    expect(canReadStoreUser(membership, managerAuth)).toBe(false);
-  });
-
-  test('prevents owners of other stores from reading memberships', () => {
-    expect(canReadStoreUser(membership, outsiderOwnerAuth)).toBe(false);
-  });
-
-  test('allows an owner to create a membership for their store', () => {
-    expect(canCreateStoreUser({ storeId: STORE_ID, uid: 'staff-2', role: 'manager' }, ownerAuth)).toBe(true);
-  });
-
-  test('prevents changing storeId on membership update', () => {
-    expect(
-      canUpdateStoreUser(
-        membership,
-        {
-          storeId: OTHER_STORE_ID,
-        },
-        ownerAuth,
-      ),
-    ).toBe(false);
-  });
-
-  test('allows owners to update other fields for memberships', () => {
-    expect(
-      canUpdateStoreUser(
-        membership,
-        {
-          role: 'manager',
-        },
-        ownerAuth,
-      ),
-    ).toBe(true);
-  });
-
-  test('allows owners to delete memberships for their store', () => {
-    expect(canDeleteStoreUser(membership, ownerAuth)).toBe(true);
-  });
-
-  test('prevents non-owners from deleting memberships', () => {
-    expect(canDeleteStoreUser(membership, managerAuth)).toBe(false);
-  });
-});
+  test('users without a role cannot access business resources', () => {
+    expect(staffAccess(outsiderAuth)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- replace multi-store claim handling with single-tenant role-based helpers across HTTPS callables
- update the auxiliary callable and auth trigger to manage team member documents without store bookkeeping
- simplify Firestore rules/tests and adjust sale handling tests to the new schema

## Testing
- npm --prefix functions run test

------
https://chatgpt.com/codex/tasks/task_e_68d83b36fe908321a4c1f87e18a52e98