### PR TITLE
Add updated timestamp to sale transaction documents

### DIFF
--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -563,6 +563,7 @@ export default function Sell() {
           items: normalizedItems,
           createdBy: user.uid,
           createdAt: timestamp,
+          updatedAt: timestamp,
         }
 
         const saleItemWrites: { ref: ReturnType<typeof doc>; data: Record<string, unknown> }[] = []
@@ -596,6 +597,7 @@ export default function Sell() {
               taxRate: item.taxRate,
               storeId: activeStoreId,
               createdAt: timestamp,
+              updatedAt: timestamp,
             },
           })
 
@@ -609,6 +611,7 @@ export default function Sell() {
               refId: saleId,
               storeId: activeStoreId,
               createdAt: timestamp,
+              updatedAt: timestamp,
             },
           })
 
@@ -630,6 +633,7 @@ export default function Sell() {
               refId: saleId,
               storeId: activeStoreId,
               createdAt: timestamp,
+              updatedAt: timestamp,
             },
           })
         }


### PR DESCRIPTION
## Summary
- add the transaction timestamp to sale documents as an updatedAt value
- include updatedAt on sale item, stock movement, and ledger transaction records created in the sale flow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dab0c08694832183ebf9e6290726bd