### PR TITLE
Refresh ID token after login

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -465,6 +465,9 @@ export default function App() {
 
         persistActiveStoreId(resolution.storeId)
         if (hasSeedData(resolution)) await persistStoreSeedData(resolution)
+
+        try { await nextUser.getIdToken(true) }
+        catch (error) { console.warn('[auth] Unable to refresh ID token after login', error) }
       } else {
         const { user: nextUser } = await createUserWithEmailAndPassword(auth, sanitizedEmail, sanitizedPassword)
         await persistSession(nextUser)


### PR DESCRIPTION
## Summary
- refresh the Firebase ID token after successful login to ensure custom claims are applied immediately
- mirror the signup branch error handling when attempting the forced token refresh

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da528556a48321b368bf38e5dfdcc2