### PR TITLE
Normalize Firebase offline error detection

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -121,7 +121,13 @@ function sortProducts(products: ProductRecord[]): ProductRecord[] {
 function isOfflineError(error: unknown) {
   if (!navigator.onLine) return true
   if (error instanceof FirebaseError) {
-    return error.code === 'unavailable' || error.code === 'internal'
+    const code = (error.code || '').toLowerCase()
+    return (
+      code === 'unavailable' ||
+      code === 'internal' ||
+      code.endsWith('/unavailable') ||
+      code.endsWith('/internal')
+    )
   }
   if (error instanceof TypeError) {
     const message = error.message.toLowerCase()

--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -18,7 +18,13 @@ type Product = {
 function isOfflineError(error: unknown) {
   if (!navigator.onLine) return true
   if (error instanceof FirebaseError) {
-    return error.code === 'unavailable' || error.code === 'internal'
+    const code = (error.code || '').toLowerCase()
+    return (
+      code === 'unavailable' ||
+      code === 'internal' ||
+      code.endsWith('/unavailable') ||
+      code.endsWith('/internal')
+    )
   }
   if (error instanceof TypeError) {
     const message = error.message.toLowerCase()

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -98,7 +98,13 @@ type CommitSaleResponse = {
 function isOfflineError(error: unknown) {
   if (!navigator.onLine) return true
   if (error instanceof FirebaseError) {
-    return error.code === 'unavailable' || error.code === 'internal'
+    const code = (error.code || '').toLowerCase()
+    return (
+      code === 'unavailable' ||
+      code === 'internal' ||
+      code.endsWith('/unavailable') ||
+      code.endsWith('/internal')
+    )
   }
   if (error instanceof TypeError) {
     const message = error.message.toLowerCase()


### PR DESCRIPTION
## Summary
- normalize Firebase error codes before classifying offline errors
- treat internal/unavailable Firebase errors and namespaced variants as offline across Sell, Receive, and Products pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d87b7c27e083219794dec8c0b90158