### PR TITLE
Add afterSignupBootstrap callable and preserve owner role

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -249,8 +249,11 @@ describe('App signup cleanup', () => {
       return {
         ok: true,
         storeId: 'sheet-store-id',
-        role: 'staff',
-        teamMember: { id: 'seed-team-member', data: { name: 'Seeded Member' } },
+        role: 'owner',
+        teamMember: {
+          id: 'seed-team-member',
+          data: { name: 'Seeded Member', role: 'staff' },
+        },
         store: { id: 'sheet-store-id', data: { name: 'Seeded Store' } },
         products: [
           {
@@ -329,7 +332,7 @@ describe('App signup cleanup', () => {
       expect.objectContaining({
         uid: createdUser.uid,
         storeId: 'sheet-store-id',
-        role: 'staff',
+        role: 'owner',
       }),
     )
     expect(ensureOptions).toEqual({ merge: true })
@@ -345,7 +348,7 @@ describe('App signup cleanup', () => {
         name: 'Owner account',
         phone: '5551234567',
         email: 'owner@example.com',
-        role: 'staff',
+        role: 'owner',
         createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
         updatedAt: expect.objectContaining({ __type: 'serverTimestamp' }),
       }),


### PR DESCRIPTION
## Summary
- add a reusable store bootstrap helper that records the owner profile, seeds the store document, and expose it as the new afterSignupBootstrap callable
- ensure resolveStoreAccess never demotes an existing owner when reconciling sheet data
- update the signup flow test to expect the preserved owner role when seed data is applied

## Testing
- npm run build (functions)
- npm test (web) *(fails: firestore.rules.emulator.test.ts requires Firebase emulator / network access)*
- npm run deploy *(fails: firebase CLI not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da902e0c8c832182f1e6339a32afe4