### PR TITLE
Persist owner metadata after signup

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { User } from 'firebase/auth'
 import { MemoryRouter } from 'react-router-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 const mocks = vi.hoisted(() => {
@@ -24,8 +24,46 @@ const mocks = vi.hoisted(() => {
   return state
 })
 
+const firestore = vi.hoisted(() => {
+  const docRefByPath = new Map<string, { path: string }>()
+  let timestampCallCount = 0
+
+  const docMock = vi.fn((_: unknown, ...segments: string[]) => {
+    const key = segments.join('/')
+    if (!docRefByPath.has(key)) {
+      docRefByPath.set(key, { path: key })
+    }
+    return docRefByPath.get(key)!
+  })
+
+  const setDocMock = vi.fn(async () => {})
+  const updateDocMock = vi.fn(async () => {})
+
+  const serverTimestampMock = vi.fn(() => {
+    timestampCallCount += 1
+    return { __type: 'serverTimestamp', order: timestampCallCount }
+  })
+
+  return {
+    docMock,
+    setDocMock,
+    updateDocMock,
+    serverTimestampMock,
+    docRefByPath,
+    reset() {
+      docMock.mockClear()
+      setDocMock.mockClear()
+      updateDocMock.mockClear()
+      serverTimestampMock.mockClear()
+      docRefByPath.clear()
+      timestampCallCount = 0
+    },
+  }
+})
+
 vi.mock('./firebase', () => ({
   auth: mocks.auth,
+  db: {},
 }))
 
 vi.mock('firebase/auth', () => ({
@@ -40,11 +78,31 @@ vi.mock('firebase/auth', () => ({
   },
 }))
 
-vi.mock('./controllers/sessionController', () => ({
-  configureAuthPersistence: (...args: unknown[]) => mocks.configureAuthPersistence(...args),
-  persistSession: (...args: unknown[]) => mocks.persistSession(...args),
-  refreshSessionHeartbeat: (...args: unknown[]) => mocks.refreshSessionHeartbeat(...args),
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: Parameters<typeof firestore.docMock>) => firestore.docMock(...args),
+  setDoc: (...args: Parameters<typeof firestore.setDocMock>) => firestore.setDocMock(...args),
+  updateDoc: (...args: Parameters<typeof firestore.updateDocMock>) => firestore.updateDocMock(...args),
+  serverTimestamp: (
+    ...args: Parameters<typeof firestore.serverTimestampMock>
+  ) => firestore.serverTimestampMock(...args),
+  Timestamp: class MockTimestamp {},
 }))
+
+vi.mock('./controllers/sessionController', async () => {
+  const actual = await vi.importActual<typeof import('./controllers/sessionController')>(
+    './controllers/sessionController',
+  )
+
+  return {
+    ...actual,
+    configureAuthPersistence: (...args: unknown[]) => mocks.configureAuthPersistence(...args),
+    persistSession: async (...args: Parameters<typeof actual.persistSession>) => {
+      await mocks.persistSession(...args)
+      return actual.persistSession(...args)
+    },
+    refreshSessionHeartbeat: (...args: unknown[]) => mocks.refreshSessionHeartbeat(...args),
+  }
+})
 
 vi.mock('./components/ToastProvider', () => ({
   useToast: () => ({ publish: mocks.publish }),
@@ -68,6 +126,7 @@ describe('App signup cleanup', () => {
     vi.clearAllMocks()
     mocks.auth.currentUser = null
     mocks.listeners.splice(0, mocks.listeners.length)
+    firestore.reset()
   })
 
   it('surfaces signup errors without deleting the new account', async () => {
@@ -93,13 +152,15 @@ describe('App signup cleanup', () => {
       expect(screen.queryByText(/Checking your session/i)).not.toBeInTheDocument(),
     )
 
-    await user.click(screen.getByRole('tab', { name: /Sign up/i }))
-    await user.type(screen.getByLabelText(/Email/i), 'owner@example.com')
-    await user.type(screen.getByLabelText(/Phone/i), '5551234567')
-    await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
-    await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
+    await act(async () => {
+      await user.click(screen.getByRole('tab', { name: /Sign up/i }))
+      await user.type(screen.getByLabelText(/Email/i), 'owner@example.com')
+      await user.type(screen.getByLabelText(/Phone/i), '5551234567')
+      await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
+      await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
 
-    await user.click(screen.getByRole('button', { name: /Create account/i }))
+      await user.click(screen.getByRole('button', { name: /Create account/i }))
+    })
 
     await waitFor(() => expect(mocks.persistSession).toHaveBeenCalled())
 
@@ -108,6 +169,62 @@ describe('App signup cleanup', () => {
     expect(mocks.auth.currentUser).toBe(createdUser)
     expect(mocks.publish).toHaveBeenCalledWith(
       expect.objectContaining({ tone: 'error', message: 'Unable to persist session' }),
+    )
+  })
+
+  it('persists owner metadata after a successful signup', async () => {
+    const user = userEvent.setup()
+    const { user: createdUser } = createTestUser()
+
+    mocks.createUserWithEmailAndPassword.mockImplementation(async () => {
+      mocks.auth.currentUser = createdUser
+      mocks.listeners.forEach(listener => listener(createdUser))
+      return { user: createdUser }
+    })
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(mocks.configureAuthPersistence).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(screen.queryByText(/Checking your session/i)).not.toBeInTheDocument(),
+    )
+
+    await act(async () => {
+      await user.click(screen.getByRole('tab', { name: /Sign up/i }))
+      await user.type(screen.getByLabelText(/Email/i), 'owner@example.com')
+      await user.type(screen.getByLabelText(/Phone/i), ' (555) 123-4567 ')
+      await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
+      await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
+
+      await user.click(screen.getByRole('button', { name: /Create account/i }))
+    })
+
+    await waitFor(() => expect(mocks.persistSession).toHaveBeenCalled())
+
+    const ownerDocKey = `teamMembers/${createdUser.uid}`
+
+    const ownerDocRef = firestore.docRefByPath.get(ownerDocKey)
+    expect(ownerDocRef).toBeDefined()
+
+    const timestampValues = firestore.serverTimestampMock.mock.results.map(result => result.value)
+    expect(timestampValues.length).toBeGreaterThanOrEqual(4)
+    const [createdTimestamp, updatedTimestamp] = timestampValues.slice(-2)
+
+    expect(firestore.setDocMock).toHaveBeenCalledWith(
+      ownerDocRef,
+      expect.objectContaining({
+        storeId: createdUser.uid,
+        name: 'Owner account',
+        phone: '5551234567',
+        email: 'owner@example.com',
+        createdAt: createdTimestamp,
+        updatedAt: updatedTimestamp,
+      }),
+      { merge: true },
     )
   })
 })


### PR DESCRIPTION
## Summary
- mock Firestore helpers in the signup test suite and verify owner metadata persistence
- persist owner contact metadata to the teamMembers collection after a successful signup

## Testing
- npm test -- App.signup.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d8fcb168cc8321b5cde07395053756