### PR TITLE
Load complete sales ranges for dashboard metrics

### DIFF
--- a/web/src/hooks/useStoreMetrics.ts
+++ b/web/src/hooks/useStoreMetrics.ts
@@ -1,15 +1,18 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
 import {
   collection,
   doc,
   getDoc,
+  getDocs,
   limit,
   onSnapshot,
   orderBy,
   query,
   serverTimestamp,
   setDoc,
+  startAfter,
   where,
+  type QueryDocumentSnapshot,
   type Timestamp,
 } from 'firebase/firestore'
 
@@ -135,7 +138,7 @@ type UseStoreMetricsResult = {
   handleGoalMonthChange: (value: string) => void
   goalFormValues: GoalFormValues
   handleGoalInputChange: (field: keyof GoalFormValues, value: string) => void
-  handleGoalSubmit: (event: React.FormEvent) => Promise<void>
+  handleGoalSubmit: (event: FormEvent) => Promise<void>
   isSavingGoals: boolean
   inventoryAlerts: InventoryAlert[]
   teamCallouts: TeamCallout[]
@@ -241,6 +244,19 @@ function formatDateKey(date: Date) {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
 }
 
+function getSaleSortValue(sale: SaleRecord) {
+  return asDate(sale.createdAt)?.getTime() ?? 0
+}
+
+function normalizeSales(records: SaleRecord[]) {
+  const byId = new Map<string, SaleRecord>()
+  records.forEach(record => {
+    if (!record?.id) return
+    byId.set(record.id, record)
+  })
+  return Array.from(byId.values()).sort((a, b) => getSaleSortValue(b) - getSaleSortValue(a))
+}
+
 function formatDateRange(start: Date, end: Date) {
   const sameYear = start.getFullYear() === end.getFullYear()
   const startFormatter = new Intl.DateTimeFormat(undefined, {
@@ -320,11 +336,83 @@ export function useStoreMetrics(): UseStoreMetricsResult {
   const [isSavingGoals, setIsSavingGoals] = useState(false)
   const [selectedRangeId, setSelectedRangeId] = useState<PresetRangeId>('today')
   const [customRange, setCustomRange] = useState<CustomRange>({ start: '', end: '' })
+  const latestSalesRequestRef = useRef<string>('')
 
   const goalDocumentId = useMemo(
     () => activeStoreId ?? `user-${authUser?.uid ?? 'default'}`,
     [activeStoreId, authUser?.uid],
   )
+
+  const today = useMemo(() => new Date(), [])
+  const defaultMonthKey = useMemo(() => formatMonthInput(today), [today])
+  const rangeInfo = useMemo(() => {
+    const fallbackPreset = RANGE_PRESETS.find(option => option.id === 'today')
+    const resolvedFallback = fallbackPreset?.getRange?.(today) ?? {
+      start: startOfDay(today),
+      end: endOfDay(today),
+    }
+
+    if (selectedRangeId === 'custom') {
+      const startDate = parseDateInput(customRange.start)
+      const endDate = parseDateInput(customRange.end)
+      if (startDate && endDate && startDate <= endDate) {
+        return {
+          rangeStart: startOfDay(startDate),
+          rangeEnd: endOfDay(endDate),
+          resolvedRangeId: 'custom' as PresetRangeId,
+        }
+      }
+      return {
+        rangeStart: resolvedFallback.start,
+        rangeEnd: resolvedFallback.end,
+        resolvedRangeId: 'today' as PresetRangeId,
+      }
+    }
+
+    const preset = RANGE_PRESETS.find(option => option.id === selectedRangeId)
+    if (preset?.getRange) {
+      const range = preset.getRange(today)
+      return {
+        rangeStart: range.start,
+        rangeEnd: range.end,
+        resolvedRangeId: preset.id,
+      }
+    }
+
+    return {
+      rangeStart: resolvedFallback.start,
+      rangeEnd: resolvedFallback.end,
+      resolvedRangeId: 'today' as PresetRangeId,
+    }
+  }, [today, selectedRangeId, customRange.start, customRange.end])
+
+  const { rangeStart, rangeEnd, resolvedRangeId } = rangeInfo
+  const rangeDays = differenceInCalendarDays(rangeStart, rangeEnd) + 1
+  const previousRangeStart = useMemo(() => addDays(rangeStart, -rangeDays), [rangeStart, rangeDays])
+  const previousRangeEnd = useMemo(() => addDays(rangeStart, -1), [rangeStart])
+
+  const goalMonthDate = useMemo(
+    () => parseMonthInput(selectedGoalMonth) ?? startOfMonth(today),
+    [selectedGoalMonth, today],
+  )
+  const goalMonthStart = useMemo(() => startOfMonth(goalMonthDate), [goalMonthDate])
+  const goalMonthEnd = useMemo(() => endOfMonth(goalMonthDate), [goalMonthDate])
+  const combinedRange = useMemo(() => {
+    const startCandidates = [rangeStart, previousRangeStart, goalMonthStart]
+    const endCandidates = [rangeEnd, previousRangeEnd, goalMonthEnd]
+    const earliest = startCandidates.reduce(
+      (current, candidate) => (candidate < current ? candidate : current),
+      startCandidates[0],
+    )
+    const latest = endCandidates.reduce(
+      (current, candidate) => (candidate > current ? candidate : current),
+      endCandidates[0],
+    )
+    return {
+      start: startOfDay(earliest),
+      end: endOfDay(latest),
+    }
+  }, [rangeStart, rangeEnd, previousRangeStart, previousRangeEnd, goalMonthStart, goalMonthEnd])
 
   useEffect(() => {
     let cancelled = false
@@ -336,39 +424,96 @@ export function useStoreMetrics(): UseStoreMetricsResult {
       }
     }
 
-    loadCachedSales<SaleRecord>({ storeId: activeStoreId })
+    const fetchStart = combinedRange.start
+    const fetchEnd = combinedRange.end
+    const cachePartition = `${fetchStart.getTime()}-${fetchEnd.getTime()}`
+    const requestKey = `${activeStoreId}:${cachePartition}`
+    latestSalesRequestRef.current = requestKey
+
+    loadCachedSales<SaleRecord>({
+      storeId: activeStoreId,
+      partition: cachePartition,
+      limit: Number.MAX_SAFE_INTEGER,
+    })
       .then(cached => {
-        if (!cancelled && cached.length) {
-          setSales(cached)
+        if (cancelled || latestSalesRequestRef.current !== requestKey) return
+        if (cached.length) {
+          setSales(normalizeSales(cached))
+        } else {
+          setSales([])
         }
       })
       .catch(error => {
         console.warn('[metrics] Failed to load cached sales', error)
       })
 
-    const q = query(
-      collection(db, 'sales'),
-      where('storeId', '==', activeStoreId),
-      orderBy('createdAt', 'desc'),
-      limit(SALES_CACHE_LIMIT),
-    )
+    async function fetchSalesForRange() {
+      const pageSize = Math.max(SALES_CACHE_LIMIT, 500)
+      const baseQuery = query(
+        collection(db, 'sales'),
+        where('storeId', '==', activeStoreId),
+        where('createdAt', '>=', fetchStart),
+        where('createdAt', '<=', fetchEnd),
+        orderBy('createdAt', 'asc'),
+      )
 
-    const unsubscribe = onSnapshot(q, snapshot => {
-      const rows: SaleRecord[] = snapshot.docs.map(docSnap => ({
-        id: docSnap.id,
-        ...(docSnap.data() as Omit<SaleRecord, 'id'>),
-      }))
-      setSales(rows)
-      saveCachedSales(rows, { storeId: activeStoreId }).catch(error => {
+      const aggregated: SaleRecord[] = []
+      let cursor: QueryDocumentSnapshot | null = null
+      let hasMore = true
+
+      while (hasMore && !cancelled && latestSalesRequestRef.current === requestKey) {
+        const pageQuery = cursor
+          ? query(baseQuery, startAfter(cursor), limit(pageSize))
+          : query(baseQuery, limit(pageSize))
+
+        const snapshot = await getDocs(pageQuery)
+        if (cancelled || latestSalesRequestRef.current !== requestKey) {
+          return
+        }
+
+        if (snapshot.empty) {
+          hasMore = false
+          break
+        }
+
+        snapshot.docs.forEach(docSnap => {
+          aggregated.push({
+            id: docSnap.id,
+            ...(docSnap.data() as Omit<SaleRecord, 'id'>),
+          })
+        })
+
+        if (snapshot.size < pageSize) {
+          hasMore = false
+        } else {
+          cursor = snapshot.docs[snapshot.docs.length - 1]
+        }
+      }
+
+      if (cancelled || latestSalesRequestRef.current !== requestKey) return
+
+      const normalized = normalizeSales(aggregated)
+      setSales(normalized)
+      saveCachedSales(normalized, {
+        storeId: activeStoreId,
+        partition: cachePartition,
+        limit: normalized.length || SALES_CACHE_LIMIT,
+      }).catch(error => {
         console.warn('[metrics] Failed to cache sales', error)
       })
+    }
+
+    fetchSalesForRange().catch(error => {
+      if (!cancelled) {
+        console.warn('[metrics] Failed to fetch sales for range', error)
+        publish({ tone: 'error', message: 'Failed to refresh sales metrics.' })
+      }
     })
 
     return () => {
       cancelled = true
-      unsubscribe()
     }
-  }, [activeStoreId])
+  }, [activeStoreId, combinedRange.start, combinedRange.end, publish])
 
   useEffect(() => {
     let cancelled = false
@@ -498,54 +643,6 @@ export function useStoreMetrics(): UseStoreMetricsResult {
       customerTarget: String(active?.customerTarget ?? DEFAULT_CUSTOMER_TARGET),
     })
   }, [monthlyGoals, selectedGoalMonth, goalFormTouched])
-
-  const today = useMemo(() => new Date(), [sales])
-  const defaultMonthKey = useMemo(() => formatMonthInput(today), [today])
-  const rangeInfo = useMemo(() => {
-    const fallbackPreset = RANGE_PRESETS.find(option => option.id === 'today')
-    const resolvedFallback = fallbackPreset?.getRange?.(today) ?? {
-      start: startOfDay(today),
-      end: endOfDay(today),
-    }
-
-    if (selectedRangeId === 'custom') {
-      const startDate = parseDateInput(customRange.start)
-      const endDate = parseDateInput(customRange.end)
-      if (startDate && endDate && startDate <= endDate) {
-        return {
-          rangeStart: startOfDay(startDate),
-          rangeEnd: endOfDay(endDate),
-          resolvedRangeId: 'custom' as PresetRangeId,
-        }
-      }
-      return {
-        rangeStart: resolvedFallback.start,
-        rangeEnd: resolvedFallback.end,
-        resolvedRangeId: 'today' as PresetRangeId,
-      }
-    }
-
-    const preset = RANGE_PRESETS.find(option => option.id === selectedRangeId)
-    if (preset?.getRange) {
-      const range = preset.getRange(today)
-      return {
-        rangeStart: range.start,
-        rangeEnd: range.end,
-        resolvedRangeId: preset.id,
-      }
-    }
-
-    return {
-      rangeStart: resolvedFallback.start,
-      rangeEnd: resolvedFallback.end,
-      resolvedRangeId: 'today' as PresetRangeId,
-    }
-  }, [today, selectedRangeId, customRange.start, customRange.end])
-
-  const { rangeStart, rangeEnd, resolvedRangeId } = rangeInfo
-  const rangeDays = differenceInCalendarDays(rangeStart, rangeEnd) + 1
-  const previousRangeStart = addDays(rangeStart, -rangeDays)
-  const previousRangeEnd = addDays(rangeStart, -1)
 
   const currentSales = useMemo(
     () =>
@@ -726,9 +823,6 @@ export function useStoreMetrics(): UseStoreMetricsResult {
     },
   ]
 
-  const goalMonthDate = useMemo(() => parseMonthInput(selectedGoalMonth) ?? startOfMonth(today), [selectedGoalMonth, today])
-  const goalMonthStart = useMemo(() => startOfMonth(goalMonthDate), [goalMonthDate])
-  const goalMonthEnd = useMemo(() => endOfMonth(goalMonthDate), [goalMonthDate])
   const goalMonthLabel = useMemo(
     () =>
       new Intl.DateTimeFormat(undefined, {
@@ -809,7 +903,7 @@ export function useStoreMetrics(): UseStoreMetricsResult {
     setGoalFormValues(current => ({ ...current, [field]: value }))
   }
 
-  async function handleGoalSubmit(event: React.FormEvent) {
+  async function handleGoalSubmit(event: FormEvent) {
     event.preventDefault()
     if (!activeStoreId) {
       publish({ tone: 'error', message: 'Select a store to save goals.' })

--- a/web/src/utils/offlineCache.ts
+++ b/web/src/utils/offlineCache.ts
@@ -95,15 +95,17 @@ function sortAndTrim<T>(items: T[], limit: number) {
     .slice(0, limit)
 }
 
-function resolvePartitionKey(baseKey: string, storeId?: string | null) {
+function resolvePartitionKey(baseKey: string, storeId?: string | null, partition?: string) {
   const normalized = typeof storeId === 'string' ? storeId.trim() : ''
   const suffix = normalized ? normalized : DEFAULT_PARTITION_KEY
-  return `${baseKey}:${suffix}`
+  const partitionSuffix = partition ? `:${partition}` : ''
+  return `${baseKey}:${suffix}${partitionSuffix}`
 }
 
 type CacheOptions = {
   limit?: number
   storeId?: string | null
+  partition?: string
 }
 
 async function loadCachedList<T>(key: string, limit: number): Promise<T[]> {
@@ -150,44 +152,44 @@ async function saveCachedList<T>(key: string, items: T[], limit: number): Promis
 export async function loadCachedProducts<T extends { updatedAt?: unknown; createdAt?: unknown }>(
   options: CacheOptions = {},
 ): Promise<T[]> {
-  const { limit = PRODUCT_CACHE_LIMIT, storeId } = options
-  return loadCachedList<T>(resolvePartitionKey('products', storeId), limit)
+  const { limit = PRODUCT_CACHE_LIMIT, storeId, partition } = options
+  return loadCachedList<T>(resolvePartitionKey('products', storeId, partition), limit)
 }
 
 export async function saveCachedProducts<T extends { updatedAt?: unknown; createdAt?: unknown }>(
   items: T[],
   options: CacheOptions = {},
 ): Promise<void> {
-  const { limit = PRODUCT_CACHE_LIMIT, storeId } = options
-  await saveCachedList(resolvePartitionKey('products', storeId), items, limit)
+  const { limit = PRODUCT_CACHE_LIMIT, storeId, partition } = options
+  await saveCachedList(resolvePartitionKey('products', storeId, partition), items, limit)
 }
 
 export async function loadCachedCustomers<T extends { updatedAt?: unknown; createdAt?: unknown }>(
   options: CacheOptions = {},
 ): Promise<T[]> {
-  const { limit = CUSTOMER_CACHE_LIMIT, storeId } = options
-  return loadCachedList<T>(resolvePartitionKey('customers', storeId), limit)
+  const { limit = CUSTOMER_CACHE_LIMIT, storeId, partition } = options
+  return loadCachedList<T>(resolvePartitionKey('customers', storeId, partition), limit)
 }
 
 export async function saveCachedCustomers<T extends { updatedAt?: unknown; createdAt?: unknown }>(
   items: T[],
   options: CacheOptions = {},
 ): Promise<void> {
-  const { limit = CUSTOMER_CACHE_LIMIT, storeId } = options
-  await saveCachedList(resolvePartitionKey('customers', storeId), items, limit)
+  const { limit = CUSTOMER_CACHE_LIMIT, storeId, partition } = options
+  await saveCachedList(resolvePartitionKey('customers', storeId, partition), items, limit)
 }
 
 export async function loadCachedSales<T extends { createdAt?: unknown }>(
   options: CacheOptions = {},
 ): Promise<T[]> {
-  const { limit = SALES_CACHE_LIMIT, storeId } = options
-  return loadCachedList<T>(resolvePartitionKey('sales', storeId), limit)
+  const { limit = SALES_CACHE_LIMIT, storeId, partition } = options
+  return loadCachedList<T>(resolvePartitionKey('sales', storeId, partition), limit)
 }
 
 export async function saveCachedSales<T extends { createdAt?: unknown }>(
   items: T[],
   options: CacheOptions = {},
 ): Promise<void> {
-  const { limit = SALES_CACHE_LIMIT, storeId } = options
-  await saveCachedList(resolvePartitionKey('sales', storeId), items, limit)
+  const { limit = SALES_CACHE_LIMIT, storeId, partition } = options
+  await saveCachedList(resolvePartitionKey('sales', storeId, partition), items, limit)
 }


### PR DESCRIPTION
## Summary
- paginate Firestore queries so the dashboard loads all sales needed for the selected, comparison, and goal ranges
- normalize the aggregated batches before computing metrics and persist them in range-aware offline cache partitions for quicker reloads

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dac63120288321946d5a24eca27ccb