### PR TITLE
Add goal planner interface and tests

### DIFF
--- a/web/src/hooks/useGoalPlanner.ts
+++ b/web/src/hooks/useGoalPlanner.ts
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { doc, onSnapshot, setDoc, updateDoc, type DocumentReference } from 'firebase/firestore'
+
+import { db } from '../firebase'
+import { useAuthUser } from './useAuthUser'
+import { useActiveStore } from './useActiveStore'
+import { useToast } from '../components/ToastProvider'
+
+type PlannerFrequency = 'daily' | 'weekly' | 'monthly'
+
+export type GoalItem = {
+  id: string
+  title: string
+  notes?: string
+  completed: boolean
+  createdAt: string
+}
+
+type GoalCollection = Record<string, GoalItem[]>
+
+export type GoalPlanDocument = {
+  daily?: GoalCollection
+  weekly?: GoalCollection
+  monthly?: GoalCollection
+}
+
+function ensureId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return `goal-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+}
+
+function formatIsoDate(date: Date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function formatIsoMonth(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  return `${year}-${month}`
+}
+
+function formatIsoWeek(date: Date) {
+  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
+  const day = utcDate.getUTCDay() || 7
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day)
+  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1))
+  const week = Math.ceil(((utcDate.getTime() - yearStart.getTime()) / 86400000 + 1) / 7)
+  return `${utcDate.getUTCFullYear()}-W${String(week).padStart(2, '0')}`
+}
+
+function emptyPlan(): Required<GoalPlanDocument> {
+  return { daily: {}, weekly: {}, monthly: {} }
+}
+
+export type UseGoalPlannerResult = {
+  documentRef: DocumentReference | null
+  plan: Required<GoalPlanDocument>
+  isLoading: boolean
+  selectedDay: string
+  setSelectedDay: (value: string) => void
+  selectedWeek: string
+  setSelectedWeek: (value: string) => void
+  selectedMonth: string
+  setSelectedMonth: (value: string) => void
+  addGoal: (frequency: PlannerFrequency, key: string, title: string, notes?: string) => Promise<void>
+  toggleGoal: (frequency: PlannerFrequency, key: string, id: string) => Promise<void>
+  updateGoalNotes: (frequency: PlannerFrequency, key: string, id: string, notes: string) => Promise<void>
+  deleteGoal: (frequency: PlannerFrequency, key: string, id: string) => Promise<void>
+}
+
+export function useGoalPlanner(): UseGoalPlannerResult {
+  const { publish } = useToast()
+  const { storeId } = useActiveStore()
+  const authUser = useAuthUser()
+
+  const initialToday = useMemo(() => new Date(), [])
+  const [selectedDay, setSelectedDay] = useState(() => formatIsoDate(initialToday))
+  const [selectedWeek, setSelectedWeek] = useState(() => formatIsoWeek(initialToday))
+  const [selectedMonth, setSelectedMonth] = useState(() => formatIsoMonth(initialToday))
+
+  const ownerId = storeId ?? authUser?.uid ?? null
+
+  const [plan, setPlan] = useState<Required<GoalPlanDocument>>(emptyPlan)
+  const [isLoading, setIsLoading] = useState(() => ownerId !== null)
+
+  const documentRef = useMemo(() => {
+    if (!ownerId) {
+      return null
+    }
+
+    return doc(db, 'storeGoalPlans', ownerId)
+  }, [ownerId])
+
+  useEffect(() => {
+    if (!documentRef) {
+      setPlan(emptyPlan())
+      setIsLoading(false)
+      return undefined
+    }
+
+    setIsLoading(true)
+
+    const unsubscribe = onSnapshot(
+      documentRef,
+      snapshot => {
+        const data = snapshot.data() as GoalPlanDocument | undefined
+        setPlan({
+          daily: data?.daily ?? {},
+          weekly: data?.weekly ?? {},
+          monthly: data?.monthly ?? {},
+        })
+        setIsLoading(false)
+      },
+      error => {
+        publish({ tone: 'error', message: 'Unable to load goals right now.' })
+        console.error('[goal-planner] snapshot error', error)
+        setPlan(emptyPlan())
+        setIsLoading(false)
+      },
+    )
+
+    return unsubscribe
+  }, [documentRef, publish])
+
+  const withMerge = useCallback(
+    async (
+      writer: typeof setDoc | typeof updateDoc,
+      data: Partial<GoalPlanDocument>,
+    ) => {
+      if (!documentRef) {
+        publish({ tone: 'error', message: 'Select a workspace to update goals.' })
+        return
+      }
+
+      try {
+        await (writer as typeof setDoc)(documentRef, data, { merge: true })
+      } catch (error) {
+        publish({ tone: 'error', message: 'We could not update your goals. Please try again.' })
+        throw error
+      }
+    },
+    [documentRef, publish],
+  )
+
+  const addGoal = useCallback(
+    async (frequency: PlannerFrequency, key: string, title: string, notes?: string) => {
+      const trimmedTitle = title.trim()
+      if (!trimmedTitle) {
+        publish({ tone: 'error', message: 'Add a goal title before saving.' })
+        return
+      }
+
+      const current = plan[frequency][key] ?? []
+      const entry: GoalItem = {
+        id: ensureId(),
+        title: trimmedTitle,
+        notes: notes?.trim() ? notes.trim() : undefined,
+        completed: false,
+        createdAt: new Date().toISOString(),
+      }
+
+      await withMerge(setDoc, {
+        [frequency]: {
+          ...plan[frequency],
+          [key]: [...current, entry],
+        },
+      })
+
+      publish({ tone: 'success', message: 'Goal added.' })
+    },
+    [plan, publish, withMerge],
+  )
+
+  const toggleGoal = useCallback(
+    async (frequency: PlannerFrequency, key: string, id: string) => {
+      const current = plan[frequency][key] ?? []
+      const next = current.map(goal =>
+        goal.id === id ? { ...goal, completed: !goal.completed } : goal,
+      )
+
+      await withMerge(updateDoc, {
+        [frequency]: {
+          ...plan[frequency],
+          [key]: next,
+        },
+      })
+    },
+    [plan, withMerge],
+  )
+
+  const updateGoalNotes = useCallback(
+    async (frequency: PlannerFrequency, key: string, id: string, notes: string) => {
+      const current = plan[frequency][key] ?? []
+      const trimmed = notes.trim()
+      const next = current.map(goal =>
+        goal.id === id ? { ...goal, notes: trimmed || undefined } : goal,
+      )
+
+      await withMerge(updateDoc, {
+        [frequency]: {
+          ...plan[frequency],
+          [key]: next,
+        },
+      })
+
+      publish({ tone: 'success', message: 'Notes updated.' })
+    },
+    [plan, publish, withMerge],
+  )
+
+  const deleteGoal = useCallback(
+    async (frequency: PlannerFrequency, key: string, id: string) => {
+      const current = plan[frequency][key] ?? []
+      const next = current.filter(goal => goal.id !== id)
+
+      await withMerge(updateDoc, {
+        [frequency]: {
+          ...plan[frequency],
+          [key]: next,
+        },
+      })
+
+      publish({ tone: 'success', message: 'Goal removed.' })
+    },
+    [plan, publish, withMerge],
+  )
+
+  return {
+    documentRef,
+    plan,
+    isLoading,
+    selectedDay,
+    setSelectedDay,
+    selectedWeek,
+    setSelectedWeek,
+    selectedMonth,
+    setSelectedMonth,
+    addGoal,
+    toggleGoal,
+    updateGoalNotes,
+    deleteGoal,
+  }
+}

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -11,7 +11,7 @@ type NavItem = { to: string; label: string; end?: boolean }
 
 const NAV_ITEMS: NavItem[] = [
   { to: '/', label: 'Dashboard', end: true },
-  { to: '/metrics', label: 'KPI & Metrics' },
+  { to: '/goals', label: 'Goals' },
   { to: '/products', label: 'Products' },
   { to: '/sell', label: 'Sell' },
   { to: '/receive', label: 'Receive' },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,7 +10,7 @@ import Receive from './pages/Receive'
 import CloseDay from './pages/CloseDay'
 import Customers from './pages/Customers'
 import Onboarding from './pages/Onboarding'
-import KpiMetrics from './pages/KpiMetrics'
+import GoalPlannerPage from './pages/KpiMetrics'
 import AccountOverview from './pages/AccountOverview'
 import { ToastProvider } from './components/ToastProvider'
 
@@ -20,7 +20,7 @@ const router = createHashRouter([
     element: <App />,
     children: [
       { index: true, element: <Shell><Dashboard /></Shell> },
-      { path: 'metrics',   element: <Shell><KpiMetrics /></Shell> },
+      { path: 'goals',     element: <Shell><GoalPlannerPage /></Shell> },
       { path: 'products',  element: <Shell><Products /></Shell> },
       { path: 'sell',      element: <Shell><Sell /></Shell> },
       { path: 'receive',   element: <Shell><Receive /></Shell> },

--- a/web/src/pages/KpiMetrics.tsx
+++ b/web/src/pages/KpiMetrics.tsx
@@ -1,509 +1,470 @@
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 
-import Sparkline from '../components/Sparkline'
-import { useStoreMetrics } from '../hooks/useStoreMetrics'
+import { useGoalPlanner, type GoalItem } from '../hooks/useGoalPlanner'
 
-function formatPercent(value: number) {
-  const sign = value > 0 ? '+' : ''
-  return `${sign}${value.toFixed(1)}%`
+type PlannerFrequency = 'daily' | 'weekly' | 'monthly'
+
+function getProgressSummary(goals: GoalItem[]) {
+  const total = goals.length
+  const completed = goals.filter(goal => goal.completed).length
+  const percent = total === 0 ? 0 : Math.round((completed / total) * 100)
+  return { total, completed, percent }
 }
 
-export default function KpiMetrics() {
+type FormState = { title: string; notes: string }
+
+function useGoalFormState(initial: FormState = { title: '', notes: '' }) {
+  const [formState, setFormState] = useState(initial)
+
+  const updateField = (field: keyof FormState, value: string) => {
+    setFormState(current => ({ ...current, [field]: value }))
+  }
+
+  const reset = () => setFormState(initial)
+
+  return { formState, updateField, reset }
+}
+
+export default function GoalPlannerPage() {
   const {
-    rangePresets,
-    resolvedRangeId,
-    customRange,
-    handleRangePresetChange,
-    handleCustomDateChange,
-    rangeSummary,
-    rangeDaysLabel,
-    showCustomHint,
-    metrics,
-    goals,
-    goalMonthLabel,
-    selectedGoalMonth,
-    handleGoalMonthChange,
-    goalFormValues,
-    handleGoalInputChange,
-    handleGoalSubmit,
-    isSavingGoals,
-    inventoryAlerts,
-    teamCallouts,
-  } = useStoreMetrics()
+    plan,
+    isLoading,
+    selectedDay,
+    setSelectedDay,
+    selectedWeek,
+    setSelectedWeek,
+    selectedMonth,
+    setSelectedMonth,
+    addGoal,
+    toggleGoal,
+    updateGoalNotes,
+    deleteGoal,
+  } = useGoalPlanner()
+
+  const dailyGoals = plan.daily[selectedDay] ?? []
+  const weeklyGoals = plan.weekly[selectedWeek] ?? []
+  const monthlyGoals = plan.monthly[selectedMonth] ?? []
+
+  const dailyProgress = useMemo(() => getProgressSummary(dailyGoals), [dailyGoals])
+  const weeklyProgress = useMemo(() => getProgressSummary(weeklyGoals), [weeklyGoals])
+  const monthlyProgress = useMemo(() => getProgressSummary(monthlyGoals), [monthlyGoals])
+
+  const dailyForm = useGoalFormState()
+  const weeklyForm = useGoalFormState()
+  const monthlyForm = useGoalFormState()
+
+  const [notesDraft, setNotesDraft] = useState<Record<string, string>>({})
+
+  const handleGoalSubmit = async (
+    frequency: PlannerFrequency,
+    key: string,
+    title: string,
+    notes: string,
+    reset: () => void,
+  ) => {
+    try {
+      await addGoal(frequency, key, title, notes)
+      reset()
+    } catch (error) {
+      console.error('[goal-planner] failed to add goal', error)
+    }
+  }
+
+  const handleToggle = (frequency: PlannerFrequency, key: string, id: string) => {
+    toggleGoal(frequency, key, id).catch(error => {
+      console.error('[goal-planner] toggle failed', error)
+    })
+  }
+
+  const handleDelete = (frequency: PlannerFrequency, key: string, id: string) => {
+    deleteGoal(frequency, key, id).catch(error => {
+      console.error('[goal-planner] delete failed', error)
+    })
+  }
+
+  const handleNotesBlur = (
+    frequency: PlannerFrequency,
+    key: string,
+    goal: GoalItem,
+    value: string,
+  ) => {
+    if (goal.notes === value.trim()) {
+      return
+    }
+
+    updateGoalNotes(frequency, key, goal.id, value).catch(error => {
+      console.error('[goal-planner] notes update failed', error)
+    })
+  }
+
+  const renderGoalList = (
+    frequency: PlannerFrequency,
+    key: string,
+    goals: GoalItem[],
+  ) => {
+    if (goals.length === 0) {
+      return (
+        <p style={{ margin: '12px 0 0', color: '#64748B', fontSize: 14 }}>
+          No goals yet. Add one to start planning.
+        </p>
+      )
+    }
+
+    return (
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 12 }}>
+        {goals.map(goal => {
+          const draftKey = `${frequency}:${goal.id}`
+          const draftValue = notesDraft[draftKey] ?? goal.notes ?? ''
+          return (
+            <li
+              key={goal.id}
+              style={{
+                display: 'grid',
+                gap: 8,
+                padding: '12px 14px',
+                borderRadius: 12,
+                border: '1px solid #E2E8F0',
+                background: '#FFFFFF',
+              }}
+            >
+              <label style={{ display: 'flex', alignItems: 'center', gap: 12, fontWeight: 600 }}>
+                <input
+                  type="checkbox"
+                  checked={goal.completed}
+                  onChange={() => handleToggle(frequency, key, goal.id)}
+                  style={{ width: 18, height: 18 }}
+                />
+                <span style={{ color: goal.completed ? '#16A34A' : '#0F172A' }}>{goal.title}</span>
+              </label>
+              <textarea
+                aria-label={`${goal.title} notes`}
+                value={draftValue}
+                onChange={event =>
+                  setNotesDraft(current => ({ ...current, [draftKey]: event.target.value }))
+                }
+                onBlur={event => handleNotesBlur(frequency, key, goal, event.target.value)}
+                placeholder="Add notes or context (optional)"
+                style={{
+                  borderRadius: 8,
+                  border: '1px solid #CBD5F5',
+                  padding: '8px 10px',
+                  fontSize: 13,
+                  minHeight: 60,
+                  resize: 'vertical',
+                }}
+              />
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <span style={{ fontSize: 12, color: '#94A3B8' }}>
+                  {goal.completed ? 'Completed' : 'In progress'}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(frequency, key, goal.id)}
+                  style={{
+                    border: 'none',
+                    background: 'transparent',
+                    color: '#DC2626',
+                    fontSize: 13,
+                    cursor: 'pointer',
+                  }}
+                  aria-label={`Delete ${goal.title}`}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    )
+  }
 
   return (
     <div>
       <header style={{ marginBottom: 24 }}>
-        <h2 style={{ color: '#4338CA', marginBottom: 8 }}>KPI &amp; Metrics</h2>
+        <h2 style={{ color: '#4338CA', marginBottom: 8 }}>Goal planner</h2>
         <p style={{ color: '#475569', margin: 0 }}>
-          Track the health of your store with real-time revenue, traffic, and inventory insights. Adjust the
-          range to compare performance trends and keep goals on target.
+          Track the outcomes you care about every day, week, and month. Create goals, capture context,
+          and check off progress as your team moves forward.
         </p>
       </header>
 
+      {isLoading && (
+        <p role="status" style={{ color: '#475569', fontSize: 14, marginBottom: 16 }}>
+          Loading goals…
+        </p>
+      )}
+
       <section
-        aria-label="Time range controls"
+        aria-labelledby="daily-goals-heading"
         style={{
-          background: '#FFFFFF',
+          display: 'grid',
+          gap: 16,
+          background: '#F8FAFC',
           borderRadius: 20,
           border: '1px solid #E2E8F0',
           padding: '20px 22px',
-          display: 'grid',
-          gap: 16,
           marginBottom: 24,
         }}
       >
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: 16,
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, justifyContent: 'space-between' }}>
           <div>
-            <h3 style={{ margin: 0, fontSize: 18, fontWeight: 700, color: '#0F172A' }}>Analyse a window</h3>
+            <h3 id="daily-goals-heading" style={{ margin: 0, fontSize: 18, fontWeight: 700, color: '#0F172A' }}>
+              Daily goals
+            </h3>
             <p style={{ margin: 0, fontSize: 13, color: '#64748B' }}>
-              Choose a preset or set specific dates. All KPIs and charts refresh instantly.
+              Choose a day to review and add focused tasks for your team.
             </p>
           </div>
-          <div role="group" aria-label="Quick ranges" style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-            {rangePresets.map(option => (
-              <button
-                key={option.id}
-                type="button"
-                onClick={() => handleRangePresetChange(option.id)}
-                aria-pressed={resolvedRangeId === option.id}
-                style={{
-                  padding: '8px 14px',
-                  borderRadius: 999,
-                  border: resolvedRangeId === option.id ? '1px solid #4338CA' : '1px solid #E2E8F0',
-                  background: resolvedRangeId === option.id ? '#4338CA' : '#F8FAFC',
-                  color: resolvedRangeId === option.id ? '#FFFFFF' : '#1E293B',
-                  fontSize: 13,
-                  fontWeight: 600,
-                  boxShadow: resolvedRangeId === option.id ? '0 4px 12px rgba(67, 56, 202, 0.25)' : 'none',
-                  cursor: 'pointer',
-                }}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: 16,
-            alignItems: 'center',
-          }}
-        >
           <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: '#475569' }}>
-            <span>From</span>
+            <span>Day</span>
             <input
               type="date"
-              value={customRange.start}
-              onChange={event => handleCustomDateChange('start', event.target.value)}
-              style={{
-                borderRadius: 8,
-                border: '1px solid #CBD5F5',
-                padding: '6px 10px',
-                fontSize: 13,
-              }}
+              value={selectedDay}
+              onChange={event => setSelectedDay(event.target.value)}
+              style={{ borderRadius: 8, border: '1px solid #CBD5F5', padding: '6px 10px', fontSize: 13 }}
             />
           </label>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: '#475569' }}>
-            <span>To</span>
-            <input
-              type="date"
-              value={customRange.end}
-              onChange={event => handleCustomDateChange('end', event.target.value)}
-              style={{
-                borderRadius: 8,
-                border: '1px solid #CBD5F5',
-                padding: '6px 10px',
-                fontSize: 13,
-              }}
-            />
-          </label>
-          <span style={{ fontSize: 13, color: '#1E293B', fontWeight: 600 }}>
-            Showing {rangeSummary} ({rangeDaysLabel})
-          </span>
-        </div>
-
-        {showCustomHint && (
-          <p style={{ margin: 0, fontSize: 12, color: '#DC2626' }}>
-            Select both start and end dates to apply your custom range. We’re showing today’s data until then.
-          </p>
-        )}
-      </section>
-
-      <section
-        aria-label="Key performance indicators"
-        style={{ display: 'grid', gap: 20, marginBottom: 32 }}
-      >
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
-            gap: 16,
-          }}
-        >
-          {metrics.map(metric => {
-            const change = metric.changePercent
-            const color = change === null ? '#475569' : change < 0 ? '#DC2626' : '#16A34A'
-            const icon = change === null ? '▬' : change < 0 ? '▼' : '▲'
-            const changeText = change !== null ? formatPercent(change) : '—'
-            return (
-              <article
-                key={metric.id}
-                style={{
-                  background: '#FFFFFF',
-                  borderRadius: 18,
-                  padding: '20px 22px',
-                  border: '1px solid #E2E8F0',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 14,
-                  boxShadow: '0 8px 24px rgba(15, 23, 42, 0.06)',
-                }}
-              >
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
-                  <div>
-                    <div style={{ fontSize: 13, fontWeight: 600, color: '#64748B', textTransform: 'uppercase', letterSpacing: 0.6 }}>
-                      {metric.title}
-                    </div>
-                    <div style={{ fontSize: 32, fontWeight: 700, color: '#0F172A', lineHeight: 1.1 }}>
-                      {metric.value}
-                    </div>
-                  </div>
-                  <div style={{ display: 'grid', gap: 4, justifyItems: 'end' }}>
-                    <span style={{ fontSize: 13, color: '#64748B' }}>{metric.subtitle}</span>
-                    <span style={{ fontSize: 12, color: '#64748B' }}>{metric.changeDescription}</span>
-                  </div>
-                </div>
-                <div style={{ height: 72 }} aria-hidden="true">
-                  {metric.sparkline && metric.sparkline.length ? (
-                    <Sparkline data={metric.sparkline} comparisonData={metric.comparisonSparkline ?? undefined} />
-                  ) : (
-                    <div
-                      style={{
-                        fontSize: 12,
-                        color: '#94A3B8',
-                        display: 'flex',
-                        alignItems: 'center',
-                        height: '100%',
-                      }}
-                    >
-                      Snapshot metric
-                    </div>
-                  )}
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <span
-                    style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: 28,
-                      height: 28,
-                      borderRadius: '999px',
-                      background: '#EEF2FF',
-                      color,
-                      fontSize: 12,
-                      fontWeight: 700,
-                    }}
-                    aria-hidden="true"
-                  >
-                    {icon}
-                  </span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color }}>{changeText}</span>
-                </div>
-              </article>
-            )
-          })}
-        </div>
-      </section>
-
-      <section
-        aria-label="Goal progress"
-        style={{
-          background: '#F1F5F9',
-          borderRadius: 20,
-          border: '1px solid #E2E8F0',
-          padding: 24,
-          display: 'grid',
-          gap: 20,
-          marginBottom: 32,
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: 16,
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <div>
-            <h3 style={{ margin: 0, fontSize: 18, fontWeight: 700, color: '#0F172A' }}>Monthly goals</h3>
-            <p style={{ margin: 0, fontSize: 13, color: '#64748B' }}>
-              Review how close the team is to this month’s revenue and customer targets.
-            </p>
-          </div>
-          <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#475569' }}>
-            <span style={{ fontWeight: 600 }}>Month</span>
-            <input
-              type="month"
-              value={selectedGoalMonth}
-              onChange={event => handleGoalMonthChange(event.target.value)}
-              style={{
-                borderRadius: 8,
-                border: '1px solid #CBD5F5',
-                padding: '6px 10px',
-                fontSize: 13,
-                background: '#FFFFFF',
-              }}
-            />
-          </label>
-        </div>
-
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-            gap: 16,
-          }}
-        >
-          {goals.map(goal => (
-            <article
-              key={goal.title}
-              style={{
-                background: '#FFFFFF',
-                borderRadius: 16,
-                padding: '18px 20px',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 12,
-                border: '1px solid #E2E8F0',
-              }}
-            >
-              <div style={{ fontSize: 13, fontWeight: 600, color: '#64748B', textTransform: 'uppercase', letterSpacing: 0.6 }}>
-                {goal.title}
-              </div>
-              <div style={{ fontSize: 26, fontWeight: 700, color: '#0F172A', lineHeight: 1 }}>{goal.value}</div>
-              <div style={{ fontSize: 13, color: '#475569' }}>{goal.target}</div>
-              <div
-                role="progressbar"
-                aria-valuenow={Math.round(goal.progress * 100)}
-                aria-valuemin={0}
-                aria-valuemax={100}
-                style={{
-                  position: 'relative',
-                  height: 8,
-                  borderRadius: 999,
-                  background: '#E2E8F0',
-                  overflow: 'hidden',
-                }}
-              >
-                <div
-                  style={{
-                    position: 'absolute',
-                    inset: 0,
-                    width: `${Math.round(goal.progress * 100)}%`,
-                    background: '#4338CA',
-                  }}
-                />
-              </div>
-            </article>
-          ))}
         </div>
 
         <form
-          onSubmit={handleGoalSubmit}
+          onSubmit={event => {
+            event.preventDefault()
+            void handleGoalSubmit(
+              'daily',
+              selectedDay,
+              dailyForm.formState.title,
+              dailyForm.formState.notes,
+              dailyForm.reset,
+            )
+          }}
           style={{ display: 'grid', gap: 12 }}
         >
-          <div
+          <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+            <label style={{ display: 'grid', gap: 6, fontSize: 13, color: '#0F172A' }}>
+              <span>Daily goal title</span>
+              <input
+                value={dailyForm.formState.title}
+                onChange={event => dailyForm.updateField('title', event.target.value)}
+                placeholder="Increase upsells"
+                style={{ borderRadius: 8, border: '1px solid #CBD5F5', padding: '8px 10px', fontSize: 13 }}
+                required
+              />
+            </label>
+            <label style={{ display: 'grid', gap: 6, fontSize: 13, color: '#0F172A' }}>
+              <span>Notes (optional)</span>
+              <input
+                value={dailyForm.formState.notes}
+                onChange={event => dailyForm.updateField('notes', event.target.value)}
+                placeholder="Share reminders or context"
+                style={{ borderRadius: 8, border: '1px solid #CBD5F5', padding: '8px 10px', fontSize: 13 }}
+              />
+            </label>
+          </div>
+          <button
+            type="submit"
             style={{
-              display: 'grid',
-              gap: 12,
-              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+              justifySelf: 'flex-start',
+              borderRadius: 999,
+              background: '#4338CA',
+              color: '#FFFFFF',
+              fontWeight: 600,
+              fontSize: 13,
+              padding: '10px 18px',
+              border: 'none',
+              cursor: 'pointer',
             }}
           >
-            <label style={{ display: 'grid', gap: 6, fontSize: 13, color: '#475569' }} htmlFor="kpi-goal-revenue">
-              <span style={{ fontWeight: 600 }}>Revenue goal (GHS)</span>
-              <input
-                id="kpi-goal-revenue"
-                type="number"
-                min={0}
-                step="0.01"
-                inputMode="decimal"
-                value={goalFormValues.revenueTarget}
-                onChange={event => handleGoalInputChange('revenueTarget', event.target.value)}
-                style={{
-                  borderRadius: 8,
-                  border: '1px solid #CBD5F5',
-                  padding: '8px 10px',
-                  fontSize: 14,
-                  background: '#FFFFFF',
-                }}
-              />
-            </label>
-            <label style={{ display: 'grid', gap: 6, fontSize: 13, color: '#475569' }} htmlFor="kpi-goal-customers">
-              <span style={{ fontWeight: 600 }}>New customers goal</span>
-              <input
-                id="kpi-goal-customers"
-                type="number"
-                min={0}
-                step={1}
-                inputMode="numeric"
-                value={goalFormValues.customerTarget}
-                onChange={event => handleGoalInputChange('customerTarget', event.target.value)}
-                style={{
-                  borderRadius: 8,
-                  border: '1px solid #CBD5F5',
-                  padding: '8px 10px',
-                  fontSize: 14,
-                  background: '#FFFFFF',
-                }}
-              />
-            </label>
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
-            <button
-              type="submit"
-              className="primary-button"
-              disabled={isSavingGoals}
-              style={{
-                background: '#4338CA',
-                border: 'none',
-                borderRadius: 999,
-                color: '#FFFFFF',
-                padding: '10px 18px',
-                fontSize: 14,
-                fontWeight: 600,
-                cursor: 'pointer',
-              }}
-            >
-              {isSavingGoals ? 'Saving…' : 'Save goals'}
-            </button>
-            <span style={{ fontSize: 12, color: '#475569' }}>
-              Targets are saved for {goalMonthLabel}. Adjust them anytime to keep your team focused.
-            </span>
-          </div>
+            Add daily goal
+          </button>
         </form>
+
+        <p style={{ margin: 0, fontSize: 13, color: '#0F172A', fontWeight: 600 }}>
+          Completed {dailyProgress.completed} of {dailyProgress.total} goals ({dailyProgress.percent}%)
+        </p>
+
+        {renderGoalList('daily', selectedDay, dailyGoals)}
       </section>
 
       <section
+        aria-labelledby="weekly-goals-heading"
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
-          gap: 20,
+          gap: 16,
+          background: '#F8FAFC',
+          borderRadius: 20,
+          border: '1px solid #E2E8F0',
+          padding: '20px 22px',
+          marginBottom: 24,
         }}
       >
-        <article
-          style={{
-            background: '#FFFFFF',
-            borderRadius: 20,
-            border: '1px solid #E2E8F0',
-            padding: '20px 22px',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 16,
-          }}
-        >
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, justifyContent: 'space-between' }}>
           <div>
-            <h3 style={{ fontSize: 18, fontWeight: 700, color: '#0F172A', marginBottom: 4 }}>Inventory alerts</h3>
-            <p style={{ fontSize: 13, color: '#64748B' }}>
-              Watch products that are running low so the floor team can replenish quickly.
+            <h3 id="weekly-goals-heading" style={{ margin: 0, fontSize: 18, fontWeight: 700, color: '#0F172A' }}>
+              Weekly goals
+            </h3>
+            <p style={{ margin: 0, fontSize: 13, color: '#64748B' }}>
+              Pick a week to track bigger objectives and share updates with your team.
             </p>
           </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: '#475569' }}>
+            <span>Week</span>
+            <input
+              type="week"
+              value={selectedWeek}
+              onChange={event => setSelectedWeek(event.target.value)}
+              style={{ borderRadius: 8, border: '1px solid #CBD5F5', padding: '6px 10px', fontSize: 13 }}
+            />
+          </label>
+        </div>
 
-          {inventoryAlerts.length ? (
-            <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 12 }}>
-              {inventoryAlerts.map(item => (
-                <li
-                  key={item.sku}
-                  style={{
-                    border: '1px solid #E2E8F0',
-                    borderRadius: 12,
-                    padding: '12px 14px',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 6,
-                    background: '#F8FAFC',
-                  }}
-                >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <span style={{ fontWeight: 600, color: '#0F172A' }}>{item.name}</span>
-                    <span
-                      style={{
-                        fontSize: 12,
-                        fontWeight: 600,
-                        color:
-                          item.severity === 'critical'
-                            ? '#DC2626'
-                            : item.severity === 'warning'
-                              ? '#C2410C'
-                              : '#2563EB',
-                      }}
-                    >
-                      {item.status}
-                    </span>
-                  </div>
-                  <span style={{ fontSize: 12, color: '#64748B' }}>SKU: {item.sku}</span>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p style={{ fontSize: 13, color: '#475569' }}>All inventory levels are healthy.</p>
-          )}
-        </article>
-
-        <article
-          style={{
-            background: '#FFFFFF',
-            borderRadius: 20,
-            border: '1px solid #E2E8F0',
-            padding: '20px 22px',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 16,
+        <form
+          onSubmit={event => {
+            event.preventDefault()
+            void handleGoalSubmit(
+              'weekly',
+              selectedWeek,
+              weeklyForm.formState.title,
+              weeklyForm.formState.notes,
+              weeklyForm.reset,
+            )
           }}
+          style={{ display: 'grid', gap: 12 }}
         >
+          <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+            <label style={{ display: 'grid', gap: 6, fontSize: 13, color: '#0F172A' }}>
+              <span>Weekly goal title</span>
+              <input
+                value={weeklyForm.formState.title}
+                onChange={event => weeklyForm.updateField('title', event.target.value)}
+                placeholder="Launch new promotion"
+                style={{ borderRadius: 8, border: '1px solid #CBD5F5', padding: '8px 10px', fontSize: 13 }}
+                required
+              />
+            </label>
+            <label style={{ display: 'grid', gap: 6, fontSize: 13, color: '#0F172A' }}>
+              <span>Notes (optional)</span>
+              <input
+                value={weeklyForm.formState.notes}
+                onChange={event => weeklyForm.updateField('notes', event.target.value)}
+                placeholder="Add milestones or blockers"
+                style={{ borderRadius: 8, border: '1px solid #CBD5F5', padding: '8px 10px', fontSize: 13 }}
+              />
+            </label>
+          </div>
+          <button
+            type="submit"
+            style={{
+              justifySelf: 'flex-start',
+              borderRadius: 999,
+              background: '#4338CA',
+              color: '#FFFFFF',
+              fontWeight: 600,
+              fontSize: 13,
+              padding: '10px 18px',
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            Add weekly goal
+          </button>
+        </form>
+
+        <p style={{ margin: 0, fontSize: 13, color: '#0F172A', fontWeight: 600 }}>
+          Completed {weeklyProgress.completed} of {weeklyProgress.total} goals ({weeklyProgress.percent}%)
+        </p>
+
+        {renderGoalList('weekly', selectedWeek, weeklyGoals)}
+      </section>
+
+      <section
+        aria-labelledby="monthly-goals-heading"
+        style={{
+          display: 'grid',
+          gap: 16,
+          background: '#F8FAFC',
+          borderRadius: 20,
+          border: '1px solid #E2E8F0',
+          padding: '20px 22px',
+        }}
+      >
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, justifyContent: 'space-between' }}>
           <div>
-            <h3 style={{ fontSize: 18, fontWeight: 700, color: '#0F172A', marginBottom: 4 }}>Team callouts</h3>
-            <p style={{ fontSize: 13, color: '#64748B' }}>
-              Share insights with staff so everyone knows what needs attention in this range.
+            <h3 id="monthly-goals-heading" style={{ margin: 0, fontSize: 18, fontWeight: 700, color: '#0F172A' }}>
+              Monthly goals
+            </h3>
+            <p style={{ margin: 0, fontSize: 13, color: '#64748B' }}>
+              Focus on strategic efforts and measure progress across the month.
             </p>
           </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: '#475569' }}>
+            <span>Month</span>
+            <input
+              type="month"
+              value={selectedMonth}
+              onChange={event => setSelectedMonth(event.target.value)}
+              style={{ borderRadius: 8, border: '1px solid #CBD5F5', padding: '6px 10px', fontSize: 13 }}
+            />
+          </label>
+        </div>
 
-          <dl style={{ margin: 0, display: 'grid', gap: 12 }}>
-            {teamCallouts.map(item => (
-              <div
-                key={item.label}
-                style={{
-                  display: 'grid',
-                  gap: 4,
-                  background: '#F8FAFC',
-                  borderRadius: 12,
-                  border: '1px solid #E2E8F0',
-                  padding: '12px 14px',
-                }}
-              >
-                <dt style={{ fontSize: 12, fontWeight: 600, color: '#64748B', textTransform: 'uppercase', letterSpacing: 0.6 }}>
-                  {item.label}
-                </dt>
-                <dd style={{ margin: 0, fontSize: 16, fontWeight: 700, color: '#0F172A' }}>{item.value}</dd>
-                <dd style={{ margin: 0, fontSize: 13, color: '#475569' }}>{item.description}</dd>
-              </div>
-            ))}
-          </dl>
-        </article>
+        <form
+          onSubmit={event => {
+            event.preventDefault()
+            void handleGoalSubmit(
+              'monthly',
+              selectedMonth,
+              monthlyForm.formState.title,
+              monthlyForm.formState.notes,
+              monthlyForm.reset,
+            )
+          }}
+          style={{ display: 'grid', gap: 12 }}
+        >
+          <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+            <label style={{ display: 'grid', gap: 6, fontSize: 13, color: '#0F172A' }}>
+              <span>Monthly goal title</span>
+              <input
+                value={monthlyForm.formState.title}
+                onChange={event => monthlyForm.updateField('title', event.target.value)}
+                placeholder="Improve repeat purchases"
+                style={{ borderRadius: 8, border: '1px solid #CBD5F5', padding: '8px 10px', fontSize: 13 }}
+                required
+              />
+            </label>
+            <label style={{ display: 'grid', gap: 6, fontSize: 13, color: '#0F172A' }}>
+              <span>Notes (optional)</span>
+              <input
+                value={monthlyForm.formState.notes}
+                onChange={event => monthlyForm.updateField('notes', event.target.value)}
+                placeholder="Document learnings or metrics"
+                style={{ borderRadius: 8, border: '1px solid #CBD5F5', padding: '8px 10px', fontSize: 13 }}
+              />
+            </label>
+          </div>
+          <button
+            type="submit"
+            style={{
+              justifySelf: 'flex-start',
+              borderRadius: 999,
+              background: '#4338CA',
+              color: '#FFFFFF',
+              fontWeight: 600,
+              fontSize: 13,
+              padding: '10px 18px',
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            Add monthly goal
+          </button>
+        </form>
+
+        <p style={{ margin: 0, fontSize: 13, color: '#0F172A', fontWeight: 600 }}>
+          Completed {monthlyProgress.completed} of {monthlyProgress.total} goals ({monthlyProgress.percent}%)
+        </p>
+
+        {renderGoalList('monthly', selectedMonth, monthlyGoals)}
       </section>
     </div>
   )

--- a/web/src/pages/__tests__/KpiMetrics.test.tsx
+++ b/web/src/pages/__tests__/KpiMetrics.test.tsx
@@ -1,27 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { vi } from 'vitest'
 
-import KpiMetrics from '../KpiMetrics'
+import GoalPlannerPage from '../KpiMetrics'
 import Shell from '../../layout/Shell'
-
-const mockLoadCachedSales = vi.fn(async () => [] as unknown[])
-const mockSaveCachedSales = vi.fn(async () => {})
-const mockLoadCachedProducts = vi.fn(async () => [] as unknown[])
-const mockSaveCachedProducts = vi.fn(async () => {})
-const mockLoadCachedCustomers = vi.fn(async () => [] as unknown[])
-const mockSaveCachedCustomers = vi.fn(async () => {})
-
-vi.mock('../../utils/offlineCache', () => ({
-  SALES_CACHE_LIMIT: 200,
-  PRODUCT_CACHE_LIMIT: 200,
-  CUSTOMER_CACHE_LIMIT: 200,
-  loadCachedSales: (...args: Parameters<typeof mockLoadCachedSales>) => mockLoadCachedSales(...args),
-  saveCachedSales: (...args: Parameters<typeof mockSaveCachedSales>) => mockSaveCachedSales(...args),
-  loadCachedProducts: (...args: Parameters<typeof mockLoadCachedProducts>) => mockLoadCachedProducts(...args),
-  saveCachedProducts: (...args: Parameters<typeof mockSaveCachedProducts>) => mockSaveCachedProducts(...args),
-  loadCachedCustomers: (...args: Parameters<typeof mockLoadCachedCustomers>) => mockLoadCachedCustomers(...args),
-  saveCachedCustomers: (...args: Parameters<typeof mockSaveCachedCustomers>) => mockSaveCachedCustomers(...args),
-}))
 
 const mockUseAuthUser = vi.fn(() => ({ uid: 'user-1', email: 'manager@example.com' }))
 vi.mock('../../hooks/useAuthUser', () => ({
@@ -58,143 +41,174 @@ vi.mock('../../hooks/useConnectivityStatus', () => ({
   }),
 }))
 
-const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
-const whereMock = vi.fn((field: string, op: string, value: unknown) => ({ type: 'where', field, op, value }))
-const orderByMock = vi.fn((field: string, direction?: string) => ({ type: 'orderBy', field, direction }))
-const limitMock = vi.fn((value: number) => ({ type: 'limit', value }))
-const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[]) => ({
-  type: 'query',
-  collection: collectionRef,
-  clauses,
-}))
-
-const docMock = vi.fn((dbRef: unknown, path: string, id?: string) => ({
-  type: 'doc',
-  path: id ? `${path}/${id}` : path,
-}))
-
+const docMock = vi.fn((_, collection: string, id: string) => ({ type: 'doc', path: `${collection}/${id}` }))
 const setDocMock = vi.fn(async () => {})
+const updateDocMock = vi.fn(async () => {})
 
-const onSnapshotMock = vi.fn(
-  (
-    ref: { type: 'collection'; collection?: { path: string } } | { type: 'query'; collection: { path: string } } | { type: 'doc'; path: string },
-    onNext: (snapshot: any) => void,
-  ) => {
-    queueMicrotask(() => {
-      if (ref.type === 'doc') {
-        const now = new Date()
-        const monthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
-        onNext({
-          data: () => ({
-            monthly: {
-              [monthKey]: { revenueTarget: 1000, customerTarget: 20 },
-            },
-          }),
-        })
-        return
-      }
-
-      const path = ref.type === 'query' ? ref.collection.path : ref.collection?.path
-      if (path === 'sales') {
-        onNext({
-          docs: [
-            {
-              id: 'sale-1',
-              data: () => ({
-                total: 120,
-                createdAt: new Date(),
-                items: [
-                  { productId: 'product-1', name: 'T-Shirt', qty: 3, price: 40 },
-                ],
-              }),
-            },
-          ],
-        })
-        return
-      }
-
-      if (path === 'products') {
-        onNext({
-          docs: [
-            {
-              id: 'product-1',
-              data: () => ({ name: 'T-Shirt', price: 40, stockCount: 2, minStock: 5 }),
-            },
-          ],
-        })
-        return
-      }
-
-      if (path === 'customers') {
-        onNext({
-          docs: [
-            {
-              id: 'customer-1',
-              data: () => ({ name: 'Akwasi', createdAt: new Date() }),
-            },
-          ],
-        })
-      }
+let snapshotData: any = null
+const onSnapshotMock = vi.fn((ref: { path: string }, onNext: (snapshot: any) => void) => {
+  queueMicrotask(() => {
+    onNext({
+      data: () => snapshotData,
     })
-    return () => {}
-  },
-)
+  })
+  return () => {}
+})
 
 vi.mock('firebase/firestore', () => ({
-  collection: (...args: Parameters<typeof collectionMock>) => collectionMock(...args),
-  query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
-  orderBy: (...args: Parameters<typeof orderByMock>) => orderByMock(...args),
-  limit: (...args: Parameters<typeof limitMock>) => limitMock(...args),
-  onSnapshot: (...args: Parameters<typeof onSnapshotMock>) => onSnapshotMock(...args),
-  where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
   doc: (...args: Parameters<typeof docMock>) => docMock(...args),
   setDoc: (...args: Parameters<typeof setDocMock>) => setDocMock(...args),
+  updateDoc: (...args: Parameters<typeof updateDocMock>) => updateDocMock(...args),
+  onSnapshot: (...args: Parameters<typeof onSnapshotMock>) => onSnapshotMock(...args),
 }))
 
-describe('KPI & Metrics page', () => {
+const renderPlanner = () => {
+  render(
+    <MemoryRouter initialEntries={['/goals']}>
+      <Routes>
+        <Route path="/goals" element={<Shell><GoalPlannerPage /></Shell>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function formatIsoDate(date: Date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function formatIsoMonth(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  return `${year}-${month}`
+}
+
+function formatIsoWeek(date: Date) {
+  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
+  const day = utcDate.getUTCDay() || 7
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day)
+  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1))
+  const week = Math.ceil(((utcDate.getTime() - yearStart.getTime()) / 86400000 + 1) / 7)
+  return `${utcDate.getUTCFullYear()}-W${String(week).padStart(2, '0')}`
+}
+
+describe('Goal planner page', () => {
+  const uuidSpy = vi.spyOn(globalThis.crypto, 'randomUUID')
+  let dayKey = ''
+  let weekKey = ''
+  let monthKey = ''
+
   beforeEach(() => {
-    mockLoadCachedSales.mockReset()
-    mockSaveCachedSales.mockReset()
-    mockLoadCachedProducts.mockReset()
-    mockSaveCachedProducts.mockReset()
-    mockLoadCachedCustomers.mockReset()
-    mockSaveCachedCustomers.mockReset()
-    collectionMock.mockClear()
-    whereMock.mockClear()
-    orderByMock.mockClear()
-    limitMock.mockClear()
-    queryMock.mockClear()
+    uuidSpy.mockReset()
+    uuidSpy.mockReturnValue('goal-new-id')
+
+    mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'manager@example.com' })
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockPublish.mockReset()
+
     docMock.mockClear()
     setDocMock.mockClear()
+    updateDocMock.mockClear()
     onSnapshotMock.mockClear()
-    mockPublish.mockReset()
-    mockUseAuthUser.mockReset()
-    mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'manager@example.com' })
-    mockUseActiveStore.mockReset()
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
 
-    mockLoadCachedSales.mockResolvedValue([])
-    mockLoadCachedProducts.mockResolvedValue([])
-    mockLoadCachedCustomers.mockResolvedValue([])
-    mockSaveCachedSales.mockResolvedValue(undefined)
-    mockSaveCachedProducts.mockResolvedValue(undefined)
-    mockSaveCachedCustomers.mockResolvedValue(undefined)
+    const now = new Date()
+    dayKey = formatIsoDate(now)
+    weekKey = formatIsoWeek(now)
+    monthKey = formatIsoMonth(now)
+
+    snapshotData = {
+      daily: {
+        [dayKey]: [
+          {
+            id: 'goal-1',
+            title: 'Call supplier',
+            completed: false,
+            createdAt: '2024-05-14T18:00:00.000Z',
+          },
+        ],
+      },
+      weekly: {
+        [weekKey]: [
+          {
+            id: 'goal-2',
+            title: 'Plan launch event',
+            completed: true,
+            createdAt: '2024-05-10T12:00:00.000Z',
+          },
+        ],
+      },
+      monthly: {
+        [monthKey]: [
+          {
+            id: 'goal-3',
+            title: 'Improve NPS score',
+            completed: false,
+            createdAt: '2024-05-02T08:00:00.000Z',
+          },
+        ],
+      },
+    }
   })
 
-  it('renders revenue KPI for the metrics route', async () => {
-    render(
-      <MemoryRouter initialEntries={['/metrics']}>
-        <Routes>
-          <Route path="/metrics" element={<Shell><KpiMetrics /></Shell>} />
-        </Routes>
-      </MemoryRouter>,
-    )
+  afterAll(() => {
+    uuidSpy.mockRestore()
+  })
 
+  it('renders daily, weekly, and monthly goal sections', async () => {
+    renderPlanner()
     await waitFor(() => expect(onSnapshotMock).toHaveBeenCalled())
 
-    const revenueValues = await screen.findAllByText(/GHS 120\.00/)
-    expect(revenueValues.length).toBeGreaterThan(0)
-    expect(screen.getAllByText(/Inventory alerts/i)[0]).toBeInTheDocument()
-    expect(screen.getAllByText(/Team callouts/i)[0]).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { level: 3, name: /daily goals/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 3, name: /weekly goals/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 3, name: /monthly goals/i })).toBeInTheDocument()
+  })
+
+  it('adds a new daily goal to Firestore with merge', async () => {
+    snapshotData.daily[dayKey] = []
+
+    renderPlanner()
+    await waitFor(() => expect(onSnapshotMock).toHaveBeenCalled())
+
+    const titleInput = await screen.findByLabelText(/daily goal title/i)
+    const notesInput = screen.getAllByLabelText(/notes \(optional\)/i)[0]
+    await userEvent.type(titleInput, 'Launch checkout prompt')
+    await userEvent.type(notesInput, 'Highlight bundles at POS')
+
+    await userEvent.click(screen.getByRole('button', { name: /add daily goal/i }))
+
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1))
+    const [, payload, options] = setDocMock.mock.calls[0]
+
+    expect(payload.daily[dayKey][0]).toMatchObject({
+      id: 'goal-new-id',
+      title: 'Launch checkout prompt',
+      notes: 'Highlight bundles at POS',
+      completed: false,
+    })
+    expect(options).toEqual({ merge: true })
+  })
+
+  it('toggles completion and deletes a goal via Firestore updates', async () => {
+    renderPlanner()
+    await waitFor(() => expect(onSnapshotMock).toHaveBeenCalled())
+
+    const checkbox = await screen.findByRole('checkbox', { name: /call supplier/i })
+    await userEvent.click(checkbox)
+
+    await waitFor(() => expect(updateDocMock).toHaveBeenCalledTimes(1))
+    const [, togglePayload, toggleOptions] = updateDocMock.mock.calls[0]
+
+    expect(togglePayload.daily[dayKey][0].completed).toBe(true)
+    expect(toggleOptions).toEqual({ merge: true })
+
+    updateDocMock.mockClear()
+
+    const deleteButton = screen.getByRole('button', { name: /delete call supplier/i })
+    await userEvent.click(deleteButton)
+
+    await waitFor(() => expect(updateDocMock).toHaveBeenCalledTimes(1))
+    const [, deletePayload, deleteOptions] = updateDocMock.mock.calls[0]
+
+    expect(deletePayload.daily[dayKey]).toEqual([])
+    expect(deleteOptions).toEqual({ merge: true })
   })
 })


### PR DESCRIPTION
## Summary
- add a Firestore-backed `useGoalPlanner` hook that manages daily, weekly, and monthly goals
- replace the KPI metrics page with a goal planner UI and update navigation/routes to point at the new experience
- refresh the page tests to cover goal CRUD interactions via Firestore mocks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d930153a908321af42d45d52b8d55d