### PR TITLE
Filter memberships by active store selection

### DIFF
--- a/web/src/hooks/useActiveStore.test.tsx
+++ b/web/src/hooks/useActiveStore.test.tsx
@@ -6,7 +6,7 @@ import { useActiveStore } from './useActiveStore'
 const mockUseMemberships = vi.fn()
 
 vi.mock('./useMemberships', () => ({
-  useMemberships: () => mockUseMemberships(),
+  useMemberships: (storeId?: string | null) => mockUseMemberships(storeId),
 }))
 
 describe('useActiveStore', () => {
@@ -16,11 +16,15 @@ describe('useActiveStore', () => {
   })
 
   it('prefers the persisted store id when it matches the membership store', async () => {
-    mockUseMemberships.mockReturnValue({
-      memberships: [{ id: 'member-1', storeId: 'matching-store' }],
-      loading: false,
-      error: null,
-    })
+    mockUseMemberships.mockImplementation(storeId =>
+      storeId === undefined
+        ? { memberships: [], loading: true, error: null }
+        : {
+            memberships: [{ id: 'member-1', storeId: 'matching-store' }],
+            loading: false,
+            error: null,
+          },
+    )
 
     window.localStorage.setItem('activeStoreId', 'matching-store')
 
@@ -35,11 +39,15 @@ describe('useActiveStore', () => {
   })
 
   it('updates the persisted store id when membership store differs', async () => {
-    mockUseMemberships.mockReturnValue({
-      memberships: [{ id: 'member-1', storeId: 'membership-store' }],
-      loading: false,
-      error: null,
-    })
+    mockUseMemberships.mockImplementation(storeId =>
+      storeId === undefined
+        ? { memberships: [], loading: true, error: null }
+        : {
+            memberships: [{ id: 'member-1', storeId: 'membership-store' }],
+            loading: false,
+            error: null,
+          },
+    )
 
     window.localStorage.setItem('activeStoreId', 'persisted-store')
 
@@ -54,14 +62,18 @@ describe('useActiveStore', () => {
   })
 
   it('falls back to the membership store id when nothing is persisted', async () => {
-    mockUseMemberships.mockReturnValue({
-      memberships: [
-        { id: 'member-1', storeId: 'membership-store' },
-        { id: 'member-2', storeId: 'membership-store-2' },
-      ],
-      loading: false,
-      error: null,
-    })
+    mockUseMemberships.mockImplementation(storeId =>
+      storeId === undefined
+        ? { memberships: [], loading: true, error: null }
+        : {
+            memberships: [
+              { id: 'member-1', storeId: 'membership-store' },
+              { id: 'member-2', storeId: 'membership-store-2' },
+            ],
+            loading: false,
+            error: null,
+          },
+    )
 
     const { result } = renderHook(() => useActiveStore())
 

--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -10,9 +10,19 @@ interface ActiveStoreState {
 const STORE_ERROR_MESSAGE = 'We could not load your workspace access. Some features may be limited.'
 
 export function useActiveStore(): ActiveStoreState {
-  const { memberships, loading: membershipLoading, error } = useMemberships()
   const [persistedStoreId, setPersistedStoreId] = useState<string | null>(null)
   const [isPersistedLoading, setIsPersistedLoading] = useState(true)
+
+  const normalizedPersistedStoreId =
+    persistedStoreId && persistedStoreId.trim() !== '' ? persistedStoreId.trim() : null
+  const membershipsHookStoreId = isPersistedLoading
+    ? undefined
+    : normalizedPersistedStoreId ?? null
+  const {
+    memberships,
+    loading: membershipLoading,
+    error,
+  } = useMemberships(membershipsHookStoreId)
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -26,8 +36,6 @@ export function useActiveStore(): ActiveStoreState {
   }, [])
 
   const membershipStoreId = memberships.find(m => m.storeId)?.storeId ?? null
-  const normalizedPersistedStoreId =
-    persistedStoreId && persistedStoreId.trim() !== '' ? persistedStoreId : null
 
   useEffect(() => {
     if (membershipLoading) {

--- a/web/src/hooks/useMemberships.test.tsx
+++ b/web/src/hooks/useMemberships.test.tsx
@@ -37,7 +37,7 @@ describe('useMemberships', () => {
   it('returns an empty membership list when the user is not authenticated', async () => {
     mockUseAuthUser.mockReturnValue(null)
 
-    const { result } = renderHook(() => useMemberships())
+    const { result } = renderHook(() => useMemberships(null))
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false)
@@ -68,15 +68,16 @@ describe('useMemberships', () => {
 
     getDocsMock.mockResolvedValue({ docs: [membershipDoc] })
 
-    const { result } = renderHook(() => useMemberships())
+    const { result } = renderHook(() => useMemberships(null))
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false)
     })
 
     expect(collectionMock).toHaveBeenCalledWith({}, 'teamMembers')
+    expect(whereMock).toHaveBeenCalledTimes(1)
     expect(whereMock).toHaveBeenCalledWith('uid', '==', 'user-123')
-    expect(queryMock).toHaveBeenCalled()
+    expect(queryMock).toHaveBeenCalledWith({ type: 'collection' }, { type: 'where' })
     expect(getDocsMock).toHaveBeenCalled()
 
     expect(result.current.memberships).toEqual([
@@ -108,7 +109,7 @@ describe('useMemberships', () => {
 
     getDocsMock.mockResolvedValue({ docs: [membershipDoc] })
 
-    const { result } = renderHook(() => useMemberships())
+    const { result } = renderHook(() => useMemberships(null))
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false)
@@ -128,5 +129,20 @@ describe('useMemberships', () => {
         updatedAt: null,
       },
     ])
+  })
+
+  it('filters memberships by active store when provided', async () => {
+    mockUseAuthUser.mockReturnValue({ uid: 'user-789' })
+
+    getDocsMock.mockResolvedValue({ docs: [] })
+
+    renderHook(() => useMemberships('active-store'))
+
+    await waitFor(() => {
+      expect(queryMock).toHaveBeenCalled()
+    })
+
+    expect(whereMock).toHaveBeenNthCalledWith(1, 'uid', '==', 'user-789')
+    expect(whereMock).toHaveBeenNthCalledWith(2, 'storeId', '==', 'active-store')
   })
 })

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -127,7 +127,12 @@ function formatTimestamp(timestamp: Timestamp | null) {
 
 export default function AccountOverview() {
   const { storeId, isLoading: storeLoading, error: storeError } = useActiveStore()
-  const { memberships, loading: membershipsLoading, error: membershipsError } = useMemberships()
+  const membershipsStoreId = storeLoading ? undefined : storeId ?? null
+  const {
+    memberships,
+    loading: membershipsLoading,
+    error: membershipsError,
+  } = useMemberships(membershipsStoreId)
   const { publish } = useToast()
 
   const [profile, setProfile] = useState<StoreProfile | null>(null)

--- a/web/src/pages/Gate.test.tsx
+++ b/web/src/pages/Gate.test.tsx
@@ -3,18 +3,30 @@ import { render, screen } from '@testing-library/react';
 
 import Gate from './Gate';
 
+const mockUseActiveStore = vi.fn();
 const mockUseMemberships = vi.fn();
+
+vi.mock('../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}));
+
 vi.mock('../hooks/useMemberships', () => ({
-  useMemberships: () => mockUseMemberships(),
+  useMemberships: (storeId?: string | null) => mockUseMemberships(storeId),
 }));
 
 describe('Gate', () => {
   beforeEach(() => {
+    mockUseActiveStore.mockReset();
     mockUseMemberships.mockReset();
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null });
   });
 
   it('renders a loading state while memberships are loading', () => {
-    mockUseMemberships.mockReturnValue({ loading: true, error: null });
+    mockUseMemberships.mockImplementation(storeId => ({
+      storeId,
+      loading: true,
+      error: null,
+    }));
 
     render(<Gate />);
 

--- a/web/src/pages/Gate.tsx
+++ b/web/src/pages/Gate.tsx
@@ -1,5 +1,6 @@
 // web/src/pages/Gate.tsx
 import type { ReactNode } from 'react'
+import { useActiveStore } from '../hooks/useActiveStore'
 import { useMemberships } from '../hooks/useMemberships'
 
 function toErrorMessage(error: unknown) {
@@ -13,9 +14,11 @@ function toErrorMessage(error: unknown) {
 }
 
 export default function Gate({ children }: { children?: ReactNode }) {
-  const { loading, error } = useMemberships()
+  const { storeId, isLoading: storeLoading } = useActiveStore()
+  const membershipsStoreId = storeLoading ? undefined : storeId ?? null
+  const { loading, error } = useMemberships(membershipsStoreId)
 
-  if (loading) {
+  if (storeLoading || loading) {
     return <div className="p-6">Loading…</div>
   }
 

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../../hooks/useActiveStore', () => ({
 
 const mockUseMemberships = vi.fn()
 vi.mock('../../hooks/useMemberships', () => ({
-  useMemberships: () => mockUseMemberships(),
+  useMemberships: (storeId?: string | null) => mockUseMemberships(storeId),
 }))
 
 const mockManageStaffAccount = vi.fn()


### PR DESCRIPTION
## Summary
- update the memberships hook to accept the active store id and filter queries accordingly
- adjust the active store hook and UI consumers to pass the persisted store id before loading memberships
- refresh related unit tests to cover the new hook contract and active-store-aware behavior

## Testing
- npm test *(fails: Firebase auth/network-request-failed in firestore.rules.emulator suite)*

------
https://chatgpt.com/codex/tasks/task_e_68da96d7e5948321b11454ac16d30350