### PR TITLE
Add product price validation and guard sell flow

### DIFF
--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -67,6 +67,10 @@ const productSnapshot = {
       id: 'product-1',
       data: () => ({ id: 'product-1', name: 'Iced Coffee', price: 12 }),
     },
+    {
+      id: 'product-2',
+      data: () => ({ id: 'product-2', name: 'Mystery Item' }),
+    },
   ],
 }
 
@@ -191,5 +195,20 @@ describe('Sell page', () => {
     )
 
     // Skip UI assertion to avoid flakiness in headless environment.
+  })
+
+  it('disables products that do not have a valid price', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<Sell />)
+
+    const unavailableButton = await screen.findByRole('button', { name: /mystery item/i })
+    expect(unavailableButton).toBeDisabled()
+    expect(unavailableButton).toHaveTextContent(/price unavailable/i)
+    expect(unavailableButton).toHaveTextContent(/set price to sell/i)
+
+    await user.click(unavailableButton)
+
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- require a price when creating or editing products, persist the value to Firestore, and surface it in the catalogue
- sanitize cached product prices so the sell page can safely disable unpriced items instead of calling toFixed on invalid values
- expand products and sell page tests to cover products missing prices and validate the new form rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d84425fec48321afe670d3b59fffe3