### PR TITLE
Preserve products when cache resolves

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -182,16 +182,19 @@ export default function Products() {
       .then(cached => {
         if (!cancelled && cached.length) {
           setProducts(prev => {
-            const optimistic = prev.filter(
-              item => item.__optimistic && item.storeId === activeStoreId,
-            )
             const sanitized = cached.map(item => ({
               ...(item as ProductRecord),
               price: sanitizePrice((item as ProductRecord).price),
               __optimistic: false,
               storeId: activeStoreId,
             }))
-            return sortProducts([...sanitized, ...optimistic])
+            const sanitizedIds = new Set(sanitized.map(item => item.id))
+            const preserved = prev.filter(
+              item =>
+                item.storeId === activeStoreId &&
+                (item.__optimistic || !sanitizedIds.has(item.id)),
+            )
+            return sortProducts([...sanitized, ...preserved])
           })
           setIsLoadingProducts(false)
         }


### PR DESCRIPTION
## Summary
- ensure cached product merges keep optimistic and non-cached records for the active store
- add a regression test covering cache resolution after a saved product

## Testing
- npm test -- src/pages/__tests__/Products.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9968b49748321889845d05b305c58