### PR TITLE
Use persisted active store when available

### DIFF
--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -11,12 +11,17 @@ const STORE_ERROR_MESSAGE = 'We could not load your workspace access. Some featu
 
 export function useActiveStore(): ActiveStoreState {
   const { memberships, loading, error } = useMemberships()
-  const activeStoreId = memberships.find(m => m.storeId)?.storeId ?? null
+  const persistedStoreId =
+    typeof window !== 'undefined' ? window.localStorage.getItem('activeStoreId') : null
+
+  const membershipStoreId = memberships.find(m => m.storeId)?.storeId ?? null
+  const activeStoreId =
+    persistedStoreId && persistedStoreId.trim() !== '' ? persistedStoreId : membershipStoreId
   const hasError = error != null
 
   return useMemo(
     () => ({
-      storeId: activeStoreId,
+      storeId: activeStoreId ?? null,
       isLoading: loading,
       error: hasError ? STORE_ERROR_MESSAGE : null,
     }),


### PR DESCRIPTION
## Summary
- read the active store identifier from localStorage when available
- fall back to the membership-derived store id when no persisted id exists
- ensure the hook memoizes the return value and returns null when no id can be determined

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d959a1eb248321a9936944fe8ede86