### PR TITLE
feat: add recordSale callable and offline sale queuing

### DIFF
--- a/web/src/pages/__tests__/Sell.test.tsx
+++ b/web/src/pages/__tests__/Sell.test.tsx
@@ -30,6 +30,11 @@ vi.mock('../../firebase', () => ({
   db: {},
 }))
 
+const mockPublish = vi.fn()
+vi.mock('../../components/ToastProvider', () => ({
+  useToast: () => ({ publish: mockPublish }),
+}))
+
 const mockUseAuthUser = vi.fn(() => ({ uid: 'user-1', email: 'cashier@example.com' }))
 vi.mock('../../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
@@ -111,6 +116,7 @@ describe('Sell page barcode scanner', () => {
     mockSaveCachedProducts.mockReset()
     mockLoadCachedCustomers.mockReset()
     mockSaveCachedCustomers.mockReset()
+    mockPublish.mockReset()
     collectionMock.mockClear()
     queryMock.mockClear()
     orderByMock.mockClear()

--- a/web/src/utils/offlineQueue.ts
+++ b/web/src/utils/offlineQueue.ts
@@ -5,7 +5,7 @@ const PROJECT_ID = import.meta.env.VITE_FB_PROJECT_ID
 
 const SYNC_TAG = 'sync-pending-requests'
 
-type QueueRequestType = 'receipt'
+type QueueRequestType = 'receipt' | 'sale'
 
 type QueueMessage = {
   type: 'QUEUE_BACKGROUND_REQUEST'


### PR DESCRIPTION
## Summary
- add a recordSale callable that validates sale payloads and performs the Firestore writes in a transaction
- update the Sell page to invoke the callable, queue offline attempts, and track optimistic stock deltas for immediate UI updates
- extend the offline queue to support queued sales and refresh related tests to cover the callable, queuing, and toast behavior

## Testing
- npm --prefix web test -- src/pages/Sell.test.tsx
- npm --prefix web test *(fails: Firebase auth network-request-failed in emulator suite)*

------
https://chatgpt.com/codex/tasks/task_e_68dafc4084248321b7235ccbf7454a56