### PR TITLE
Add callable telemetry logging and tests

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "serve": "firebase emulators:start --only functions,firestore",
     "deploy": "npm run build && firebase deploy --only functions",
-    "test": "npm run build && node ./test/resolveStoreAccess.test.js && node ./test/dailySummaries.test.js",
+    "test": "npm run build && node ./test/resolveStoreAccess.test.js && node ./test/dailySummaries.test.js && node ./test/callablesLogging.test.js",
     "backfill-store": "ts-node ./scripts/backfillStoreIds.ts"
   },
   "dependencies": {

--- a/functions/src/callables.ts
+++ b/functions/src/callables.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions'
 import { applyRoleClaims } from './customClaims'
 import { admin, defaultDb, rosterDb } from './firestore'
+import { deriveStoreIdFromContext, withCallableErrorLogging } from './telemetry'
 
 const db = defaultDb
 
@@ -53,48 +54,78 @@ function normalizeContact(contact: ContactPayload | undefined) {
   return { phone, hasPhone, firstSignupEmail, hasFirstSignupEmail }
 }
 
-export const backfillMyStore = functions.https.onCall(async (data, context) => {
-  if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Sign in first.')
+export const backfillMyStore = functions.https.onCall(
+  withCallableErrorLogging(
+    'backfillMyStore',
+    async (data, context) => {
+      if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Sign in first.')
 
-  const uid = context.auth.uid
-  const token = context.auth.token as Record<string, unknown>
-  const email = typeof token.email === 'string' ? (token.email as string) : null
-  const phone = typeof token.phone_number === 'string' ? (token.phone_number as string) : null
+      const uid = context.auth.uid
+      const token = context.auth.token as Record<string, unknown>
+      const email = typeof token.email === 'string' ? (token.email as string) : null
+      const phone = typeof token.phone_number === 'string' ? (token.phone_number as string) : null
 
-  const payload = (data ?? {}) as BackfillPayload
-  const contact = normalizeContact(payload.contact)
-  const resolvedPhone = contact.hasPhone ? contact.phone ?? null : phone ?? null
-  const resolvedFirstSignupEmail = contact.hasFirstSignupEmail
-    ? contact.firstSignupEmail ?? null
-    : email?.toLowerCase() ?? null
+      const payload = (data ?? {}) as BackfillPayload
+      const contact = normalizeContact(payload.contact)
+      const resolvedPhone = contact.hasPhone ? contact.phone ?? null : phone ?? null
+      const resolvedFirstSignupEmail = contact.hasFirstSignupEmail
+        ? contact.firstSignupEmail ?? null
+        : email?.toLowerCase() ?? null
 
-  const memberRef = rosterDb.collection('teamMembers').doc(uid)
-  const memberSnap = await memberRef.get()
-  const timestamp = admin.firestore.FieldValue.serverTimestamp()
-  const existingData = memberSnap.data() ?? {}
-  const existingStoreId =
-    typeof existingData.storeId === 'string' && existingData.storeId.trim() !== ''
-      ? (existingData.storeId as string)
-      : null
-  const storeId = existingStoreId ?? uid
+      const memberRef = rosterDb.collection('teamMembers').doc(uid)
+      const memberSnap = await memberRef.get()
+      const timestamp = admin.firestore.FieldValue.serverTimestamp()
+      const existingData = memberSnap.data() ?? {}
+      const existingStoreId =
+        typeof existingData.storeId === 'string' && existingData.storeId.trim() !== ''
+          ? (existingData.storeId as string)
+          : null
+      const storeId = existingStoreId ?? uid
 
-  const memberData: admin.firestore.DocumentData = {
-    uid,
-    email,
-    role: 'owner',
-    storeId,
-    phone: resolvedPhone,
-    firstSignupEmail: resolvedFirstSignupEmail,
-    invitedBy: uid,
-    updatedAt: timestamp,
-  }
+      const memberData: admin.firestore.DocumentData = {
+        uid,
+        email,
+        role: 'owner',
+        storeId,
+        phone: resolvedPhone,
+        firstSignupEmail: resolvedFirstSignupEmail,
+        invitedBy: uid,
+        updatedAt: timestamp,
+      }
 
-  if (!memberSnap.exists) {
-    memberData.createdAt = timestamp
-  }
+      if (!memberSnap.exists) {
+        memberData.createdAt = timestamp
+      }
 
-  await memberRef.set(memberData, { merge: true })
-  const claims = await applyRoleClaims({ uid, role: 'owner', storeId })
+      await memberRef.set(memberData, { merge: true })
+      const claims = await applyRoleClaims({ uid, role: 'owner', storeId })
 
-  return { ok: true, claims, storeId }
-})
+      return { ok: true, claims, storeId }
+    },
+    {
+      resolveStoreId: async (_data, context) => {
+        const uid = context.auth?.uid
+        if (uid) {
+          try {
+            const memberSnap = await rosterDb.collection('teamMembers').doc(uid).get()
+            const existingStoreId = memberSnap?.data()?.storeId
+            if (typeof existingStoreId === 'string') {
+              const trimmed = existingStoreId.trim()
+              if (trimmed) {
+                return trimmed
+              }
+            }
+          } catch (error) {
+            functions.logger.warn('[backfillMyStore] Failed to resolve storeId for telemetry', {
+              error,
+            })
+          }
+        }
+
+        const fromContext = deriveStoreIdFromContext(context)
+        if (fromContext) return fromContext
+        return uid ?? null
+      },
+    },
+  ),
+)

--- a/functions/src/telemetry.ts
+++ b/functions/src/telemetry.ts
@@ -1,0 +1,219 @@
+import * as functions from 'firebase-functions'
+import { admin, defaultDb } from './firestore'
+
+type CallableContext = functions.https.CallableContext
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'UTC',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+const MAX_SANITIZE_DEPTH = 4
+const MAX_ARRAY_SAMPLE = 5
+const MAX_OBJECT_KEYS = 25
+
+function formatDateKey(timestamp: admin.firestore.Timestamp): string {
+  return DATE_FORMATTER.format(timestamp.toDate())
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function sanitizePayload(value: unknown, depth = 0): unknown {
+  if (depth >= MAX_SANITIZE_DEPTH) {
+    return '[max-depth]'
+  }
+
+  if (value === null) return 'null'
+
+  const valueType = typeof value
+  if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') {
+    return valueType
+  }
+
+  if (valueType === 'bigint') return 'bigint'
+  if (valueType === 'undefined') return 'undefined'
+  if (valueType === 'symbol') return 'symbol'
+  if (valueType === 'function') return 'function'
+
+  if (Array.isArray(value)) {
+    if (depth + 1 >= MAX_SANITIZE_DEPTH) {
+      return { __type: 'array', length: value.length }
+    }
+
+    const samples = value.slice(0, MAX_ARRAY_SAMPLE).map(entry => sanitizePayload(entry, depth + 1))
+    if (value.length > MAX_ARRAY_SAMPLE) {
+      samples.push(`[+${value.length - MAX_ARRAY_SAMPLE} more]`)
+    }
+    return samples
+  }
+
+  if (value instanceof admin.firestore.Timestamp) {
+    return 'timestamp'
+  }
+
+  if (value instanceof Date) {
+    return 'date'
+  }
+
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value).slice(0, MAX_OBJECT_KEYS)
+    const result: Record<string, unknown> = {}
+    for (const [key, entry] of entries) {
+      result[key] = sanitizePayload(entry, depth + 1)
+    }
+    if (Object.keys(value).length > MAX_OBJECT_KEYS) {
+      result.__truncatedKeys = Object.keys(value).length - MAX_OBJECT_KEYS
+    }
+    return result
+  }
+
+  if (value && typeof value === 'object') {
+    const constructorName = value.constructor?.name ?? 'object'
+    return constructorName
+  }
+
+  return valueType
+}
+
+function sanitizeError(error: unknown): Record<string, unknown> {
+  if (!error || typeof error !== 'object') {
+    return { message: typeof error === 'string' ? error : String(error) }
+  }
+
+  const result: Record<string, unknown> = {}
+  const payload = error as Record<string, unknown>
+
+  const message = payload.message
+  if (typeof message === 'string' && message.trim()) {
+    result.message = message
+  }
+
+  const code = payload.code
+  if (typeof code === 'string' && code.trim()) {
+    result.code = code
+  }
+
+  const status = payload.status
+  if (typeof status === 'string' && status.trim()) {
+    result.status = status
+  }
+
+  if ('details' in payload && payload.details !== undefined) {
+    result.details = sanitizePayload(payload.details)
+  }
+
+  if (!('message' in result)) {
+    result.message = String(error)
+  }
+
+  return result
+}
+
+export function deriveStoreIdFromContext(context: CallableContext): string | null {
+  const token = (context.auth?.token ?? {}) as Record<string, unknown>
+  const candidateKeys = ['activeStoreId', 'storeId', 'store_id', 'store', 'sid']
+  for (const key of candidateKeys) {
+    const raw = token?.[key]
+    if (typeof raw === 'string') {
+      const trimmed = raw.trim()
+      if (trimmed) return trimmed
+    }
+  }
+  return null
+}
+
+type CallableErrorLogInput<T> = {
+  route: string
+  context: CallableContext
+  data: T
+  error: unknown
+  storeId?: string | null
+}
+
+export async function logCallableError<T>({
+  route,
+  context,
+  data,
+  error,
+  storeId,
+}: CallableErrorLogInput<T>): Promise<void> {
+  try {
+    const timestamp = admin.firestore.Timestamp.now()
+    const dateKey = formatDateKey(timestamp)
+    const logDocRef = defaultDb.collection('logs').doc(dateKey)
+    await logDocRef.set({ dateKey, createdAt: timestamp }, { merge: true })
+    const eventsCollection = logDocRef.collection('events')
+    const docRef = eventsCollection.doc()
+
+    const payload = {
+      route,
+      storeId: (storeId ?? deriveStoreIdFromContext(context)) ?? null,
+      authUid: context.auth?.uid ?? null,
+      payloadShape: sanitizePayload(data),
+      error: sanitizeError(error),
+      createdAt: timestamp,
+    }
+
+    await docRef.set(payload, { merge: false })
+  } catch (loggingError) {
+    const loggingErrorMessage =
+      loggingError instanceof Error ? loggingError.message : String(loggingError)
+    functions.logger.error('[telemetry] Failed to record callable error', {
+      route,
+      loggingError: loggingErrorMessage,
+    })
+  }
+}
+
+type ResolveStoreIdFn<T> = (
+  data: T,
+  context: CallableContext,
+  error: unknown,
+) => string | null | Promise<string | null>
+
+type CallableHandler<T, R> = (data: T, context: CallableContext) => R | Promise<R>
+
+type WithLoggingOptions<T> = {
+  resolveStoreId?: ResolveStoreIdFn<T>
+}
+
+async function safelyResolveStoreId<T>(
+  resolver: ResolveStoreIdFn<T> | undefined,
+  data: T,
+  context: CallableContext,
+  error: unknown,
+): Promise<string | null | undefined> {
+  if (!resolver) return undefined
+  try {
+    return await resolver(data, context, error)
+  } catch (resolveError) {
+    functions.logger.warn('[telemetry] Failed to resolve storeId for callable error', {
+      resolveError,
+    })
+    return undefined
+  }
+}
+
+export function withCallableErrorLogging<T, R>(
+  route: string,
+  handler: CallableHandler<T, R>,
+  options: WithLoggingOptions<T> = {},
+): CallableHandler<T, R> {
+  return (async (data, context) => {
+    try {
+      return await handler(data, context)
+    } catch (error) {
+      const resolvedStoreId = await safelyResolveStoreId(options.resolveStoreId, data, context, error)
+      await logCallableError({ route, context, data, error, storeId: resolvedStoreId ?? undefined })
+      throw error
+    }
+  })
+}
+
+export { sanitizePayload }

