### PR TITLE
Restrict staff writes on admin Firestore collections

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -86,13 +86,13 @@ service cloud.firestore {
       return storeId != null && hasStoreAccess(getRequesterMembership(), storeId);
     }
 
-    function canCreateStoreResource() {
+    function canStaffCreateStoreResource() {
       let storeId = storeIdFromData(request.resource.data);
       return storeId != null
         && hasStoreAccess(getRequesterMembership(), storeId);
     }
 
-    function canUpdateStoreResource() {
+    function canStaffUpdateStoreResource() {
       let currentStoreId = storeIdFromData(resource.data);
       let newStoreId = storeIdFromData(request.resource.data);
       return currentStoreId != null
@@ -101,10 +101,27 @@ service cloud.firestore {
         && hasStoreAccess(getRequesterMembership(), currentStoreId);
     }
 
+    function canCreateStoreResource() {
+      return canOwnerCreateStoreResource();
+    }
+
+    function canUpdateStoreResource() {
+      return canOwnerUpdateStoreResource();
+    }
+
     function canOwnerCreateStoreResource() {
       let storeId = storeIdFromData(request.resource.data);
       return storeId != null
         && hasOwnerAccess(getRequesterMembership(), storeId);
+    }
+
+    function canOwnerUpdateStoreResource() {
+      let currentStoreId = storeIdFromData(resource.data);
+      let newStoreId = storeIdFromData(request.resource.data);
+      return currentStoreId != null
+        && newStoreId != null
+        && currentStoreId == newStoreId
+        && hasOwnerAccess(getRequesterMembership(), currentStoreId);
     }
 
     function canOwnerWriteStoreResource() {
@@ -181,35 +198,35 @@ service cloud.firestore {
     match /products/{productId} {
       allow read: if canReadStoreResource();
       allow create: if canOwnerCreateStoreResource();
-      allow update: if canUpdateStoreResource();
+      allow update: if canOwnerUpdateStoreResource();
       allow delete: if canOwnerWriteStoreResource();
     }
 
     match /sales/{saleId} {
       allow read: if canReadStoreResource();
-      allow create: if canCreateStoreResource();
-      allow update: if canUpdateStoreResource();
+      allow create: if canStaffCreateStoreResource();
+      allow update: if canStaffUpdateStoreResource();
       allow delete: if canOwnerWriteStoreResource();
     }
 
     match /saleItems/{saleItemId} {
       allow read: if canReadStoreResource();
-      allow create: if canCreateStoreResource();
-      allow update: if canUpdateStoreResource();
+      allow create: if canStaffCreateStoreResource();
+      allow update: if canStaffUpdateStoreResource();
       allow delete: if canOwnerWriteStoreResource();
     }
 
     match /ledger/{entryId} {
       allow read: if canReadStoreResource();
-      allow create: if canCreateStoreResource();
-      allow update: if canUpdateStoreResource();
+      allow create: if canOwnerCreateStoreResource();
+      allow update: if canOwnerUpdateStoreResource();
       allow delete: if canOwnerWriteStoreResource();
     }
 
     match /stock/{entryId} {
       allow read: if canReadStoreResource();
-      allow create: if canCreateStoreResource();
-      allow update: if canUpdateStoreResource();
+      allow create: if canOwnerCreateStoreResource();
+      allow update: if canOwnerUpdateStoreResource();
       allow delete: if canOwnerWriteStoreResource();
     }
 


### PR DESCRIPTION
## Summary
- add staff-scoped helper functions so owner-only helpers gate admin collection writes
- switch products, ledger, stock and similar matches to the owner-only helpers while keeping staff access to sales flows
- ensure shared create/update helpers now require owner access to avoid accidental staff permissions

## Testing
- npm run test:rules *(fails: firebase CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daf028f44c83218ec66bbbbb29a668