### PR TITLE
Use roster Firestore for team members

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,5 +9,13 @@
       "**/.*",
       "**/node_modules/**"
     ]
+  },
+  "emulators": {
+    "functions": {
+      "port": 5001
+    },
+    "firestore": {
+      "port": 8080
+    }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "serve": "firebase emulators:start --only functions",
+    "serve": "firebase emulators:start --only functions,firestore",
     "deploy": "npm run build && firebase deploy --only functions",
     "test": "npm run build && node ./test/commitSale.test.js",
     "backfill-store": "ts-node ./scripts/backfillStoreIds.ts"

--- a/functions/src/callables.ts
+++ b/functions/src/callables.ts
@@ -1,9 +1,7 @@
 import * as functions from 'firebase-functions'
-import * as admin from 'firebase-admin'
+import { admin, defaultDb, rosterDb } from './firestore'
 
-if (!admin.apps.length) admin.initializeApp()
-
-const db = admin.firestore()
+const db = defaultDb
 
 const VALID_ROLES = new Set(['owner', 'staff'])
 
@@ -91,7 +89,7 @@ export const backfillMyStore = functions.https.onCall(async (data, context) => {
     ? contact.firstSignupEmail ?? null
     : email?.toLowerCase() ?? null
 
-  const memberRef = db.collection('teamMembers').doc(uid)
+  const memberRef = rosterDb.collection('teamMembers').doc(uid)
   const memberSnap = await memberRef.get()
   const timestamp = admin.firestore.FieldValue.serverTimestamp()
   const existingData = memberSnap.data() ?? {}

--- a/functions/src/firestore.ts
+++ b/functions/src/firestore.ts
@@ -1,0 +1,11 @@
+import * as admin from 'firebase-admin'
+import { getFirestore } from 'firebase-admin/firestore'
+
+if (!admin.apps.length) {
+  admin.initializeApp()
+}
+
+export const defaultDb = getFirestore()
+export const rosterDb = getFirestore(admin.app(), 'roster')
+
+export { admin }

--- a/functions/src/onAuthCreate.ts
+++ b/functions/src/onAuthCreate.ts
@@ -1,15 +1,11 @@
 import * as functions from 'firebase-functions'
-import { getFirestore } from 'firebase-admin/firestore'
-import * as admin from 'firebase-admin'
-
-if (!admin.apps.length) admin.initializeApp()
+import { admin, rosterDb } from './firestore'
 
 export const onAuthCreate = functions.auth.user().onCreate(async user => {
-  const db = getFirestore()
   const uid = user.uid
   const timestamp = admin.firestore.FieldValue.serverTimestamp()
 
-  await db
+  await rosterDb
     .collection('teamMembers')
     .doc(uid)
     .set(


### PR DESCRIPTION
## Summary
- create a shared Firestore helper that initializes the default and roster databases once
- switch all teamMembers reads and writes in Cloud Functions to the roster database handle
- update the emulator configuration to start Firestore so the roster database is available locally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8e8ee9fe883219f07b36f9676903a