### PR TITLE
Enforce inactive workspace gating

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "serve": "firebase emulators:start --only functions,firestore",
     "deploy": "npm run build && firebase deploy --only functions",
-    "test": "npm run build && node ./test/commitSale.test.js",
+    "test": "npm run build && node ./test/commitSale.test.js && node ./test/resolveStoreAccess.test.js",
     "backfill-store": "ts-node ./scripts/backfillStoreIds.ts"
   },
   "dependencies": {

--- a/functions/src/types/googleapis.d.ts
+++ b/functions/src/types/googleapis.d.ts
@@ -1,0 +1,14 @@
+declare module 'googleapis' {
+  export const google: {
+    auth: {
+      GoogleAuth: new (options: any) => {
+        getClient(): Promise<any>
+      }
+    }
+    sheets(options: any): any
+  }
+
+  export namespace sheets_v4 {
+    type Sheets = any
+  }
+}

--- a/functions/test/commitSale.test.js
+++ b/functions/test/commitSale.test.js
@@ -1,151 +1,26 @@
 const assert = require('assert')
 const Module = require('module')
-
-class MockDocSnapshot {
-  constructor(data) {
-    this._data = data
-  }
-
-  get exists() {
-    return this._data !== undefined
-  }
-
-  data() {
-    return this._data ? { ...this._data } : undefined
-  }
-
-  get(field) {
-    return this._data ? this._data[field] : undefined
-  }
-}
-
-class MockDocumentReference {
-  constructor(db, path) {
-    this._db = db
-    this.path = path
-  }
-
-  get id() {
-    const parts = this.path.split('/')
-    return parts[parts.length - 1]
-  }
-
-  collection(name) {
-    return new MockCollectionReference(this._db, `${this.path}/${name}`)
-  }
-}
-
-class MockCollectionReference {
-  constructor(db, path) {
-    this._db = db
-    this._path = path
-  }
-
-  doc(id) {
-    const docId = id || this._db.generateId()
-    return new MockDocumentReference(this._db, `${this._path}/${docId}`)
-  }
-}
-
-class MockTransaction {
-  constructor(db) {
-    this._db = db
-    this._writes = new Map()
-  }
-
-  async get(ref) {
-    const pending = this._writes.get(ref.path)
-    const base = pending || this._db.getRaw(ref.path)
-    return new MockDocSnapshot(base ? { ...base } : undefined)
-  }
-
-  set(ref, data) {
-    this._writes.set(ref.path, clone(data))
-  }
-
-  update(ref, data) {
-    const existing = this._writes.get(ref.path) || this._db.getRaw(ref.path)
-    if (!existing) {
-      throw new Error('Document does not exist')
-    }
-    this._writes.set(ref.path, { ...clone(existing), ...clone(data) })
-  }
-
-  commit() {
-    for (const [path, value] of this._writes.entries()) {
-      this._db.setRaw(path, value)
-    }
-  }
-}
-
-class MockFirestore {
-  constructor(initialData = {}) {
-    this._store = new Map()
-    this._idCounter = 0
-    for (const [path, value] of Object.entries(initialData)) {
-      this.setRaw(path, value)
-    }
-  }
-
-  collection(path) {
-    return new MockCollectionReference(this, path)
-  }
-
-  generateId() {
-    this._idCounter += 1
-    return `mock-id-${this._idCounter}`
-  }
-
-  async runTransaction(fn) {
-    const tx = new MockTransaction(this)
-    const result = await fn(tx)
-    tx.commit()
-    return result
-  }
-
-  getRaw(path) {
-    const value = this._store.get(path)
-    return value ? { ...value } : undefined
-  }
-
-  setRaw(path, data) {
-    this._store.set(path, clone(data))
-  }
-
-  getDoc(path) {
-    return this.getRaw(path)
-  }
-
-  listCollection(path) {
-    const prefix = `${path}/`
-    const results = []
-    for (const [docPath, value] of this._store.entries()) {
-      if (docPath.startsWith(prefix)) {
-        const remainder = docPath.slice(prefix.length)
-        if (!remainder.includes('/')) {
-          results.push({ id: remainder, data: { ...value } })
-        }
-      }
-    }
-    return results
-  }
-}
-
-function clone(value) {
-  return value === undefined ? value : JSON.parse(JSON.stringify(value))
-}
+const { MockFirestore, MockTimestamp } = require('./helpers/mockFirestore')
 
 let currentDb
 const originalLoad = Module._load
 Module._load = function patchedLoad(request, parent, isMain) {
   if (request === 'firebase-admin') {
+    const apps = []
     const firestore = () => currentDb
     firestore.FieldValue = {
       serverTimestamp: () => ({ __mockServerTimestamp: true }),
     }
+    firestore.Timestamp = MockTimestamp
 
     return {
-      initializeApp: () => {},
+      initializeApp: () => {
+        const app = { name: 'mock-app' }
+        apps[0] = app
+        return app
+      },
+      app: () => apps[0] || null,
+      apps,
       firestore,
       auth: () => ({
         getUser: async () => null,
@@ -158,6 +33,17 @@ Module._load = function patchedLoad(request, parent, isMain) {
         updateUser: async () => {},
         createUser: async () => ({ uid: 'new-user' }),
       }),
+    }
+  }
+  if (request === 'firebase-admin/firestore') {
+    return {
+      getFirestore: () => currentDb,
+    }
+  }
+  if (request === './googleSheets' || request.endsWith('/googleSheets')) {
+    return {
+      fetchClientRowByEmail: async () => null,
+      getDefaultSpreadsheetId: () => 'test-sheet',
     }
   }
   return originalLoad(request, parent, isMain)

--- a/functions/test/helpers/mockFirestore.js
+++ b/functions/test/helpers/mockFirestore.js
@@ -1,0 +1,164 @@
+const clone = value => (value === undefined ? value : JSON.parse(JSON.stringify(value)))
+
+class MockTimestamp {
+  constructor(millis = Date.now()) {
+    this._millis = millis
+  }
+
+  static now() {
+    return new MockTimestamp(Date.now())
+  }
+
+  toMillis() {
+    return this._millis
+  }
+}
+
+class MockDocSnapshot {
+  constructor(data) {
+    this._data = data
+  }
+
+  get exists() {
+    return this._data !== undefined
+  }
+
+  data() {
+    return this._data ? clone(this._data) : undefined
+  }
+
+  get(field) {
+    return this._data ? this._data[field] : undefined
+  }
+}
+
+class MockDocumentReference {
+  constructor(db, path) {
+    this._db = db
+    this.path = path
+  }
+
+  get id() {
+    const parts = this.path.split('/')
+    return parts[parts.length - 1]
+  }
+
+  collection(name) {
+    return new MockCollectionReference(this._db, `${this.path}/${name}`)
+  }
+
+  async get() {
+    const data = this._db.getRaw(this.path)
+    return new MockDocSnapshot(data ? clone(data) : undefined)
+  }
+
+  async set(data, options = {}) {
+    const existing = this._db.getRaw(this.path)
+    if (options && options.merge && existing) {
+      this._db.setRaw(this.path, { ...existing, ...clone(data) })
+    } else {
+      this._db.setRaw(this.path, clone(data))
+    }
+  }
+}
+
+class MockCollectionReference {
+  constructor(db, path) {
+    this._db = db
+    this._path = path
+  }
+
+  doc(id) {
+    const docId = id || this._db.generateId()
+    return new MockDocumentReference(this._db, `${this._path}/${docId}`)
+  }
+}
+
+class MockTransaction {
+  constructor(db) {
+    this._db = db
+    this._writes = new Map()
+  }
+
+  async get(ref) {
+    const pending = this._writes.get(ref.path)
+    const base = pending || this._db.getRaw(ref.path)
+    return new MockDocSnapshot(base ? clone(base) : undefined)
+  }
+
+  set(ref, data) {
+    this._writes.set(ref.path, clone(data))
+  }
+
+  update(ref, data) {
+    const existing = this._writes.get(ref.path) || this._db.getRaw(ref.path)
+    if (!existing) {
+      throw new Error('Document does not exist')
+    }
+    this._writes.set(ref.path, { ...clone(existing), ...clone(data) })
+  }
+
+  commit() {
+    for (const [path, value] of this._writes.entries()) {
+      this._db.setRaw(path, value)
+    }
+  }
+}
+
+class MockFirestore {
+  constructor(initialData = {}) {
+    this._store = new Map()
+    this._idCounter = 0
+    for (const [path, value] of Object.entries(initialData)) {
+      this.setRaw(path, value)
+    }
+  }
+
+  collection(path) {
+    return new MockCollectionReference(this, path)
+  }
+
+  generateId() {
+    this._idCounter += 1
+    return `mock-id-${this._idCounter}`
+  }
+
+  async runTransaction(fn) {
+    const tx = new MockTransaction(this)
+    const result = await fn(tx)
+    tx.commit()
+    return result
+  }
+
+  getRaw(path) {
+    const value = this._store.get(path)
+    return value ? clone(value) : undefined
+  }
+
+  setRaw(path, data) {
+    this._store.set(path, clone(data))
+  }
+
+  getDoc(path) {
+    return this.getRaw(path)
+  }
+
+  listCollection(path) {
+    const prefix = `${path}/`
+    const results = []
+    for (const [docPath, value] of this._store.entries()) {
+      if (docPath.startsWith(prefix)) {
+        const remainder = docPath.slice(prefix.length)
+        if (!remainder.includes('/')) {
+          results.push({ id: remainder, data: clone(value) })
+        }
+      }
+    }
+    return results
+  }
+}
+
+module.exports = {
+  MockFirestore,
+  MockTimestamp,
+}

--- a/functions/test/resolveStoreAccess.test.js
+++ b/functions/test/resolveStoreAccess.test.js
@@ -1,0 +1,159 @@
+const assert = require('assert')
+const Module = require('module')
+const path = require('path')
+const { MockFirestore, MockTimestamp } = require('./helpers/mockFirestore')
+
+let currentDefaultDb
+let currentRosterDb
+let sheetRowMock
+const apps = []
+
+const originalLoad = Module._load
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'firebase-admin') {
+    const firestore = () => currentDefaultDb
+    firestore.FieldValue = {
+      serverTimestamp: () => ({ __mockServerTimestamp: true }),
+    }
+    firestore.Timestamp = MockTimestamp
+
+    return {
+      initializeApp: () => {
+        const app = { name: 'mock-app' }
+        apps[0] = app
+        return app
+      },
+      app: () => apps[0] || null,
+      apps,
+      firestore,
+      auth: () => ({
+        getUser: async () => null,
+        setCustomUserClaims: async () => {},
+        getUserByEmail: async () => {
+          const err = new Error('not found')
+          err.code = 'auth/user-not-found'
+          throw err
+        },
+        updateUser: async () => {},
+        createUser: async () => ({ uid: 'new-user' }),
+      }),
+    }
+  }
+
+  if (request === 'firebase-admin/firestore') {
+    return {
+      getFirestore: (_app, name) => (name === 'roster' ? currentRosterDb : currentDefaultDb),
+    }
+  }
+
+  if (request === './googleSheets' || request.endsWith(`${path.sep}googleSheets`)) {
+    return {
+      fetchClientRowByEmail: async () => sheetRowMock,
+      getDefaultSpreadsheetId: () => 'sheet-123',
+    }
+  }
+
+  return originalLoad(request, parent, isMain)
+}
+
+function loadFunctionsModule() {
+  apps.length = 0
+  delete require.cache[require.resolve('../lib/firestore.js')]
+  delete require.cache[require.resolve('../lib/googleSheets.js')]
+  delete require.cache[require.resolve('../lib/index.js')]
+  return require('../lib/index.js')
+}
+
+async function runActiveStatusTest() {
+  currentDefaultDb = new MockFirestore()
+  currentRosterDb = new MockFirestore()
+  sheetRowMock = {
+    spreadsheetId: 'sheet-123',
+    headers: [],
+    normalizedHeaders: [],
+    values: [],
+    record: {
+      store_id: 'store-001',
+      store_status: 'Active',
+      role: 'Owner',
+      member_email: 'owner@example.com',
+      member_name: 'Owner One',
+    },
+  }
+
+  const { resolveStoreAccess } = loadFunctionsModule()
+  const context = {
+    auth: {
+      uid: 'user-1',
+      token: { email: 'owner@example.com' },
+    },
+  }
+
+  const result = await resolveStoreAccess.run({}, context)
+
+  assert.strictEqual(result.ok, true)
+  assert.strictEqual(result.storeId, 'store-001')
+  assert.strictEqual(result.role, 'owner')
+
+  const rosterDoc = currentRosterDb.getDoc('teamMembers/user-1')
+  assert.ok(rosterDoc)
+  assert.strictEqual(rosterDoc.storeId, 'store-001')
+
+  const storeDoc = currentDefaultDb.getDoc('stores/store-001')
+  assert.ok(storeDoc)
+  assert.strictEqual(storeDoc.status, 'Active')
+}
+
+async function runInactiveStatusTest() {
+  currentDefaultDb = new MockFirestore()
+  currentRosterDb = new MockFirestore()
+  sheetRowMock = {
+    spreadsheetId: 'sheet-123',
+    headers: [],
+    normalizedHeaders: [],
+    values: [],
+    record: {
+      store_id: 'store-002',
+      status: 'Contract Terminated',
+      member_email: 'owner@example.com',
+    },
+  }
+
+  const { resolveStoreAccess } = loadFunctionsModule()
+  const context = {
+    auth: {
+      uid: 'user-2',
+      token: { email: 'owner@example.com' },
+    },
+  }
+
+  let error
+  try {
+    await resolveStoreAccess.run({}, context)
+  } catch (err) {
+    error = err
+  }
+
+  assert.ok(error, 'Expected inactive contract to throw')
+  assert.strictEqual(error.code, 'permission-denied')
+  assert.match(
+    error.message,
+    /workspace contract is not active/i,
+    'Expected inactive status rejection message',
+  )
+}
+
+async function run() {
+  await runActiveStatusTest()
+  await runInactiveStatusTest()
+  console.log('resolveStoreAccess tests passed')
+}
+
+run()
+  .catch(err => {
+    console.error(err)
+    process.exitCode = 1
+  })
+  .finally(() => {
+    Module._load = originalLoad
+  })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,7 +18,13 @@ import {
   persistSession,
   refreshSessionHeartbeat,
 } from './controllers/sessionController'
-import { resolveStoreAccess, type ResolveStoreAccessResult, type SeededDocument } from './controllers/accessController'
+import {
+  resolveStoreAccess,
+  type ResolveStoreAccessResult,
+  type SeededDocument,
+  extractCallableErrorMessage,
+  INACTIVE_WORKSPACE_MESSAGE,
+} from './controllers/accessController'
 import { AuthUserContext } from './hooks/useAuthUser'
 import { getOnboardingStatus, setOnboardingStatus } from './utils/onboarding'
 
@@ -839,6 +845,11 @@ function getErrorMessage(error: unknown): string {
         return 'An account already exists with this email.'
       case 'auth/weak-password':
         return 'Please choose a stronger password. It must be at least 8 characters and include uppercase, lowercase, number, and symbol.'
+      case 'functions/permission-denied': {
+        const callableMessage =
+          extractCallableErrorMessage(error) ?? INACTIVE_WORKSPACE_MESSAGE
+        return callableMessage
+      }
       default:
         return (error as any).message || 'Something went wrong. Please try again.'
     }

--- a/web/src/controllers/accessController.ts
+++ b/web/src/controllers/accessController.ts
@@ -1,4 +1,5 @@
 // web/src/controllers/accessController.ts
+import { FirebaseError } from 'firebase/app'
 import { httpsCallable } from 'firebase/functions'
 import { functions } from '../firebase'
 
@@ -80,8 +81,48 @@ const resolveStoreAccessCallable = httpsCallable<void, RawResolveStoreAccessResp
   'resolveStoreAccess',
 )
 
