### PR TITLE
Adopt tenders-based sale payments

### DIFF
--- a/functions/test/dailySummaries.test.js
+++ b/functions/test/dailySummaries.test.js
@@ -71,7 +71,7 @@ async function runSalesAggregationTest() {
     createSnapshot('sale-1', {
       storeId: 'store-123',
       total: 120.5,
-      payment: { method: 'cash' },
+      tenders: { cash: 120.5 },
       createdAt: saleTimestamp,
     }),
     {
@@ -96,7 +96,7 @@ async function runSalesAggregationTest() {
     createSnapshot('sale-2', {
       storeId: 'store-123',
       total: 100,
-      payment: { method: 'card' },
+      tenders: { card: 100 },
       createdAt: secondSaleTimestamp,
     }),
     {

--- a/web/src/hooks/useStoreMetrics.ts
+++ b/web/src/hooks/useStoreMetrics.ts
@@ -39,11 +39,8 @@ type SaleRecord = {
   total?: number
   createdAt?: Timestamp | Date | null
   items?: Array<{ productId: string; name?: string; price?: number; qty?: number }>
-  payment?: {
-    method?: string
-    amountPaid?: number
-    changeDue?: number
-  }
+  tenders?: Record<string, number> | null
+  changeDue?: number
   storeId?: string | null
 }
 

--- a/web/src/pages/Sell.css
+++ b/web/src/pages/Sell.css
@@ -150,6 +150,13 @@
   border-top: 1px solid #e2e8f0;
 }
 
+.sell-page__payment-breakdown {
+  display: block;
+  margin-top: 4px;
+  font-size: 13px;
+  color: #64748b;
+}
+
 @media (min-width: 720px) {
   .sell-page__payment-summary {
     flex-direction: row;
@@ -326,6 +333,14 @@
 .receipt-print__summary div {
   display: flex;
   justify-content: space-between;
+}
+
+.receipt-print__tenders {
+  flex-basis: 100%;
+  text-align: right;
+  font-size: 13px;
+  color: #475569;
+  margin-top: 4px;
 }
 
 .receipt-print__footer {

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -254,7 +254,8 @@ describe('Sell page', () => {
     expect(saleOperation?.data).toMatchObject({
       branchId: 'store-1',
       total: 12,
-      payment: { method: 'cash', amountPaid: 15, changeDue: 3 },
+      tenders: { cash: 15 },
+      changeDue: 3,
       items: [expect.objectContaining({ productId: 'product-1', qty: 1, price: 12 })],
     })
 


### PR DESCRIPTION
## Summary
- replace the Sell page payment payload with the new tenders map and surface tender breakdowns in the UI and receipt PDF
- update customers, store metrics, and unit tests to read the tender map instead of the legacy payment object
- adjust daily summary aggregation in Cloud Functions and related tests to consume the new tenders schema

## Testing
- npm test (web) *(fails: Firebase auth emulator network request in firestore.rules.emulator.test.ts)*
- npm test (functions)


------
https://chatgpt.com/codex/tasks/task_e_68dad6430c0083218cbb1cf4349f369c