### PR TITLE
Add social navigation to unauthenticated card

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -332,6 +332,58 @@ body {
   pointer-events: none;
 }
 
+.app__socials {
+  margin-top: clamp(20px, 4vw, 32px);
+}
+
+.app__socials-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.app__social-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition: background-color 180ms ease, border-color 180ms ease, transform 180ms ease;
+}
+
+.app__social-link:hover,
+.app__social-link:focus-visible {
+  background: rgba(99, 102, 241, 0.2);
+  border-color: var(--color-border-strong);
+  transform: translateY(-1px);
+}
+
+.app__social-link:focus-visible {
+  outline: 2px solid rgba(191, 219, 254, 0.85);
+  outline-offset: 3px;
+}
+
+@media (max-width: 560px) {
+  .app__socials-list {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .app__social-link {
+    width: 100%;
+  }
+}
+
 .app__visual {
   position: relative;
   display: grid;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -757,6 +757,51 @@ export default function App() {
                 {status.message}
               </p>
             )}
+
+            <nav className="app__socials" aria-label="Sedifex social channels">
+              <ul className="app__socials-list">
+                <li>
+                  <a
+                    className="app__social-link"
+                    href="https://www.facebook.com/sedifex"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    Facebook
+                  </a>
+                </li>
+                <li>
+                  <a
+                    className="app__social-link"
+                    href="https://www.instagram.com/sedifex"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    Instagram
+                  </a>
+                </li>
+                <li>
+                  <a
+                    className="app__social-link"
+                    href="https://www.linkedin.com/company/sedifex"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    LinkedIn
+                  </a>
+                </li>
+                <li>
+                  <a
+                    className="app__social-link"
+                    href="https://www.twitter.com/sedifex"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    Twitter / X
+                  </a>
+                </li>
+              </ul>
+            </nav>
           </div>
 
           <aside className="app__visual" aria-hidden="true">


### PR DESCRIPTION
## Summary
- add a social links navigation section to the sign-in/sign-up card when no user session is present
- style the new social link pills to match the card aesthetic and adapt layout on small screens

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da3bcf8dc083219d3f22c02e5cb41a