### PR TITLE
Add active store context provider

### DIFF
--- a/web/src/context/ActiveStoreProvider.tsx
+++ b/web/src/context/ActiveStoreProvider.tsx
@@ -1,0 +1,24 @@
+import { createContext, ReactNode, useContext } from 'react'
+import { useActiveStore } from '../hooks/useActiveStore'
+
+const ActiveStoreContext = createContext<ReturnType<typeof useActiveStore> | undefined>(undefined)
+
+interface ActiveStoreProviderProps {
+  children: ReactNode
+}
+
+export function ActiveStoreProvider({ children }: ActiveStoreProviderProps) {
+  const value = useActiveStore()
+
+  return <ActiveStoreContext.Provider value={value}>{children}</ActiveStoreContext.Provider>
+}
+
+export function useActiveStoreContext() {
+  const context = useContext(ActiveStoreContext)
+
+  if (context === undefined) {
+    throw new Error('useActiveStoreContext must be used within an ActiveStoreProvider')
+  }
+
+  return context
+}

--- a/web/src/hooks/useGoalPlanner.ts
+++ b/web/src/hooks/useGoalPlanner.ts
@@ -3,7 +3,7 @@ import { doc, onSnapshot, setDoc, updateDoc, type DocumentReference } from 'fire
 
 import { db } from '../firebase'
 import { useAuthUser } from './useAuthUser'
-import { useActiveStore } from './useActiveStore'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import { useToast } from '../components/ToastProvider'
 
 type PlannerFrequency = 'daily' | 'weekly' | 'monthly'
