### PR TITLE
Add timestamps to closeout payload

### DIFF
--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -142,6 +142,8 @@ export default function CloseDay() {
             }
           : null,
         closedAt: serverTimestamp(),
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
         storeId: activeStoreId,
       }
 


### PR DESCRIPTION
## Summary
- add createdAt and updatedAt server timestamps when submitting close day payloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab0d43ee083218914ca05beedbe42