### PR TITLE
Ensure active store syncs with memberships

### DIFF
--- a/web/src/hooks/useActiveStore.test.tsx
+++ b/web/src/hooks/useActiveStore.test.tsx
@@ -15,7 +15,26 @@ describe('useActiveStore', () => {
     window.localStorage.clear()
   })
 
-  it('prefers the persisted store id when available after initialization', async () => {
+  it('prefers the persisted store id when it matches the membership store', async () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [{ id: 'member-1', storeId: 'matching-store' }],
+      loading: false,
+      error: null,
+    })
+
+    window.localStorage.setItem('activeStoreId', 'matching-store')
+
+    const { result } = renderHook(() => useActiveStore())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.storeId).toBe('matching-store')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('updates the persisted store id when membership store differs', async () => {
     mockUseMemberships.mockReturnValue({
       memberships: [{ id: 'member-1', storeId: 'membership-store' }],
       loading: false,
@@ -28,10 +47,10 @@ describe('useActiveStore', () => {
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false)
+      expect(result.current.storeId).toBe('membership-store')
     })
 
-    expect(result.current.storeId).toBe('persisted-store')
-    expect(result.current.error).toBeNull()
+    expect(window.localStorage.getItem('activeStoreId')).toBe('membership-store')
   })
 
   it('falls back to the membership store id when nothing is persisted', async () => {

--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -28,6 +28,32 @@ export function useActiveStore(): ActiveStoreState {
   const membershipStoreId = memberships.find(m => m.storeId)?.storeId ?? null
   const normalizedPersistedStoreId =
     persistedStoreId && persistedStoreId.trim() !== '' ? persistedStoreId : null
+
+  useEffect(() => {
+    if (membershipLoading) {
+      return
+    }
+
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (!membershipStoreId) {
+      return
+    }
+
+    const trimmedPersistedStoreId =
+      persistedStoreId && persistedStoreId.trim() !== ''
+        ? persistedStoreId.trim()
+        : null
+
+    if (trimmedPersistedStoreId === membershipStoreId) {
+      return
+    }
+
+    setPersistedStoreId(membershipStoreId)
+    window.localStorage.setItem('activeStoreId', membershipStoreId)
+  }, [membershipLoading, membershipStoreId, persistedStoreId])
   const activeStoreId = isPersistedLoading
     ? null
     : normalizedPersistedStoreId ?? membershipStoreId


### PR DESCRIPTION
## Summary
- sync the persisted active store with the membership store id when they differ
- guard the synchronization effect against SSR environments
- expand hook tests to cover persisted overrides by membership data

## Testing
- npm test -- useActiveStore

------
https://chatgpt.com/codex/tasks/task_e_68da92cf537c8321b74cfbc5a57c042e