@@ -73,7 +73,7 @@ export type UseGoalPlannerResult = {
 
 export function useGoalPlanner(): UseGoalPlannerResult {
   const { publish } = useToast()
-  const { storeId } = useActiveStore()
+  const { storeId } = useActiveStoreContext()
   const authUser = useAuthUser()
 
   const initialToday = useMemo(() => new Date(), [])

--- a/web/src/hooks/useStoreMetrics.ts
+++ b/web/src/hooks/useStoreMetrics.ts
@@ -15,7 +15,7 @@ import {
 
 import { db } from '../firebase'
 import { useAuthUser } from './useAuthUser'
-import { useActiveStore } from './useActiveStore'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import { useToast } from '../components/ToastProvider'
 import {
   CUSTOMER_CACHE_LIMIT,
@@ -304,7 +304,7 @@ function buildDailyMetricSeries(
 
 export function useStoreMetrics(): UseStoreMetricsResult {
   const authUser = useAuthUser()
-  const { storeId: activeStoreId } = useActiveStore()
+  const { storeId: activeStoreId } = useActiveStoreContext()
   const { publish } = useToast()
 
   const [sales, setSales] = useState<SaleRecord[]>([])

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -14,6 +14,7 @@ import Onboarding from './pages/Onboarding'
 import GoalPlannerPage from './pages/KpiMetrics'
 import AccountOverview from './pages/AccountOverview'
 import { ToastProvider } from './components/ToastProvider'
+import { ActiveStoreProvider } from './context/ActiveStoreProvider'
 
 const router = createHashRouter([
   {
@@ -40,7 +41,9 @@ const router = createHashRouter([
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ToastProvider>
-      <RouterProvider router={router} />
+      <ActiveStoreProvider>
+        <RouterProvider router={router} />
+      </ActiveStoreProvider>
     </ToastProvider>
   </React.StrictMode>,
 )

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -12,7 +12,7 @@ import {
   type QueryDocumentSnapshot,
 } from 'firebase/firestore'
 import { db } from '../firebase'
-import { useActiveStore } from '../hooks/useActiveStore'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import { useMemberships, type Membership } from '../hooks/useMemberships'
 import { manageStaffAccount } from '../controllers/storeController'
 import { useToast } from '../components/ToastProvider'
@@ -153,7 +153,7 @@ function formatTimestamp(timestamp: Timestamp | null) {
 }
 
 export default function AccountOverview() {
-  const { storeId, isLoading: storeLoading, error: storeError } = useActiveStore()
+  const { storeId, isLoading: storeLoading, error: storeError } = useActiveStoreContext()
   const membershipsStoreId = storeLoading ? undefined : storeId ?? null
   const {
     memberships,

--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { collection, query, where, orderBy, onSnapshot, Timestamp, addDoc, serverTimestamp } from 'firebase/firestore'
 import { db } from '../firebase'
 import { useAuthUser } from '../hooks/useAuthUser'
-import { useActiveStore } from '../hooks/useActiveStore'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 
 const DENOMINATIONS = [200, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1] as const
 
@@ -31,7 +31,7 @@ function parseQuantity(input: string): number {
 
 export default function CloseDay() {
   const user = useAuthUser()
-  const { storeId: activeStoreId } = useActiveStore()
+  const { storeId: activeStoreId } = useActiveStoreContext()
 
   const [total, setTotal] = useState(0)
   const [cashCounts, setCashCounts] = useState<CashCountState>(() => createInitialCashCountState())

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -15,7 +15,7 @@ import {
 import { Timestamp } from 'firebase/firestore'
 import { Link } from 'react-router-dom'
 import { db } from '../firebase'
-import { useActiveStore } from '../hooks/useActiveStore'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import './Customers.css'
 import {
   CUSTOMER_CACHE_LIMIT,
@@ -190,7 +190,7 @@ function buildCsvValue(value: string): string {
 }
 
 export default function Customers() {
-  const { storeId: activeStoreId } = useActiveStore()
+  const { storeId: activeStoreId } = useActiveStoreContext()
   const [customers, setCustomers] = useState<Customer[]>([])
   const [name, setName] = useState('')
   const [phone, setPhone] = useState('')

--- a/web/src/pages/Gate.test.tsx
+++ b/web/src/pages/Gate.test.tsx
@@ -3,11 +3,11 @@ import { render, screen } from '@testing-library/react';
 
 import Gate from './Gate';
 
-const mockUseActiveStore = vi.fn();
+const mockUseActiveStoreContext = vi.fn();
 const mockUseMemberships = vi.fn();
 
-vi.mock('../hooks/useActiveStore', () => ({
-  useActiveStore: () => mockUseActiveStore(),
+vi.mock('../context/ActiveStoreProvider', () => ({
+  useActiveStoreContext: () => mockUseActiveStoreContext(),
 }));
 
 vi.mock('../hooks/useMemberships', () => ({
@@ -16,9 +16,9 @@ vi.mock('../hooks/useMemberships', () => ({
 
 describe('Gate', () => {
   beforeEach(() => {
-    mockUseActiveStore.mockReset();
+    mockUseActiveStoreContext.mockReset();
     mockUseMemberships.mockReset();
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null });
+    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null });
   });
 
   it('renders a loading state while memberships are loading', () => {

--- a/web/src/pages/Gate.tsx
+++ b/web/src/pages/Gate.tsx
@@ -1,6 +1,6 @@
 // web/src/pages/Gate.tsx
 import type { ReactNode } from 'react'
-import { useActiveStore } from '../hooks/useActiveStore'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import { useMemberships } from '../hooks/useMemberships'
 
 function toErrorMessage(error: unknown) {
@@ -14,7 +14,7 @@ function toErrorMessage(error: unknown) {
 }
 
 export default function Gate({ children }: { children?: ReactNode }) {
-  const { storeId, isLoading: storeLoading } = useActiveStore()
+  const { storeId, isLoading: storeLoading } = useActiveStoreContext()
   const membershipsStoreId = storeLoading ? undefined : storeId ?? null
   const { loading, error } = useMemberships(membershipsStoreId)
 

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -14,7 +14,7 @@ import {
 import { FirebaseError } from 'firebase/app'
 import { Link } from 'react-router-dom'
 import { db } from '../firebase'
-import { useActiveStore } from '../hooks/useActiveStore'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import {
   PRODUCT_CACHE_LIMIT,
   loadCachedProducts,
@@ -150,7 +150,7 @@ function isOfflineError(error: unknown) {
 }
 
 export default function Products() {
-  const { storeId: activeStoreId } = useActiveStore()
+  const { storeId: activeStoreId } = useActiveStoreContext()
   const [products, setProducts] = useState<ProductRecord[]>([])
   const [isLoadingProducts, setIsLoadingProducts] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)

--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -3,7 +3,7 @@ import { collection, query, orderBy, limit, onSnapshot, where } from 'firebase/f
 import { FirebaseError } from 'firebase/app'
 import { httpsCallable } from 'firebase/functions'
 import { db, functions } from '../firebase'
-import { useActiveStore } from '../hooks/useActiveStore'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import './Receive.css'
 import { queueCallableRequest } from '../utils/offlineQueue'
 import { loadCachedProducts, saveCachedProducts, PRODUCT_CACHE_LIMIT } from '../utils/offlineCache'
@@ -35,7 +35,7 @@ function isOfflineError(error: unknown) {
 }
 
 export default function Receive() {
-  const { storeId: activeStoreId } = useActiveStore()
+  const { storeId: activeStoreId } = useActiveStoreContext()
   const [products, setProducts] = useState<Product[]>([])
   const [selected, setSelected] = useState<string>('')
   const [qty, setQty] = useState<string>('')

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -11,9 +11,9 @@ vi.mock('../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
 }))
 
-const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
-vi.mock('../hooks/useActiveStore', () => ({
-  useActiveStore: () => mockUseActiveStore(),
+const mockUseActiveStoreContext = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+vi.mock('../context/ActiveStoreProvider', () => ({
+  useActiveStoreContext: () => mockUseActiveStoreContext(),
 }))
 
 const originalCreateObjectURL = globalThis.URL.createObjectURL
@@ -201,12 +201,12 @@ function renderWithProviders(ui: ReactElement) {
 describe('Sell page', () => {
   beforeEach(() => {
     mockUseAuthUser.mockReset()
-    mockUseActiveStore.mockReset()
+    mockUseActiveStoreContext.mockReset()
     mockUseAuthUser.mockReturnValue({
       uid: 'cashier-123',
       email: 'cashier@example.com',
     })
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
 
     autoCounters = {}
     firestoreState = {

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -13,7 +13,7 @@ import {
 import { FirebaseError } from 'firebase/app'
 import { db } from '../firebase'
 import { useAuthUser } from '../hooks/useAuthUser'
-import { useActiveStore } from '../hooks/useActiveStore'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import './Sell.css'
 import { Link } from 'react-router-dom'
 import BarcodeScanner, { ScanResult } from '../components/BarcodeScanner'
@@ -159,7 +159,7 @@ function sanitizePrice(value: unknown): number | null {
 
 export default function Sell() {
   const user = useAuthUser()
-  const { storeId: activeStoreId } = useActiveStore()
+  const { storeId: activeStoreId } = useActiveStoreContext()
 
   const [products, setProducts] = useState<Product[]>([])
   const [customers, setCustomers] = useState<Customer[]>([])

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -9,9 +9,9 @@ vi.mock('../../components/ToastProvider', () => ({
   useToast: () => ({ publish: mockPublish }),
 }))
 
-const mockUseActiveStore = vi.fn()
-vi.mock('../../hooks/useActiveStore', () => ({
-  useActiveStore: () => mockUseActiveStore(),
+const mockUseActiveStoreContext = vi.fn()
+vi.mock('../../context/ActiveStoreProvider', () => ({
+  useActiveStoreContext: () => mockUseActiveStoreContext(),
 }))
 
 const mockUseMemberships = vi.fn()
@@ -70,7 +70,7 @@ afterAll(() => {
 describe('AccountOverview', () => {
   beforeEach(() => {
     mockPublish.mockReset()
-    mockUseActiveStore.mockReset()
+    mockUseActiveStoreContext.mockReset()
     mockUseMemberships.mockReset()
     mockManageStaffAccount.mockReset()
     collectionMock.mockClear()
@@ -80,7 +80,7 @@ describe('AccountOverview', () => {
     queryMock.mockClear()
     whereMock.mockClear()
 
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
+    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
     getDocMock.mockResolvedValue({
       exists: () => true,
       data: () => ({

--- a/web/src/pages/__tests__/KpiMetrics.test.tsx
+++ b/web/src/pages/__tests__/KpiMetrics.test.tsx
@@ -11,9 +11,9 @@ vi.mock('../../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
 }))
 
-const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
-vi.mock('../../hooks/useActiveStore', () => ({
-  useActiveStore: () => mockUseActiveStore(),
+const mockUseActiveStoreContext = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+vi.mock('../../context/ActiveStoreProvider', () => ({
+  useActiveStoreContext: () => mockUseActiveStoreContext(),
 }))
 
 const mockPublish = vi.fn()
@@ -102,7 +102,7 @@ describe('Goal planner page', () => {
     uuidSpy.mockReturnValue('goal-new-id')
 
     mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'manager@example.com' })
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
     mockPublish.mockReset()
 
     docMock.mockClear()

--- a/web/src/pages/__tests__/Products.test.tsx
+++ b/web/src/pages/__tests__/Products.test.tsx
@@ -20,9 +20,9 @@ vi.mock('../../firebase', () => ({
   db: {},
 }))
 
-const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
-vi.mock('../../hooks/useActiveStore', () => ({
-  useActiveStore: () => mockUseActiveStore(),
+const mockUseActiveStoreContext = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+vi.mock('../../context/ActiveStoreProvider', () => ({
+  useActiveStoreContext: () => mockUseActiveStoreContext(),
 }))
 
 const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
@@ -86,8 +86,8 @@ describe('Products page', () => {
     serverTimestampMock.mockClear()
     docMock.mockClear()
     whereMock.mockClear()
-    mockUseActiveStore.mockReset()
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStoreContext.mockReset()
+    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
 
 
 

--- a/web/src/pages/__tests__/Sell.test.tsx
+++ b/web/src/pages/__tests__/Sell.test.tsx
@@ -35,9 +35,9 @@ vi.mock('../../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
 }))
 
-const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
-vi.mock('../../hooks/useActiveStore', () => ({
-  useActiveStore: () => mockUseActiveStore(),
+const mockUseActiveStoreContext = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+vi.mock('../../context/ActiveStoreProvider', () => ({
+  useActiveStoreContext: () => mockUseActiveStoreContext(),
 }))
 
 const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
@@ -112,8 +112,8 @@ describe('Sell page barcode scanner', () => {
     docMock.mockClear()
     mockUseAuthUser.mockReset()
     mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'cashier@example.com' })
-    mockUseActiveStore.mockReset()
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStoreContext.mockReset()
+    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
 
     mockLoadCachedProducts.mockResolvedValue([])
     mockLoadCachedCustomers.mockResolvedValue([])


### PR DESCRIPTION
## Summary
- add an ActiveStoreProvider context so the active store state is provided once
- wrap the router with the provider and update hooks/pages to consume the shared context
- adjust related tests to mock the new context helper

## Testing
- npm test *(fails: Firebase auth/network-request-failed in tests/firestore.rules.emulator.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dab909d0a483219da6fcd8311874d9