### PR TITLE
Add loyalty scaffold to customers and update sale tracking

### DIFF
--- a/web/src/pages/__tests__/Customers.duplicates.test.tsx
+++ b/web/src/pages/__tests__/Customers.duplicates.test.tsx
@@ -232,4 +232,26 @@ describe('Customers duplicate handling', () => {
 
     await screen.findByText('Customer already exists. Updated their details instead.')
   })
+
+  it('includes loyalty defaults when creating a new customer', async () => {
+    customerDocs = []
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <Customers />
+      </MemoryRouter>,
+    )
+
+    const nameInput = await screen.findByLabelText(/Full name/i)
+    await user.clear(nameInput)
+    await user.type(nameInput, 'New Customer')
+
+    const submitButton = screen.getByRole('button', { name: /Save customer/i })
+    await user.click(submitButton)
+
+    await waitFor(() => expect(addDocMock).toHaveBeenCalledTimes(1))
+    const payload = addDocMock.mock.calls[0]?.[1] as Record<string, unknown>
+    expect(payload.loyalty).toEqual({ points: 0, lastVisitAt: null })
+  })
 })

--- a/web/src/pages/__tests__/Sell.test.tsx
+++ b/web/src/pages/__tests__/Sell.test.tsx
@@ -23,7 +23,7 @@ vi.mock('../../utils/offlineCache', () => ({
 }))
 
 vi.mock('../../utils/pdf', () => ({
-  buildSimplePdf: vi.fn(async () => ({ blob: new Blob(), url: 'blob:test' })),
+  buildSimplePdf: vi.fn(() => new Uint8Array([0, 1, 2, 3])),
 }))
 
 vi.mock('../../firebase', () => ({
@@ -72,11 +72,21 @@ const onSnapshotMock = vi.fn(
     return () => {}
   },
 )
-const docMock = vi.fn((collectionRef: { path: string }, id?: string) => ({
-  type: 'doc',
-  path: id ? `${collectionRef.path}/${id}` : `${collectionRef.path}/auto-id`,
-  id: id ?? 'auto-id',
-}))
+const docMock = vi.fn((...args: unknown[]) => {
+  if (args.length === 1) {
+    const [collectionRef] = args as [{ path: string }]
+    return { type: 'doc', path: `${collectionRef.path}/auto-id`, id: 'auto-id' }
+  }
+  if (args.length === 2) {
+    const [collectionRef, id] = args as [{ path: string }, string]
+    return { type: 'doc', path: `${collectionRef.path}/${id}`, id }
+  }
+  if (args.length === 3) {
+    const [, collectionPath, id] = args as [unknown, string, string]
+    return { type: 'doc', path: `${collectionPath}/${id}`, id }
+  }
+  throw new Error('Unexpected doc invocation in test')
+})
 const runTransactionMock = vi.fn(async () => {})
 const serverTimestampMock = vi.fn(() => 'server-timestamp')
 
@@ -118,6 +128,8 @@ describe('Sell page barcode scanner', () => {
     onSnapshotMock.mockClear()
     whereMock.mockClear()
     docMock.mockClear()
+    runTransactionMock.mockReset()
+    runTransactionMock.mockImplementation(async () => {})
     mockUseAuthUser.mockReset()
     mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'cashier@example.com' })
     mockUseActiveStoreContext.mockReset()
@@ -142,6 +154,15 @@ describe('Sell page barcode scanner', () => {
       })
       return () => {}
     })
