### PR TITLE
Fix SheetAccessGuard relative imports

### DIFF
--- a/web/src/SheetAccessGuard.tsx
+++ b/web/src/SheetAccessGuard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { onAuthStateChanged, signOut, User } from 'firebase/auth'
-import { auth } from '../firebase'
-import { fetchSheetRows, findUserRow, isContractActive } from '../sheetClient'
+import { auth } from './firebase'
+import { fetchSheetRows, findUserRow, isContractActive } from './sheetClient'
 
 export default function SheetAccessGuard({ children }: { children: React.ReactNode }) {
   const [ready, setReady] = useState(false)


### PR DESCRIPTION
## Summary
- update SheetAccessGuard to import firebase and sheet client utilities via relative paths within the module directory

## Testing
- npm run build *(fails: existing TypeScript errors in tests and pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d96b491ab883219c470e12f6fd6a8f