### PR TITLE
Add customer displayName metadata and update consumers

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -357,13 +357,17 @@ export default function App() {
         await persistSession(nextUser)
         await persistOwnerMetadata(nextUser, sanitizedEmail, sanitizedPhone)
         try {
+          const preferredDisplayName = nextUser.displayName?.trim() || sanitizedEmail
           await setDoc(
             doc(db, 'customers', nextUser.uid),
             {
               storeId: nextUser.uid,
-              name: nextUser.displayName?.trim() || sanitizedEmail,
+              name: preferredDisplayName,
+              displayName: preferredDisplayName,
               email: sanitizedEmail,
               phone: sanitizedPhone,
+              status: 'active',
+              role: 'client',
               createdAt: serverTimestamp(),
               updatedAt: serverTimestamp(),
             },

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -48,6 +48,7 @@ type ProductRecord = {
 type CustomerRecord = {
   id: string
   name: string
+  displayName?: string
   createdAt?: Timestamp | Date | null
   storeId?: string | null
 }


### PR DESCRIPTION
## Summary
- store a displayName alongside status and role when creating a customer during signup
- prefer the new displayName field across customer listings and checkout flows while falling back to legacy data
- extend the signup test to assert the new Firestore payload shape

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9061156f0832186312c631697d8c1