### PR TITLE
Scope active store cache by user

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -3,6 +3,7 @@ import type { User } from 'firebase/auth'
 import { MemoryRouter } from 'react-router-dom'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { getActiveStoreStorageKey } from './utils/activeStoreStorage'
 
 /** ---------------- hoisted state/mocks ---------------- */
 const mocks = vi.hoisted(() => {
@@ -283,8 +284,9 @@ describe('App signup cleanup', () => {
     expect(mocks.publish).toHaveBeenCalledWith(
       expect.objectContaining({ tone: 'success', message: expect.stringMatching(/All set/i) }),
     )
-    expect(localStorageSetItemSpy).toHaveBeenCalledWith('activeStoreId', storeId)
-    expect(window.localStorage.getItem('activeStoreId')).toBe(storeId)
+    const storageKey = getActiveStoreStorageKey(createdUser.uid)
+    expect(localStorageSetItemSpy).toHaveBeenCalledWith(storageKey, storeId)
+    expect(window.localStorage.getItem(storageKey)).toBe(storeId)
   })
 
   it('creates a team member profile when logging in without an existing doc', async () => {
@@ -340,8 +342,9 @@ describe('App signup cleanup', () => {
     expect(overrideCall).toBeDefined()
     expect(overrideCall?.[1]).toEqual(expect.objectContaining({ storeId }))
 
-    expect(localStorageSetItemSpy).toHaveBeenCalledWith('activeStoreId', storeId)
-    expect(window.localStorage.getItem('activeStoreId')).toBe(storeId)
+    const storageKey = getActiveStoreStorageKey(existingUser.uid)
+    expect(localStorageSetItemSpy).toHaveBeenCalledWith(storageKey, storeId)
+    expect(window.localStorage.getItem(storageKey)).toBe(storeId)
     expect(mocks.publish).toHaveBeenCalledWith(
       expect.objectContaining({ tone: 'success', message: expect.stringMatching(/Welcome back/i) }),
     )

--- a/web/src/SheetAccessGuard.tsx
+++ b/web/src/SheetAccessGuard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { onAuthStateChanged, signOut, type User } from 'firebase/auth'
 import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore'
 import { auth, db } from './firebase'
+import { clearActiveStoreIdForUser, persistActiveStoreIdForUser } from './utils/activeStoreStorage'
 
 type TeamMemberSnapshot = {
   storeId: string | null
@@ -97,16 +98,12 @@ export default function SheetAccessGuard({ children }: { children: React.ReactNo
           throw new Error('Your Sedifex workspace contract is not active.')
         }
 
-        if (typeof window !== 'undefined') {
-          window.localStorage.setItem('activeStoreId', member.storeId)
-        }
+        persistActiveStoreIdForUser(user.uid, member.storeId)
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : 'Access denied.'
         setError(message)
         await signOut(auth)
-        if (typeof window !== 'undefined') {
-          window.localStorage.removeItem('activeStoreId')
-        }
+        clearActiveStoreIdForUser(user.uid)
       } finally {
         setReady(true)
       }

--- a/web/src/hooks/useActiveStore.test.tsx
+++ b/web/src/hooks/useActiveStore.test.tsx
@@ -2,17 +2,25 @@ import { describe, beforeEach, it, expect, vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 
 import { useActiveStore } from './useActiveStore'
+import { getActiveStoreStorageKey } from '../utils/activeStoreStorage'
 
 const mockUseMemberships = vi.fn()
+const mockUseAuthUser = vi.fn()
 
 vi.mock('./useMemberships', () => ({
   useMemberships: (storeId?: string | null) => mockUseMemberships(storeId),
 }))
 
+vi.mock('./useAuthUser', () => ({
+  useAuthUser: () => mockUseAuthUser(),
+}))
+
 describe('useActiveStore', () => {
   beforeEach(() => {
     mockUseMemberships.mockReset()
+    mockUseAuthUser.mockReset()
     window.localStorage.clear()
+    mockUseAuthUser.mockReturnValue({ uid: 'user-1' })
   })
 
   it('prefers the persisted store id when it matches the membership store', async () => {
@@ -26,7 +34,8 @@ describe('useActiveStore', () => {
           },
     )
 
-    window.localStorage.setItem('activeStoreId', 'matching-store')
+    const storageKey = getActiveStoreStorageKey('user-1')
+    window.localStorage.setItem(storageKey, 'matching-store')
 
     const { result } = renderHook(() => useActiveStore())
 
@@ -49,7 +58,8 @@ describe('useActiveStore', () => {
           },
     )
 
-    window.localStorage.setItem('activeStoreId', 'persisted-store')
+    const storageKey = getActiveStoreStorageKey('user-1')
+    window.localStorage.setItem(storageKey, 'persisted-store')
 
     const { result } = renderHook(() => useActiveStore())
 
@@ -58,7 +68,7 @@ describe('useActiveStore', () => {
       expect(result.current.storeId).toBe('membership-store')
     })
 
-    expect(window.localStorage.getItem('activeStoreId')).toBe('membership-store')
+    expect(window.localStorage.getItem(storageKey)).toBe('membership-store')
   })
 
   it('falls back to the membership store id when nothing is persisted', async () => {
@@ -82,5 +92,53 @@ describe('useActiveStore', () => {
     })
 
     expect(result.current.storeId).toBe('membership-store')
+  })
+
+  it('resets the active store when switching to a different user', async () => {
+    let currentUser: { uid: string } = { uid: 'user-1' }
+    mockUseAuthUser.mockImplementation(() => currentUser)
+
+    mockUseMemberships.mockImplementation(storeId => {
+      if (storeId === undefined) {
+        return { memberships: [], loading: true, error: null }
+      }
+
+      if (currentUser.uid === 'user-1') {
+        return {
+          memberships: [{ id: 'member-1', storeId: 'user-1-store' }],
+          loading: false,
+          error: null,
+        }
+      }
+
+      return {
+        memberships: [{ id: 'member-2', storeId: 'user-2-store' }],
+        loading: false,
+        error: null,
+      }
+    })
+
+    const user1Key = getActiveStoreStorageKey('user-1')
+    window.localStorage.setItem(user1Key, 'user-1-store')
+
+    const { result, rerender } = renderHook(() => useActiveStore())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.storeId).toBe('user-1-store')
+    })
+
+    currentUser = { uid: 'user-2' }
+    const user2Key = getActiveStoreStorageKey('user-2')
+    window.localStorage.setItem(user2Key, 'user-2-store')
+    rerender()
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.storeId).toBe('user-2-store')
+    })
+
+    expect(window.localStorage.getItem(user1Key)).toBe('user-1-store')
+    expect(window.localStorage.getItem(user2Key)).toBe('user-2-store')
   })
 })

--- a/web/src/utils/activeStoreStorage.ts
+++ b/web/src/utils/activeStoreStorage.ts
@@ -1,0 +1,60 @@
+const ACTIVE_STORE_STORAGE_PREFIX = 'activeStoreId:'
+const LEGACY_ACTIVE_STORE_STORAGE_KEY = 'activeStoreId'
+
+function hasWindow(): boolean {
+  return typeof window !== 'undefined'
+}
+
+export function getActiveStoreStorageKey(uid: string): string {
+  return `${ACTIVE_STORE_STORAGE_PREFIX}${uid}`
+}
+
+export function readActiveStoreId(uid: string | null | undefined): string | null {
+  if (!uid || !hasWindow()) {
+    return null
+  }
+
+  try {
+    const value = window.localStorage.getItem(getActiveStoreStorageKey(uid))
+    return value && value.trim() ? value.trim() : null
+  } catch {
+    return null
+  }
+}
+
+export function persistActiveStoreIdForUser(uid: string | null | undefined, storeId: string | null | undefined) {
+  if (!uid || !storeId || !hasWindow()) {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(getActiveStoreStorageKey(uid), storeId)
+    window.localStorage.removeItem(LEGACY_ACTIVE_STORE_STORAGE_KEY)
+  } catch {
+    /* noop */
+  }
+}
+
+export function clearActiveStoreIdForUser(uid: string | null | undefined) {
+  if (!uid || !hasWindow()) {
+    return
+  }
+
+  try {
+    window.localStorage.removeItem(getActiveStoreStorageKey(uid))
+  } catch {
+    /* noop */
+  }
+}
+
+export function clearLegacyActiveStoreId() {
+  if (!hasWindow()) {
+    return
+  }
+
+  try {
+    window.localStorage.removeItem(LEGACY_ACTIVE_STORE_STORAGE_KEY)
+  } catch {
+    /* noop */
+  }
+}


### PR DESCRIPTION
## Summary
- add shared helpers to read, write, and clear the active store cache using per-user localStorage keys
- update useActiveStore to key persistence by uid, load the current user via useAuthUser, and sync the cache when memberships load
- adjust App and SheetAccessGuard to write and clear per-user cache entries and extend tests to cover user switching

## Testing
- npm test -- useActiveStore
- npm test -- App.signup

------
https://chatgpt.com/codex/tasks/task_e_68dac91669088321b0f87e88afd413fb