### PR TITLE
Handle persisted active store loading state

### DIFF
--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -16,6 +16,7 @@ export function useActiveStore(): ActiveStoreState {
 
   useEffect(() => {
     if (typeof window === 'undefined') {
+      setIsPersistedLoading(false)
       return
     }
 


### PR DESCRIPTION
## Summary
- ensure `useActiveStore` clears the persisted loading flag when running outside the browser

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d966c71728832196ebb02b289c7689