### PR TITLE
Add barcode scanning workflow to Sell page

### DIFF
--- a/web/src/components/BarcodeScanner.tsx
+++ b/web/src/components/BarcodeScanner.tsx
@@ -1,0 +1,211 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+
+type ScanSource = 'keyboard' | 'manual' | 'camera'
+
+export type ScanResult = {
+  code: string
+  source: ScanSource
+}
+
+type BarcodeScannerProps = {
+  onScan: (result: ScanResult) => void
+  onError?: (message: string) => void
+  minLength?: number
+  debounceMs?: number
+  enableCameraFallback?: boolean
+  manualEntryLabel?: string
+  className?: string
+}
+
+function isTextInput(element: EventTarget | null): element is HTMLElement {
+  if (!(element instanceof HTMLElement)) return false
+  const tag = element.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA') return true
+  if (element.isContentEditable) return true
+  return false
+}
+
+export function useKeyboardScanner(
+  onScan: (result: ScanResult) => void,
+  onError?: (message: string) => void,
+  minLength = 3,
+  debounceMs = 30,
+) {
+  const bufferRef = useRef('')
+  const timerRef = useRef<number | null>(null)
+
+  const resetBuffer = useCallback(() => {
+    bufferRef.current = ''
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.defaultPrevented) return
+      if (isTextInput(event.target)) return
+
+      if (event.key === 'Enter') {
+        const value = bufferRef.current.trim()
+        resetBuffer()
+        if (!value) return
+        if (value.length < minLength) {
+          onError?.('Scanned codes look too short. Try again or use manual entry.')
+          return
+        }
+        onScan({ code: value, source: 'keyboard' })
+        return
+      }
+
+      if (event.key === 'Escape') {
+        resetBuffer()
+        return
+      }
+
+      if (event.key.length === 1) {
+        bufferRef.current += event.key
+        if (timerRef.current !== null) {
+          window.clearTimeout(timerRef.current)
+        }
+        timerRef.current = window.setTimeout(() => {
+          bufferRef.current = ''
+          timerRef.current = null
+        }, debounceMs)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown)
+    return () => {
+      window.removeEventListener('keydown', handleKeydown)
+      resetBuffer()
+    }
+  }, [debounceMs, minLength, onError, onScan, resetBuffer])
+}
+
+export default function BarcodeScanner({
+  onScan,
+  onError,
+  minLength = 3,
+  debounceMs = 30,
+  enableCameraFallback = false,
+  manualEntryLabel = 'Manual barcode entry',
+  className,
+}: BarcodeScannerProps) {
+  const [manualCode, setManualCode] = useState('')
+  const [isCameraActive, setIsCameraActive] = useState(false)
+  const videoRef = useRef<HTMLVideoElement | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+
+  useKeyboardScanner(onScan, onError, minLength, debounceMs)
+
+  const stopStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(track => track.stop())
+    }
+    streamRef.current = null
+    if (videoRef.current) {
+      videoRef.current.srcObject = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!enableCameraFallback || !isCameraActive) return
+
+    let cancelled = false
+
+    async function startCamera() {
+      try {
+        if (!navigator.mediaDevices?.getUserMedia) {
+          throw new Error('Camera access is not supported on this device.')
+        }
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        })
+        if (cancelled) {
+          stream.getTracks().forEach(track => track.stop())
+          return
+        }
+        streamRef.current = stream
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream
+          try {
+            await videoRef.current.play()
+          } catch (error) {
+            console.warn('[BarcodeScanner] Unable to autoplay camera stream', error)
+          }
+        }
+      } catch (error) {
+        console.error('[BarcodeScanner] Unable to start camera', error)
+        onError?.('Unable to access the camera. Enter the code manually instead.')
+        setIsCameraActive(false)
+      }
+    }
+
+    startCamera()
+
+    return () => {
+      cancelled = true
+      stopStream()
+    }
+  }, [enableCameraFallback, isCameraActive, onError, stopStream])
+
+  useEffect(() => () => stopStream(), [stopStream])
+
+  const handleManualSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const normalized = manualCode.trim()
+      if (!normalized) {
+        onError?.('Enter a barcode value before submitting.')
+        return
+      }
+      setManualCode('')
+      onScan({ code: normalized, source: 'manual' })
+    },
+    [manualCode, onError, onScan],
+  )
+
+  return (
+    <div className={className}>
+      {enableCameraFallback && (
+        <div className="barcode-scanner__camera">
+          <button
+            type="button"
+            className="button button--ghost button--small"
+            onClick={() => setIsCameraActive(active => !active)}
+          >
+            {isCameraActive ? 'Stop camera preview' : 'Use camera to scan'}
+          </button>
+          {isCameraActive && (
+            <div className="barcode-scanner__camera-preview">
+              <video ref={videoRef} playsInline muted autoPlay className="barcode-scanner__video" />
+              <p className="field__hint">
+                Align the barcode within the frame. If detection fails, type the code below.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      <form className="barcode-scanner__manual" onSubmit={handleManualSubmit}>
+        <label className="field__label" htmlFor="barcode-manual-input">
+          {manualEntryLabel}
+        </label>
+        <div className="barcode-scanner__manual-row">
+          <input
+            id="barcode-manual-input"
+            placeholder="Type or paste a barcode"
+            value={manualCode}
+            onChange={event => setManualCode(event.target.value)}
+          />
+          <button type="submit" className="button button--secondary">
+            Add
+          </button>
+        </div>
+        <p className="field__hint">Scanned codes automatically fill here if hardware is unavailable.</p>
+      </form>
+    </div>
+  )
+}

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -333,6 +333,13 @@ export default function Products() {
       setCreateStatus({ tone: 'error', message: 'Enter a valid price that is zero or greater.' })
       return
     }
+    if (!sku) {
+      setCreateStatus({
+        tone: 'error',
+        message: 'Add a SKU that matches the barcode so you can scan it during checkout.',
+      })
+      return
+    }
     if (createForm.reorderThreshold && reorderThreshold === null) {
       setCreateStatus({ tone: 'error', message: 'Enter a valid reorder point that is zero or greater.' })
       return
@@ -351,7 +358,7 @@ export default function Products() {
       id: `optimistic-${Date.now()}`,
       name,
       price,
-      sku: sku || null,
+      sku,
       reorderThreshold: reorderThreshold ?? null,
       stockCount: initialStock ?? 0,
       lastReceipt: null,
@@ -369,7 +376,7 @@ export default function Products() {
       const ref = await addDoc(collection(db, 'products'), {
         name,
         price,
-        sku: sku || null,
+        sku,
         reorderThreshold: reorderThreshold ?? null,
         stockCount: initialStock ?? 0,
         storeId: activeStoreId,
@@ -428,6 +435,13 @@ export default function Products() {
       setEditStatus({ tone: 'error', message: 'Enter a valid price that is zero or greater.' })
       return
     }
+    if (!sku) {
+      setEditStatus({
+        tone: 'error',
+        message: 'Every product needs a SKU that matches its barcode for scanning.',
+      })
+      return
+    }
     if (editForm.reorderThreshold && reorderThreshold === null) {
       setEditStatus({ tone: 'error', message: 'Enter a valid reorder point that is zero or greater.' })
       return
@@ -447,7 +461,7 @@ export default function Products() {
     const updatedValues: Partial<ProductRecord> = {
       name,
       price,
-      sku: sku || null,
+      sku,
       reorderThreshold: reorderThreshold ?? null,
       updatedAt: new Date(),
       storeId: activeStoreId,
@@ -469,7 +483,7 @@ export default function Products() {
       await updateDoc(doc(collection(db, 'products'), editingProductId), {
         name,
         price,
-        sku: sku || null,
+        sku,
         reorderThreshold: reorderThreshold ?? null,
         storeId: activeStoreId,
         updatedAt: serverTimestamp(),
@@ -616,7 +630,8 @@ export default function Products() {
       <section className="card products-page__card">
         <h3 className="card__title">Add product</h3>
         <p className="card__subtitle">
-          Capture items you stock so sales and receipts stay accurate.
+          Capture items you stock so sales and receipts stay accurate. Give each one a SKU that
+          matches the barcode you plan to scan at checkout.
         </p>
         <form className="products-page__form" onSubmit={handleCreateProduct}>
           <label className="field">
@@ -635,9 +650,14 @@ export default function Products() {
               name="sku"
               value={createForm.sku}
               onChange={handleCreateFieldChange}
-              placeholder="Optional stock keeping unit"
+              placeholder="Barcode or SKU"
+              required
+              aria-describedby="create-sku-hint"
             />
           </label>
+          <p className="field__hint" id="create-sku-hint">
+            This must match the value encoded in your barcode so cashiers can scan products.
+          </p>
           <label className="field">
             <span className="field__label">Price</span>
             <input
@@ -692,8 +712,17 @@ export default function Products() {
               </label>
               <label className="field">
                 <span className="field__label">SKU</span>
-                <input name="sku" value={editForm.sku} onChange={handleEditFieldChange} />
+                <input
+                  name="sku"
+                  value={editForm.sku}
+                  onChange={handleEditFieldChange}
+                  required
+                  aria-describedby="edit-sku-hint"
+                />
               </label>
+              <p className="field__hint" id="edit-sku-hint">
+                Update the SKU to mirror the barcode if you need to reprint or relabel items.
+              </p>
               <label className="field">
                 <span className="field__label">Price</span>
                 <input

--- a/web/src/pages/__tests__/Products.test.tsx
+++ b/web/src/pages/__tests__/Products.test.tsx
@@ -224,6 +224,7 @@ describe('Products page', () => {
     })
 
     await user.type(screen.getByLabelText('Name'), 'Incomplete Product')
+    await user.type(screen.getByLabelText('SKU'), 'INC-01')
     await user.type(screen.getByLabelText('Price'), '-5')
 
     await user.click(screen.getByRole('button', { name: /add product/i }))

--- a/web/src/pages/__tests__/Sell.test.tsx
+++ b/web/src/pages/__tests__/Sell.test.tsx
@@ -1,0 +1,259 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import Sell from '../Sell'
+
+const mockLoadCachedProducts = vi.fn(async () => [] as unknown[])
+const mockSaveCachedProducts = vi.fn(async () => {})
+const mockLoadCachedCustomers = vi.fn(async () => [] as unknown[])
+const mockSaveCachedCustomers = vi.fn(async () => {})
+
+vi.mock('../../utils/offlineCache', () => ({
+  PRODUCT_CACHE_LIMIT: 200,
+  CUSTOMER_CACHE_LIMIT: 200,
+  loadCachedProducts: (...args: Parameters<typeof mockLoadCachedProducts>) =>
+    mockLoadCachedProducts(...args),
+  saveCachedProducts: (...args: Parameters<typeof mockSaveCachedProducts>) =>
+    mockSaveCachedProducts(...args),
+  loadCachedCustomers: (...args: Parameters<typeof mockLoadCachedCustomers>) =>
+    mockLoadCachedCustomers(...args),
+  saveCachedCustomers: (...args: Parameters<typeof mockSaveCachedCustomers>) =>
+    mockSaveCachedCustomers(...args),
+}))
+
+vi.mock('../../utils/offlineQueue', () => ({
+  queueCallableRequest: vi.fn(async () => false),
+}))
+
+vi.mock('../../utils/pdf', () => ({
+  buildSimplePdf: vi.fn(async () => ({ blob: new Blob(), url: 'blob:test' })),
+}))
+
+vi.mock('../../firebase', () => ({
+  db: {},
+  functions: {},
+}))
+
+const mockUseAuthUser = vi.fn(() => ({ uid: 'user-1', email: 'cashier@example.com' }))
+vi.mock('../../hooks/useAuthUser', () => ({
+  useAuthUser: () => mockUseAuthUser(),
+}))
+
+const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+vi.mock('../../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
+const whereMock = vi.fn((field: string, op: string, value: unknown) => ({
+  type: 'where',
+  field,
+  op,
+  value,
+}))
+const orderByMock = vi.fn((field: string, direction?: string) => ({ type: 'orderBy', field, direction }))
+const limitMock = vi.fn((value: number) => ({ type: 'limit', value }))
+const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[]) => ({
+  collection: collectionRef,
+  clauses,
+}))
+const onSnapshotMock = vi.fn(
+  (
+    queryRef: { collection: { path: string } },
+    onNext: (snapshot: { docs: { id: string; data: () => Record<string, unknown> }[] }) => void,
+  ) => {
+    queueMicrotask(() => {
+      onNext({ docs: [] })
+    })
+    return () => {}
+  },
+)
+const docMock = vi.fn((collectionRef: { path: string }, id?: string) => ({
+  type: 'doc',
+  path: id ? `${collectionRef.path}/${id}` : collectionRef.path,
+  id,
+}))
+
+vi.mock('firebase/firestore', () => ({
+  collection: (...args: Parameters<typeof collectionMock>) => collectionMock(...args),
+  query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
+  orderBy: (...args: Parameters<typeof orderByMock>) => orderByMock(...args),
+  limit: (...args: Parameters<typeof limitMock>) => limitMock(...args),
+  onSnapshot: (...args: Parameters<typeof onSnapshotMock>) => onSnapshotMock(...args),
+  where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
+  doc: (...args: Parameters<typeof docMock>) => docMock(...args),
+}))
+
+vi.mock('firebase/functions', () => ({
+  httpsCallable: vi.fn(() => vi.fn(async () => ({ data: { ok: true, saleId: 'sale-1' } }))),
+}))
+
+function createProductDoc(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    data: () => ({
+      name: 'Test Product',
+      sku: '12345',
+      price: 8,
+      stockCount: 5,
+      ...overrides,
+    }),
+  }
+}
+
+describe('Sell page barcode scanner', () => {
+  beforeEach(() => {
+    mockLoadCachedProducts.mockReset()
+    mockSaveCachedProducts.mockReset()
+    mockLoadCachedCustomers.mockReset()
+    mockSaveCachedCustomers.mockReset()
+    collectionMock.mockClear()
+    queryMock.mockClear()
+    orderByMock.mockClear()
+    limitMock.mockClear()
+    onSnapshotMock.mockClear()
+    whereMock.mockClear()
+    docMock.mockClear()
+    mockUseAuthUser.mockReset()
+    mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'cashier@example.com' })
+    mockUseActiveStore.mockReset()
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+
+    mockLoadCachedProducts.mockResolvedValue([])
+    mockLoadCachedCustomers.mockResolvedValue([])
+    mockSaveCachedProducts.mockResolvedValue(undefined)
+    mockSaveCachedCustomers.mockResolvedValue(undefined)
+
+    onSnapshotMock.mockImplementation((queryRef, onNext) => {
+      queueMicrotask(() => {
+        onNext({ docs: [] })
+      })
+      return () => {}
+    })
+  })
+
+  it('adds a matching product to the cart when a barcode is scanned', async () => {
+    let productSnapshot: ((snap: { docs: { id: string; data: () => Record<string, unknown> }[] }) => void) | null =
+      null
+
+    onSnapshotMock.mockImplementation((queryRef, onNext) => {
+      if (queryRef.collection.path === 'products') {
+        productSnapshot = onNext
+      }
+      queueMicrotask(() => {
+        onNext({ docs: [] })
+      })
+      return () => {}
+    })
+
+    render(
+      <MemoryRouter>
+        <Sell />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(onSnapshotMock).toHaveBeenCalled())
+
+    await waitFor(() => expect(productSnapshot).toBeTruthy())
+
+    await act(async () => {
+      productSnapshot?.({ docs: [createProductDoc('product-1', { sku: 'ABC-123', price: 10 })] })
+    })
+
+    fireEvent.keyDown(window, { key: 'A' })
+    fireEvent.keyDown(window, { key: 'B' })
+    fireEvent.keyDown(window, { key: 'C' })
+    fireEvent.keyDown(window, { key: '-' })
+    fireEvent.keyDown(window, { key: '1' })
+    fireEvent.keyDown(window, { key: '2' })
+    fireEvent.keyDown(window, { key: '3' })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    expect(await screen.findByText(/added test product via the scanner/i)).toBeInTheDocument()
+
+    const cart = screen.getByLabelText('Cart')
+    await waitFor(() => {
+      const rows = within(cart).getAllByRole('row')
+      expect(rows).toHaveLength(2)
+      expect(within(rows[1]).getByText('Test Product')).toBeInTheDocument()
+      expect(within(rows[1]).getByText(/GHS 10\.00/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows an error when a scanned code is unknown', async () => {
+    let productSnapshot: ((snap: { docs: { id: string; data: () => Record<string, unknown> }[] }) => void) | null =
+      null
+
+    onSnapshotMock.mockImplementation((queryRef, onNext) => {
+      if (queryRef.collection.path === 'products') {
+        productSnapshot = onNext
+      }
+      queueMicrotask(() => {
+        onNext({ docs: [] })
+      })
+      return () => {}
+    })
+
+    render(
+      <MemoryRouter>
+        <Sell />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(productSnapshot).toBeTruthy())
+
+    await act(async () => {
+      productSnapshot?.({ docs: [createProductDoc('product-2', { sku: 'KNOWN-1', price: 5 })] })
+    })
+
+    fireEvent.keyDown(window, { key: '9' })
+    fireEvent.keyDown(window, { key: '9' })
+    fireEvent.keyDown(window, { key: '9' })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    expect(await screen.findByText(/we couldn't find a product for code 999/i)).toBeInTheDocument()
+  })
+
+  it('accepts manual barcode entry as a fallback', async () => {
+    const user = userEvent.setup()
+    let productSnapshot: ((snap: { docs: { id: string; data: () => Record<string, unknown> }[] }) => void) | null =
+      null
+
+    onSnapshotMock.mockImplementation((queryRef, onNext) => {
+      if (queryRef.collection.path === 'products') {
+        productSnapshot = onNext
+      }
+      queueMicrotask(() => {
+        onNext({ docs: [] })
+      })
+      return () => {}
+    })
+
+    render(
+      <MemoryRouter>
+        <Sell />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(productSnapshot).toBeTruthy())
+
+    await act(async () => {
+      productSnapshot?.({ docs: [createProductDoc('product-3', { sku: '654321', price: 7 })] })
+    })
+
+    const input = await screen.findByLabelText('Scan or type a barcode')
+    await user.type(input, '654321')
+    await user.click(screen.getByRole('button', { name: /^add$/i }))
+
+    expect(await screen.findByText(/added test product via manual entry/i)).toBeInTheDocument()
+
+    const cart = screen.getByLabelText('Cart')
+    await waitFor(() => {
+      const rows = within(cart).getAllByRole('row')
+      expect(rows).toHaveLength(2)
+      expect(within(rows[1]).getByText('Test Product')).toBeInTheDocument()
+      expect(within(rows[1]).getByText(/GHS 7\.00/)).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable barcode scanner component that handles keyboard wedge input, manual entry, and camera preview fallback
- connect the Sell page to the scanner so SKU matches add products automatically and display scanner feedback
- require SKU values in product forms with updated copy and expand tests for scanning flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8eb9748b0832180503ee8ff3ad96a