### PR TITLE
Align offline queue request types with shared typing

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,6 +26,7 @@ import {
   persistActiveStoreIdForUser,
 } from './utils/activeStoreStorage'
 import { getOnboardingStatus, setOnboardingStatus } from './utils/onboarding'
+import type { QueueRequestType } from './utils/offlineQueue'
 
 /* ------------------------------ config ------------------------------ */
 /** If you want to ALSO mirror the team member to a fixed doc id, put it here. */
@@ -36,8 +37,6 @@ const OVERRIDE_MEMBER_DOC_ID = 'l8Rbmym8aBVMwL6NpZHntjBHmCo2' // set '' to disab
 type AuthMode = 'login' | 'signup'
 type StatusTone = 'idle' | 'loading' | 'success' | 'error'
 interface StatusState { tone: StatusTone; message: string }
-
-type QueueRequestType = 'sale' | 'receipt'
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const PASSWORD_MIN_LENGTH = 8

--- a/web/src/utils/__tests__/offlineQueue.test.ts
+++ b/web/src/utils/__tests__/offlineQueue.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../firebase', () => ({
+  auth: { currentUser: null },
+}))
+
+describe('offlineQueue', () => {
+  const originalNavigator = globalThis.navigator
+  let postMessageMock: ReturnType<typeof vi.fn>
+  let queueCallableRequest: (typeof import('../offlineQueue'))['queueCallableRequest']
+
+  beforeEach(async () => {
+    vi.resetModules()
+    postMessageMock = vi.fn()
+    const registration = {
+      active: { postMessage: postMessageMock },
+    }
+
+    const serviceWorker = {
+      ready: Promise.resolve(registration),
+    }
+
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { serviceWorker } as Navigator,
+      configurable: true,
+      writable: true,
+    })
+
+    Object.assign(import.meta.env, {
+      VITE_FB_PROJECT_ID: 'demo-project',
+      VITE_FB_FUNCTIONS_REGION: 'us-central1',
+    })
+
+    ;({ queueCallableRequest } = await import('../offlineQueue'))
+  })
+
+  afterEach(() => {
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: originalNavigator,
+        configurable: true,
+        writable: true,
+      })
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).navigator
+    }
+  })
+
+  it('queues sale request with the correct request type', async () => {
+    const queued = await queueCallableRequest('processSale', { total: 100 }, 'sale')
+
+    expect(queued).toBe(true)
+    const firstMessage = postMessageMock.mock.calls[0]?.[0]
+    expect(firstMessage?.payload?.requestType).toBe('sale')
+  })
+})

--- a/web/src/utils/offlineQueue.ts
+++ b/web/src/utils/offlineQueue.ts
@@ -5,7 +5,7 @@ const PROJECT_ID = import.meta.env.VITE_FB_PROJECT_ID
 
 const SYNC_TAG = 'sync-pending-requests'
 
-type QueueRequestType = 'receipt'
+export type QueueRequestType = 'sale' | 'receipt'
 
 type QueueMessage = {
   type: 'QUEUE_BACKGROUND_REQUEST'


### PR DESCRIPTION
## Summary
- export a shared `QueueRequestType` that covers both sale and receipt requests
- consume the shared type in the app so queue handlers stay in sync
- add a focused unit test that verifies queued sale requests preserve their request type

## Testing
- npm test -- offlineQueue

------
https://chatgpt.com/codex/tasks/task_e_68dafc3c7128832185f0a6597e7d3ef8