+export const INACTIVE_WORKSPACE_MESSAGE =
+  'Your Sedifex workspace contract is not active. Reach out to your Sedifex administrator to restore access.'
+
+type FirebaseCallableError = FirebaseError & {
+  customData?: {
+    body?: {
+      error?: { message?: unknown }
+    }
+  }
+}
+
+export function extractCallableErrorMessage(error: FirebaseError): string | null {
+  const callableError = error as FirebaseCallableError
+  const bodyMessage = callableError.customData?.body?.error?.message
+  if (typeof bodyMessage === 'string') {
+    const trimmed = bodyMessage.trim()
+    if (trimmed) {
+      return trimmed
+    }
+  }
+
+  const raw = typeof error.message === 'string' ? error.message : ''
+  const withoutFirebasePrefix = raw.replace(/^Firebase:\s*/i, '')
+  const colonIndex = withoutFirebasePrefix.indexOf(':')
+  const normalized =
+    colonIndex >= 0
+      ? withoutFirebasePrefix.slice(colonIndex + 1).trim()
+      : withoutFirebasePrefix.trim()
+  return normalized || null
+}
+
 export async function resolveStoreAccess(): Promise<ResolveStoreAccessResult> {
-  const response = await resolveStoreAccessCallable()
+  let response
+  try {
+    response = await resolveStoreAccessCallable()
+  } catch (error) {
+    if (error instanceof FirebaseError && error.code === 'functions/permission-denied') {
+      const message = extractCallableErrorMessage(error) ?? INACTIVE_WORKSPACE_MESSAGE
+      throw new Error(message)
+    }
+    throw error
+  }
   const payload = response.data ?? {}
 
   const ok = payload.ok === true


### PR DESCRIPTION
## Summary
- block resolveStoreAccess when the workspace status indicates an inactive contract and share the inactive workspace messaging constant
- tighten Google Sheets typing assumptions and add shared Firestore test helpers alongside new resolveStoreAccess coverage
- surface permission-denied callable messages in the web login flow so inactive workspace notices reach users

## Testing
- npm --prefix functions test

------
https://chatgpt.com/codex/tasks/task_e_68d92661a2808321b7d33d1ae094ee19