+
+    if (typeof URL.createObjectURL !== 'function') {
+      // @ts-expect-error - jsdom does not implement createObjectURL
+      URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    }
+    if (typeof URL.revokeObjectURL !== 'function') {
+      // @ts-expect-error - jsdom does not implement revokeObjectURL
+      URL.revokeObjectURL = vi.fn()
+    }
   })
 
   it('adds a matching product to the cart when a barcode is scanned', async () => {
@@ -266,5 +287,98 @@ describe('Sell page barcode scanner', () => {
       expect(within(rows[1]).getByText('Test Product')).toBeInTheDocument()
       expect(within(rows[1]).getByText(/GHS 7\.00/)).toBeInTheDocument()
     })
+  })
+
+  it('updates customer loyalty when recording a sale', async () => {
+    const user = userEvent.setup()
+
+    const customerDoc = {
+      id: 'customer-1',
+      data: () => ({
+        name: 'Loyal Customer',
+        loyalty: { points: 7, lastVisitAt: null },
+        storeId: 'store-1',
+      }),
+    }
+
+    onSnapshotMock.mockImplementation((queryRef, onNext) => {
+      queueMicrotask(() => {
+        if (queryRef.collection.path === 'products') {
+          onNext({ docs: [createProductDoc('product-1', { price: 10, stockCount: 5 })] })
+        } else if (queryRef.collection.path === 'customers') {
+          onNext({ docs: [customerDoc] })
+        } else {
+          onNext({ docs: [] })
+        }
+      })
+      return () => {}
+    })
+
+    const sets: Array<{ ref: { path: string }; data: Record<string, unknown> }> = []
+    const updates: Array<{ ref: { path: string }; data: Record<string, unknown> }> = []
+
+    runTransactionMock.mockImplementation(async (_db, updater: unknown) => {
+      if (typeof updater !== 'function') return
+      await (updater as (transaction: unknown) => Promise<void> | void)({
+        async get(ref: { path: string }) {
+          if (ref.path.startsWith('sales/')) {
+            return { exists: () => false }
+          }
+          if (ref.path === 'products/product-1') {
+            return {
+              exists: () => true,
+              get: (field: string) => (field === 'stockCount' ? 5 : undefined),
+              data: { stockCount: 5 },
+            }
+          }
+          if (ref.path === 'customers/customer-1') {
+            return {
+              exists: () => true,
+              data: () => ({ loyalty: { points: 7, lastVisitAt: null } }),
+            }
+          }
+          return { exists: () => false, data: () => ({}) }
+        },
+        set(ref: { path: string }, data: Record<string, unknown>) {
+          sets.push({ ref, data })
+        },
+        update(ref: { path: string }, data: Record<string, unknown>) {
+          updates.push({ ref, data })
+        },
+      })
+    })
+
+    render(
+      <MemoryRouter>
+        <Sell />
+      </MemoryRouter>,
+    )
+
+    const addButton = await screen.findByRole('button', { name: /Test Product/i })
+    await user.click(addButton)
+
+    const cashInput = await screen.findByLabelText(/Cash received/i)
+    await user.clear(cashInput)
+    await user.type(cashInput, '10')
+
+    const customerSelect = screen.getByLabelText('Customer')
+    await user.selectOptions(customerSelect, 'customer-1')
+
+    const recordButton = screen.getByRole('button', { name: /Record sale/i })
+    await user.click(recordButton)
+
+    await waitFor(() => {
+      expect(runTransactionMock).toHaveBeenCalled()
+      const customerUpdate = updates.find(entry => entry.ref.path === 'customers/customer-1')
+      expect(customerUpdate).toBeTruthy()
+    })
+
+    const customerUpdate = updates.find(entry => entry.ref.path === 'customers/customer-1')!
+    expect(customerUpdate.data).toMatchObject({
+      'loyalty.lastVisitAt': 'server-timestamp',
+      'loyalty.points': 7,
+      updatedAt: 'server-timestamp',
+    })
+    expect(sets.find(entry => entry.ref.path === 'customers/customer-1')).toBeFalsy()
   })
 })

--- a/web/src/utils/customerLoyalty.ts
+++ b/web/src/utils/customerLoyalty.ts
@@ -1,0 +1,51 @@
+import type { Timestamp } from 'firebase/firestore'
+
+export type CustomerLoyalty = {
+  points: number
+  lastVisitAt: Timestamp | null
+}
+
+export function createCustomerLoyalty(): CustomerLoyalty {
+  return { points: 0, lastVisitAt: null }
+}
+
+function isTimestamp(value: unknown): value is Timestamp {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as Timestamp).toDate === 'function' &&
+    typeof (value as Timestamp).toMillis === 'function'
+  )
+}
+
+export function normalizeCustomerLoyalty(value: unknown): CustomerLoyalty {
+  if (!value || typeof value !== 'object') {
+    return createCustomerLoyalty()
+  }
+
+  const source = value as { points?: unknown; lastVisitAt?: unknown }
+  const points =
+    typeof source.points === 'number' && Number.isFinite(source.points) ? source.points : 0
+  const lastVisitAt = isTimestamp(source.lastVisitAt) ? source.lastVisitAt : null
+
+  return { points, lastVisitAt }
+}
+
+export function ensureCustomerLoyalty<T extends { loyalty?: unknown }>(
+  customer: T,
+): Omit<T, 'loyalty'> & { loyalty: CustomerLoyalty } {
+  return {
+    ...(customer as Omit<T, 'loyalty'>),
+    loyalty: normalizeCustomerLoyalty(customer.loyalty),
+  }
+}
+
+export function loyaltyTimestampToDate(timestamp: Timestamp | null): Date | null {
+  if (!timestamp) return null
+  try {
+    return timestamp.toDate()
+  } catch (error) {
+    console.warn('[loyalty] Failed to convert loyalty timestamp', error)
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- add loyalty defaults when creating, editing, or importing customers and surface loyalty data in the CRM view
- normalize cached customer loyalty data across pages and update sales transactions to record last-visit timestamps
- introduce customer loyalty utilities and tests covering customer creation scaffolding and sale-driven loyalty updates

## Testing
- npx vitest run src/pages/__tests__/Customers.duplicates.test.tsx src/pages/__tests__/Sell.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db7da96c0c83218af9603c3c528959