### PR TITLE
Implement workspace switcher and reset store-scoped data on store change

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -91,6 +91,44 @@
   justify-content: flex-end;
 }
 
+.shell__store-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 200px;
+}
+
+.shell__store-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.shell__store-select {
+  min-width: 200px;
+}
+
+.shell__store-select:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.shell__store-empty {
+  font-size: 13px;
+  color: #64748b;
+  padding: 9px 12px;
+  border-radius: 12px;
+  border: 1px dashed #cbd5f5;
+  background: #eef2ff;
+}
+
+.shell__store-status {
+  font-size: 12px;
+  color: #475569;
+}
+
 .shell__account {
   display: flex;
   align-items: center;

--- a/web/src/layout/Shell.test.tsx
+++ b/web/src/layout/Shell.test.tsx
@@ -6,6 +6,7 @@ import Shell from './Shell'
 
 const mockUseAuthUser = vi.fn()
 const mockUseConnectivityStatus = vi.fn()
+const mockUseActiveStoreContext = vi.fn()
 
 vi.mock('../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
@@ -13,6 +14,10 @@ vi.mock('../hooks/useAuthUser', () => ({
 
 vi.mock('../hooks/useConnectivityStatus', () => ({
   useConnectivityStatus: () => mockUseConnectivityStatus(),
+}))
+
+vi.mock('../context/ActiveStoreProvider', () => ({
+  useActiveStoreContext: () => mockUseActiveStoreContext(),
 }))
 
 vi.mock('../firebase', () => ({
@@ -37,6 +42,7 @@ describe('Shell', () => {
   beforeEach(() => {
     mockUseAuthUser.mockReset()
     mockUseConnectivityStatus.mockReset()
+    mockUseActiveStoreContext.mockReset()
 
     mockUseAuthUser.mockReturnValue({ email: 'owner@example.com' })
     mockUseConnectivityStatus.mockReturnValue({
@@ -47,12 +53,35 @@ describe('Shell', () => {
       heartbeatError: null,
       queue: { status: 'idle', pending: 0, lastError: null, updatedAt: null },
     })
+    mockUseActiveStoreContext.mockReturnValue({
+      storeId: 'store-1',
+      isLoading: false,
+      error: null,
+      memberships: [
+        {
+          id: 'membership-1',
+          uid: 'user-1',
+          role: 'owner',
+          storeId: 'store-1',
+          email: null,
+          phone: null,
+          invitedBy: null,
+          firstSignupEmail: null,
+          createdAt: null,
+          updatedAt: null,
+        },
+      ],
+      membershipsLoading: false,
+      setActiveStoreId: vi.fn(),
+      storeChangeToken: 0,
+    })
   })
 
   it('renders the workspace status', () => {
     renderShell()
 
     expect(screen.getByText('Workspace ready')).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /workspace/i })).toHaveValue('store-1')
 
   })
 })

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useId, useMemo } from 'react'
 import { NavLink } from 'react-router-dom'
 import { signOut } from 'firebase/auth'
 import { auth } from '../firebase'
 import { useAuthUser } from '../hooks/useAuthUser'
 import { useConnectivityStatus } from '../hooks/useConnectivityStatus'
+import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import './Shell.css'
 import './Workspace.css'
 
@@ -72,6 +73,13 @@ export default function Shell({ children }: { children: React.ReactNode }) {
   const user = useAuthUser()
   const userEmail = user?.email ?? 'Account'
   const connectivity = useConnectivityStatus()
+  const {
+    storeId: activeStoreId,
+    memberships,
+    membershipsLoading,
+    setActiveStoreId,
+    isLoading: storeLoading,
+  } = useActiveStoreContext()
 
   const { isOnline, isReachable, queue } = connectivity
 
@@ -110,7 +118,55 @@ export default function Shell({ children }: { children: React.ReactNode }) {
   }, [isOnline, isReachable, queue.lastError, queue.pending, queue.status])
 
 
-  const workspaceStatus = 'Workspace ready'
+  const storeSelectId = useId()
+
+  const storeOptions = useMemo(() => {
+    const seen = new Set<string>()
+    return memberships
+      .map(membership => membership.storeId)
+      .filter((storeId): storeId is string => typeof storeId === 'string' && storeId.trim().length > 0)
+      .filter(storeId => {
+        if (seen.has(storeId)) return false
+        seen.add(storeId)
+        return true
+      })
+      .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+      .map(storeId => ({ id: storeId, label: storeId }))
+  }, [memberships])
+
+  const storeStatusLabel = useMemo(() => {
+    if (storeLoading || membershipsLoading) {
+      return 'Loading workspace access…'
+    }
+
+    if (!storeOptions.length) {
+      return 'No workspace available'
+    }
+
+    if (!activeStoreId) {
+      return 'Select a workspace'
+    }
+
+    return 'Workspace ready'
+  }, [activeStoreId, membershipsLoading, storeLoading, storeOptions.length])
+
+  const storeSelectValue = activeStoreId ?? ''
+
+  const handleStoreChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = event.target.value
+      if (!value) {
+        return
+      }
+
+      if (value === activeStoreId) {
+        return
+      }
+
+      setActiveStoreId(value)
+    },
+    [activeStoreId, setActiveStoreId],
+  )
 
 
   return (
@@ -138,8 +194,35 @@ export default function Shell({ children }: { children: React.ReactNode }) {
           <div className="shell__controls">
 
             <div className="shell__store-switcher" role="status" aria-live="polite">
-              <span className="shell__store-label">Workspace</span>
-              <span className="shell__store-select" data-readonly>{workspaceStatus}</span>
+              <label className="shell__store-label" htmlFor={storeSelectId}>
+                Workspace
+              </label>
+              {storeOptions.length ? (
+                <select
+                  id={storeSelectId}
+                  className="shell__store-select"
+                  value={storeSelectValue}
+                  onChange={handleStoreChange}
+                  disabled={storeLoading || membershipsLoading}
+                >
+                  <option value="" disabled>
+                    Select a workspace…
+                  </option>
+                  {storeOptions.map(option => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <span
+                  className="shell__store-empty"
+                  data-state={storeLoading || membershipsLoading ? 'loading' : 'empty'}
+                >
+                  {storeLoading || membershipsLoading ? 'Loading workspaces…' : 'No workspace assigned'}
+                </span>
+              )}
+              <span className="shell__store-status">{storeStatusLabel}</span>
             </div>
 
 

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -153,7 +153,8 @@ function formatTimestamp(timestamp: Timestamp | null) {
 }
 
 export default function AccountOverview() {
-  const { storeId, isLoading: storeLoading, error: storeError } = useActiveStoreContext()
+  const { storeId, isLoading: storeLoading, error: storeError, storeChangeToken } =
+    useActiveStoreContext()
   const membershipsStoreId = storeLoading ? undefined : storeId ?? null
   const {
     memberships,
@@ -224,7 +225,7 @@ export default function AccountOverview() {
     return () => {
       cancelled = true
     }
-  }, [storeId, publish])
+  }, [storeId, publish, storeChangeToken])
 
   useEffect(() => {
     if (!storeId) {
@@ -261,7 +262,20 @@ export default function AccountOverview() {
     return () => {
       cancelled = true
     }
-  }, [storeId, rosterVersion, publish])
+  }, [storeId, rosterVersion, publish, storeChangeToken])
+
+  useEffect(() => {
+    setProfile(null)
+    setProfileError(null)
+    setRoster([])
+    setRosterError(null)
+    setEmail('')
+    setRole('staff')
+    setPassword('')
+    setFormError(null)
+    setSubmitting(false)
+    setRosterVersion(0)
+  }, [storeChangeToken])
 
   function validateForm() {
     if (!storeId) {

--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -31,7 +31,7 @@ function parseQuantity(input: string): number {
 
 export default function CloseDay() {
   const user = useAuthUser()
-  const { storeId: activeStoreId } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
 
   const [total, setTotal] = useState(0)
   const [cashCounts, setCashCounts] = useState<CashCountState>(() => createInitialCashCountState())
@@ -47,6 +47,7 @@ export default function CloseDay() {
   useEffect(() => {
     const start = new Date()
     start.setHours(0, 0, 0, 0)
+    setTotal(0)
     if (!activeStoreId) {
       setTotal(0)
       return () => {
@@ -65,7 +66,19 @@ export default function CloseDay() {
       snap.forEach(d => sum += (d.data().total || 0))
       setTotal(sum)
     })
-  }, [activeStoreId])
+  }, [activeStoreId, storeChangeToken])
+
+  useEffect(() => {
+    setCashCounts(createInitialCashCountState())
+    setLooseCash('')
+    setCardAndDigital('')
+    setCashRemoved('')
+    setCashAdded('')
+    setNotes('')
+    setSubmitError(null)
+    setSubmitSuccess(false)
+    setIsSubmitting(false)
+  }, [storeChangeToken])
 
   useEffect(() => {
     const style = document.createElement('style')

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -214,7 +214,7 @@ function buildCsvValue(value: string): string {
 }
 
 export default function Customers() {
-  const { storeId: activeStoreId } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
   const [customers, setCustomers] = useState<Customer[]>([])
   const [name, setName] = useState('')
   const [phone, setPhone] = useState('')
@@ -256,6 +256,8 @@ export default function Customers() {
 
   useEffect(() => {
     let cancelled = false
+
+    setCustomers([])
 
     if (!activeStoreId) {
       setCustomers([])
@@ -311,7 +313,7 @@ export default function Customers() {
       cancelled = true
       unsubscribe()
     }
-  }, [activeStoreId])
+  }, [activeStoreId, storeChangeToken])
 
   function normalizeSaleDate(value: unknown): Date | null {
     if (!value) return null
@@ -414,6 +416,9 @@ export default function Customers() {
   useEffect(() => {
     let cancelled = false
 
+    setCustomerStats({})
+    setSalesHistory({})
+
     if (!activeStoreId) {
       setCustomerStats({})
       setSalesHistory({})
@@ -451,7 +456,17 @@ export default function Customers() {
       cancelled = true
       unsubscribe()
     }
-  }, [activeStoreId])
+  }, [activeStoreId, storeChangeToken])
+
+  useEffect(() => {
+    setSelectedCustomerId(null)
+    setEditingCustomerId(null)
+    setSearchTerm('')
+    setTagFilter(null)
+    setQuickFilter('all')
+    setSuccess(null)
+    setError(null)
+  }, [storeChangeToken])
 
   useEffect(() => {
     if (!selectedCustomerId) return

--- a/web/src/pages/Gate.test.tsx
+++ b/web/src/pages/Gate.test.tsx
@@ -18,7 +18,15 @@ describe('Gate', () => {
   beforeEach(() => {
     mockUseActiveStoreContext.mockReset();
     mockUseMemberships.mockReset();
-    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null });
+    mockUseActiveStoreContext.mockReturnValue({
+      storeId: 'store-1',
+      isLoading: false,
+      error: null,
+      memberships: [],
+      membershipsLoading: false,
+      setActiveStoreId: vi.fn(),
+      storeChangeToken: 0,
+    });
   });
 
   it('renders a loading state while memberships are loading', () => {

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -150,7 +150,7 @@ function isOfflineError(error: unknown) {
 }
 
 export default function Products() {
-  const { storeId: activeStoreId } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
   const [products, setProducts] = useState<ProductRecord[]>([])
   const [isLoadingProducts, setIsLoadingProducts] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -165,8 +165,10 @@ export default function Products() {
   const [isUpdating, setIsUpdating] = useState(false)
 
   useEffect(() => {
-    let cancelled = false
+    setProducts([])
     setLoadError(null)
+
+    let cancelled = false
 
     if (!activeStoreId) {
       setProducts([])
@@ -251,7 +253,17 @@ export default function Products() {
       cancelled = true
       unsubscribe()
     }
-  }, [activeStoreId])
+  }, [activeStoreId, storeChangeToken])
+
+  useEffect(() => {
+    setFilterText('')
+    setShowLowStockOnly(false)
+    setCreateForm(DEFAULT_CREATE_FORM)
+    setCreateStatus(null)
+    setEditForm(DEFAULT_EDIT_FORM)
+    setEditStatus(null)
+    setEditingProductId(null)
+  }, [storeChangeToken])
 
   useEffect(() => {
     if (!editingProductId) {

--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -35,7 +35,7 @@ function isOfflineError(error: unknown) {
 }
 
 export default function Receive() {
-  const { storeId: activeStoreId } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
   const [products, setProducts] = useState<Product[]>([])
   const [selected, setSelected] = useState<string>('')
   const [qty, setQty] = useState<string>('')
@@ -68,6 +68,8 @@ export default function Receive() {
 
   useEffect(() => {
     let cancelled = false
+
+    setProducts([])
 
     if (!activeStoreId) {
       setProducts([])
@@ -111,7 +113,16 @@ export default function Receive() {
       cancelled = true
       unsubscribe()
     }
-  }, [activeStoreId])
+  }, [activeStoreId, storeChangeToken])
+
+  useEffect(() => {
+    setSelected('')
+    setQty('')
+    setSupplier('')
+    setReference('')
+    setUnitCost('')
+    setStatus(null)
+  }, [storeChangeToken])
 
   async function receive() {
     if (!selected || qty === '') return

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -11,7 +11,15 @@ vi.mock('../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
 }))
 
-const mockUseActiveStoreContext = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+const mockUseActiveStoreContext = vi.fn(() => ({
+  storeId: 'store-1',
+  isLoading: false,
+  error: null,
+  memberships: [],
+  membershipsLoading: false,
+  setActiveStoreId: vi.fn(),
+  storeChangeToken: 0,
+}))
 vi.mock('../context/ActiveStoreProvider', () => ({
   useActiveStoreContext: () => mockUseActiveStoreContext(),
 }))
@@ -206,7 +214,15 @@ describe('Sell page', () => {
       uid: 'cashier-123',
       email: 'cashier@example.com',
     })
-    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStoreContext.mockReturnValue({
+      storeId: 'store-1',
+      isLoading: false,
+      error: null,
+      memberships: [],
+      membershipsLoading: false,
+      setActiveStoreId: vi.fn(),
+      storeChangeToken: 0,
+    })
 
     autoCounters = {}
     firestoreState = {

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -185,7 +185,7 @@ function formatTenderBreakdown(tenders: Record<string, number>): string {
 
 export default function Sell() {
   const user = useAuthUser()
-  const { storeId: activeStoreId } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
 
   const [products, setProducts] = useState<Product[]>([])
   const [customers, setCustomers] = useState<Customer[]>([])
@@ -226,6 +226,8 @@ export default function Sell() {
 
   useEffect(() => {
     let cancelled = false
+
+    setProducts([])
 
     if (!activeStoreId) {
       setProducts([])
@@ -280,10 +282,12 @@ export default function Sell() {
       cancelled = true
       unsubscribe()
     }
-  }, [activeStoreId])
+  }, [activeStoreId, storeChangeToken])
 
   useEffect(() => {
     let cancelled = false
+
+    setCustomers([])
 
     if (!activeStoreId) {
       setCustomers([])
@@ -333,7 +337,7 @@ export default function Sell() {
       cancelled = true
       unsubscribe()
     }
-  }, [activeStoreId])
+  }, [activeStoreId, storeChangeToken])
 
   useEffect(() => {
     if (!receipt) return
@@ -418,6 +422,20 @@ export default function Sell() {
       URL.revokeObjectURL(pdfUrl)
     }
   }, [receipt, user?.email])
+
+  useEffect(() => {
+    setQueryText('')
+    setCart([])
+    setSelectedCustomerId('')
+    setPaymentMethod('cash')
+    setAmountTendered('')
+    setSaleError(null)
+    setSaleSuccess(null)
+    setIsRecording(false)
+    setScannerStatus(null)
+    setReceipt(null)
+    setReceiptSharePayload(null)
+  }, [storeChangeToken])
 
   const handleDownloadPdf = useCallback(() => {
     setReceiptSharePayload(prev => {

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -163,7 +163,7 @@ function formatTime(value: Date | null) {
 }
 
 export default function Today() {
-  const { storeId, isLoading: storeLoading } = useActiveStoreContext()
+  const { storeId, isLoading: storeLoading, storeChangeToken } = useActiveStoreContext()
 
   const today = useMemo(() => new Date(), [])
   const todayKey = useMemo(() => formatDateKey(today), [today])
@@ -221,7 +221,7 @@ export default function Today() {
     return () => {
       cancelled = true
     }
-  }, [storeId, todayKey])
+  }, [storeId, todayKey, storeChangeToken])
 
   useEffect(() => {
     if (!storeId) {
@@ -262,7 +262,14 @@ export default function Today() {
     return () => {
       cancelled = true
     }
-  }, [storeId, todayKey])
+  }, [storeId, todayKey, storeChangeToken])
+
+  useEffect(() => {
+    setSummary(null)
+    setSummaryError(null)
+    setActivities([])
+    setActivitiesError(null)
+  }, [storeChangeToken])
 
   if (storeLoading) {
     return (

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -80,7 +80,15 @@ describe('AccountOverview', () => {
     queryMock.mockClear()
     whereMock.mockClear()
 
-    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
+    mockUseActiveStoreContext.mockReturnValue({
+      storeId: 'store-123',
+      isLoading: false,
+      error: null,
+      memberships: [],
+      membershipsLoading: false,
+      setActiveStoreId: vi.fn(),
+      storeChangeToken: 0,
+    })
     getDocMock.mockResolvedValue({
       exists: () => true,
       data: () => ({

--- a/web/src/pages/__tests__/Products.test.tsx
+++ b/web/src/pages/__tests__/Products.test.tsx
@@ -20,7 +20,15 @@ vi.mock('../../firebase', () => ({
   db: {},
 }))
 
-const mockUseActiveStoreContext = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+const mockUseActiveStoreContext = vi.fn(() => ({
+  storeId: 'store-1',
+  isLoading: false,
+  error: null,
+  memberships: [],
+  membershipsLoading: false,
+  setActiveStoreId: vi.fn(),
+  storeChangeToken: 0,
+}))
 vi.mock('../../context/ActiveStoreProvider', () => ({
   useActiveStoreContext: () => mockUseActiveStoreContext(),
 }))
@@ -87,7 +95,15 @@ describe('Products page', () => {
     docMock.mockClear()
     whereMock.mockClear()
     mockUseActiveStoreContext.mockReset()
-    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStoreContext.mockReturnValue({
+      storeId: 'store-1',
+      isLoading: false,
+      error: null,
+      memberships: [],
+      membershipsLoading: false,
+      setActiveStoreId: vi.fn(),
+      storeChangeToken: 0,
+    })
 
 
 

--- a/web/src/pages/__tests__/Sell.test.tsx
+++ b/web/src/pages/__tests__/Sell.test.tsx
@@ -35,7 +35,15 @@ vi.mock('../../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
 }))
 
-const mockUseActiveStoreContext = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+const mockUseActiveStoreContext = vi.fn(() => ({
+  storeId: 'store-1',
+  isLoading: false,
+  error: null,
+  memberships: [],
+  membershipsLoading: false,
+  setActiveStoreId: vi.fn(),
+  storeChangeToken: 0,
+}))
 vi.mock('../../context/ActiveStoreProvider', () => ({
   useActiveStoreContext: () => mockUseActiveStoreContext(),
 }))
@@ -113,7 +121,15 @@ describe('Sell page barcode scanner', () => {
     mockUseAuthUser.mockReset()
     mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'cashier@example.com' })
     mockUseActiveStoreContext.mockReset()
-    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStoreContext.mockReturnValue({
+      storeId: 'store-1',
+      isLoading: false,
+      error: null,
+      memberships: [],
+      membershipsLoading: false,
+      setActiveStoreId: vi.fn(),
+      storeChangeToken: 0,
+    })
 
     mockLoadCachedProducts.mockResolvedValue([])
     mockLoadCachedCustomers.mockResolvedValue([])

--- a/web/src/pages/__tests__/Today.test.tsx
+++ b/web/src/pages/__tests__/Today.test.tsx
@@ -8,6 +8,10 @@ const mockUseActiveStoreContext = vi.fn(() => ({
   storeId: 'store-123',
   isLoading: false,
   error: null,
+  memberships: [],
+  membershipsLoading: false,
+  setActiveStoreId: vi.fn(),
+  storeChangeToken: 0,
 }))
 
 vi.mock('../../context/ActiveStoreProvider', () => ({
@@ -74,6 +78,10 @@ describe('Today page', () => {
       storeId: 'store-123',
       isLoading: false,
       error: null,
+      memberships: [],
+      membershipsLoading: false,
+      setActiveStoreId: vi.fn(),
+      storeChangeToken: 0,
     })
 
     collectionMock.mockClear()


### PR DESCRIPTION
## Summary
- replace the shell workspace badge with a store switcher driven by memberships and persist selections
- extend `useActiveStore` with manual selection helpers, membership exposure, and a change token
- clear cached state for products, customers, sales, receiving, close day, and today views whenever the active store changes

## Testing
- npm test *(fails: tests/firestore.rules.emulator.test.ts → Firebase auth network-request-failed in the emulator)*

------
https://chatgpt.com/codex/tasks/task_e_68daf3aad68483219d6060a2890ea367