### PR TITLE
Call afterSignupBootstrap during signup flow

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => {
     refreshSessionHeartbeat: vi.fn(async () => {}),
     publish: vi.fn(),
     resolveStoreAccess: vi.fn(),
+    afterSignupBootstrap: vi.fn(async () => {}),
   }
   return state
 })
@@ -116,6 +117,7 @@ vi.mock('./components/ToastProvider', () => ({
 
 vi.mock('./controllers/accessController', () => ({
   resolveStoreAccess: (...args: unknown[]) => mocks.resolveStoreAccess(...args),
+  afterSignupBootstrap: (...args: unknown[]) => mocks.afterSignupBootstrap(...args),
 }))
 
 // IMPORTANT: mock the sheet fallback to be deterministic when a test expects cleanup
@@ -153,6 +155,8 @@ describe('App signup cleanup', () => {
     firestore.reset()
     mocks.resolveStoreAccess.mockReset()
     mocks.resolveStoreAccess.mockResolvedValue(null)
+    mocks.afterSignupBootstrap.mockReset()
+    mocks.afterSignupBootstrap.mockImplementation(async () => {})
     window.localStorage.clear()
     localStorageSetItemSpy = vi.spyOn(Storage.prototype, 'setItem')
   })
@@ -265,6 +269,7 @@ describe('App signup cleanup', () => {
     })
 
     await waitFor(() => expect(mocks.persistSession).toHaveBeenCalled())
+    await waitFor(() => expect(mocks.afterSignupBootstrap).toHaveBeenCalledWith('sheet-store-id'))
     await waitFor(() =>
       expect(mocks.resolveStoreAccess).toHaveBeenCalledWith('sheet-store-id'),
     )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,6 +24,7 @@ import {
   type SeededDocument,
   extractCallableErrorMessage,
   INACTIVE_WORKSPACE_MESSAGE,
+  afterSignupBootstrap,
 } from './controllers/accessController'
 import { fetchSheetRows, findUserRow, isContractActive } from './sheetClient'
 import { AuthUserContext } from './hooks/useAuthUser'
@@ -492,6 +493,8 @@ export default function App() {
         const { user: nextUser } = await createUserWithEmailAndPassword(auth, sanitizedEmail, sanitizedPassword)
         await persistSession(nextUser)
         createdSignupUser = nextUser
+
+        await afterSignupBootstrap(sanitizedStoreId)
 
         let resolution: ResolveStoreAccessResult | null = null
         try {

--- a/web/src/controllers/accessController.ts
+++ b/web/src/controllers/accessController.ts
@@ -78,12 +78,21 @@ type ResolveStoreAccessPayload = {
   storeId?: string
 }
 
+type AfterSignupBootstrapPayload = {
+  storeId?: string
+}
+
 const resolveStoreAccessCallable = httpsCallable<
   ResolveStoreAccessPayload,
   RawResolveStoreAccessResponse
 >(
   functions,
   'resolveStoreAccess',
+)
+
+const afterSignupBootstrapCallable = httpsCallable<AfterSignupBootstrapPayload, void>(
+  functions,
+  'afterSignupBootstrap',
 )
 
 export const INACTIVE_WORKSPACE_MESSAGE =
@@ -148,4 +157,10 @@ export async function resolveStoreAccess(storeId?: string): Promise<ResolveStore
     products: normalizeSeededCollection(payload.products),
     customers: normalizeSeededCollection(payload.customers),
   }
+}
+
+export async function afterSignupBootstrap(storeId?: string): Promise<void> {
+  const trimmedStoreId = typeof storeId === 'string' ? storeId.trim() : ''
+  const payload = trimmedStoreId ? { storeId: trimmedStoreId } : undefined
+  await afterSignupBootstrapCallable(payload)
 }


### PR DESCRIPTION
## Summary
- load the new afterSignupBootstrap helper from the access controller and call it after signup
- expose the helper wrapper so the client can request server-side bootstrap work
- extend the signup test to mock the helper and verify it runs on success

## Testing
- npm test -- App.signup.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da81ad7ed08321b5e7592e3e9c2cda