### PR TITLE
Preserve SheetAccessGuard errors while rendering children

### DIFF
--- a/web/src/SheetAccessGuard.tsx
+++ b/web/src/SheetAccessGuard.tsx
@@ -9,8 +9,8 @@ export default function SheetAccessGuard({ children }: { children: React.ReactNo
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, async (user: User | null) => {
-      setError(null)
       if (!user?.email) { setReady(true); return }
+      setError(null)
       try {
         const rows = await fetchSheetRows()
         const row = findUserRow(rows, user.email)
@@ -34,6 +34,10 @@ export default function SheetAccessGuard({ children }: { children: React.ReactNo
   }, [])
 
   if (!ready) return <p>Checking workspace access…</p>
-  if (error) return <div role="alert">{error}</div>
-  return <>{children}</>
+  return (
+    <>
+      {error ? <div role="alert">{error}</div> : null}
+      {children}
+    </>
+  )
 }


### PR DESCRIPTION
## Summary
- only clear the sheet access guard error state when an authenticated user is present
- render the guarded children alongside any active alert so login surfaces authorization errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d985acbb9c8321941450d06d464417