### PR TITLE
Normalize roster emails and add sheet client test

### DIFF
--- a/web/src/sheetClient.test.ts
+++ b/web/src/sheetClient.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchSheetRows, findUserRow } from './sheetClient'
+
+const wrapGviz = (payload: unknown) => JSON.stringify(payload)
+
+describe('sheetClient', () => {
+  it('matches emails regardless of surrounding whitespace in the roster', async () => {
+    const payload = {
+      table: {
+        cols: [{ label: 'Email' }],
+        rows: [
+          {
+            c: [
+              {
+                v: '  Person@Example.com  ',
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      text: async () => wrapGviz(payload),
+    } as Response)
+
+    const rows = await fetchSheetRows()
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].email).toBe('person@example.com')
+
+    const found = findUserRow(rows, ' PERSON@EXAMPLE.COM ')
+    expect(found).toBe(rows[0])
+
+    fetchSpy.mockRestore()
+  })
+})

--- a/web/src/sheetClient.ts
+++ b/web/src/sheetClient.ts
@@ -33,7 +33,9 @@ export async function fetchSheetRows(): Promise<SheetRow[]> {
     const obj: Record<string, any> = {}
     r.c.forEach((cell, i) => { obj[headers[i] || `col${i}`] = cell?.v ?? '' })
     const row: SheetRow = {
-      email: String((obj['email'] ?? '')).toLowerCase(),
+      email: String(obj['email'] ?? '')
+        .trim()
+        .toLowerCase(),
       name: obj['name'] || undefined,
       storeId: obj['storeid'] || obj['store'] || undefined,
       role: roleFix(obj['role']),
@@ -49,7 +51,7 @@ export async function fetchSheetRows(): Promise<SheetRow[]> {
 }
 
 export const findUserRow = (rows: SheetRow[], email: string) =>
-  rows.find(r => r.email === email.trim().toLowerCase()) ?? null
+  rows.find(r => r.email.trim().toLowerCase() === email.trim().toLowerCase()) ?? null
 
 export function isContractActive(row: SheetRow, now = new Date()): boolean {
   const s = row.contractStart ? Date.parse(row.contractStart) : NaN


### PR DESCRIPTION
## Summary
- trim and lowercase roster email addresses when ingesting spreadsheet rows
- trim sheet row emails during lookups for extra resilience
- add a Vitest case proving whitespace-padded emails match successfully

## Testing
- `npx vitest run src/sheetClient.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d98096d8548321b4045a5e5ecaccd3