### PR TITLE
Update dashboard low stock threshold property

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -39,7 +39,7 @@ type ProductRecord = {
   name: string
   price?: number
   stockCount?: number
-  minStock?: number
+  reorderThreshold?: number
   createdAt?: unknown
   updatedAt?: unknown
   storeId?: string | null
@@ -546,7 +546,7 @@ export default function Dashboard() {
   const lowStock = products
     .map(product => {
       const stock = product.stockCount ?? 0
-      const minStock = product.minStock ?? 5
+      const minStock = product.reorderThreshold ?? 5
       if (stock > minStock) return null
       const severity: InventorySeverity = stock <= 0 ? 'critical' : stock <= minStock ? 'warning' : 'info'
       const status = stock <= 0 ? 'Out of stock' : `Low (${stock} remaining)`


### PR DESCRIPTION
## Summary
- rename the dashboard product record threshold property to `reorderThreshold`
- update low-stock calculation to use the new property name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8e7a7356483218432776a77c94cbb