### PR TITLE
Ensure useActiveStore prefers persisted store id

### DIFF
--- a/web/src/hooks/useActiveStore.test.tsx
+++ b/web/src/hooks/useActiveStore.test.tsx
@@ -1,0 +1,55 @@
+import { describe, beforeEach, it, expect, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { useActiveStore } from './useActiveStore'
+
+const mockUseMemberships = vi.fn()
+
+vi.mock('./useMemberships', () => ({
+  useMemberships: () => mockUseMemberships(),
+}))
+
+describe('useActiveStore', () => {
+  beforeEach(() => {
+    mockUseMemberships.mockReset()
+    window.localStorage.clear()
+  })
+
+  it('prefers the persisted store id when available after initialization', async () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [{ id: 'member-1', storeId: 'membership-store' }],
+      loading: false,
+      error: null,
+    })
+
+    window.localStorage.setItem('activeStoreId', 'persisted-store')
+
+    const { result } = renderHook(() => useActiveStore())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.storeId).toBe('persisted-store')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('falls back to the membership store id when nothing is persisted', async () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [
+        { id: 'member-1', storeId: 'membership-store' },
+        { id: 'member-2', storeId: 'membership-store-2' },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    const { result } = renderHook(() => useActiveStore())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.storeId).toBe('membership-store')
+  })
+})

--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -28,7 +28,9 @@ export function useActiveStore(): ActiveStoreState {
   const membershipStoreId = memberships.find(m => m.storeId)?.storeId ?? null
   const normalizedPersistedStoreId =
     persistedStoreId && persistedStoreId.trim() !== '' ? persistedStoreId : null
-  const activeStoreId = membershipStoreId ?? (isPersistedLoading ? null : normalizedPersistedStoreId)
+  const activeStoreId = isPersistedLoading
+    ? null
+    : normalizedPersistedStoreId ?? membershipStoreId
   const hasError = error != null
 
   return useMemo(


### PR DESCRIPTION
## Summary
- prioritize the persisted active store identifier after the local storage value is loaded
- keep the hook loading/error handling intact while falling back to membership data only when nothing is stored
- add unit tests that exercise the persisted preference and membership fallback behaviour

## Testing
- npm test -- src/hooks/useActiveStore.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9b3fb78408321b4decea9d187e426