--- a/functions/test/callablesLogging.test.js
+++ b/functions/test/callablesLogging.test.js
@@ -1,0 +1,164 @@
+const assert = require('assert')
+const Module = require('module')
+const path = require('path')
+const { MockFirestore, MockTimestamp } = require('./helpers/mockFirestore')
+
+let currentDefaultDb
+const apps = []
+
+const originalLoad = Module._load
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'firebase-admin') {
+    const firestore = () => currentDefaultDb
+    firestore.FieldValue = {
+      serverTimestamp: () => MockTimestamp.now(),
+      increment: amount => ({ __mockIncrement: amount }),
+    }
+    firestore.Timestamp = MockTimestamp
+
+    return {
+      initializeApp: () => {
+        const app = { name: 'mock-app' }
+        apps[0] = app
+        return app
+      },
+      app: () => apps[0] || null,
+      apps,
+      firestore,
+      auth: () => ({
+        getUser: async () => ({ customClaims: undefined }),
+        getUserByEmail: async email => ({ uid: `uid-for-${email}` }),
+        updateUser: async () => {},
+        createUser: async () => ({ uid: 'new-user' }),
+        setCustomUserClaims: async () => {},
+      }),
+    }
+  }
+
+  if (request === 'firebase-admin/firestore') {
+    return {
+      getFirestore: () => currentDefaultDb,
+    }
+  }
+
+  if (request === './googleSheets' || request.endsWith(`${path.sep}googleSheets`)) {
+    return {
+      fetchClientRowByEmail: async () => null,
+      getDefaultSpreadsheetId: () => 'sheet-123',
+      normalizeHeader: value => (typeof value === 'string' ? value.trim().toLowerCase() : ''),
+    }
+  }
+
+  return originalLoad(request, parent, isMain)
+}
+
+function clearModuleCache(modulePath) {
+  try {
+    delete require.cache[require.resolve(modulePath)]
+  } catch (error) {
+    if (error && error.code !== 'MODULE_NOT_FOUND') {
+      throw error
+    }
+  }
+}
+
+function loadCallablesModule() {
+  apps.length = 0
+  clearModuleCache('../lib/firestore.js')
+  clearModuleCache('../lib/telemetry.js')
+  clearModuleCache('../lib/callables.js')
+  return require('../lib/callables.js')
+}
+
+function loadIndexModule() {
+  apps.length = 0
+  clearModuleCache('../lib/firestore.js')
+  clearModuleCache('../lib/telemetry.js')
+  clearModuleCache('../lib/index.js')
+  return require('../lib/index.js')
+}
+
+function extractLatestLog() {
+  const dateDocs = currentDefaultDb.listCollection('logs')
+  assert.strictEqual(dateDocs.length, 1, 'Expected one log date document')
+  const dateDoc = dateDocs[0]
+  const events = currentDefaultDb.listCollection(`logs/${dateDoc.id}/events`)
+  assert.strictEqual(events.length, 1, 'Expected one logged event')
+  return events[0].data
+}
+
+async function runBackfillLoggingTest() {
+  currentDefaultDb = new MockFirestore()
+  const { backfillMyStore } = loadCallablesModule()
+
+  const context = {
+    auth: {
+      uid: 'user-123',
+      token: { activeStoreId: 'store-xyz' },
+    },
+  }
+
+  let error
+  try {
+    await backfillMyStore.run({ contact: { phone: 123 } }, context)
+  } catch (err) {
+    error = err
+  }
+
+  assert.ok(error, 'Expected backfillMyStore to throw')
+  assert.strictEqual(error.code, 'invalid-argument')
+
+  const logEntry = extractLatestLog()
+  assert.strictEqual(logEntry.route, 'backfillMyStore')
+  assert.strictEqual(logEntry.storeId, 'store-xyz')
+  assert.strictEqual(logEntry.authUid, 'user-123')
+  assert.deepStrictEqual(logEntry.payloadShape, { contact: { phone: 'number' } })
+  assert.strictEqual(logEntry.error.code, 'invalid-argument')
+  assert.match(logEntry.error.message, /phone must be a string/i)
+}
+
+async function runManageStaffLoggingTest() {
+  currentDefaultDb = new MockFirestore()
+  const { manageStaffAccount } = loadIndexModule()
+
+  const context = {
+    auth: {
+      uid: 'owner-1',
+      token: { role: 'owner', activeStoreId: 'store-abc' },
+    },
+  }
+
+  let error
+  try {
+    await manageStaffAccount.run(
+      { storeId: 123, email: 'staff@example.com', role: 'manager' },
+      context,
+    )
+  } catch (err) {
+    error = err
+  }
+
+  assert.ok(error, 'Expected manageStaffAccount to throw')
+  assert.strictEqual(error.code, 'invalid-argument')
+
+  const logEntry = extractLatestLog()
+  assert.strictEqual(logEntry.route, 'manageStaffAccount')
+  assert.strictEqual(logEntry.storeId, 'store-abc')
+  assert.strictEqual(logEntry.authUid, 'owner-1')
+  assert.strictEqual(logEntry.payloadShape.storeId, 'number')
+  assert.strictEqual(logEntry.payloadShape.email, 'string')
+  assert.strictEqual(logEntry.payloadShape.role, 'string')
+  assert.strictEqual(logEntry.error.code, 'invalid-argument')
+  assert.match(logEntry.error.message, /storeid is required/i)
+}
+
+async function main() {
+  await runBackfillLoggingTest()
+  await runManageStaffLoggingTest()
+  console.log('callables logging tests passed')
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/functions/test/helpers/mockFirestore.js
+++ b/functions/test/helpers/mockFirestore.js
@@ -72,6 +72,10 @@ class MockTimestamp {
   toMillis() {
     return this._millis
   }
+
+  toDate() {
+    return new Date(this._millis)
+  }
 }
 
 class MockDocSnapshot {


### PR DESCRIPTION
## Summary
- add a reusable telemetry helper that records callable errors with sanitized payloads
- wrap callable endpoints so failures are logged before rethrowing
- add integration-style tests ensuring failing callables create log entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db7e26e0f08321ac1c43f68d0984c1