### PR TITLE
Initialize Firestore with roster database

### DIFF
--- a/web/src/firebase.ts
+++ b/web/src/firebase.ts
@@ -34,7 +34,11 @@ const firebaseConfig = {
 export const app = initializeApp(firebaseConfig)
 export const auth = getAuth(app)
 
-export const db = initializeFirestore(app, { ignoreUndefinedProperties: true })
+export const db = initializeFirestore(
+  app,
+  { ignoreUndefinedProperties: true },
+  'roster'
+)
 enableIndexedDbPersistence(db).catch(() => {/* multi-tab fallback handled */})
 
 export const storage = getStorage(app)


### PR DESCRIPTION
## Summary
- update the web Firebase configuration to connect to the `roster` Firestore database ID

## Testing
- pnpm vitest run src/hooks/useMemberships.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d8e9d9177883218a310bf3c2e0fd0e