### PR TITLE
Adjust active store selection priority

### DIFF
--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -28,9 +28,7 @@ export function useActiveStore(): ActiveStoreState {
   const membershipStoreId = memberships.find(m => m.storeId)?.storeId ?? null
   const normalizedPersistedStoreId =
     persistedStoreId && persistedStoreId.trim() !== '' ? persistedStoreId : null
-  const activeStoreId = isPersistedLoading
-    ? membershipStoreId
-    : normalizedPersistedStoreId ?? membershipStoreId
+  const activeStoreId = membershipStoreId ?? (isPersistedLoading ? null : normalizedPersistedStoreId)
   const hasError = error != null
 
   return useMemo(


### PR DESCRIPTION
## Summary
- update useActiveStore hook to prioritize membership-provided store IDs
- ensure persisted store ID is only used once storage lookup completes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97076ffec83218c7c9dbbd63aa165