### PR TITLE
Add security rules for summaries and activities

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -113,6 +113,12 @@ service cloud.firestore {
         && hasOwnerAccess(getRequesterMembership(), storeId);
     }
 
+    function isServiceAccountRequest() {
+      return request.auth != null
+        && request.auth.token != null
+        && request.auth.token.serviceAccount == true;
+    }
+
     match /teamMembers/{memberId} {
       allow read: if resource != null
         && dataHasStore(resource.data)
@@ -160,6 +166,16 @@ service cloud.firestore {
         allow read: if canReadStoreDocument(storeId);
         allow write: if canManageStoreDocument(storeId);
       }
+    }
+
+    match /dailySummaries/{docId} {
+      allow read: if canReadStoreResource() || isServiceAccountRequest();
+      allow create, update, delete: if isServiceAccountRequest();
+    }
+
+    match /activities/{activityId} {
+      allow read: if canReadStoreResource() || isServiceAccountRequest();
+      allow create, update, delete: if isServiceAccountRequest();
     }
 
     match /products/{productId} {


### PR DESCRIPTION
## Summary
- add explicit security rules for `dailySummaries` and `activities`, tying reads to store membership and restricting writes to trusted service accounts
- introduce an `isServiceAccountRequest` helper to allow backend writes while blocking client mutations
- extend the Firestore emulator test suite with REST-based seeding helpers and coverage for the new collections

## Testing
- `npm run test:rules` *(fails: firebase CLI is unavailable in the environment)*
- `npx firebase-tools emulators:exec --config ../firebase.json --project demo-sedifex --only firestore,auth "npm run test:rules:vitest"` *(fails: npm registry access is forbidden in the environment)*
- `npm run test:rules:vitest` *(fails: Auth emulator cannot be reached without the Firebase CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68dada968ee08321ae9ee0933071bdee