### PR TITLE
Align memberships with teamMembers schema

### DIFF
--- a/functions/src/callables.ts
+++ b/functions/src/callables.ts
@@ -94,11 +94,18 @@ export const backfillMyStore = functions.https.onCall(async (data, context) => {
   const memberRef = db.collection('teamMembers').doc(uid)
   const memberSnap = await memberRef.get()
   const timestamp = admin.firestore.FieldValue.serverTimestamp()
+  const existingData = memberSnap.data() ?? {}
+  const existingStoreId =
+    typeof existingData.storeId === 'string' && existingData.storeId.trim() !== ''
+      ? (existingData.storeId as string)
+      : null
+  const storeId = existingStoreId ?? uid
 
   const memberData: admin.firestore.DocumentData = {
     uid,
     email,
     role: 'owner',
+    storeId,
     phone: resolvedPhone,
     firstSignupEmail: resolvedFirstSignupEmail,
     invitedBy: uid,
@@ -112,5 +119,5 @@ export const backfillMyStore = functions.https.onCall(async (data, context) => {
   await memberRef.set(memberData, { merge: true })
   const claims = await applyRoleClaim(uid, 'owner')
 
-  return { ok: true, claims }
+  return { ok: true, claims, storeId }
 })

--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -11,7 +11,7 @@ const STORE_ERROR_MESSAGE = 'We could not load your workspace access. Some featu
 
 export function useActiveStore(): ActiveStoreState {
   const { memberships, loading, error } = useMemberships()
-  const activeStoreId = memberships[0]?.storeId ?? null
+  const activeStoreId = memberships.find(m => m.storeId)?.storeId ?? null
   const hasError = error != null
 
   return useMemo(

--- a/web/src/hooks/useMemberships.test.tsx
+++ b/web/src/hooks/useMemberships.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { useMemberships } from './useMemberships'
+
+const mockUseAuthUser = vi.fn()
+vi.mock('./useAuthUser', () => ({
+  useAuthUser: () => mockUseAuthUser(),
+}))
+
+vi.mock('../firebase', () => ({
+  db: {},
+}))
+
+const collectionMock = vi.fn(() => ({ type: 'collection' }))
+const whereMock = vi.fn(() => ({ type: 'where' }))
+const queryMock = vi.fn(() => ({ type: 'query' }))
+const getDocsMock = vi.fn()
+
+vi.mock('firebase/firestore', () => ({
+  Timestamp: class MockTimestamp {},
+  collection: (...args: Parameters<typeof collectionMock>) => collectionMock(...args),
+  where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
+  query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
+  getDocs: (...args: Parameters<typeof getDocsMock>) => getDocsMock(...args),
+}))
+
+describe('useMemberships', () => {
+  beforeEach(() => {
+    mockUseAuthUser.mockReset()
+    collectionMock.mockClear()
+    whereMock.mockClear()
+    queryMock.mockClear()
+    getDocsMock.mockReset()
+  })
+
+  it('returns an empty membership list when the user is not authenticated', async () => {
+    mockUseAuthUser.mockReturnValue(null)
+
+    const { result } = renderHook(() => useMemberships())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.memberships).toEqual([])
+    expect(collectionMock).not.toHaveBeenCalled()
+  })
+
+  it('loads memberships for the authenticated user and normalizes the document shape', async () => {
+    mockUseAuthUser.mockReturnValue({ uid: 'user-123' })
+
+    const membershipDoc = {
+      id: 'member-doc',
+      data: () => ({
+        uid: 'user-123',
+        role: 'staff',
+        storeId: 'store-abc',
+        email: 'member@example.com',
+        phone: '+1234567890',
+        invitedBy: 'owner-1',
+        firstSignupEmail: 'owner@example.com',
+        createdAt: null,
+        updatedAt: null,
+      }),
+    }
+
+    getDocsMock.mockResolvedValue({ docs: [membershipDoc] })
+
+    const { result } = renderHook(() => useMemberships())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(collectionMock).toHaveBeenCalledWith({}, 'teamMembers')
+    expect(whereMock).toHaveBeenCalledWith('uid', '==', 'user-123')
+    expect(queryMock).toHaveBeenCalled()
+    expect(getDocsMock).toHaveBeenCalled()
+
+    expect(result.current.memberships).toEqual([
+      {
+        id: 'member-doc',
+        uid: 'user-123',
+        role: 'staff',
+        storeId: 'store-abc',
+        email: 'member@example.com',
+        phone: '+1234567890',
+        invitedBy: 'owner-1',
+        firstSignupEmail: 'owner@example.com',
+        createdAt: null,
+        updatedAt: null,
+      },
+    ])
+    expect(result.current.error).toBeNull()
+  })
+
+  it('falls back to the document id and null values when fields are missing', async () => {
+    mockUseAuthUser.mockReturnValue({ uid: 'user-456' })
+
+    const membershipDoc = {
+      id: 'user-456',
+      data: () => ({
+        role: 'unknown-role',
+      }),
+    }
+
+    getDocsMock.mockResolvedValue({ docs: [membershipDoc] })
+
+    const { result } = renderHook(() => useMemberships())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.memberships).toEqual([
+      {
+        id: 'user-456',
+        uid: 'user-456',
+        role: 'staff',
+        storeId: null,
+        email: null,
+        phone: null,
+        invitedBy: null,
+        firstSignupEmail: null,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- update the memberships hook to read teamMembers documents and normalize the Firestore schema
- propagate store identifiers and staff role support through membership-aware Cloud Functions and consumers
- add unit coverage to verify hook loading states and document mapping

## Testing
- npm test --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68d87fdd2148832180a533c2531b9b16