### PR TITLE
Partition Firestore data by active store

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -9,13 +9,15 @@
     "build": "tsc",
     "serve": "firebase emulators:start --only functions",
     "deploy": "npm run build && firebase deploy --only functions",
-    "test": "npm run build && node ./test/commitSale.test.js"
+    "test": "npm run build && node ./test/commitSale.test.js",
+    "backfill-store": "ts-node ./scripts/backfillStoreIds.ts"
   },
   "dependencies": {
     "firebase-admin": "^12.5.0",
     "firebase-functions": "^5.0.1"
   },
   "devDependencies": {
+    "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
   }
 }

--- a/functions/scripts/backfillStoreIds.ts
+++ b/functions/scripts/backfillStoreIds.ts
@@ -1,0 +1,96 @@
+import * as admin from 'firebase-admin'
+
+const TARGET_STORE_ID = (process.argv[2] ?? '').trim()
+
+if (!TARGET_STORE_ID) {
+  console.error('Usage: npm run backfill-store <storeId>')
+  process.exit(1)
+}
+
+if (!admin.apps.length) {
+  admin.initializeApp()
+}
+
+const db = admin.firestore()
+
+async function commitBatch(batch: admin.firestore.WriteBatch, writes: number) {
+  if (writes === 0) {
+    return 0
+  }
+  await batch.commit()
+  return 0
+}
+
+function resolveStoreId(doc: admin.firestore.DocumentSnapshot<admin.firestore.DocumentData>) {
+  const data = doc.data() || {}
+  const storeId = typeof data.storeId === 'string' ? data.storeId.trim() : ''
+  if (storeId) return storeId
+  const branchId = typeof data.branchId === 'string' ? data.branchId.trim() : ''
+  if (branchId) return branchId
+  return TARGET_STORE_ID
+}
+
+async function backfillCollection(
+  collectionName: string,
+  resolver: (
+    doc: admin.firestore.DocumentSnapshot<admin.firestore.DocumentData>,
+    existingStore: string,
+  ) => { storeId: string; updates?: Record<string, unknown> } | null,
+) {
+  const snapshot = await db.collection(collectionName).get()
+  let batch = db.batch()
+  let writes = 0
+  let processed = 0
+
+  for (const doc of snapshot.docs) {
+    processed += 1
+    const existingStore = resolveStoreId(doc)
+    const result = resolver(doc, existingStore)
+    if (!result) continue
+    batch.update(doc.ref, result.updates ? { storeId: result.storeId, ...result.updates } : { storeId: result.storeId })
+    writes += 1
+    if (writes >= 400) {
+      writes = await commitBatch(batch, writes)
+      batch = db.batch()
+    }
+  }
+
+  await commitBatch(batch, writes)
+  console.log(`Backfilled ${processed} documents in ${collectionName}`)
+}
+
+async function run() {
+  const saleStoreMap = new Map<string, string>()
+
+  await backfillCollection('products', (_doc, storeId) => {
+    return { storeId }
+  })
+
+  await backfillCollection('customers', (_doc, storeId) => {
+    return { storeId }
+  })
+
+  await backfillCollection('sales', (doc, existingStore) => {
+    saleStoreMap.set(doc.id, existingStore)
+    return { storeId: existingStore, updates: { branchId: existingStore } }
+  })
+
+  await backfillCollection('saleItems', (doc, existingStore) => {
+    const parentSaleId = typeof doc.get('saleId') === 'string' ? (doc.get('saleId') as string) : ''
+    const resolved = saleStoreMap.get(parentSaleId) ?? existingStore
+    return { storeId: resolved }
+  })
+
+  await backfillCollection('ledger', (doc, existingStore) => {
+    const refId = typeof doc.get('refId') === 'string' ? (doc.get('refId') as string) : ''
+    const resolved = saleStoreMap.get(refId) ?? existingStore
+    return { storeId: resolved }
+  })
+
+  console.log('Backfill complete.')
+}
+
+run().catch(error => {
+  console.error('Backfill failed', error)
+  process.exit(1)
+})

--- a/web/src/pages/__tests__/Products.test.tsx
+++ b/web/src/pages/__tests__/Products.test.tsx
@@ -20,6 +20,11 @@ vi.mock('../../firebase', () => ({
   db: {},
 }))
 
+const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+vi.mock('../../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
 const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
 const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[]) => ({
   collection: collectionRef,
@@ -27,6 +32,12 @@ const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[])
 }))
 const orderByMock = vi.fn((field: string, direction?: string) => ({ type: 'orderBy', field, direction }))
 const limitMock = vi.fn((value: number) => ({ type: 'limit', value }))
