### PR TITLE
Add composite Firestore index for product name queries

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -14,6 +14,14 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "storeId", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "storeId", "order": "ASCENDING" },
         { "fieldPath": "updatedAt", "order": "DESCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]


### PR DESCRIPTION
## Summary
- add a composite index on products collection for storeId and name ordering

## Testing
- ❌ `firebase deploy --only firestore:indexes` *(fails: firebase CLI not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da96e48100832183db571444c9ed4e