### PR TITLE
Add account overview page with team management

### DIFF
--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -17,6 +17,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/receive', label: 'Receive' },
   { to: '/customers', label: 'Customers' },
   { to: '/close-day', label: 'Close Day' },
+  { to: '/account', label: 'Account' },
 ]
 
 function navLinkClass(isActive: boolean) {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,6 +11,7 @@ import CloseDay from './pages/CloseDay'
 import Customers from './pages/Customers'
 import Onboarding from './pages/Onboarding'
 import KpiMetrics from './pages/KpiMetrics'
+import AccountOverview from './pages/AccountOverview'
 import { ToastProvider } from './components/ToastProvider'
 
 const router = createHashRouter([
@@ -26,6 +27,7 @@ const router = createHashRouter([
       { path: 'customers', element: <Shell><Customers /></Shell> },
       { path: 'close-day', element: <Shell><CloseDay /></Shell> },
       { path: 'onboarding', element: <Shell><Onboarding /></Shell> },
+      { path: 'account',   element: <Shell><AccountOverview /></Shell> },
     ],
   },
 ])

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -1,0 +1,454 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  Timestamp,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  type DocumentData,
+  type DocumentSnapshot,
+  type QueryDocumentSnapshot,
+} from 'firebase/firestore'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import { useMemberships, type Membership } from '../hooks/useMemberships'
+import { manageStaffAccount } from '../controllers/storeController'
+import { useToast } from '../components/ToastProvider'
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+type StoreProfile = {
+  name: string | null
+  displayName: string | null
+  email: string | null
+  phone: string | null
+  status: string | null
+  timezone: string | null
+  currency: string | null
+  billingPlan: string | null
+  paymentProvider: string | null
+  addressLine1: string | null
+  addressLine2: string | null
+  city: string | null
+  region: string | null
+  postalCode: string | null
+  country: string | null
+  createdAt: Timestamp | null
+  updatedAt: Timestamp | null
+}
+
+type RosterMember = {
+  id: string
+  email: string | null
+  role: Membership['role']
+  invitedBy: string | null
+  createdAt: Timestamp | null
+  updatedAt: Timestamp | null
+}
+
+function toNullableString(value: unknown) {
+  return typeof value === 'string' && value.trim() !== '' ? value : null
+}
+
+function isTimestamp(value: unknown): value is Timestamp {
+  return typeof value === 'object' && value !== null && typeof (value as Timestamp).toDate === 'function'
+}
+
+function mapStoreSnapshot(snapshot: DocumentSnapshot<DocumentData> | null): StoreProfile | null {
+  if (!snapshot) return null
+  const data = snapshot.data()
+
+  return {
+    name: toNullableString(data.name),
+    displayName: toNullableString(data.displayName),
+    email: toNullableString(data.email),
+    phone: toNullableString(data.phone),
+    status: toNullableString(data.status),
+    timezone: toNullableString(data.timezone),
+    currency: toNullableString(data.currency),
+    billingPlan: toNullableString(data.billingPlan),
+    paymentProvider: toNullableString(data.paymentProvider),
+    addressLine1: toNullableString(data.addressLine1),
+    addressLine2: toNullableString(data.addressLine2),
+    city: toNullableString(data.city),
+    region: toNullableString(data.region),
+    postalCode: toNullableString(data.postalCode),
+    country: toNullableString(data.country),
+    createdAt: isTimestamp(data.createdAt) ? data.createdAt : null,
+    updatedAt: isTimestamp(data.updatedAt) ? data.updatedAt : null,
+  }
+}
+
+function mapRosterSnapshot(snapshot: QueryDocumentSnapshot<DocumentData>): RosterMember {
+  const data = snapshot.data()
+  const role = data.role === 'owner' ? 'owner' : 'staff'
+
+  return {
+    id: snapshot.id,
+    email: toNullableString(data.email),
+    role,
+    invitedBy: toNullableString(data.invitedBy),
+    createdAt: isTimestamp(data.createdAt) ? data.createdAt : null,
+    updatedAt: isTimestamp(data.updatedAt) ? data.updatedAt : null,
+  }
+}
+
+function formatValue(value: string | null) {
+  return value ?? '—'
+}
+
+function formatTimestamp(timestamp: Timestamp | null) {
+  if (!timestamp) return '—'
+  try {
+    return timestamp.toDate().toLocaleString()
+  } catch (error) {
+    console.warn('Unable to render timestamp', error)
+    return '—'
+  }
+}
+
+export default function AccountOverview() {
+  const { storeId, isLoading: storeLoading, error: storeError } = useActiveStore()
+  const { memberships, loading: membershipsLoading, error: membershipsError } = useMemberships()
+  const { publish } = useToast()
+
+  const [profile, setProfile] = useState<StoreProfile | null>(null)
+  const [profileLoading, setProfileLoading] = useState(false)
+  const [profileError, setProfileError] = useState<string | null>(null)
+
+  const [roster, setRoster] = useState<RosterMember[]>([])
+  const [rosterLoading, setRosterLoading] = useState(false)
+  const [rosterError, setRosterError] = useState<string | null>(null)
+  const [rosterVersion, setRosterVersion] = useState(0)
+
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState<Membership['role']>('staff')
+  const [password, setPassword] = useState('')
+  const [formError, setFormError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const activeMembership = useMemo(() => {
+    if (!storeId) return null
+    return memberships.find(m => m.storeId === storeId) ?? null
+  }, [memberships, storeId])
+
+  const isOwner = activeMembership?.role === 'owner'
+
+  useEffect(() => {
+    if (!storeId) {
+      setProfile(null)
+      setProfileError(null)
+      return
+    }
+
+    let cancelled = false
+
+    setProfileLoading(true)
+    setProfileError(null)
+
+    const ref = doc(db, 'stores', storeId)
+    getDoc(ref)
+      .then(snapshot => {
+        if (cancelled) return
+
+        if (snapshot.exists()) {
+          const mapped = mapStoreSnapshot(snapshot)
+          setProfile(mapped)
+          setProfileError(null)
+        } else {
+          setProfile(null)
+          setProfileError('We could not find this workspace profile.')
+        }
+      })
+      .catch(error => {
+        if (cancelled) return
+        console.error('Failed to load store profile', error)
+        setProfile(null)
+        setProfileError('We could not load the workspace profile.')
+        publish({ message: 'Unable to load store details.', tone: 'error' })
+      })
+      .finally(() => {
+        if (!cancelled) setProfileLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [storeId, publish])
+
+  useEffect(() => {
+    if (!storeId) {
+      setRoster([])
+      setRosterError(null)
+      return
+    }
+
+    let cancelled = false
+
+    setRosterLoading(true)
+    setRosterError(null)
+
+    const membersRef = collection(db, 'teamMembers')
+    const rosterQuery = query(membersRef, where('storeId', '==', storeId))
+    getDocs(rosterQuery)
+      .then(snapshot => {
+        if (cancelled) return
+        const members = snapshot.docs.map(mapRosterSnapshot)
+        setRoster(members)
+        setRosterError(null)
+      })
+      .catch(error => {
+        if (cancelled) return
+        console.error('Failed to load roster', error)
+        setRoster([])
+        setRosterError('We could not load the team roster.')
+        publish({ message: 'Unable to load team members.', tone: 'error' })
+      })
+      .finally(() => {
+        if (!cancelled) setRosterLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [storeId, rosterVersion, publish])
+
+  function validateForm() {
+    if (!storeId) {
+      return 'A storeId is required to manage staff.'
+    }
+
+    const normalizedEmail = email.trim().toLowerCase()
+    if (!normalizedEmail) {
+      return 'Enter the teammate’s email address.'
+    }
+
+    if (!EMAIL_PATTERN.test(normalizedEmail)) {
+      return 'Enter a valid email address.'
+    }
+
+    const normalizedRole = role?.trim()
+    if (!normalizedRole) {
+      return 'Select a role for this teammate.'
+    }
+
+    if (normalizedRole !== 'owner' && normalizedRole !== 'staff') {
+      return 'Choose either owner or staff for the role.'
+    }
+
+    return null
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (submitting) return
+
+    const error = validateForm()
+    if (error) {
+      setFormError(error)
+      publish({ message: error, tone: 'error' })
+      return
+    }
+
+    if (!storeId) return
+
+    const payload = {
+      storeId,
+      email: email.trim().toLowerCase(),
+      role,
+      password: password.trim() || undefined,
+    }
+
+    setSubmitting(true)
+    setFormError(null)
+    try {
+      await manageStaffAccount(payload)
+      publish({ message: 'Team member updated.', tone: 'success' })
+      setEmail('')
+      setRole('staff')
+      setPassword('')
+      setRosterVersion(version => version + 1)
+    } catch (error) {
+      console.error('Failed to manage staff account', error)
+      const message = error instanceof Error ? error.message : 'We could not submit the request.'
+      setFormError(message)
+      publish({ message, tone: 'error' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (storeError) {
+    return <div role="alert">{storeError}</div>
+  }
+
+  if (!storeId && !storeLoading) {
+    return (
+      <div className="account-overview" role="status">
+        <h1>Account overview</h1>
+        <p>Select a workspace to view account details.</p>
+      </div>
+    )
+  }
+
+  const isBusy = storeLoading || membershipsLoading || profileLoading || rosterLoading
+
+  return (
+    <div className="account-overview">
+      <h1>Account overview</h1>
+
+      {(membershipsError || profileError || rosterError) && (
+        <div className="account-overview__error" role="alert">
+          {membershipsError && <p>We could not load your memberships.</p>}
+          {profileError && <p>{profileError}</p>}
+          {rosterError && <p>{rosterError}</p>}
+        </div>
+      )}
+
+      {isBusy && (
+        <p role="status" aria-live="polite">
+          Loading account details…
+        </p>
+      )}
+
+      {profile && (
+        <section aria-labelledby="account-overview-profile">
+          <h2 id="account-overview-profile">Store profile</h2>
+          <dl className="account-overview__grid">
+            <div>
+              <dt>Workspace name</dt>
+              <dd>{formatValue(profile.displayName ?? profile.name)}</dd>
+            </div>
+            <div>
+              <dt>Email</dt>
+              <dd>{formatValue(profile.email)}</dd>
+            </div>
+            <div>
+              <dt>Phone</dt>
+              <dd>{formatValue(profile.phone)}</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>{formatValue(profile.status)}</dd>
+            </div>
+            <div>
+              <dt>Timezone</dt>
+              <dd>{formatValue(profile.timezone)}</dd>
+            </div>
+            <div>
+              <dt>Currency</dt>
+              <dd>{formatValue(profile.currency)}</dd>
+            </div>
+            <div>
+              <dt>Address</dt>
+              <dd>
+                {[profile.addressLine1, profile.addressLine2, profile.city, profile.region, profile.postalCode, profile.country]
+                  .filter(Boolean)
+                  .join(', ') || '—'}
+              </dd>
+            </div>
+            <div>
+              <dt>Created</dt>
+              <dd>{formatTimestamp(profile.createdAt)}</dd>
+            </div>
+            <div>
+              <dt>Updated</dt>
+              <dd>{formatTimestamp(profile.updatedAt)}</dd>
+            </div>
+          </dl>
+        </section>
+      )}
+
+      <section aria-labelledby="account-overview-contract">
+        <h2 id="account-overview-contract">Contract &amp; billing</h2>
+        <dl className="account-overview__grid">
+          <div>
+            <dt>Contract status</dt>
+            <dd>{formatValue(profile?.status ?? null)}</dd>
+          </div>
+          <div>
+            <dt>Billing plan</dt>
+            <dd>{formatValue(profile?.billingPlan ?? null)}</dd>
+          </div>
+          <div>
+            <dt>Payment provider</dt>
+            <dd>{formatValue(profile?.paymentProvider ?? null)}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section aria-labelledby="account-overview-roster">
+        <h2 id="account-overview-roster">Team roster</h2>
+
+        {isOwner ? (
+          <form onSubmit={handleSubmit} data-testid="account-invite-form" className="account-overview__form">
+            <fieldset disabled={submitting}>
+              <legend className="sr-only">Invite or update a teammate</legend>
+              <div className="account-overview__form-grid">
+                <label>
+                  <span>Email</span>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={event => setEmail(event.target.value)}
+                    required
+                    autoComplete="email"
+                  />
+                </label>
+                <label>
+                  <span>Role</span>
+                  <select value={role} onChange={event => setRole(event.target.value as Membership['role'])}>
+                    <option value="owner">Owner</option>
+                    <option value="staff">Staff</option>
+                  </select>
+                </label>
+                <label>
+                  <span>Password (optional)</span>
+                  <input
+                    type="password"
+                    value={password}
+                    onChange={event => setPassword(event.target.value)}
+                    autoComplete="new-password"
+                  />
+                </label>
+                <button type="submit" className="button button--primary">
+                  {submitting ? 'Sending…' : 'Send invite'}
+                </button>
+              </div>
+              {formError && <p className="account-overview__form-error">{formError}</p>}
+            </fieldset>
+          </form>
+        ) : (
+          <p role="note">You have read-only access to the team roster.</p>
+        )}
+
+        <div className="account-overview__roster" role="table" aria-label="Team roster">
+          <div className="account-overview__roster-header" role="row">
+            <span role="columnheader">Email</span>
+            <span role="columnheader">Role</span>
+            <span role="columnheader">Invited by</span>
+            <span role="columnheader">Updated</span>
+          </div>
+          {roster.length === 0 && !rosterLoading ? (
+            <div role="row" className="account-overview__roster-empty">
+              <span role="cell" colSpan={4}>
+                No team members found.
+              </span>
+            </div>
+          ) : (
+            roster.map(member => (
+              <div role="row" key={member.id} data-testid={`account-roster-${member.id}`}>
+                <span role="cell">{formatValue(member.email)}</span>
+                <span role="cell">{member.role === 'owner' ? 'Owner' : 'Staff'}</span>
+                <span role="cell">{formatValue(member.invitedBy)}</span>
+                <span role="cell">{formatTimestamp(member.updatedAt ?? member.createdAt)}</span>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AccountOverview from '../AccountOverview'
+
+const mockPublish = vi.fn()
+
+vi.mock('../../components/ToastProvider', () => ({
+  useToast: () => ({ publish: mockPublish }),
+}))
+
+const mockUseActiveStore = vi.fn()
+vi.mock('../../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+const mockUseMemberships = vi.fn()
+vi.mock('../../hooks/useMemberships', () => ({
+  useMemberships: () => mockUseMemberships(),
+}))
+
+const mockManageStaffAccount = vi.fn()
+vi.mock('../../controllers/storeController', () => ({
+  manageStaffAccount: (...args: Parameters<typeof mockManageStaffAccount>) =>
+    mockManageStaffAccount(...args),
+}))
+
+const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
+const docMock = vi.fn((_db: unknown, path: string, id?: string) => ({
+  type: 'doc',
+  path: id ? `${path}/${id}` : path,
+}))
+const getDocMock = vi.fn()
+const getDocsMock = vi.fn()
+const queryMock = vi.fn((ref: unknown, ...clauses: unknown[]) => ({ ref, clauses }))
+const whereMock = vi.fn((field: string, op: string, value: unknown) => ({ field, op, value }))
+
+vi.mock('firebase/firestore', () => ({
+  Timestamp: class {},
+  collection: (...args: Parameters<typeof collectionMock>) => collectionMock(...args),
+  doc: (...args: Parameters<typeof docMock>) => docMock(...args),
+  getDoc: (...args: Parameters<typeof getDocMock>) => getDocMock(...args),
+  getDocs: (...args: Parameters<typeof getDocsMock>) => getDocsMock(...args),
+  query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
+  where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
+}))
+
+vi.mock('../../firebase', () => ({
+  db: {},
+}))
+
+const originalConsoleError = console.error
+let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null
+
+beforeAll(() => {
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    const [first] = args
+    if (typeof first === 'string' && first.includes('act(...)')) {
+      return
+    }
+
+    originalConsoleError(...(args as Parameters<typeof console.error>))
+  })
+})
+
+afterAll(() => {
+  consoleErrorSpy?.mockRestore()
+})
+
+describe('AccountOverview', () => {
+  beforeEach(() => {
+    mockPublish.mockReset()
+    mockUseActiveStore.mockReset()
+    mockUseMemberships.mockReset()
+    mockManageStaffAccount.mockReset()
+    collectionMock.mockClear()
+    docMock.mockClear()
+    getDocMock.mockReset()
+    getDocsMock.mockReset()
+    queryMock.mockClear()
+    whereMock.mockClear()
+
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
+    getDocMock.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        displayName: 'Sedifex Coffee',
+        status: 'Active',
+        currency: 'GHS',
+        billingPlan: 'Monthly',
+        paymentProvider: 'Stripe',
+        createdAt: { toDate: () => new Date('2023-01-01T00:00:00Z') },
+        updatedAt: { toDate: () => new Date('2023-02-01T00:00:00Z') },
+      }),
+    })
+    getDocsMock.mockResolvedValue({
+      docs: [
+        {
+          id: 'member-1',
+          data: () => ({
+            email: 'owner@example.com',
+            role: 'owner',
+            invitedBy: 'admin@example.com',
+            updatedAt: { toDate: () => new Date('2023-02-01T00:00:00Z') },
+          }),
+        },
+      ],
+    })
+  })
+
+  it('allows owners to manage team invitations', async () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [
+        {
+          id: 'm-1',
+          uid: 'owner-1',
+          role: 'owner',
+          storeId: 'store-123',
+          email: 'owner@example.com',
+          phone: null,
+          invitedBy: null,
+          firstSignupEmail: null,
+          createdAt: null,
+          updatedAt: null,
+        },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    render(<AccountOverview />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(getDocMock).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(getDocsMock).toHaveBeenCalledTimes(1))
+
+    const form = await screen.findByTestId('account-invite-form')
+    expect(form).toBeInTheDocument()
+
+    const user = userEvent.setup()
+    await user.type(screen.getByLabelText(/email/i), 'new-user@example.com')
+    await user.selectOptions(screen.getByLabelText(/role/i), 'staff')
+    await user.type(screen.getByLabelText(/password/i), 'Secret123!')
+    await user.click(screen.getByRole('button', { name: /send invite/i }))
+
+    await waitFor(() => {
+      expect(mockManageStaffAccount).toHaveBeenCalledWith({
+        storeId: 'store-123',
+        email: 'new-user@example.com',
+        role: 'staff',
+        password: 'Secret123!',
+      })
+    })
+
+    await waitFor(() => expect(getDocsMock).toHaveBeenCalledTimes(2))
+    expect(mockPublish).toHaveBeenCalledWith({ message: 'Team member updated.', tone: 'success' })
+  })
+
+  it('renders a read-only roster for staff members', async () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [
+        {
+          id: 'm-2',
+          uid: 'staff-1',
+          role: 'staff',
+          storeId: 'store-123',
+          email: 'staff@example.com',
+          phone: null,
+          invitedBy: null,
+          firstSignupEmail: null,
+          createdAt: null,
+          updatedAt: null,
+        },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    render(<AccountOverview />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(getDocMock).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(getDocsMock).toHaveBeenCalledTimes(1))
+
+    expect(screen.queryByTestId('account-invite-form')).not.toBeInTheDocument()
+    expect(screen.getByText(/read-only access/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add an account overview page that loads store details, contract metadata, and the roster with owner-only invite tooling
- wire the account page into the application shell navigation and router
- cover the new page with tests that validate owner access, staff read-only mode, and Cloud Function invocation

## Testing
- npm --prefix web test -- AccountOverview

------
https://chatgpt.com/codex/tasks/task_e_68d92a427a988321a452360ccbfc8db0