### PR TITLE
Fix goal planner Firestore writes

### DIFF
--- a/web/src/hooks/useGoalPlanner.ts
+++ b/web/src/hooks/useGoalPlanner.ts
@@ -136,7 +136,11 @@ export function useGoalPlanner(): UseGoalPlannerResult {
       }
 
       try {
-        await (writer as typeof setDoc)(documentRef, data, { merge: true })
+        if (writer === setDoc) {
+          await setDoc(documentRef, data, { merge: true })
+        } else {
+          await updateDoc(documentRef, data)
+        }
       } catch (error) {
         publish({ tone: 'error', message: 'We could not update your goals. Please try again.' })
         throw error


### PR DESCRIPTION
## Summary
- ensure the goal planner helper calls `setDoc` with merge options and uses `updateDoc` without merge flags
- expand the goal planner page test to expect `updateDoc` calls without merge options and verify snapshot refresh behavior

## Testing
- npm run test -- src/pages/__tests__/KpiMetrics.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d99bb7ece88321a791a0bb956398c0