+const whereMock = vi.fn((field: string, op: string, value: unknown) => ({
+  type: 'where',
+  field,
+  op,
+  value,
+}))
 const onSnapshotMock = vi.fn(
   (
     queryRef: { collection: { path: string } },
@@ -58,6 +69,7 @@ vi.mock('firebase/firestore', () => ({
   updateDoc: (...args: Parameters<typeof updateDocMock>) => updateDocMock(...args),
   serverTimestamp: (...args: Parameters<typeof serverTimestampMock>) => serverTimestampMock(...args),
   doc: (...args: Parameters<typeof docMock>) => docMock(...args),
+  where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
 }))
 
 describe('Products page', () => {
@@ -73,6 +85,9 @@ describe('Products page', () => {
     updateDocMock.mockClear()
     serverTimestampMock.mockClear()
     docMock.mockClear()
+    whereMock.mockClear()
+    mockUseActiveStore.mockReset()
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
 
 
 

--- a/web/src/utils/offlineCache.ts
+++ b/web/src/utils/offlineCache.ts
@@ -1,6 +1,7 @@
 const DB_NAME = 'sedifex-offline-cache'
 const DB_VERSION = 1
 const STORE_NAME = 'lists'
+const DEFAULT_PARTITION_KEY = '__global'
 
 export const PRODUCT_CACHE_LIMIT = 200
 export const CUSTOMER_CACHE_LIMIT = 200
@@ -94,6 +95,17 @@ function sortAndTrim<T>(items: T[], limit: number) {
     .slice(0, limit)
 }
 
+function resolvePartitionKey(baseKey: string, storeId?: string | null) {
+  const normalized = typeof storeId === 'string' ? storeId.trim() : ''
+  const suffix = normalized ? normalized : DEFAULT_PARTITION_KEY
+  return `${baseKey}:${suffix}`
+}
+
+type CacheOptions = {
+  limit?: number
+  storeId?: string | null
+}
+
 async function loadCachedList<T>(key: string, limit: number): Promise<T[]> {
   if (!isIndexedDbAvailable()) return []
   try {
@@ -136,40 +148,46 @@ async function saveCachedList<T>(key: string, items: T[], limit: number): Promis
 }
 
 export async function loadCachedProducts<T extends { updatedAt?: unknown; createdAt?: unknown }>(
-  limit = PRODUCT_CACHE_LIMIT,
+  options: CacheOptions = {},
 ): Promise<T[]> {
-  return loadCachedList<T>('products', limit)
+  const { limit = PRODUCT_CACHE_LIMIT, storeId } = options
+  return loadCachedList<T>(resolvePartitionKey('products', storeId), limit)
 }
 
 export async function saveCachedProducts<T extends { updatedAt?: unknown; createdAt?: unknown }>(
   items: T[],
-  limit = PRODUCT_CACHE_LIMIT,
+  options: CacheOptions = {},
 ): Promise<void> {
-  await saveCachedList('products', items, limit)
+  const { limit = PRODUCT_CACHE_LIMIT, storeId } = options
+  await saveCachedList(resolvePartitionKey('products', storeId), items, limit)
 }
 
 export async function loadCachedCustomers<T extends { updatedAt?: unknown; createdAt?: unknown }>(
-  limit = CUSTOMER_CACHE_LIMIT,
+  options: CacheOptions = {},
 ): Promise<T[]> {
-  return loadCachedList<T>('customers', limit)
+  const { limit = CUSTOMER_CACHE_LIMIT, storeId } = options
+  return loadCachedList<T>(resolvePartitionKey('customers', storeId), limit)
 }
 
 export async function saveCachedCustomers<T extends { updatedAt?: unknown; createdAt?: unknown }>(
   items: T[],
-  limit = CUSTOMER_CACHE_LIMIT,
+  options: CacheOptions = {},
 ): Promise<void> {
-  await saveCachedList('customers', items, limit)
+  const { limit = CUSTOMER_CACHE_LIMIT, storeId } = options
+  await saveCachedList(resolvePartitionKey('customers', storeId), items, limit)
 }
 
 export async function loadCachedSales<T extends { createdAt?: unknown }>(
-  limit = SALES_CACHE_LIMIT,
+  options: CacheOptions = {},
 ): Promise<T[]> {
-  return loadCachedList<T>('sales', limit)
+  const { limit = SALES_CACHE_LIMIT, storeId } = options
+  return loadCachedList<T>(resolvePartitionKey('sales', storeId), limit)
 }
 
 export async function saveCachedSales<T extends { createdAt?: unknown }>(
   items: T[],
-  limit = SALES_CACHE_LIMIT,
+  options: CacheOptions = {},
 ): Promise<void> {
-  await saveCachedList('sales', items, limit)
+  const { limit = SALES_CACHE_LIMIT, storeId } = options
+  await saveCachedList(resolvePartitionKey('sales', storeId), items, limit)
 }


### PR DESCRIPTION
## Summary
- scope the offline cache helpers and front-end Firestore queries to the active store so inventory, customer, and sales data stay partitioned per workspace
- propagate the store identifier through sale recording, stock receipts, and closeout flows while adding a scripted backfill for existing documents
- update unit tests to mock the active store hook and exercise the new filtering behaviour

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d87fe2ad24832192ed783cac1c131c