### PR TITLE
Remove custom claim updates in favor of roster data

### DIFF
--- a/functions/test/resolveStoreAccess.test.js
+++ b/functions/test/resolveStoreAccess.test.js
@@ -37,7 +37,6 @@ Module._load = function patchedLoad(request, parent, isMain) {
       firestore,
       auth: () => ({
         getUser: async () => null,
-        setCustomUserClaims: async () => {},
         getUserByEmail: async () => {
           const err = new Error('not found')
           err.code = 'auth/user-not-found'

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -448,6 +448,8 @@ export default function App() {
       message: mode === 'login' ? 'Signing you in…' : 'Creating your account…',
     })
 
+    let createdSignupUser: User | null = null
+
     try {
       if (mode === 'login') {
         const { user: nextUser } = await signInWithEmailAndPassword(auth, sanitizedEmail, sanitizedPassword)
@@ -471,6 +473,7 @@ export default function App() {
       } else {
         const { user: nextUser } = await createUserWithEmailAndPassword(auth, sanitizedEmail, sanitizedPassword)
         await persistSession(nextUser)
+        createdSignupUser = nextUser
 
         let resolution: ResolveStoreAccessResult | null = null
         try {
@@ -531,6 +534,9 @@ export default function App() {
       setPhone('')
       setNormalizedPhone('')
     } catch (err: unknown) {
+      if (mode === 'signup' && createdSignupUser) {
+        await cleanupFailedSignup(createdSignupUser)
+      }
       setStatus({ tone: 'error', message: getErrorMessage(err) })
     }
   }

--- a/web/src/controllers/accessController.ts
+++ b/web/src/controllers/accessController.ts
@@ -12,7 +12,6 @@ type RawResolveStoreAccessResponse = {
   ok?: unknown
   storeId?: unknown
   role?: unknown
-  claims?: unknown
   teamMember?: RawSeededDocument
   store?: RawSeededDocument
   products?: RawSeededDocument[] | unknown
@@ -28,7 +27,6 @@ export type ResolveStoreAccessResult = {
   ok: boolean
   storeId: string
   role: 'owner' | 'staff'
-  claims?: unknown
   teamMember: SeededDocument | null
   store: SeededDocument | null
   products: SeededDocument[]
@@ -145,7 +143,6 @@ export async function resolveStoreAccess(storeId?: string): Promise<ResolveStore
     ok,
     storeId: resolvedStoreId,
     role: normalizeRole(payload.role),
-    claims: payload.claims,
     teamMember: normalizeSeededDocument(payload.teamMember ?? null),
     store: normalizeSeededDocument(payload.store ?? null),
     products: normalizeSeededCollection(payload.products),

--- a/web/src/controllers/storeController.ts
+++ b/web/src/controllers/storeController.ts
@@ -16,7 +16,6 @@ type ManageStaffAccountResult = {
   email: string
   uid: string
   created: boolean
-  claims?: unknown
 }
 
 export async function manageStaffAccount(payload: ManageStaffAccountPayload) {


### PR DESCRIPTION
## Summary
- delete the custom-claim helper in the callable entrypoint and stop returning claim payloads
- update frontend controllers and tests to rely on Firestore membership data instead of custom claims
- adjust signup flow cleanup logic and mocks to keep tests aligned with the new access resolution behaviour

## Testing
- npm test (functions)
- npm test -- src/App.signup.test.tsx (web)
- npm test (web) *(fails: Firebase auth anonymous sign-in requires network access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da5e5417788321b729f0324c7b1b0d