### PR TITLE
Refactor Firestore rules to use membership records

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,17 +1,180 @@
 service cloud.firestore {
   match /databases/{database}/documents {
-    function isStoreUser(storeId) {
-      return request.auth != null &&
-        request.auth.token.storeId is string &&
-        request.auth.token.storeId == storeId;
+    function getRequesterMembership() {
+      return request.auth != null
+        ? get(/databases/$(database)/documents/teamMembers/$(request.auth.uid))
+        : null;
+    }
+
+    function membershipExists(member) {
+      return member != null && member.exists();
+    }
+
+    function memberStoreId(member) {
+      return membershipExists(member) && member.data.storeId is string && member.data.storeId != ''
+        ? member.data.storeId
+        : null;
+    }
+
+    function memberRole(member) {
+      return membershipExists(member) && member.data.role is string && member.data.role != ''
+        ? member.data.role
+        : null;
+    }
+
+    function isOwner(member) {
+      return memberRole(member) == 'owner';
+    }
+
+    function hasStaffAccess(member) {
+      let role = memberRole(member);
+      return role == 'owner' || role == 'staff';
+    }
+
+    function matchesMemberStore(member, storeId) {
+      let store = memberStoreId(member);
+      return store != null && store == storeId;
+    }
+
+    function hasStoreAccess(member, storeId) {
+      return hasStaffAccess(member) && matchesMemberStore(member, storeId);
+    }
+
+    function hasOwnerAccess(member, storeId) {
+      return isOwner(member) && matchesMemberStore(member, storeId);
+    }
+
+    function dataHasStore(data) {
+      return data.keys().hasAll(['storeId']) && data.storeId is string && data.storeId != '';
+    }
+
+    function requestRoleIsValid() {
+      return request.resource.data.role is string
+        && (request.resource.data.role == 'owner' || request.resource.data.role == 'staff');
+    }
+
+    function requestUidMatches(memberId) {
+      return !request.resource.data.keys().hasAny(['uid']) || request.resource.data.uid == memberId;
+    }
+
+    function canReadStoreDocument(storeId) {
+      let member = getRequesterMembership();
+      return hasStoreAccess(member, storeId);
+    }
+
+    function canManageStoreDocument(storeId) {
+      let member = getRequesterMembership();
+      return hasOwnerAccess(member, storeId);
+    }
+
+    function canReadStoreResource() {
+      return dataHasStore(resource.data) && hasStoreAccess(getRequesterMembership(), resource.data.storeId);
+    }
+
+    function canCreateStoreResource() {
+      return dataHasStore(request.resource.data)
+        && hasStoreAccess(getRequesterMembership(), request.resource.data.storeId);
+    }
+
+    function canUpdateStoreResource() {
+      return dataHasStore(resource.data)
+        && dataHasStore(request.resource.data)
+        && resource.data.storeId == request.resource.data.storeId
+        && hasStoreAccess(getRequesterMembership(), resource.data.storeId);
+    }
+
+    function canOwnerCreateStoreResource() {
+      return dataHasStore(request.resource.data)
+        && hasOwnerAccess(getRequesterMembership(), request.resource.data.storeId);
+    }
+
+    function canOwnerWriteStoreResource() {
+      return dataHasStore(resource.data)
+        && hasOwnerAccess(getRequesterMembership(), resource.data.storeId);
+    }
+
+    match /teamMembers/{memberId} {
+      allow read: if resource != null
+        && resource.data.keys().hasAll(['storeId'])
+        && (
+          (request.auth != null && request.auth.uid == memberId && membershipExists(getRequesterMembership()))
+          || hasOwnerAccess(getRequesterMembership(), resource.data.storeId)
+        );
+
+      allow create: if request.auth != null
+        && requestUidMatches(memberId)
+        && dataHasStore(request.resource.data)
+        && requestRoleIsValid()
+        && (
+          (
+            membershipExists(getRequesterMembership())
+            && hasOwnerAccess(getRequesterMembership(), request.resource.data.storeId)
+          )
+          || (
+            !membershipExists(getRequesterMembership())
+            && request.auth.uid == memberId
+            && request.resource.data.role == 'owner'
+          )
+        );
+
+      allow update: if request.auth != null
+        && requestUidMatches(memberId)
+        && dataHasStore(resource.data)
+        && dataHasStore(request.resource.data)
+        && resource.data.storeId == request.resource.data.storeId
+        && membershipExists(getRequesterMembership())
+        && hasOwnerAccess(getRequesterMembership(), resource.data.storeId)
+        && requestRoleIsValid();
+
+      allow delete: if request.auth != null
+        && dataHasStore(resource.data)
+        && membershipExists(getRequesterMembership())
+        && hasOwnerAccess(getRequesterMembership(), resource.data.storeId);
     }
 
     match /stores/{storeId} {
-      allow read, write: if isStoreUser(storeId);
+      allow read: if canReadStoreDocument(storeId);
+      allow write: if canManageStoreDocument(storeId);
 
       match /{document=**} {
-        allow read, write: if isStoreUser(storeId);
+        allow read: if canReadStoreDocument(storeId);
+        allow write: if canManageStoreDocument(storeId);
       }
+    }
+
+    match /products/{productId} {
+      allow read: if canReadStoreResource();
+      allow create: if canOwnerCreateStoreResource();
+      allow update: if canUpdateStoreResource();
+      allow delete: if canOwnerWriteStoreResource();
+    }
+
+    match /sales/{saleId} {
+      allow read: if canReadStoreResource();
+      allow create: if canCreateStoreResource();
+      allow update: if canUpdateStoreResource();
+      allow delete: if canOwnerWriteStoreResource();
+    }
+
+    match /saleItems/{saleItemId} {
+      allow read: if canReadStoreResource();
+      allow create: if canCreateStoreResource();
+      allow update: if canUpdateStoreResource();
+      allow delete: if canOwnerWriteStoreResource();
+    }
+
+    match /ledger/{entryId} {
+      allow read: if canReadStoreResource();
+      allow create: if canCreateStoreResource();
+      allow update: if canUpdateStoreResource();
+      allow delete: if canOwnerWriteStoreResource();
+    }
+
+    match /stock/{entryId} {
+      allow read: if canReadStoreResource();
+      allow create: if canCreateStoreResource();
+      allow update: if canUpdateStoreResource();
+      allow delete: if canOwnerWriteStoreResource();
     }
 
     match /{document=**} {

--- a/web/tests/firestore.rules.test.ts
+++ b/web/tests/firestore.rules.test.ts
@@ -1,55 +1,70 @@
 import { describe, expect, test } from 'vitest'
 
-type Role = 'owner' | 'staff' | undefined
-
-type AuthContext = {
-  uid: string
-  token: {
-    role?: Role
-  }
+type MemberDoc = {
+  storeId?: string | null
+  role?: string | null
 } | null
 
-function isAuthed(auth: AuthContext): auth is { uid: string; token: { role?: Role } } {
-  return auth !== null
+function memberStoreId(member: MemberDoc): string | null {
+  const store = member?.storeId
+  return typeof store === 'string' && store.trim() ? store : null
 }
 
-function hasAnyRole(roles: readonly Role[], auth: AuthContext) {
-  return isAuthed(auth) && roles.includes((auth.token.role ?? undefined) as Role)
+function memberRole(member: MemberDoc): 'owner' | 'staff' | null {
+  const role = member?.role
+  if (typeof role !== 'string') return null
+  const normalized = role.trim().toLowerCase()
+  return normalized === 'owner' || normalized === 'staff' ? normalized : null
 }
 
-function ownerOrSelf(uid: string, auth: AuthContext) {
-  return hasAnyRole(['owner'], auth) || (isAuthed(auth) && auth.uid === uid)
+function hasStaffAccess(member: MemberDoc): boolean {
+  const role = memberRole(member)
+  return role === 'owner' || role === 'staff'
 }
 
-function staffAccess(auth: AuthContext) {
-  return hasAnyRole(['owner', 'staff'], auth)
+function hasOwnerAccess(member: MemberDoc): boolean {
+  return memberRole(member) === 'owner'
 }
 
-describe('Firestore security rules helpers (single tenant)', () => {
-  const ownerAuth: AuthContext = { uid: 'owner-1', token: { role: 'owner' } }
-  const staffAuth: AuthContext = { uid: 'staff-1', token: { role: 'staff' } }
-  const outsiderAuth: AuthContext = { uid: 'outsider-1', token: {} }
+function matchesStore(member: MemberDoc, storeId: string): boolean {
+  const store = memberStoreId(member)
+  return store !== null && store === storeId
+}
 
-  test('owner can manage team members', () => {
-    expect(ownerOrSelf('team-1', ownerAuth)).toBe(true)
-    expect(hasAnyRole(['owner'], ownerAuth)).toBe(true)
+describe('Firestore rules helpers - membership derived access', () => {
+  const owner: MemberDoc = { storeId: 'store-1', role: 'owner' }
+  const staff: MemberDoc = { storeId: 'store-1', role: 'staff' }
+  const outsider: MemberDoc = { storeId: 'store-2', role: 'staff' }
+  const unknown: MemberDoc = null
+
+  test('owner has owner and staff access for their store', () => {
+    expect(memberStoreId(owner)).toBe('store-1')
+    expect(memberRole(owner)).toBe('owner')
+    expect(hasOwnerAccess(owner)).toBe(true)
+    expect(hasStaffAccess(owner)).toBe(true)
+    expect(matchesStore(owner, 'store-1')).toBe(true)
   })
 
-  test('staff cannot write team member documents', () => {
-    expect(hasAnyRole(['owner'], staffAuth)).toBe(false)
+  test('staff has staff access but not owner privileges', () => {
+    expect(memberStoreId(staff)).toBe('store-1')
+    expect(memberRole(staff)).toBe('staff')
+    expect(hasStaffAccess(staff)).toBe(true)
+    expect(hasOwnerAccess(staff)).toBe(false)
+    expect(matchesStore(staff, 'store-1')).toBe(true)
   })
 
-  test('users can read their own team member document', () => {
-    expect(ownerOrSelf('staff-1', staffAuth)).toBe(true)
-    expect(ownerOrSelf('staff-1', outsiderAuth)).toBe(false)
+  test('members cannot access other stores', () => {
+    expect(matchesStore(owner, 'store-2')).toBe(false)
+    expect(matchesStore(staff, 'store-2')).toBe(false)
+    expect(hasStaffAccess(outsider)).toBe(true)
+    expect(matchesStore(outsider, 'store-1')).toBe(false)
   })
 
-  test('owner and staff can access business resources', () => {
-    expect(staffAccess(ownerAuth)).toBe(true)
-    expect(staffAccess(staffAuth)).toBe(true)
-  })
-
-  test('users without a role cannot access business resources', () => {
-    expect(staffAccess(outsiderAuth)).toBe(false)
+  test('missing membership data denies access', () => {
+    expect(memberStoreId(unknown)).toBeNull()
+    expect(memberRole(unknown)).toBeNull()
+    expect(hasStaffAccess(unknown)).toBe(false)
+    expect(hasOwnerAccess(unknown)).toBe(false)
+    expect(matchesStore(unknown, 'store-1')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- derive store membership and role from teamMembers/{uid} instead of custom claims and gate access accordingly
- add store-scoped rules for sales, saleItems, ledger, stock, and products with role-based write permissions
- refresh rule unit tests and emulator scenarios to cover membership-backed authorisation flows

## Testing
- npm run test:rules *(fails: firebase CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da5b468c488321a9a381d3acdb4b33