### PR TITLE
Normalize sheet record lookups for store access

### DIFF
--- a/functions/src/googleSheets.ts
+++ b/functions/src/googleSheets.ts
@@ -32,7 +32,7 @@ type SheetsConfig = {
   spreadsheet_id?: string
 }
 
-function normalizeHeader(header: unknown): string {
+export function normalizeHeader(header: unknown): string {
   if (typeof header !== 'string') return ''
   return header
     .trim()

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,6 @@
 import * as functions from 'firebase-functions'
 import { admin, defaultDb, rosterDb } from './firestore'
-import { fetchClientRowByEmail, getDefaultSpreadsheetId } from './googleSheets'
+import { fetchClientRowByEmail, getDefaultSpreadsheetId, normalizeHeader } from './googleSheets'
 
 const db = defaultDb
 
@@ -176,7 +176,9 @@ function getOptionalEmail(value: unknown): string | null {
 
 function getValueFromRecord(record: SheetRecord, keys: string[]): string | null {
   for (const key of keys) {
-    const value = record[key]
+    const normalizedKey = normalizeHeader(key)
+    if (!normalizedKey) continue
+    const value = record[normalizedKey]
     const resolved = getOptionalString(value)
     if (resolved) return resolved
   }
@@ -185,7 +187,9 @@ function getValueFromRecord(record: SheetRecord, keys: string[]): string | null 
 
 function getEmailFromRecord(record: SheetRecord, keys: string[]): string | null {
   for (const key of keys) {
-    const value = record[key]
+    const normalizedKey = normalizeHeader(key)
+    if (!normalizedKey) continue
+    const value = record[normalizedKey]
     const resolved = getOptionalEmail(value)
     if (resolved) return resolved
   }
@@ -267,7 +271,9 @@ function getTimestampFromRecord(
   keys: string[],
 ): admin.firestore.Timestamp | null {
   for (const key of keys) {
-    const raw = record[key]
+    const normalizedKey = normalizeHeader(key)
+    if (!normalizedKey) continue
+    const raw = record[normalizedKey]
     const parsed = parseDateValue(raw)
     if (parsed) return parsed
   }
@@ -276,7 +282,9 @@ function getTimestampFromRecord(
 
 function getNumberFromRecord(record: SheetRecord, keys: string[]): number | null {
   for (const key of keys) {
-    const raw = record[key]
+    const normalizedKey = normalizeHeader(key)
+    if (!normalizedKey) continue
+    const raw = record[normalizedKey]
     const parsed = parseNumberValue(raw)
     if (parsed !== null) return parsed
   }

--- a/functions/test/resolveStoreAccess.test.js
+++ b/functions/test/resolveStoreAccess.test.js
@@ -8,6 +8,15 @@ let currentRosterDb
 let sheetRowMock
 const apps = []
 
+function normalizeHeader(header) {
+  if (typeof header !== 'string') return ''
+  return header
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+}
+
 const originalLoad = Module._load
 Module._load = function patchedLoad(request, parent, isMain) {
   if (request === 'firebase-admin') {
@@ -50,6 +59,7 @@ Module._load = function patchedLoad(request, parent, isMain) {
     return {
       fetchClientRowByEmail: async () => sheetRowMock,
       getDefaultSpreadsheetId: () => 'sheet-123',
+      normalizeHeader,
     }
   }
 
@@ -73,16 +83,16 @@ async function runActiveStatusTest() {
     normalizedHeaders: [],
     values: [],
     record: {
-      store_id: 'store-001',
-      store_status: 'Active',
-      role: 'Owner',
-      member_email: 'owner@example.com',
-      member_name: 'Owner One',
-      contractStart: '2024-01-15',
-      contract_end: '2024-12-31',
-      payment_status: 'Paid',
-      amount_paid: '$1,234.56',
-      company: 'Example Company',
+      [normalizeHeader('store_id')]: 'store-001',
+      [normalizeHeader('store_status')]: 'Active',
+      [normalizeHeader('role')]: 'Owner',
+      [normalizeHeader('member_email')]: 'owner@example.com',
+      [normalizeHeader('member_name')]: 'Owner One',
+      [normalizeHeader('contractStart')]: '2024-01-15',
+      [normalizeHeader('contract_end')]: '2024-12-31',
+      [normalizeHeader('paymentStatus')]: 'Paid',
+      [normalizeHeader('amountPaid')]: '$1,234.56',
+      [normalizeHeader('company')]: 'Example Company',
     },
   }
 
@@ -132,9 +142,9 @@ async function runInactiveStatusTest() {
     normalizedHeaders: [],
     values: [],
     record: {
-      store_id: 'store-002',
-      status: 'Contract Terminated',
-      member_email: 'owner@example.com',
+      [normalizeHeader('store_id')]: 'store-002',
+      [normalizeHeader('status')]: 'Contract Terminated',
+      [normalizeHeader('member_email')]: 'owner@example.com',
     },
   }
 
@@ -171,9 +181,9 @@ async function runStoreIdMismatchTest() {
     normalizedHeaders: [],
     values: [],
     record: {
-      store_id: 'store-777',
-      status: 'Active',
-      member_email: 'owner@example.com',
+      [normalizeHeader('store_id')]: 'store-777',
+      [normalizeHeader('status')]: 'Active',
+      [normalizeHeader('member_email')]: 'owner@example.com',
     },
   }
 


### PR DESCRIPTION
## Summary
- export the Google Sheets header normalizer and apply it when reading sheet records
- rely on normalized keys in resolveStoreAccess so camelCase columns like contractStart and amountPaid are handled
- update resolveStoreAccess tests to mock normalized sheet data that matches fetchClientRowByEmail

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9353937888321982061a7717867d3