### PR TITLE
Use default Firestore database for web client

### DIFF
--- a/web/src/firebase.ts
+++ b/web/src/firebase.ts
@@ -59,7 +59,7 @@ try {
   }
 }
 
-export const db = initializeFirestore(app, firestoreSettings, 'roster')
+export const db = initializeFirestore(app, firestoreSettings)
 
 export const storage = getStorage(app)
 export const functions = getFunctions(app)


### PR DESCRIPTION
## Summary
- update the Firestore initialization to use the default database rather than the roster-specific ID

## Testing
- npm test *(fails: FirebaseError auth/network-request-failed in tests/firestore.rules.emulator.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68da6c96195083219234de7f59eda20d