### PR TITLE
Add application error boundary with toast notification

### DIFF
--- a/web/src/components/AppErrorBoundary.test.tsx
+++ b/web/src/components/AppErrorBoundary.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+const toast = vi.hoisted(() => ({
+  publish: vi.fn(),
+  dismiss: vi.fn(),
+}))
+
+vi.mock('./ToastProvider', () => ({
+  useToast: () => toast,
+}))
+
+import { AppErrorBoundary } from './AppErrorBoundary'
+
+describe('AppErrorBoundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn> | undefined
+
+  beforeEach(() => {
+    toast.publish.mockClear()
+    toast.dismiss.mockClear()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy?.mockRestore()
+  })
+
+  it('renders a fallback UI, surfaces the error, and leaves surrounding UI intact', async () => {
+    function ProblemChild() {
+      throw new Error('Kaboom!')
+    }
+
+    render(
+      <div>
+        <span>App chrome</span>
+        <AppErrorBoundary>
+          <ProblemChild />
+        </AppErrorBoundary>
+      </div>,
+    )
+
+    expect(await screen.findByRole('heading', { name: /something went wrong/i })).toBeInTheDocument()
+    expect(screen.getByText('App chrome')).toBeInTheDocument()
+    expect(toast.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tone: 'error',
+        message: expect.stringContaining('Kaboom!'),
+      }),
+    )
+  })
+})

--- a/web/src/components/AppErrorBoundary.tsx
+++ b/web/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,96 @@
+import { Component, ErrorInfo, ReactNode, useCallback } from 'react'
+import { useToast } from './ToastProvider'
+
+type AppErrorBoundaryProps = {
+  children: ReactNode
+}
+
+type AppErrorBoundaryState = {
+  hasError: boolean
+}
+
+type InternalBoundaryProps = {
+  onError: (error: Error, info: ErrorInfo) => void
+  onReset?: () => void
+  children: ReactNode
+}
+
+class InternalErrorBoundary extends Component<InternalBoundaryProps, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = {
+    hasError: false,
+  }
+
+  static getDerivedStateFromError(_error: Error): AppErrorBoundaryState {
+    return {
+      hasError: true,
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError(error, info)
+  }
+
+  handleTryAgain = () => {
+    this.setState({ hasError: false })
+    this.props.onReset?.()
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" className="app-error-boundary">
+          <h1>Something went wrong</h1>
+          <p>We hit a snag while loading this section. Please try again.</p>
+          <button type="button" onClick={this.handleTryAgain}>
+            Try again
+          </button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export function AppErrorBoundary({ children }: AppErrorBoundaryProps) {
+  const { publish } = useToast()
+
+  const notifyError = useCallback(
+    (error: Error) => {
+      const message = error?.message?.trim()
+      publish({
+        tone: 'error',
+        message: message ? `Something went wrong: ${message}` : 'Something went wrong. Please try again.',
+        duration: 8000,
+      })
+    },
+    [publish],
+  )
+
+  const handleError = useCallback(
+    (error: Error, info: ErrorInfo) => {
+      notifyError(error)
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('AppErrorBoundary caught an error', error, info)
+      }
+    },
+    [notifyError],
+  )
+
+  const handleReset = useCallback(() => {
+    publish({
+      tone: 'info',
+      message: 'Retrying…',
+      duration: 3000,
+    })
+  }, [publish])
+
+  return (
+    <InternalErrorBoundary onError={handleError} onReset={handleReset}>
+      {children}
+    </InternalErrorBoundary>
+  )
+}
+
+export default AppErrorBoundary

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -14,6 +14,7 @@ import Onboarding from './pages/Onboarding'
 import Today from './pages/Today'
 import AccountOverview from './pages/AccountOverview'
 import { ToastProvider } from './components/ToastProvider'
+import { AppErrorBoundary } from './components/AppErrorBoundary'
 import { ActiveStoreProvider } from './context/ActiveStoreProvider'
 
 const router = createHashRouter([
@@ -42,7 +43,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ToastProvider>
       <ActiveStoreProvider>
-        <RouterProvider router={router} />
+        <AppErrorBoundary>
+          <RouterProvider router={router} />
+        </AppErrorBoundary>
       </ActiveStoreProvider>
     </ToastProvider>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary
- add an AppErrorBoundary component that shows a friendly fallback and publishes toast notifications when errors occur
- wrap the RouterProvider render in main.tsx with the new boundary inside the ToastProvider
- add a focused unit test that forces a child to throw to verify the fallback renders and the toast is triggered

## Testing
- npx vitest run src/components/AppErrorBoundary.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db7e25e26883218cc5b50ab4ebb216