### PR TITLE
Add Firestore closeout trigger to update daily summaries

### DIFF
--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -152,6 +152,8 @@ export default function CloseDay() {
               uid: user.uid,
               displayName: user.displayName || null,
               email: user.email || null,
+              phoneNumber: user.phoneNumber || null,
+              photoURL: user.photoURL || null,
             }
           : null,
         closedAt: serverTimestamp(),


### PR DESCRIPTION
## Summary
- add a Firestore trigger for closeout documents to update store daily summaries and log an activity entry
- add a helper to format closeout activity summaries
- capture additional operator details when submitting a closeout so the trigger has the data it needs

## Testing
- npm test --prefix functions

------
https://chatgpt.com/codex/tasks/task_e_68db0ab01d608321ba4ecbb988650e0d