### PR TITLE
Add metrics overview page with navigation and tests

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -69,6 +69,15 @@
   line-height: 1.4;
 }
 
+.shell__nav-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.shell__nav-label {
+  line-height: 1.3;
+}
+
 .shell__nav-link:is(:hover, :focus-visible) {
   border-color: rgba(67, 56, 202, 0.25);
   box-shadow: 0 6px 18px rgba(67, 56, 202, 0.1);

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -7,15 +7,16 @@ import { useConnectivityStatus } from '../hooks/useConnectivityStatus'
 import './Shell.css'
 import './Workspace.css'
 
-type NavItem = { to: string; label: string; end?: boolean }
+type NavItem = { to: string; label: string; end?: boolean; icon?: string }
 
 const NAV_ITEMS: NavItem[] = [
-  { to: '/', label: 'Dashboard', end: true },
-  { to: '/products', label: 'Products' },
-  { to: '/sell', label: 'Sell' },
-  { to: '/receive', label: 'Receive' },
-  { to: '/customers', label: 'Customers' },
-  { to: '/close-day', label: 'Close Day' },
+  { to: '/', label: 'Dashboard', end: true, icon: '🏠' },
+  { to: '/metrics', label: 'Metrics', icon: '📈' },
+  { to: '/products', label: 'Products', icon: '📦' },
+  { to: '/sell', label: 'Sell', icon: '🛒' },
+  { to: '/receive', label: 'Receive', icon: '📥' },
+  { to: '/customers', label: 'Customers', icon: '👥' },
+  { to: '/close-day', label: 'Close Day', icon: '🗓️' },
 ]
 
 function navLinkClass(isActive: boolean) {
@@ -128,7 +129,12 @@ export default function Shell({ children }: { children: React.ReactNode }) {
                 end={item.end}
                 className={({ isActive }) => navLinkClass(isActive)}
               >
-                {item.label}
+                {item.icon && (
+                  <span className="shell__nav-icon" aria-hidden="true">
+                    {item.icon}
+                  </span>
+                )}
+                <span className="shell__nav-label">{item.label}</span>
               </NavLink>
             ))}
           </nav>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,6 +10,7 @@ import Receive from './pages/Receive'
 import CloseDay from './pages/CloseDay'
 import Customers from './pages/Customers'
 import Onboarding from './pages/Onboarding'
