### PR TITLE
Add activities index for Firestore queries

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -33,6 +33,15 @@
         { "fieldPath": "storeId", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "activities",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "storeId", "order": "ASCENDING" },
+        { "fieldPath": "dateKey", "order": "ASCENDING" },
+        { "fieldPath": "at", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- add a composite index for the activities collection group keyed by store, date key, and timestamp

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dadc8dcbac83219b212d78d3ae7dc5