### PR TITLE
Store active store ID in local storage

### DIFF
--- a/web/src/SheetAccessGuard.tsx
+++ b/web/src/SheetAccessGuard.tsx
@@ -17,10 +17,16 @@ export default function SheetAccessGuard({ children }: { children: React.ReactNo
         if (!row) throw new Error('We could not find a workspace assignment for this account.')
         if (!row.storeId) throw new Error('Your account is missing a workspace store ID.')
         if (!isContractActive(row)) throw new Error('Your Sedifex workspace contract is not active.')
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem('activeStoreId', row.storeId)
+        }
         setReady(true)                           // allowed
       } catch (e: any) {
         setError(e?.message || 'Access denied.') // block
         await signOut(auth)
+        if (typeof window !== 'undefined') {
+          window.localStorage.removeItem('activeStoreId')
+        }
         setReady(true)
       }
     })


### PR DESCRIPTION
## Summary
- persist the active store ID in local storage when a user passes sheet validation
- clear the stored active store ID when access checks fail and the user is signed out

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d959a0f21083218bc81d9885dce120