### PR TITLE
Add updated timestamp when creating customers

### DIFF
--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -501,6 +501,7 @@ export default function Customers() {
           ...(notes.trim() ? { notes: notes.trim() } : {}),
           ...(parsedTags.length ? { tags: parsedTags } : {}),
           createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
         })
         showSuccess('Customer saved successfully.')
       }


### PR DESCRIPTION
## Summary
- populate the updatedAt timestamp when creating a customer so both createdAt and updatedAt are set immediately

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8e7933db8832182b27f535aabab34