### PR TITLE
Add CSV import tooling for products

### DIFF
--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -25,6 +25,7 @@ import {
   saveCachedCustomers,
   saveCachedSales,
 } from '../utils/offlineCache'
+import { parseCsv } from '../utils/csv'
 
 type Customer = {
   id: string
@@ -151,59 +152,6 @@ function formatTenderSummary(tenders: Record<string, unknown>): string | null {
 function formatDate(date: Date | null): string {
   if (!date) return '—'
   return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
-}
-
-function parseCsv(text: string): string[][] {
-  const rows: string[][] = []
-  let current = ''
-  let row: string[] = []
-  let insideQuotes = false
-
-  const pushValue = () => {
-    row.push(current)
-    current = ''
-  }
-
-  const pushRow = () => {
-    if (!row.length) return
-    rows.push(row.map(cell => cell.trim()))
-    row = []
-  }
-
-  for (let i = 0; i < text.length; i += 1) {
-    const char = text[i]
-    if (char === '"') {
-      if (insideQuotes && text[i + 1] === '"') {
-        current += '"'
-        i += 1
-      } else {
-        insideQuotes = !insideQuotes
-      }
-    } else if (char === ',' && !insideQuotes) {
-      pushValue()
-    } else if ((char === '\n' || char === '\r') && !insideQuotes) {
-      if (char === '\r' && text[i + 1] === '\n') {
-        i += 1
-      }
-      pushValue()
-      if (row.some(cell => cell.trim().length > 0)) {
-        pushRow()
-      } else {
-        row = []
-      }
-    } else {
-      current += char
-    }
-  }
-
-  if (current.length > 0 || row.length > 0) {
-    pushValue()
-    if (row.some(cell => cell.trim().length > 0)) {
-      pushRow()
-    }
-  }
-
-  return rows
 }
 
 function buildCsvValue(value: string): string {

--- a/web/src/pages/Products.css
+++ b/web/src/pages/Products.css
@@ -15,6 +15,23 @@
   margin-bottom: 16px;
 }
 
+.products-page__toolbar-left {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.products-page__tool-buttons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.products-page__import-input {
+  display: none;
+}
+
 .products-page__search {
   display: flex;
   flex-direction: column;
@@ -200,6 +217,14 @@
   .products-page__toolbar {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .products-page__toolbar-left {
+    width: 100%;
+  }
+
+  .products-page__tool-buttons {
+    justify-content: flex-start;
   }
 
   .products-page__actions {

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useMemo, useState } from 'react'
+import React, { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 import {
   addDoc,
   collection,
@@ -10,6 +10,7 @@ import {
   serverTimestamp,
   updateDoc,
   where,
+  writeBatch,
 } from 'firebase/firestore'
 import { FirebaseError } from 'firebase/app'
 import { Link } from 'react-router-dom'
@@ -20,6 +21,12 @@ import {
   loadCachedProducts,
   saveCachedProducts,
 } from '../utils/offlineCache'
+import { parseCsv } from '../utils/csv'
+import {
+  buildProductImportOperations,
+  normalizeProductCsvRows,
+  type ProductImportOperation,
+} from './productsImport'
 import './Products.css'
 
 interface ReceiptDetails {
@@ -163,6 +170,9 @@ export default function Products() {
   const [editStatus, setEditStatus] = useState<StatusState | null>(null)
   const [editingProductId, setEditingProductId] = useState<string | null>(null)
   const [isUpdating, setIsUpdating] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const [isImporting, setIsImporting] = useState(false)
+  const [importStatus, setImportStatus] = useState<StatusState | null>(null)
 
   useEffect(() => {
     setProducts([])
@@ -263,6 +273,11 @@ export default function Products() {
     setEditForm(DEFAULT_EDIT_FORM)
     setEditStatus(null)
     setEditingProductId(null)
+    setImportStatus(null)
+    setIsImporting(false)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
   }, [storeChangeToken])
 
   useEffect(() => {
@@ -531,6 +546,192 @@ export default function Products() {
     }
   }
 
+  function isCreateOperation(
+    operation: ProductImportOperation,
+  ): operation is Extract<ProductImportOperation, { type: 'create' }> {
+    return operation.type === 'create'
+  }
+
+  function buildCreatePayload(
+    operation: Extract<ProductImportOperation, { type: 'create' }>,
+    storeId: string,
+  ) {
+    return {
+      name: operation.payload.name,
+      price: operation.payload.price,
+      sku: operation.payload.sku,
+      reorderThreshold: operation.payload.reorderThreshold ?? null,
+      stockCount: operation.payload.stockCount ?? 0,
+      storeId,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    }
+  }
+
+  function buildUpdatePayload(
+    operation: Extract<ProductImportOperation, { type: 'update' }>,
+    storeId: string,
+  ) {
+    const payload: Record<string, unknown> = {
+      name: operation.payload.name,
+      price: operation.payload.price,
+      sku: operation.payload.sku,
+      reorderThreshold: operation.payload.reorderThreshold ?? null,
+      storeId,
+      updatedAt: serverTimestamp(),
+    }
+
+    if (operation.payload.stockCount !== null) {
+      payload.stockCount = operation.payload.stockCount
+    }
+
+    return payload
+  }
+
+  async function handleProductCsvImport(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    setIsImporting(true)
+    setImportStatus(null)
+
+    try {
+      if (!activeStoreId) {
+        throw new Error('Select a workspace before importing products.')
+      }
+
+      const text = await file.text()
+      const rows = parseCsv(text)
+      if (!rows.length) {
+        throw new Error('No rows detected in the file.')
+      }
+
+      const normalization = normalizeProductCsvRows(rows)
+      const { rows: normalizedRows, skipped, errors, total } = normalization
+      if (!normalizedRows.length) {
+        const message = errors[0] ?? 'No valid product rows were found in this file.'
+        throw new Error(message)
+      }
+
+      const storeProducts = products.filter(product => product.storeId === activeStoreId)
+      const { operations, counts } = buildProductImportOperations({
+        rows: normalizedRows,
+        existingProducts: storeProducts,
+      })
+
+      if (!operations.length) {
+        const message = errors[0] ?? 'No valid product rows were found in this file.'
+        throw new Error(message)
+      }
+
+      const BATCH_LIMIT = 400
+      let completedCreates = 0
+      let completedUpdates = 0
+      let offlineFallbackUsed = false
+      let index = 0
+
+      while (index < operations.length) {
+        const chunk = operations.slice(index, index + BATCH_LIMIT)
+        const createCount = chunk.filter(isCreateOperation).length
+        const updateCount = chunk.length - createCount
+        const batch = writeBatch(db)
+
+        chunk.forEach(operation => {
+          if (isCreateOperation(operation)) {
+            const ref = doc(collection(db, 'products'))
+            batch.set(ref, buildCreatePayload(operation, activeStoreId))
+          } else {
+            batch.update(doc(db, 'products', operation.id), buildUpdatePayload(operation, activeStoreId))
+          }
+        })
+
+        try {
+          await batch.commit()
+          completedCreates += createCount
+          completedUpdates += updateCount
+        } catch (error) {
+          if (isOfflineError(error)) {
+            offlineFallbackUsed = true
+            for (let j = index; j < operations.length; j += 1) {
+              const operation = operations[j]
+              try {
+                if (isCreateOperation(operation)) {
+                  await addDoc(collection(db, 'products'), buildCreatePayload(operation, activeStoreId))
+                  completedCreates += 1
+                } else {
+                  await updateDoc(doc(db, 'products', operation.id), buildUpdatePayload(operation, activeStoreId))
+                  completedUpdates += 1
+                }
+              } catch (fallbackError) {
+                if (isOfflineError(fallbackError)) {
+                  if (operation.type === 'create') {
+                    completedCreates += 1
+                  } else {
+                    completedUpdates += 1
+                  }
+                } else {
+                  console.error('[products] Failed to import products', fallbackError)
+                  setImportStatus({
+                    tone: 'error',
+                    message: 'We were unable to import products from this file.',
+                  })
+                  return
+                }
+              }
+            }
+            index = operations.length
+            break
+          }
+
+          const processed = completedCreates + completedUpdates
+          console.error('[products] Failed to import products', error)
+          let message = processed
+            ? `Imported ${processed} product${processed === 1 ? '' : 's'} before we hit an error. Please review the file and try again.`
+            : 'We were unable to import products from this file.'
+          if (skipped > 0) {
+            message += ` Skipped ${skipped} row${skipped === 1 ? '' : 's'} due to formatting issues.`
+          }
+          if (errors[0]) {
+            message += ` First skipped row: ${errors[0]}.`
+          }
+          setImportStatus({ tone: 'error', message })
+          return
+        }
+
+        index += chunk.length
+      }
+
+      const finalCreates = offlineFallbackUsed ? counts.toCreate : completedCreates
+      const finalUpdates = offlineFallbackUsed ? counts.toUpdate : completedUpdates
+      const processedRows = finalCreates + finalUpdates
+      const totalRows = total || processedRows + skipped
+      const skippedRows = Math.max(skipped, totalRows - processedRows)
+
+      const prefix = offlineFallbackUsed
+        ? 'Offline — product import saved and will sync when you reconnect.'
+        : 'Imported products successfully.'
+
+      let message = `${prefix} Processed ${processedRows} of ${totalRows} row${totalRows === 1 ? '' : 's'} (${finalCreates} added, ${finalUpdates} updated).`
+      if (skippedRows > 0) {
+        message += ` Skipped ${skippedRows} row${skippedRows === 1 ? '' : 's'} due to formatting issues.`
+        if (errors[0]) {
+          message += ` First skipped row: ${errors[0]}.`
+        }
+      }
+
+      setImportStatus({ tone: 'success', message })
+    } catch (error) {
+      console.error('[products] Unable to import CSV', error)
+      const message = error instanceof Error ? error.message : 'We were unable to import products from this file.'
+      setImportStatus({ tone: 'error', message })
+    } finally {
+      setIsImporting(false)
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ''
+      }
+    }
+  }
+
   function renderStatus(status: StatusState | null) {
     if (!status) return null
     return (
@@ -557,24 +758,44 @@ export default function Products() {
 
       <section className="card products-page__card">
         <div className="products-page__toolbar">
-          <label className="products-page__search">
-            <span className="products-page__search-label">Search</span>
+          <div className="products-page__toolbar-left">
+            <label className="products-page__search">
+              <span className="products-page__search-label">Search</span>
+              <input
+                type="search"
+                placeholder="Search by product or SKU"
+                value={filterText}
+                onChange={event => setFilterText(event.target.value)}
+              />
+            </label>
+            <label className="products-page__filter">
+              <input
+                type="checkbox"
+                checked={showLowStockOnly}
+                onChange={event => setShowLowStockOnly(event.target.checked)}
+              />
+              <span>Show low stock only</span>
+            </label>
+          </div>
+          <div className="products-page__tool-buttons">
+            <button
+              type="button"
+              className="button button--outline button--small"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isImporting}
+            >
+              {isImporting ? 'Importing…' : 'Import CSV'}
+            </button>
             <input
-              type="search"
-              placeholder="Search by product or SKU"
-              value={filterText}
-              onChange={event => setFilterText(event.target.value)}
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,text/csv"
+              className="products-page__import-input"
+              onChange={handleProductCsvImport}
             />
-          </label>
-          <label className="products-page__filter">
-            <input
-              type="checkbox"
-              checked={showLowStockOnly}
-              onChange={event => setShowLowStockOnly(event.target.checked)}
-            />
-            <span>Show low stock only</span>
-          </label>
+          </div>
         </div>
+        {renderStatus(importStatus)}
         {loadError ? <div className="products-page__error">{loadError}</div> : null}
         {isLoadingProducts ? <div className="products-page__loading">Loading products…</div> : null}
         {!isLoadingProducts && filteredProducts.length === 0 ? (

--- a/web/src/pages/__tests__/ProductsImport.test.ts
+++ b/web/src/pages/__tests__/ProductsImport.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildProductImportOperations,
+  normalizeProductCsvRows,
+  type ProductImportRow,
+} from '../productsImport'
+
+describe('normalizeProductCsvRows', () => {
+  it('normalizes valid product rows with optional values', () => {
+    const rows = [
+      ['Name', 'SKU', 'Price', 'Reorder Threshold', 'Stock Count'],
+      ['House Blend Coffee', 'HB-01', '12.5', '3', '25'],
+      ['Breakfast Tea', 'BT-02', '8', '', ''],
+    ]
+
+    const result = normalizeProductCsvRows(rows)
+
+    expect(result.total).toBe(2)
+    expect(result.skipped).toBe(0)
+    expect(result.errors).toEqual([])
+
+    const expected: ProductImportRow[] = [
+      {
+        name: 'House Blend Coffee',
+        sku: 'HB-01',
+        price: 12.5,
+        reorderThreshold: 3,
+        stockCount: 25,
+        sourceIndex: 2,
+      },
+      {
+        name: 'Breakfast Tea',
+        sku: 'BT-02',
+        price: 8,
+        reorderThreshold: null,
+        stockCount: null,
+        sourceIndex: 3,
+      },
+    ]
+
+    expect(result.rows).toEqual(expected)
+  })
+
+  it('skips invalid rows and surfaces descriptive errors', () => {
+    const rows = [
+      ['Name', 'SKU', 'Price', 'Reorder Point', 'Stock On Hand'],
+      ['Espresso Beans', 'EB-10', '18.75', '5', 'abc'],
+      ['', 'EB-11', '14.5', '2', '7'],
+      ['Drip Filters', '', '4.5', '', '15'],
+      ['Mocha Syrup', 'MS-42', '-2', '', '6'],
+      ['Reusable Cup', 'RC-01', '7.25', '2', '9'],
+    ]
+
+    const result = normalizeProductCsvRows(rows)
+
+    expect(result.total).toBe(5)
+    expect(result.rows).toHaveLength(1)
+    expect(result.skipped).toBe(4)
+    expect(result.errors).toEqual([
+      'Row 2: Invalid stock count.',
+      'Row 3: Missing product name.',
+      'Row 4: Missing SKU.',
+      'Row 5: Invalid price.',
+    ])
+    expect(result.rows[0]).toMatchObject({ sku: 'RC-01', price: 7.25 })
+  })
+})
+
+describe('buildProductImportOperations', () => {
+  it('creates update and create operations based on SKU matches', () => {
+    const rows: ProductImportRow[] = [
+      {
+        name: 'House Blend Coffee',
+        sku: 'HB-01',
+        price: 12.5,
+        reorderThreshold: 3,
+        stockCount: 25,
+        sourceIndex: 2,
+      },
+      {
+        name: 'Breakfast Tea',
+        sku: 'BT-02',
+        price: 8,
+        reorderThreshold: null,
+        stockCount: null,
+        sourceIndex: 3,
+      },
+    ]
+
+    const existingProducts = [
+      { id: 'prod-hb-01', sku: 'hb-01' },
+      { id: 'prod-old', sku: 'OLD-99' },
+    ]
+
+    const { operations, counts } = buildProductImportOperations({ rows, existingProducts })
+
+    expect(counts).toEqual({ toCreate: 1, toUpdate: 1 })
+    expect(operations).toEqual([
+      {
+        type: 'update',
+        id: 'prod-hb-01',
+        sku: 'HB-01',
+        sourceIndex: 2,
+        payload: {
+          name: 'House Blend Coffee',
+          sku: 'HB-01',
+          price: 12.5,
+          reorderThreshold: 3,
+          stockCount: 25,
+        },
+      },
+      {
+        type: 'create',
+        sku: 'BT-02',
+        sourceIndex: 3,
+        payload: {
+          name: 'Breakfast Tea',
+          sku: 'BT-02',
+          price: 8,
+          reorderThreshold: null,
+          stockCount: null,
+        },
+      },
+    ])
+  })
+})

--- a/web/src/pages/productsImport.ts
+++ b/web/src/pages/productsImport.ts
@@ -1,0 +1,193 @@
+import type { ProductRecord } from './Products'
+
+export interface ProductImportRow {
+  name: string
+  sku: string
+  price: number
+  reorderThreshold: number | null
+  stockCount: number | null
+  sourceIndex: number
+}
+
+export interface ProductCsvNormalizationResult {
+  rows: ProductImportRow[]
+  skipped: number
+  errors: string[]
+  total: number
+}
+
+export interface ProductImportPayload {
+  name: string
+  sku: string
+  price: number
+  reorderThreshold: number | null
+  stockCount: number | null
+}
+
+export type ProductImportOperation =
+  | { type: 'create'; payload: ProductImportPayload; sku: string; sourceIndex: number }
+  | { type: 'update'; payload: ProductImportPayload; id: string; sku: string; sourceIndex: number }
+
+const OPTIONAL_REORDER_HEADERS = new Set(['reorderthreshold', 'reorderpoint', 'reorderlevel'])
+const OPTIONAL_STOCK_HEADERS = new Set(['stockcount', 'stockonhand', 'onhand', 'quantity'])
+
+function normalizeHeaderName(header: string): string {
+  return header.trim().toLowerCase().replace(/[\s_-]+/g, '')
+}
+
+function parsePositiveNumber(value: string): number | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const normalized = Number(trimmed.replace(/,/g, ''))
+  if (!Number.isFinite(normalized)) return null
+  if (normalized < 0) return null
+  return normalized
+}
+
+export function normalizeProductCsvRows(rows: string[][]): ProductCsvNormalizationResult {
+  if (!rows.length) {
+    return { rows: [], skipped: 0, errors: [], total: 0 }
+  }
+
+  const [header, ...dataRows] = rows
+  const normalizedHeaders = header.map(cell => normalizeHeaderName(cell))
+
+  const nameIndex = normalizedHeaders.indexOf('name')
+  const skuIndex = normalizedHeaders.indexOf('sku')
+  const priceIndex = normalizedHeaders.indexOf('price')
+
+  if (nameIndex < 0 || skuIndex < 0 || priceIndex < 0) {
+    throw new Error('"Name", "SKU", and "Price" columns are required to import products.')
+  }
+
+  const reorderIndex = normalizedHeaders.findIndex(value => OPTIONAL_REORDER_HEADERS.has(value))
+  const stockIndex = normalizedHeaders.findIndex(value => OPTIONAL_STOCK_HEADERS.has(value))
+
+  const validRows: ProductImportRow[] = []
+  const errors: string[] = []
+  let consideredRows = 0
+
+  dataRows.forEach((rawRow, rowOffset) => {
+    const row = rawRow.map(cell => (cell ?? '').trim())
+    if (row.every(cell => cell.length === 0)) {
+      return
+    }
+
+    consideredRows += 1
+    const rowNumber = rowOffset + 2
+
+    const name = row[nameIndex] ?? ''
+    if (!name) {
+      errors.push(`Row ${rowNumber}: Missing product name.`)
+      return
+    }
+
+    const sku = row[skuIndex] ?? ''
+    if (!sku) {
+      errors.push(`Row ${rowNumber}: Missing SKU.`)
+      return
+    }
+
+    const priceValue = row[priceIndex] ?? ''
+    const price = parsePositiveNumber(priceValue)
+    if (price === null) {
+      errors.push(`Row ${rowNumber}: Invalid price.`)
+      return
+    }
+
+    let reorderThreshold: number | null = null
+    if (reorderIndex >= 0) {
+      const reorderValue = row[reorderIndex] ?? ''
+      if (reorderValue) {
+        const parsed = parsePositiveNumber(reorderValue)
+        if (parsed === null) {
+          errors.push(`Row ${rowNumber}: Invalid reorder point.`)
+          return
+        }
+        reorderThreshold = parsed
+      } else {
+        reorderThreshold = null
+      }
+    }
+
+    let stockCount: number | null = null
+    if (stockIndex >= 0) {
+      const stockValue = row[stockIndex] ?? ''
+      if (stockValue) {
+        const parsed = parsePositiveNumber(stockValue)
+        if (parsed === null) {
+          errors.push(`Row ${rowNumber}: Invalid stock count.`)
+          return
+        }
+        stockCount = parsed
+      } else {
+        stockCount = null
+      }
+    }
+
+    validRows.push({
+      name,
+      sku,
+      price,
+      reorderThreshold,
+      stockCount,
+      sourceIndex: rowNumber,
+    })
+  })
+
+  return {
+    rows: validRows,
+    skipped: errors.length,
+    errors,
+    total: consideredRows,
+  }
+}
+
+function buildPayload(row: ProductImportRow): ProductImportPayload {
+  return {
+    name: row.name,
+    sku: row.sku,
+    price: row.price,
+    reorderThreshold: row.reorderThreshold,
+    stockCount: row.stockCount,
+  }
+}
+
+export function buildProductImportOperations({
+  rows,
+  existingProducts,
+}: {
+  rows: ProductImportRow[]
+  existingProducts: Pick<ProductRecord, 'id' | 'sku'>[]
+}): {
+  operations: ProductImportOperation[]
+  counts: { toCreate: number; toUpdate: number }
+} {
+  const operations: ProductImportOperation[] = []
+  const existingBySku = new Map<string, Pick<ProductRecord, 'id' | 'sku'>>()
+
+  existingProducts.forEach(product => {
+    const sku = (product.sku ?? '').trim()
+    if (!sku) return
+    existingBySku.set(sku.toLowerCase(), product)
+  })
+
+  rows.forEach(row => {
+    const skuKey = row.sku.trim().toLowerCase()
+    const payload = buildPayload(row)
+    const existing = existingBySku.get(skuKey)
+    if (existing) {
+      operations.push({ type: 'update', id: existing.id, payload, sku: row.sku, sourceIndex: row.sourceIndex })
+    } else {
+      operations.push({ type: 'create', payload, sku: row.sku, sourceIndex: row.sourceIndex })
+    }
+  })
+
+  const toCreate = operations.filter(operation => operation.type === 'create').length
+  const toUpdate = operations.length - toCreate
+
+  return {
+    operations,
+    counts: { toCreate, toUpdate },
+  }
+}

--- a/web/src/utils/csv.ts
+++ b/web/src/utils/csv.ts
@@ -1,0 +1,52 @@
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = []
+  let current = ''
+  let row: string[] = []
+  let insideQuotes = false
+
+  const pushValue = () => {
+    row.push(current)
+    current = ''
+  }
+
+  const pushRow = () => {
+    if (!row.length) return
+    rows.push(row.map(cell => cell.trim()))
+    row = []
+  }
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i]
+    if (char === '"') {
+      if (insideQuotes && text[i + 1] === '"') {
+        current += '"'
+        i += 1
+      } else {
+        insideQuotes = !insideQuotes
+      }
+    } else if (char === ',' && !insideQuotes) {
+      pushValue()
+    } else if ((char === '\n' || char === '\r') && !insideQuotes) {
+      if (char === '\r' && text[i + 1] === '\n') {
+        i += 1
+      }
+      pushValue()
+      if (row.some(cell => cell.trim().length > 0)) {
+        pushRow()
+      } else {
+        row = []
+      }
+    } else {
+      current += char
+    }
+  }
+
+  if (current.length > 0 || row.length > 0) {
+    pushValue()
+    if (row.some(cell => cell.trim().length > 0)) {
+      pushRow()
+    }
+  }
+
+  return rows
+}


### PR DESCRIPTION
## Summary
- add a shared CSV parsing helper and reuse it across import flows
- implement product CSV import controls, batching, and offline-friendly messaging
- cover product import normalization and upsert selection with unit tests

## Testing
- npm run test *(fails: firestore.rules.emulator.test.ts cannot sign in anonymously in CI env; existing App.signup.test.ts also fails — see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68db770a112483219d335c65ba995289