+import Metrics from './pages/Metrics'
 import { ToastProvider } from './components/ToastProvider'
 
 const router = createHashRouter([
@@ -18,6 +19,7 @@ const router = createHashRouter([
     element: <App />,
     children: [
       { index: true, element: <Shell><Dashboard /></Shell> },
+      { path: 'metrics',   element: <Shell><Metrics /></Shell> },
       { path: 'products',  element: <Shell><Products /></Shell> },
       { path: 'sell',      element: <Shell><Sell /></Shell> },
       { path: 'receive',   element: <Shell><Receive /></Shell> },

--- a/web/src/pages/Metrics.css
+++ b/web/src/pages/Metrics.css
@@ -1,0 +1,239 @@
+.metrics-page {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  color: #0f172a;
+}
+
+.metrics-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.metrics-page__title {
+  font-size: clamp(26px, 2.6vw, 34px);
+  font-weight: 700;
+  color: #1e1b4b;
+  margin: 0;
+}
+
+.metrics-page__subtitle {
+  margin: 0;
+  font-size: 15px;
+  color: #475569;
+  max-width: 640px;
+}
+
+.metrics-page__loading,
+.metrics-page__error {
+  padding: 16px 18px;
+  border-radius: 14px;
+  font-weight: 500;
+  border: 1px solid rgba(67, 56, 202, 0.18);
+  background: rgba(99, 102, 241, 0.08);
+  color: #312e81;
+}
+
+.metrics-page__error {
+  border-color: rgba(220, 38, 38, 0.25);
+  background: rgba(254, 226, 226, 0.6);
+  color: #7f1d1d;
+}
+
+.metrics-page__empty {
+  padding: 24px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.1), rgba(59, 130, 246, 0.08));
+  border: 1px solid rgba(79, 70, 229, 0.18);
+  display: grid;
+  gap: 8px;
+  max-width: 640px;
+}
+
+.metrics-page__empty h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.metrics-page__empty p {
+  margin: 0;
+  font-size: 15px;
+  color: #475569;
+}
+
+.metrics-page__kpi-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.metrics-page__kpi-card {
+  padding: 18px;
+  background: #ffffff;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  box-shadow: 0 10px 30px -20px rgba(79, 70, 229, 0.35);
+  display: grid;
+  gap: 6px;
+}
+
+.metrics-page__kpi-card h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #312e81;
+}
+
+.metrics-page__kpi-value {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.metrics-page__kpi-value.is-negative {
+  color: #dc2626;
+}
+
+.metrics-page__kpi-meta {
+  margin: 0;
+  font-size: 13px;
+  color: #64748b;
+}
+
+.metrics-page__panel {
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid rgba(203, 213, 225, 0.7);
+  padding: 22px;
+  display: grid;
+  gap: 18px;
+  box-shadow: 0 18px 44px -28px rgba(15, 23, 42, 0.3);
+}
+
+.metrics-page__panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metrics-page__panel-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1e1b4b;
+}
+
+.metrics-page__panel-header p {
+  margin: 0;
+  font-size: 14px;
+  color: #475569;
+}
+
+.metrics-page__trend {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.metrics-page__trend-point {
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  text-align: center;
+}
+
+.metrics-page__trend-bar {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  width: 100%;
+  height: 140px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(224, 231, 255, 0.8), rgba(129, 140, 248, 0.15));
+  overflow: hidden;
+}
+
+.metrics-page__trend-bar-fill {
+  width: 80%;
+  border-radius: 12px 12px 4px 4px;
+  background: linear-gradient(180deg, #4338ca, #6366f1);
+  height: var(--trend-height, 0%);
+  transition: height 0.3s ease;
+}
+
+.metrics-page__trend-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #4338ca;
+}
+
+.metrics-page__trend-value {
+  font-size: 13px;
+  color: #475569;
+}
+
+.metrics-page__top-products {
+  display: grid;
+  gap: 12px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.metrics-page__top-product {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.metrics-page__top-product-name {
+  display: block;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.metrics-page__top-product-meta {
+  display: block;
+  font-size: 13px;
+  color: #64748b;
+}
+
+.metrics-page__top-product-value {
+  font-weight: 600;
+  color: #4338ca;
+}
+
+@media (min-width: 960px) {
+  .metrics-page__header {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+
+  .metrics-page__subtitle {
+    text-align: right;
+  }
+
+  .metrics-page__trend {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 599px) {
+  .metrics-page__trend-bar {
+    height: 120px;
+  }
+
+  .metrics-page__kpi-value {
+    font-size: 22px;
+  }
+}

--- a/web/src/pages/Metrics.tsx
+++ b/web/src/pages/Metrics.tsx
@@ -1,0 +1,400 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { loadCachedProducts, loadCachedSales } from '../utils/offlineCache'
+import { useActiveStore } from '../hooks/useActiveStore'
+import './Metrics.css'
+
+type TimestampLike = { toDate?: () => Date; seconds?: number; nanoseconds?: number }
+
+type SaleItem = {
+  productId?: string | null
+  name?: string | null
+  price?: number | null
+  qty?: number | null
+}
+
+type SaleRecord = {
+  id: string
+  total?: number | null
+  createdAt?: Date | TimestampLike | null
+  items?: SaleItem[] | null
+}
+
+type ProductRecord = {
+  id: string
+  name?: string | null
+  price?: number | null
+  stockCount?: number | null
+}
+
+type TrendPoint = {
+  label: string
+  value: number
+  date: Date
+}
+
+type MetricsState = 'idle' | 'loading' | 'ready' | 'error'
+
+function asDate(value?: Date | TimestampLike | null): Date | null {
+  if (!value) return null
+  if (value instanceof Date) return value
+  if (typeof value === 'object') {
+    if (typeof value.toDate === 'function') {
+      try {
+        return value.toDate()
+      } catch (error) {
+        console.warn('[metrics] Failed to convert timestamp via toDate', error)
+      }
+    }
+    if (typeof value.seconds === 'number') {
+      const millis = value.seconds * 1000 + Math.round((value.nanoseconds ?? 0) / 1_000_000)
+      if (Number.isFinite(millis)) {
+        return new Date(millis)
+      }
+    }
+  }
+  return null
+}
+
+function addDays(base: Date, days: number) {
+  const copy = new Date(base)
+  copy.setDate(copy.getDate() + days)
+  return copy
+}
+
+function startOfDay(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+function endOfDay(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999)
+}
+
+function isWithinRange(value: Date | null, start: Date, end: Date) {
+  if (!value) return false
+  const time = value.getTime()
+  return time >= start.getTime() && time <= end.getTime()
+}
+
+function calculateSaleTotal(sale: SaleRecord): number {
+  if (typeof sale.total === 'number' && Number.isFinite(sale.total)) {
+    return sale.total
+  }
+
+  if (Array.isArray(sale.items)) {
+    return sale.items.reduce((acc, item) => {
+      const qty = typeof item.qty === 'number' ? item.qty : 0
+      const price = typeof item.price === 'number' ? item.price : 0
+      return acc + qty * price
+    }, 0)
+  }
+
+  return 0
+}
+
+function calculateSaleUnits(sale: SaleRecord): number {
+  if (!Array.isArray(sale.items)) return 0
+  return sale.items.reduce((acc, item) => {
+    const qty = typeof item.qty === 'number' ? item.qty : 0
+    return acc + Math.max(0, qty)
+  }, 0)
+}
+
+function formatCurrency(value: number) {
+  return `GHS ${value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+function formatPercent(value: number, { showSign = true }: { showSign?: boolean } = {}) {
+  const sign = showSign && value > 0 ? '+' : ''
+  return `${sign}${value.toFixed(1)}%`
+}
+
+function formatTurns(value: number) {
+  return value.toFixed(2)
+}
+
+const WEEKDAY_FORMATTER = new Intl.DateTimeFormat(undefined, { weekday: 'short' })
+
+const TREND_DAYS = 7
+const WINDOW_DAYS = 30
+
+export default function Metrics() {
+  const { storeId, isLoading: isStoreLoading } = useActiveStore()
+  const [sales, setSales] = useState<SaleRecord[]>([])
+  const [products, setProducts] = useState<ProductRecord[]>([])
+  const [status, setStatus] = useState<MetricsState>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isCancelled = false
+
+    async function load() {
+      if (isStoreLoading) {
+        return
+      }
+
+      setStatus('loading')
+      setError(null)
+
+      try {
+        const [salesData, productData] = await Promise.all([
+          loadCachedSales<SaleRecord>({ storeId }),
+          loadCachedProducts<ProductRecord>({ storeId }),
+        ])
+
+        if (!isCancelled) {
+          setSales(salesData)
+          setProducts(productData)
+          setStatus('ready')
+        }
+      } catch (loadError) {
+        if (isCancelled) return
+        console.error('[metrics] Failed to load cached data', loadError)
+        setSales([])
+        setProducts([])
+        setStatus('error')
+        setError('We could not load your latest metrics. Try refreshing the page.')
+      }
+    }
+
+    void load()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [storeId, isStoreLoading])
+
+  const summary = useMemo(() => {
+    if (status !== 'ready') {
+      return {
+        totalRevenue: 0,
+        averageOrderValue: 0,
+        salesGrowth: 0,
+        inventoryTurns: 0,
+        sellThroughRate: 0,
+        trend: [] as TrendPoint[],
+        topProducts: [] as Array<{ id: string; name: string; qty: number; revenue: number }>,
+        ordersCount: 0,
+      }
+    }
+
+    const today = new Date()
+    const windowStart = startOfDay(addDays(today, -(WINDOW_DAYS - 1)))
+    const windowEnd = endOfDay(today)
+    const currentRangeStart = startOfDay(addDays(today, -(TREND_DAYS - 1)))
+    const previousRangeStart = startOfDay(addDays(currentRangeStart, -TREND_DAYS))
+    const previousRangeEnd = endOfDay(addDays(currentRangeStart, -1))
+
+    let totalRevenue = 0
+    let ordersCount = 0
+    let totalUnits = 0
+    let currentRangeRevenue = 0
+    let previousRangeRevenue = 0
+
+    const productIndex = new Map<string, ProductRecord>()
+    products.forEach(product => {
+      productIndex.set(product.id, product)
+    })
+
+    const productPerformance = new Map<string, { id: string; name: string; qty: number; revenue: number }>()
+
+    sales.forEach(sale => {
+      const createdAt = asDate(sale.createdAt)
+      const saleTotal = calculateSaleTotal(sale)
+      const saleUnits = calculateSaleUnits(sale)
+      const isInWindow = !createdAt || isWithinRange(createdAt, windowStart, windowEnd)
+
+      if (isInWindow) {
+        totalRevenue += saleTotal
+        totalUnits += saleUnits
+        ordersCount += 1
+      }
+
+      if (isWithinRange(createdAt, currentRangeStart, windowEnd)) {
+        currentRangeRevenue += saleTotal
+      } else if (isWithinRange(createdAt, previousRangeStart, previousRangeEnd)) {
+        previousRangeRevenue += saleTotal
+      }
+
+      if (!isInWindow || !Array.isArray(sale.items)) {
+        return
+      }
+
+      sale.items.forEach(item => {
+        const productId = item.productId ?? undefined
+        const key = productId ?? item.name ?? 'unknown'
+        if (!key) return
+        const existing = productPerformance.get(key) ?? {
+          id: productId ?? key,
+          name: productIndex.get(productId ?? '')?.name ?? item.name ?? 'Unnamed item',
+          qty: 0,
+          revenue: 0,
+        }
+        const qty = typeof item.qty === 'number' ? Math.max(0, item.qty) : 0
+        const price = typeof item.price === 'number' ? item.price : 0
+        existing.qty += qty
+        existing.revenue += qty * price
+        productPerformance.set(key, existing)
+      })
+    })
+
+    const totalStockOnHand = products.reduce((acc, product) => {
+      const stock = typeof product.stockCount === 'number' ? Math.max(0, product.stockCount) : 0
+      return acc + stock
+    }, 0)
+
+    const averageInventory = totalStockOnHand > 0 ? (totalStockOnHand + Math.max(totalStockOnHand - totalUnits, 0)) / 2 : totalUnits
+    const inventoryTurns = averageInventory > 0 ? totalUnits / averageInventory : 0
+    const sellThroughRate = totalUnits + totalStockOnHand > 0 ? (totalUnits / (totalUnits + totalStockOnHand)) * 100 : 0
+
+    const salesGrowth = previousRangeRevenue > 0
+      ? ((currentRangeRevenue - previousRangeRevenue) / previousRangeRevenue) * 100
+      : currentRangeRevenue > 0
+        ? 100
+        : 0
+
+    const trend: TrendPoint[] = Array.from({ length: TREND_DAYS }).map((_, index) => {
+      const day = startOfDay(addDays(today, index - (TREND_DAYS - 1)))
+      const end = endOfDay(day)
+      const value = sales.reduce((acc, sale) => {
+        const createdAt = asDate(sale.createdAt)
+        if (!createdAt) return acc
+        return isWithinRange(createdAt, day, end) ? acc + calculateSaleTotal(sale) : acc
+      }, 0)
+
+      return {
+        label: WEEKDAY_FORMATTER.format(day),
+        value,
+        date: day,
+      }
+    })
+
+    const topProducts = Array.from(productPerformance.values())
+      .sort((a, b) => b.qty - a.qty || b.revenue - a.revenue)
+      .slice(0, 5)
+
+    const averageOrderValue = ordersCount > 0 ? totalRevenue / ordersCount : 0
+
+    return {
+      totalRevenue,
+      averageOrderValue,
+      salesGrowth,
+      inventoryTurns,
+      sellThroughRate,
+      trend,
+      topProducts,
+      ordersCount,
+    }
+  }, [products, sales, status])
+
+  const hasData = status === 'ready' && (summary.ordersCount > 0 || products.length > 0)
+
+  return (
+    <div className="metrics-page" data-status={status}>
+      <header className="metrics-page__header">
+        <h1 className="metrics-page__title">Metrics overview</h1>
+        <p className="metrics-page__subtitle">
+          Keep an eye on key performance indicators across sales velocity and inventory health.
+        </p>
+      </header>
+
+      {status === 'loading' && (
+        <div role="status" className="metrics-page__loading">
+          Loading metrics…
+        </div>
+      )}
+
+      {status === 'error' && error && (
+        <div role="alert" className="metrics-page__error">
+          {error}
+        </div>
+      )}
+
+      {status === 'ready' && !hasData && (
+        <section className="metrics-page__empty">
+          <h2>No metrics yet</h2>
+          <p>
+            We’ll populate this dashboard as you record sales and update your product catalogue. Check back
+            after syncing recent activity.
+          </p>
+        </section>
+      )}
+
+      {hasData && (
+        <>
+          <section className="metrics-page__kpi-grid" aria-label="Key performance indicators">
+            <article className="metrics-page__kpi-card">
+              <h2>Total revenue</h2>
+              <p className="metrics-page__kpi-value">{formatCurrency(summary.totalRevenue)}</p>
+              <p className="metrics-page__kpi-meta">Last {WINDOW_DAYS} days</p>
+            </article>
+            <article className="metrics-page__kpi-card">
+              <h2>Average order value</h2>
+              <p className="metrics-page__kpi-value">{formatCurrency(summary.averageOrderValue)}</p>
+              <p className="metrics-page__kpi-meta">Across {summary.ordersCount} orders</p>
+            </article>
+            <article className="metrics-page__kpi-card">
+              <h2>Sales growth</h2>
+              <p className={`metrics-page__kpi-value${summary.salesGrowth < 0 ? ' is-negative' : ''}`}>
+                {formatPercent(summary.salesGrowth)}
+              </p>
+              <p className="metrics-page__kpi-meta">vs. prior {TREND_DAYS} days</p>
+            </article>
+            <article className="metrics-page__kpi-card">
+              <h2>Inventory turns</h2>
+              <p className="metrics-page__kpi-value">{formatTurns(summary.inventoryTurns)}</p>
+              <p className="metrics-page__kpi-meta">Approximate turns in the last {WINDOW_DAYS} days</p>
+            </article>
+            <article className="metrics-page__kpi-card">
+              <h2>Sell-through</h2>
+              <p className="metrics-page__kpi-value">{formatPercent(summary.sellThroughRate, { showSign: false })}</p>
+              <p className="metrics-page__kpi-meta">Units sold vs. current stock</p>
+            </article>
+          </section>
+
+          <section className="metrics-page__panel">
+            <div className="metrics-page__panel-header">
+              <h2>7-day sales trend</h2>
+              <p>Spot acceleration or slowdowns in revenue at a glance.</p>
+            </div>
+            <ul className="metrics-page__trend" role="list">
+              {summary.trend.map(point => {
+                const max = summary.trend.reduce((acc, value) => Math.max(acc, value.value), 0)
+                const percent = max > 0 ? Math.round((point.value / max) * 100) : 0
+                return (
+                  <li key={point.label} className="metrics-page__trend-point">
+                    <span className="metrics-page__trend-bar" style={{ '--trend-height': `${percent}%` } as React.CSSProperties}>
+                      <span className="metrics-page__trend-bar-fill" />
+                    </span>
+                    <span className="metrics-page__trend-label">{point.label}</span>
+                    <span className="metrics-page__trend-value">{formatCurrency(point.value)}</span>
+                  </li>
+                )
+              })}
+            </ul>
+          </section>
+
+          <section className="metrics-page__panel">
+            <div className="metrics-page__panel-header">
+              <h2>Top performers</h2>
+              <p>Products driving the most movement in the last {WINDOW_DAYS} days.</p>
+            </div>
+            <ul className="metrics-page__top-products" role="list">
+              {summary.topProducts.map(product => (
+                <li key={product.id} className="metrics-page__top-product" data-testid={`top-product-${product.id}`}>
+                  <div>
+                    <span className="metrics-page__top-product-name">{product.name}</span>
+                    <span className="metrics-page__top-product-meta">{product.qty} units sold</span>
+                  </div>
+                  <span className="metrics-page__top-product-value">{formatCurrency(product.revenue)}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/__tests__/Metrics.test.tsx
+++ b/web/src/pages/__tests__/Metrics.test.tsx
@@ -1,0 +1,181 @@
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { MemoryRouter, Route, Routes, Outlet } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import Metrics from '../Metrics'
+import Shell from '../../layout/Shell'
+
+const mockLoadCachedSales = vi.fn()
+const mockLoadCachedProducts = vi.fn()
+const mockUseActiveStore = vi.fn()
+const mockSignOut = vi.fn()
+
+vi.mock('../../utils/offlineCache', () => ({
+  loadCachedSales: (...args: Parameters<typeof mockLoadCachedSales>) => mockLoadCachedSales(...args),
+  loadCachedProducts: (...args: Parameters<typeof mockLoadCachedProducts>) => mockLoadCachedProducts(...args),
+}))
+
+vi.mock('../../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+vi.mock('../../hooks/useAuthUser', () => ({
+  useAuthUser: () => ({ email: 'owner@example.com' }),
+}))
+
+vi.mock('../../hooks/useConnectivityStatus', () => ({
+  useConnectivityStatus: () => ({
+    isOnline: true,
+    isReachable: true,
+    isChecking: false,
+    lastHeartbeatAt: null,
+    heartbeatError: null,
+    queue: { status: 'idle', pending: 0, lastError: null, updatedAt: null },
+    checkHeartbeat: vi.fn(),
+  }),
+}))
+
+vi.mock('../../firebase', () => ({
+  auth: {},
+}))
+
+vi.mock('firebase/auth', () => ({
+  signOut: (...args: Parameters<typeof mockSignOut>) => mockSignOut(...args),
+}))
+
+function buildSale({
+  id,
+  createdAt,
+  items,
+}: {
+  id: string
+  createdAt: Date
+  items: Array<{ productId?: string; name?: string; qty?: number; price?: number }>
+}) {
+  return {
+    id,
+    createdAt,
+    items,
+  }
+}
+
+function daysAgo(base: Date, days: number) {
+  const date = new Date(base)
+  date.setDate(base.getDate() - days)
+  return date
+}
+
+describe('Metrics page', () => {
+  beforeEach(() => {
+    mockLoadCachedSales.mockReset()
+    mockLoadCachedProducts.mockReset()
+    mockUseActiveStore.mockReset()
+    mockSignOut.mockReset()
+
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
+    mockLoadCachedSales.mockResolvedValue([])
+    mockLoadCachedProducts.mockResolvedValue([])
+  })
+
+  it('renders KPI metrics and top performers from cached data', async () => {
+    const now = new Date()
+    mockLoadCachedSales.mockResolvedValue([
+      buildSale({
+        id: 'sale-1',
+        createdAt: daysAgo(now, 1),
+        items: [
+          { productId: 'p1', qty: 2, price: 120 },
+          { productId: 'p2', qty: 1, price: 180 },
+        ],
+      }),
+      buildSale({
+        id: 'sale-2',
+        createdAt: daysAgo(now, 3),
+        items: [
+          { productId: 'p1', qty: 1, price: 110 },
+          { name: 'Gift Card', qty: 1, price: 50 },
+        ],
+      }),
+      buildSale({
+        id: 'sale-3',
+        createdAt: daysAgo(now, 9),
+        items: [{ productId: 'p2', qty: 1, price: 200 }],
+      }),
+      buildSale({
+        id: 'sale-older',
+        createdAt: daysAgo(now, 40),
+        items: [{ productId: 'p1', qty: 1, price: 90 }],
+      }),
+    ])
+
+    mockLoadCachedProducts.mockResolvedValue([
+      { id: 'p1', name: 'Cold Brew', stockCount: 5 },
+      { id: 'p2', name: 'Chai Latte', stockCount: 3 },
+    ])
+
+    render(
+      <MemoryRouter>
+        <Metrics />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Total revenue')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('GHS 780.00')).toBeInTheDocument()
+    expect(screen.getByText('GHS 260.00')).toBeInTheDocument()
+    expect(screen.getByText('+190.0%')).toBeInTheDocument()
+    expect(screen.getByText('1.20')).toBeInTheDocument()
+    expect(screen.getByText('42.9%')).toBeInTheDocument()
+    expect(screen.getByTestId('top-product-p1')).toHaveTextContent('Cold Brew')
+    expect(screen.getByTestId('top-product-p2')).toHaveTextContent('Chai Latte')
+    expect(screen.getByText('Gift Card')).toBeInTheDocument()
+  })
+
+  it('activates the metrics route within the shell navigation', async () => {
+    const now = new Date()
+    mockLoadCachedSales.mockResolvedValue([
+      buildSale({
+        id: 'sale-1',
+        createdAt: daysAgo(now, 1),
+        items: [{ productId: 'p1', qty: 1, price: 100 }],
+      }),
+    ])
+
+    mockLoadCachedProducts.mockResolvedValue([{ id: 'p1', name: 'Cold Brew', stockCount: 5 }])
+
+    render(
+      <MemoryRouter initialEntries={['/metrics']}>
+        <Routes>
+          <Route path="/" element={<Shell><Outlet /></Shell>}>
+            <Route index element={<div>Home</div>} />
+            <Route path="metrics" element={<Metrics />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Metrics overview')).toBeInTheDocument()
+    })
+
+    const metricsLink = screen.getByRole('link', { name: 'Metrics' })
+    expect(metricsLink).toHaveClass('is-active')
+  })
+
+  it('shows an empty state when no data is available', async () => {
+    render(
+      <MemoryRouter>
+        <Metrics />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(mockLoadCachedSales).toHaveBeenCalled())
+
+    expect(await screen.findByText('No metrics yet')).toBeInTheDocument()
+
+    expect(screen.getByText(/record sales/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add a dedicated metrics overview screen with KPI cards, sales trends, and top product insights
- wire the new metrics route into the router and shell navigation with icon styling updates
- provide responsive styles and vitest coverage for routing and KPI rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8eb9a4b88832186b90511d9b4aa4b