### PR TITLE
Remove store context from web flows

### DIFF
--- a/web/src/layout/Shell.test.tsx
+++ b/web/src/layout/Shell.test.tsx
@@ -4,13 +4,8 @@ import { render, screen } from '@testing-library/react'
 
 import Shell from './Shell'
 
-const mockUseActiveStore = vi.fn()
 const mockUseAuthUser = vi.fn()
 const mockUseConnectivityStatus = vi.fn()
-
-vi.mock('../hooks/useActiveStore', () => ({
-  useActiveStore: () => mockUseActiveStore(),
-}))
 
 vi.mock('../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
@@ -41,7 +36,6 @@ function renderShell() {
 describe('Shell', () => {
   beforeEach(() => {
     mockUseAuthUser.mockReset()
-    mockUseActiveStore.mockReset()
     mockUseConnectivityStatus.mockReset()
 
     mockUseAuthUser.mockReturnValue({ email: 'owner@example.com' })
@@ -55,45 +49,9 @@ describe('Shell', () => {
     })
   })
 
-  it('shows the resolved store identifier', () => {
-    mockUseActiveStore.mockReturnValue({
-      storeId: 'store-1',
-      stores: ['store-1'],
-      isLoading: false,
-      error: null,
-      selectStore: vi.fn(),
-    })
-
+  it('renders the workspace status', () => {
     renderShell()
 
-    expect(screen.getByText('store-1')).toBeInTheDocument()
-  })
-
-  it('indicates when store details are loading', () => {
-    mockUseActiveStore.mockReturnValue({
-      storeId: null,
-      stores: [],
-      isLoading: true,
-      error: null,
-      selectStore: vi.fn(),
-    })
-
-    renderShell()
-
-    expect(screen.getByText(/loading store/i)).toBeInTheDocument()
-  })
-
-  it('surfaces store resolution errors', () => {
-    mockUseActiveStore.mockReturnValue({
-      storeId: null,
-      stores: [],
-      isLoading: false,
-      error: 'Unable to determine store access.',
-      selectStore: vi.fn(),
-    })
-
-    renderShell()
-
-    expect(screen.getByRole('alert')).toHaveTextContent('Unable to determine store access.')
+    expect(screen.getByText('Workspace ready')).toBeInTheDocument()
   })
 })

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -4,7 +4,6 @@ import { signOut } from 'firebase/auth'
 import { auth } from '../firebase'
 import { useAuthUser } from '../hooks/useAuthUser'
 import { useConnectivityStatus } from '../hooks/useConnectivityStatus'
-import { useActiveStore } from '../hooks/useActiveStore'
 import './Shell.css'
 import './Workspace.css'
 
@@ -71,11 +70,6 @@ export default function Shell({ children }: { children: React.ReactNode }) {
   const user = useAuthUser()
   const userEmail = user?.email ?? 'Account'
   const connectivity = useConnectivityStatus()
-  const {
-    storeId: activeStoreId,
-    isLoading: storeLoading,
-    error: storeError,
-  } = useActiveStore()
 
   const { isOnline, isReachable, queue } = connectivity
 
@@ -113,8 +107,7 @@ export default function Shell({ children }: { children: React.ReactNode }) {
     return null
   }, [isOnline, isReachable, queue.lastError, queue.pending, queue.status])
 
-  const storeErrorId = storeError ? 'shell-store-error' : undefined
-  const storeStatus = storeLoading ? 'Loading store…' : activeStoreId ?? 'No store access'
+  const workspaceStatus = 'Workspace ready'
 
   return (
     <div className="shell">
@@ -140,10 +133,8 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
           <div className="shell__controls">
             <div className="shell__store-switcher" role="status" aria-live="polite">
-              <span className="shell__store-label">Store</span>
-              <span className="shell__store-select" data-readonly>
-                {storeStatus}
-              </span>
+              <span className="shell__store-label">Workspace</span>
+              <span className="shell__store-select" data-readonly>{workspaceStatus}</span>
             </div>
 
             {banner && (
@@ -173,12 +164,7 @@ export default function Shell({ children }: { children: React.ReactNode }) {
                 Sign out
               </button>
             </div>
-          </div>
-          {storeError ? (
-            <div className="shell__store-error" role="alert" id={storeErrorId}>
-              {storeError}
             </div>
-          ) : null}
         </div>
       </header>
 

--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -1,16 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import {
-  collection,
-  query,
-  where,
-  orderBy,
-  onSnapshot,
-  Timestamp,
-  addDoc,
-  serverTimestamp,
-} from 'firebase/firestore'
+import { collection, query, where, orderBy, onSnapshot, Timestamp, addDoc, serverTimestamp } from 'firebase/firestore'
 import { db } from '../firebase'
-import { useActiveStore } from '../hooks/useActiveStore'
 import { useAuthUser } from '../hooks/useAuthUser'
 
 const DENOMINATIONS = [200, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1] as const
@@ -39,7 +29,6 @@ function parseQuantity(input: string): number {
 }
 
 export default function CloseDay() {
-  const { storeId: STORE_ID, isLoading: storeLoading, error: storeError } = useActiveStore()
   const user = useAuthUser()
 
   const [total, setTotal] = useState(0)
@@ -54,20 +43,19 @@ export default function CloseDay() {
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   useEffect(() => {
-    if (!STORE_ID) return
-    const start = new Date(); start.setHours(0,0,0,0)
+    const start = new Date()
+    start.setHours(0, 0, 0, 0)
     const q = query(
-      collection(db,'sales'),
-      where('storeId','==',STORE_ID),
-      where('createdAt','>=', Timestamp.fromDate(start)),
-      orderBy('createdAt','desc')
+      collection(db, 'sales'),
+      where('createdAt', '>=', Timestamp.fromDate(start)),
+      orderBy('createdAt', 'desc')
     )
     return onSnapshot(q, snap => {
       let sum = 0
       snap.forEach(d => sum += (d.data().total || 0))
       setTotal(sum)
     })
-  }, [STORE_ID])
+  }, [])
 
   useEffect(() => {
     const style = document.createElement('style')
@@ -108,8 +96,6 @@ export default function CloseDay() {
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async event => {
     event.preventDefault()
-    if (!STORE_ID) return
-
     setSubmitError(null)
     setSubmitSuccess(false)
     setIsSubmitting(true)
@@ -117,7 +103,6 @@ export default function CloseDay() {
     try {
       const start = new Date(); start.setHours(0, 0, 0, 0)
       const closePayload = {
-        storeId: STORE_ID,
         businessDay: Timestamp.fromDate(start),
         salesTotal: total,
         expectedCash,
@@ -162,13 +147,9 @@ export default function CloseDay() {
     }
   }
 
-  if (storeLoading) return <div>Loading…</div>
-  if (!STORE_ID) return <div>We were unable to determine your store access. Please sign out and back in.</div>
-
   return (
     <div className="print-summary" style={{ maxWidth: 760 }}>
       <h2 style={{ color: '#4338CA' }}>Close Day</h2>
-      {storeError && <p style={{ color: '#b91c1c' }}>{storeError}</p>}
 
       <form onSubmit={handleSubmit}>
         <section style={{ marginTop: 24 }}>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,20 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import {
-  collection,
-  doc,
-  limit,
-  onSnapshot,
-  orderBy,
-  query,
-  setDoc,
-  where,
-  type Timestamp,
-} from 'firebase/firestore'
+import { collection, doc, limit, onSnapshot, orderBy, query, setDoc, type Timestamp } from 'firebase/firestore'
 import { db } from '../firebase'
 
 import { useAuthUser } from '../hooks/useAuthUser'
-import { useActiveStore } from '../hooks/useActiveStore'
 import { useToast } from '../components/ToastProvider'
 import {
   CUSTOMER_CACHE_LIMIT,
@@ -273,7 +262,7 @@ function parseDateInput(value: string) {
 }
 
 export default function Dashboard() {
-  const { storeId: STORE_ID, isLoading: storeLoading, error: storeError } = useActiveStore()
+  const authUser = useAuthUser()
 
   const [sales, setSales] = useState<SaleRecord[]>([])
   const [products, setProducts] = useState<ProductRecord[]>([])
@@ -289,12 +278,12 @@ export default function Dashboard() {
   const [isSavingGoals, setIsSavingGoals] = useState(false)
   const [selectedRangeId, setSelectedRangeId] = useState<PresetRangeId>('today')
   const [customRange, setCustomRange] = useState<{ start: string; end: string }>({ start: '', end: '' })
+  const goalDocumentId = authUser?.uid ?? 'default'
 
   useEffect(() => {
-    if (!STORE_ID) return
     let cancelled = false
 
-    loadCachedSales<SaleRecord>(STORE_ID)
+    loadCachedSales<SaleRecord>()
       .then(cached => {
         if (!cancelled && cached.length) {
           setSales(cached)
@@ -304,12 +293,7 @@ export default function Dashboard() {
         console.warn('[dashboard] Failed to load cached sales', error)
       })
 
-    const q = query(
-      collection(db, 'sales'),
-      where('storeId', '==', STORE_ID),
-      orderBy('createdAt', 'desc'),
-      limit(SALES_CACHE_LIMIT),
-    )
+    const q = query(collection(db, 'sales'), orderBy('createdAt', 'desc'), limit(SALES_CACHE_LIMIT))
 
     const unsubscribe = onSnapshot(q, snapshot => {
       const rows: SaleRecord[] = snapshot.docs.map(docSnap => ({
@@ -317,7 +301,7 @@ export default function Dashboard() {
         ...(docSnap.data() as Omit<SaleRecord, 'id'>),
       }))
       setSales(rows)
-      saveCachedSales(STORE_ID, rows).catch(error => {
+      saveCachedSales(rows).catch(error => {
         console.warn('[dashboard] Failed to cache sales', error)
       })
     })
@@ -326,13 +310,12 @@ export default function Dashboard() {
       cancelled = true
       unsubscribe()
     }
-  }, [STORE_ID])
+  }, [])
 
   useEffect(() => {
-    if (!STORE_ID) return
     let cancelled = false
 
-    loadCachedProducts<ProductRecord>(STORE_ID)
+    loadCachedProducts<ProductRecord>()
       .then(cached => {
         if (!cancelled && cached.length) {
           setProducts(cached)
@@ -344,7 +327,6 @@ export default function Dashboard() {
 
     const q = query(
       collection(db, 'products'),
-      where('storeId', '==', STORE_ID),
       orderBy('updatedAt', 'desc'),
       orderBy('createdAt', 'desc'),
       limit(PRODUCT_CACHE_LIMIT),
@@ -356,7 +338,7 @@ export default function Dashboard() {
         ...(docSnap.data() as Omit<ProductRecord, 'id'>),
       }))
       setProducts(rows)
-      saveCachedProducts(STORE_ID, rows).catch(error => {
+      saveCachedProducts(rows).catch(error => {
         console.warn('[dashboard] Failed to cache products', error)
       })
     })
@@ -365,13 +347,12 @@ export default function Dashboard() {
       cancelled = true
       unsubscribe()
     }
-  }, [STORE_ID])
+  }, [])
 
   useEffect(() => {
-    if (!STORE_ID) return
     let cancelled = false
 
-    loadCachedCustomers<CustomerRecord>(STORE_ID)
+    loadCachedCustomers<CustomerRecord>()
       .then(cached => {
         if (!cancelled && cached.length) {
           setCustomers(cached)
@@ -383,7 +364,6 @@ export default function Dashboard() {
 
     const q = query(
       collection(db, 'customers'),
-      where('storeId', '==', STORE_ID),
       orderBy('updatedAt', 'desc'),
       orderBy('createdAt', 'desc'),
       limit(CUSTOMER_CACHE_LIMIT),
@@ -395,7 +375,7 @@ export default function Dashboard() {
         ...(docSnap.data() as Omit<CustomerRecord, 'id'>),
       }))
       setCustomers(rows)
-      saveCachedCustomers(STORE_ID, rows).catch(error => {
+      saveCachedCustomers(rows).catch(error => {
         console.warn('[dashboard] Failed to cache customers', error)
       })
     })
@@ -404,11 +384,10 @@ export default function Dashboard() {
       cancelled = true
       unsubscribe()
     }
-  }, [STORE_ID])
+  }, [])
 
   useEffect(() => {
-    if (!STORE_ID) return
-    const ref = doc(db, 'storeGoals', STORE_ID)
+    const ref = doc(db, 'storeGoals', goalDocumentId)
     return onSnapshot(ref, snapshot => {
       const data = snapshot.data() as MonthlyGoalDocument | undefined
       if (!data?.monthly) {
@@ -426,7 +405,7 @@ export default function Dashboard() {
       })
       setMonthlyGoals(parsed)
     })
-  }, [STORE_ID])
+  }, [goalDocumentId])
 
   useEffect(() => {
     setGoalFormTouched(false)
@@ -750,7 +729,6 @@ export default function Dashboard() {
 
   async function handleGoalSubmit(event: React.FormEvent) {
     event.preventDefault()
-    if (!STORE_ID) return
     setIsSavingGoals(true)
     try {
       const revenueValue = Number(goalFormValues.revenueTarget)
@@ -760,9 +738,8 @@ export default function Dashboard() {
       const monthKey = selectedGoalMonth || defaultMonthKey
 
       await setDoc(
-        doc(db, 'storeGoals', STORE_ID),
+        doc(db, 'storeGoals', goalDocumentId),
         {
-          storeId: STORE_ID,
           monthly: {
             [monthKey]: {
               revenueTarget,
@@ -813,18 +790,9 @@ export default function Dashboard() {
     },
   ]
 
-  if (storeLoading) {
-    return <div>Loading…</div>
-  }
-
-  if (!STORE_ID) {
-    return <div>We were unable to determine your store access. Please sign out and back in.</div>
-  }
-
   return (
     <div>
       <h2 style={{ color: '#4338CA', marginBottom: 8 }}>Dashboard</h2>
-      {storeError && <p style={{ color: '#b91c1c', marginBottom: 12 }}>{storeError}</p>}
       <p style={{ color: '#475569', marginBottom: 24 }}>
         Welcome back! Choose what you’d like to work on — the most important Sedifex pages are just one tap away.
       </p>

--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { collection, query, where, orderBy, limit, onSnapshot } from 'firebase/firestore'
+import { collection, query, orderBy, limit, onSnapshot } from 'firebase/firestore'
 import { FirebaseError } from 'firebase/app'
 import { httpsCallable } from 'firebase/functions'
 import { db, functions } from '../firebase'
-import { useActiveStore } from '../hooks/useActiveStore'
 import './Receive.css'
 import { queueCallableRequest } from '../utils/offlineQueue'
 import { loadCachedProducts, saveCachedProducts, PRODUCT_CACHE_LIMIT } from '../utils/offlineCache'
@@ -12,7 +11,6 @@ type Product = {
   id: string
   name: string
   stockCount?: number
-  storeId: string
   createdAt?: unknown
   updatedAt?: unknown
 }
@@ -30,8 +28,6 @@ function isOfflineError(error: unknown) {
 }
 
 export default function Receive() {
-  const { storeId: STORE_ID, isLoading: storeLoading, error: storeError } = useActiveStore()
-
   const [products, setProducts] = useState<Product[]>([])
   const [selected, setSelected] = useState<string>('')
   const [qty, setQty] = useState<string>('')
@@ -63,11 +59,9 @@ export default function Receive() {
   }
 
   useEffect(() => {
-    if (!STORE_ID) return
-
     let cancelled = false
 
-    loadCachedProducts<Product>(STORE_ID)
+    loadCachedProducts<Product>()
       .then(cached => {
         if (!cancelled && cached.length) {
           setProducts(
@@ -81,7 +75,6 @@ export default function Receive() {
 
     const q = query(
       collection(db, 'products'),
-      where('storeId', '==', STORE_ID),
       orderBy('updatedAt', 'desc'),
       orderBy('createdAt', 'desc'),
       limit(PRODUCT_CACHE_LIMIT),
@@ -89,7 +82,7 @@ export default function Receive() {
 
     const unsubscribe = onSnapshot(q, snap => {
       const rows = snap.docs.map(d => ({ id: d.id, ...(d.data() as any) }))
-      saveCachedProducts(STORE_ID, rows).catch(error => {
+      saveCachedProducts(rows).catch(error => {
         console.warn('[receive] Failed to cache products', error)
       })
       const sortedRows = [...rows].sort((a, b) =>
@@ -102,13 +95,9 @@ export default function Receive() {
       cancelled = true
       unsubscribe()
     }
-  }, [STORE_ID])
+  }, [])
 
   async function receive() {
-    if (!STORE_ID) {
-      showStatus('error', 'Store access is not ready. Please refresh and try again.')
-      return
-    }
     if (!selected || qty === '') return
     const p = products.find(x=>x.id===selected); if (!p) return
     const amount = Number(qty)
@@ -134,7 +123,6 @@ export default function Receive() {
     }
     setBusy(true)
     const payload = {
-      storeId: STORE_ID,
       productId: selected,
       qty: amount,
       supplier: supplierName,
@@ -167,9 +155,6 @@ export default function Receive() {
       setBusy(false)
     }
   }
-
-  if (storeLoading) return <div>Loading…</div>
-  if (!STORE_ID) return <div>We were unable to determine your store access. Please sign out and back in.</div>
 
   return (
     <div className="page receive-page">
@@ -257,9 +242,6 @@ export default function Receive() {
             >
               {status.message}
             </p>
-          )}
-          {storeError && (
-            <p className="receive-page__message receive-page__message--error" role="alert">{storeError}</p>
           )}
         </div>
       </section>

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -24,11 +24,6 @@ afterAll(() => {
   ;(globalThis.URL as any).revokeObjectURL = originalRevokeObjectURL
 })
 
-const mockUseActiveStore = vi.fn()
-vi.mock('../hooks/useActiveStore', () => ({
-  useActiveStore: () => mockUseActiveStore(),
-}))
-
 const mockQueueCallableRequest = vi.fn()
 vi.mock('../utils/offlineQueue', () => ({
   queueCallableRequest: (...args: unknown[]) => mockQueueCallableRequest(...args),
@@ -70,7 +65,7 @@ const productSnapshot = {
   docs: [
     {
       id: 'product-1',
-      data: () => ({ id: 'product-1', name: 'Iced Coffee', price: 12, storeId: 'store-1' }),
+      data: () => ({ id: 'product-1', name: 'Iced Coffee', price: 12 }),
     },
   ],
 }
@@ -90,7 +85,6 @@ const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[])
   collection: collectionRef,
   clauses,
 }))
-const whereMock = vi.fn((...args: unknown[]) => ({ type: 'where', args }))
 const orderByMock = vi.fn((field: string, direction?: string) => ({ type: 'orderBy', field, direction }))
 const docMock = vi.fn(() => ({ id: 'generated-sale-id' }))
 const limitMock = vi.fn((value: number) => ({ type: 'limit', value }))
@@ -116,9 +110,6 @@ vi.mock('firebase/firestore', () => ({
   query: (
     ...args: Parameters<typeof queryMock>
   ) => queryMock(...args),
-  where: (
-    ...args: Parameters<typeof whereMock>
-  ) => whereMock(...args),
   orderBy: (
     ...args: Parameters<typeof orderByMock>
   ) => orderByMock(...args),
@@ -140,19 +131,10 @@ function renderWithProviders(ui: ReactElement) {
 describe('Sell page', () => {
   beforeEach(() => {
     mockUseAuthUser.mockReset()
-    mockUseActiveStore.mockReset()
     mockCommitSale.mockReset()
     mockUseAuthUser.mockReturnValue({
       uid: 'cashier-123',
       email: 'cashier@example.com',
-    })
-    const selectStoreMock = vi.fn()
-    mockUseActiveStore.mockReturnValue({
-      storeId: 'store-1',
-      stores: ['store-1'],
-      isLoading: false,
-      error: null,
-      selectStore: selectStoreMock,
     })
     mockCommitSale.mockResolvedValue({
       data: {
@@ -171,7 +153,6 @@ describe('Sell page', () => {
     mockSaveCachedCustomers.mockResolvedValue(undefined)
     collectionMock.mockClear()
     queryMock.mockClear()
-    whereMock.mockClear()
     orderByMock.mockClear()
     limitMock.mockClear()
     docMock.mockClear()
@@ -199,7 +180,6 @@ describe('Sell page', () => {
 
     expect(mockCommitSale).toHaveBeenCalledWith(
       expect.objectContaining({
-        storeId: 'store-1',
         totals: expect.objectContaining({ total: 12 }),
         payment: expect.objectContaining({ method: 'cash', amountPaid: 15, changeDue: 3 }),
         items: [

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -1,18 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import {
-  collection,
-  query,
-  where,
-  orderBy,
-  limit,
-  onSnapshot,
-  doc,
-} from 'firebase/firestore'
+import { collection, query, orderBy, limit, onSnapshot, doc } from 'firebase/firestore'
 import { FirebaseError } from 'firebase/app'
 import { httpsCallable } from 'firebase/functions'
 import { db, functions as cloudFunctions } from '../firebase'
 import { useAuthUser } from '../hooks/useAuthUser'
-import { useActiveStore } from '../hooks/useActiveStore'
 import './Sell.css'
 import { Link } from 'react-router-dom'
 import { queueCallableRequest } from '../utils/offlineQueue'
@@ -31,7 +22,6 @@ type Product = {
   name: string
   price: number
   stockCount?: number
-  storeId: string
   createdAt?: unknown
   updatedAt?: unknown
 }
@@ -73,7 +63,6 @@ type ReceiptSharePayload = {
 }
 
 type CommitSalePayload = {
-  storeId: string
   branchId: string | null
   saleId: string
   cashierId: string
@@ -120,7 +109,6 @@ function isOfflineError(error: unknown) {
 
 export default function Sell() {
   const user = useAuthUser()
-  const { storeId: STORE_ID, isLoading: storeLoading, error: storeError } = useActiveStore()
 
   const [products, setProducts] = useState<Product[]>([])
   const [customers, setCustomers] = useState<Customer[]>([])
@@ -141,11 +129,9 @@ export default function Sell() {
   const isCashShort = paymentMethod === 'cash' && amountPaid < subtotal && subtotal > 0
 
   useEffect(() => {
-    if (!STORE_ID) return
-
     let cancelled = false
 
-    loadCachedProducts<Product>(STORE_ID)
+    loadCachedProducts<Product>()
       .then(cached => {
         if (!cancelled && cached.length) {
           setProducts(
@@ -159,7 +145,6 @@ export default function Sell() {
 
     const q = query(
       collection(db, 'products'),
-      where('storeId', '==', STORE_ID),
       orderBy('updatedAt', 'desc'),
       orderBy('createdAt', 'desc'),
       limit(PRODUCT_CACHE_LIMIT),
@@ -167,7 +152,7 @@ export default function Sell() {
 
     const unsubscribe = onSnapshot(q, snap => {
       const rows = snap.docs.map(d => ({ id: d.id, ...(d.data() as any) }))
-      saveCachedProducts(STORE_ID, rows).catch(error => {
+      saveCachedProducts(rows).catch(error => {
         console.warn('[sell] Failed to cache products', error)
       })
       const sortedRows = [...rows].sort((a, b) =>
@@ -180,14 +165,12 @@ export default function Sell() {
       cancelled = true
       unsubscribe()
     }
-  }, [STORE_ID])
+  }, [])
 
   useEffect(() => {
-    if (!STORE_ID) return
-
     let cancelled = false
 
-    loadCachedCustomers<Customer>(STORE_ID)
+    loadCachedCustomers<Customer>()
       .then(cached => {
         if (!cancelled && cached.length) {
           setCustomers(
@@ -201,7 +184,6 @@ export default function Sell() {
 
     const q = query(
       collection(db, 'customers'),
-      where('storeId', '==', STORE_ID),
       orderBy('updatedAt', 'desc'),
       orderBy('createdAt', 'desc'),
       limit(CUSTOMER_CACHE_LIMIT),
@@ -209,7 +191,7 @@ export default function Sell() {
 
     const unsubscribe = onSnapshot(q, snap => {
       const rows = snap.docs.map(docSnap => ({ id: docSnap.id, ...(docSnap.data() as Customer) }))
-      saveCachedCustomers(STORE_ID, rows).catch(error => {
+      saveCachedCustomers(rows).catch(error => {
         console.warn('[sell] Failed to cache customers', error)
       })
       const sortedRows = [...rows].sort((a, b) =>
@@ -222,7 +204,7 @@ export default function Sell() {
       cancelled = true
       unsubscribe()
     }
-  }, [STORE_ID])
+  }, [])
 
   useEffect(() => {
     if (!receipt) return
@@ -351,7 +333,7 @@ export default function Sell() {
     setCart(cs => cs.map(l => l.productId === id ? { ...l, qty: Math.max(0, qty) } : l).filter(l => l.qty > 0))
   }
   async function recordSale() {
-    if (!STORE_ID || cart.length === 0) return
+    if (cart.length === 0) return
     if (!user) {
       setSaleError('You must be signed in to record a sale.')
       return
@@ -367,7 +349,6 @@ export default function Sell() {
     const saleId = doc(collection(db, 'sales')).id
     const commitSale = httpsCallable<CommitSalePayload, CommitSaleResponse>(cloudFunctions, 'commitSale')
     const payload: CommitSalePayload = {
-      storeId: STORE_ID,
       branchId: null,
       saleId,
       cashierId: user.uid,
@@ -466,11 +447,6 @@ export default function Sell() {
     }
   }
 
-  if (storeLoading) return <div>Loading…</div>
-  if (!STORE_ID) {
-    return <div>We were unable to determine your store access. Please sign out and back in.</div>
-  }
-
   const filtered = products.filter(p => p.name.toLowerCase().includes(queryText.toLowerCase()))
 
   return (
@@ -498,10 +474,6 @@ export default function Sell() {
           <p className="field__hint">Tip: start typing and tap a product to add it to the cart.</p>
         </div>
       </section>
-
-      {storeError && (
-        <p className="sell-page__message sell-page__message--error" role="alert">{storeError}</p>
-      )}
 
       <div className="sell-page__grid">
         <section className="card sell-page__catalog" aria-label="Product list">

--- a/web/src/pages/__tests__/Products.test.tsx
+++ b/web/src/pages/__tests__/Products.test.tsx
@@ -5,11 +5,6 @@ import userEvent from '@testing-library/user-event'
 
 import Products from '../Products'
 
-const mockUseActiveStore = vi.fn()
-vi.mock('../../hooks/useActiveStore', () => ({
-  useActiveStore: () => mockUseActiveStore(),
-}))
-
 const mockLoadCachedProducts = vi.fn(async () => [] as unknown[])
 const mockSaveCachedProducts = vi.fn(async () => {})
 
@@ -30,7 +25,6 @@ const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[])
   collection: collectionRef,
   clauses,
 }))
-const whereMock = vi.fn((...args: unknown[]) => ({ type: 'where', args }))
 const orderByMock = vi.fn((field: string, direction?: string) => ({ type: 'orderBy', field, direction }))
 const limitMock = vi.fn((value: number) => ({ type: 'limit', value }))
 const onSnapshotMock = vi.fn(
@@ -55,7 +49,6 @@ const docMock = vi.fn((collectionRef: { path: string }, id: string) => ({
 vi.mock('firebase/firestore', () => ({
   collection: (...args: Parameters<typeof collectionMock>) => collectionMock(...args),
   query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
-  where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
   orderBy: (...args: Parameters<typeof orderByMock>) => orderByMock(...args),
   limit: (...args: Parameters<typeof limitMock>) => limitMock(...args),
   onSnapshot: (
@@ -69,12 +62,10 @@ vi.mock('firebase/firestore', () => ({
 
 describe('Products page', () => {
   beforeEach(() => {
-    mockUseActiveStore.mockReset()
     mockLoadCachedProducts.mockReset()
     mockSaveCachedProducts.mockReset()
     collectionMock.mockClear()
     queryMock.mockClear()
-    whereMock.mockClear()
     orderByMock.mockClear()
     limitMock.mockClear()
     onSnapshotMock.mockClear()
@@ -82,14 +73,6 @@ describe('Products page', () => {
     updateDocMock.mockClear()
     serverTimestampMock.mockClear()
     docMock.mockClear()
-
-    mockUseActiveStore.mockReturnValue({
-      storeId: 'store-1',
-      stores: ['store-1'],
-      isLoading: false,
-      error: null,
-      selectStore: vi.fn(),
-    })
 
     mockLoadCachedProducts.mockResolvedValue([])
     mockSaveCachedProducts.mockResolvedValue(undefined)
@@ -99,24 +82,6 @@ describe('Products page', () => {
       })
       return () => {}
     })
-  })
-
-  it('renders store loading state', () => {
-    mockUseActiveStore.mockReturnValue({
-      storeId: null,
-      stores: [],
-      isLoading: true,
-      error: null,
-      selectStore: vi.fn(),
-    })
-
-    render(
-      <MemoryRouter>
-        <Products />
-      </MemoryRouter>,
-    )
-
-    expect(screen.getByText('Loading…')).toBeInTheDocument()
   })
 
   it('shows an empty state when no products are available', async () => {
@@ -220,7 +185,6 @@ describe('Products page', () => {
     expect(addDocMock).toHaveBeenCalledWith(
       expect.objectContaining({ path: 'products' }),
       expect.objectContaining({
-        storeId: 'store-1',
         name: 'New Blend',
         sku: 'NB-01',
         reorderThreshold: 4,

--- a/web/src/utils/offlineCache.ts
+++ b/web/src/utils/offlineCache.ts
@@ -135,51 +135,41 @@ async function saveCachedList<T>(key: string, items: T[], limit: number): Promis
   }
 }
 
-function cacheKey(prefix: string, storeId: string) {
-  return `${prefix}:${storeId}`
-}
-
 export async function loadCachedProducts<T extends { updatedAt?: unknown; createdAt?: unknown }>(
-  storeId: string,
   limit = PRODUCT_CACHE_LIMIT,
 ): Promise<T[]> {
-  return loadCachedList<T>(cacheKey('products', storeId), limit)
+  return loadCachedList<T>('products', limit)
 }
 
 export async function saveCachedProducts<T extends { updatedAt?: unknown; createdAt?: unknown }>(
-  storeId: string,
   items: T[],
   limit = PRODUCT_CACHE_LIMIT,
 ): Promise<void> {
-  await saveCachedList(cacheKey('products', storeId), items, limit)
+  await saveCachedList('products', items, limit)
 }
 
 export async function loadCachedCustomers<T extends { updatedAt?: unknown; createdAt?: unknown }>(
-  storeId: string,
   limit = CUSTOMER_CACHE_LIMIT,
 ): Promise<T[]> {
-  return loadCachedList<T>(cacheKey('customers', storeId), limit)
+  return loadCachedList<T>('customers', limit)
 }
 
 export async function saveCachedCustomers<T extends { updatedAt?: unknown; createdAt?: unknown }>(
-  storeId: string,
   items: T[],
   limit = CUSTOMER_CACHE_LIMIT,
 ): Promise<void> {
-  await saveCachedList(cacheKey('customers', storeId), items, limit)
+  await saveCachedList('customers', items, limit)
 }
 
 export async function loadCachedSales<T extends { createdAt?: unknown }>(
-  storeId: string,
   limit = SALES_CACHE_LIMIT,
 ): Promise<T[]> {
-  return loadCachedList<T>(cacheKey('sales', storeId), limit)
+  return loadCachedList<T>('sales', limit)
 }
 
 export async function saveCachedSales<T extends { createdAt?: unknown }>(
-  storeId: string,
   items: T[],
   limit = SALES_CACHE_LIMIT,
 ): Promise<void> {
-  await saveCachedList(cacheKey('sales', storeId), items, limit)
+  await saveCachedList('sales', items, limit)
 }


### PR DESCRIPTION
## Summary
- remove store-aware cache keys and adjust offline data helpers
- update dashboard, inventory, sales, and close-day pages to drop store filters and payloads
- refresh related tests and shell layout for store-agnostic behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d83b360d1c8321b2886099c80c2322