### PR TITLE
Enforce sheet store ID validation

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -559,12 +559,14 @@ export const resolveStoreAccess = functions.https.onCall(async (data, context) =
   ])
   const normalizedSheetStoreId =
     typeof sheetStoreIdValue === 'string' ? sheetStoreIdValue.trim() : ''
-  const storeId = (normalizedSheetStoreId || existingStoreId || uid).trim()
-  if (!storeId) {
-    throw new functions.https.HttpsError('failed-precondition', 'The assigned workspace is missing a store identifier.')
-  }
 
-  if (requestedStoreId !== null && normalizedSheetStoreId) {
+  const missingStoreIdMessage =
+    'We could not confirm the store ID assigned to your Sedifex workspace. Reach out to your Sedifex administrator.'
+
+  if (requestedStoreId !== null) {
+    if (!normalizedSheetStoreId) {
+      throw new functions.https.HttpsError('failed-precondition', missingStoreIdMessage)
+    }
     if (requestedStoreId !== normalizedSheetStoreId) {
       throw new functions.https.HttpsError(
         'permission-denied',
@@ -572,6 +574,14 @@ export const resolveStoreAccess = functions.https.onCall(async (data, context) =
       )
     }
   }
+
+  const storeIdCandidate = normalizedSheetStoreId || existingStoreId || null
+
+  if (!storeIdCandidate) {
+    throw new functions.https.HttpsError('failed-precondition', missingStoreIdMessage)
+  }
+
+  const storeId = storeIdCandidate
 
   const resolvedRoleCandidate = getValueFromRecord(record, ['role', 'member_role', 'store_role', 'workspace_role'])
   let resolvedRole = 'staff'

--- a/functions/test/resolveStoreAccess.test.js
+++ b/functions/test/resolveStoreAccess.test.js
@@ -200,10 +200,48 @@ async function runStoreIdMismatchTest() {
   )
 }
 
+async function runMissingStoreIdTest() {
+  currentDefaultDb = new MockFirestore()
+  currentRosterDb = new MockFirestore()
+  sheetRowMock = {
+    spreadsheetId: 'sheet-123',
+    headers: [],
+    normalizedHeaders: [],
+    values: [],
+    record: {
+      status: 'Active',
+      member_email: 'owner@example.com',
+    },
+  }
+
+  const { resolveStoreAccess } = loadFunctionsModule()
+  const context = {
+    auth: {
+      uid: 'user-4',
+      token: { email: 'owner@example.com' },
+    },
+  }
+
+  let error
+  try {
+    await resolveStoreAccess.run({ storeId: 'store-001' }, context)
+  } catch (err) {
+    error = err
+  }
+
+  assert.ok(error, 'Expected missing store ID to throw')
+  assert.strictEqual(error.code, 'failed-precondition')
+  assert.strictEqual(
+    error.message,
+    'We could not confirm the store ID assigned to your Sedifex workspace. Reach out to your Sedifex administrator.',
+  )
+}
+
 async function run() {
   await runActiveStatusTest()
   await runInactiveStatusTest()
   await runStoreIdMismatchTest()
+  await runMissingStoreIdTest()
   console.log('resolveStoreAccess tests passed')
 }
 

--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -336,7 +336,9 @@ describe('App signup cleanup', () => {
     })
 
     mocks.resolveStoreAccess.mockRejectedValueOnce(
-      new Error('Your account is assigned to store store-999. Enter the correct store ID to continue.'),
+      new Error(
+        'We could not confirm the store ID assigned to your Sedifex workspace. Reach out to your Sedifex administrator.',
+      ),
     )
 
     render(
@@ -384,7 +386,8 @@ describe('App signup cleanup', () => {
       expect(mocks.publish).toHaveBeenCalledWith(
         expect.objectContaining({
           tone: 'error',
-          message: 'Your account is assigned to store store-999. Enter the correct store ID to continue.',
+          message:
+            'We could not confirm the store ID assigned to your Sedifex workspace. Reach out to your Sedifex administrator.',
         }),
       ),
     )


### PR DESCRIPTION
## Summary
- require a store identifier from the client roster before resolving access and fall back to existing Firestore store IDs instead of generating one from the UID
- update the resolveStoreAccess tests to cover missing store IDs and ensure the web signup flow surfaces the new error message

## Testing
- npm --prefix functions test
- npm --prefix web test -- src/App.signup.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d933a9a4b48321b10911b4da64b019