### PR TITLE
Enhance app error boundary handling

### DIFF
--- a/web/src/components/AppErrorBoundary.test.tsx
+++ b/web/src/components/AppErrorBoundary.test.tsx
@@ -42,6 +42,7 @@ describe('AppErrorBoundary', () => {
 
     expect(await screen.findByRole('heading', { name: /something went wrong/i })).toBeInTheDocument()
     expect(screen.getByText('App chrome')).toBeInTheDocument()
+    expect(screen.getByTestId('app-error-boundary-details')).toHaveTextContent('Kaboom!')
     expect(toast.publish).toHaveBeenCalledWith(
       expect.objectContaining({
         tone: 'error',

--- a/web/src/components/AppErrorBoundary.tsx
+++ b/web/src/components/AppErrorBoundary.tsx
@@ -7,6 +7,7 @@ type AppErrorBoundaryProps = {
 
 type AppErrorBoundaryState = {
   hasError: boolean
+  error?: Error
 }
 
 type InternalBoundaryProps = {
@@ -18,11 +19,13 @@ type InternalBoundaryProps = {
 class InternalErrorBoundary extends Component<InternalBoundaryProps, AppErrorBoundaryState> {
   state: AppErrorBoundaryState = {
     hasError: false,
+    error: undefined,
   }
 
-  static getDerivedStateFromError(_error: Error): AppErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
     return {
       hasError: true,
+      error,
     }
   }
 
@@ -31,16 +34,25 @@ class InternalErrorBoundary extends Component<InternalBoundaryProps, AppErrorBou
   }
 
   handleTryAgain = () => {
-    this.setState({ hasError: false })
+    this.setState({
+      hasError: false,
+      error: undefined,
+    })
     this.props.onReset?.()
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        <div role="alert" className="app-error-boundary">
+        <div role="alert" aria-live="polite" aria-atomic="true" className="app-error-boundary">
           <h1>Something went wrong</h1>
           <p>We hit a snag while loading this section. Please try again.</p>
+          {import.meta.env.DEV && this.state.error?.message ? (
+            <p className="app-error-boundary__details">
+              <strong>Details:</strong>{' '}
+              <span data-testid="app-error-boundary-details">{this.state.error.message}</span>
+            </p>
+          ) : null}
           <button type="button" onClick={this.handleTryAgain}>
             Try again
           </button>


### PR DESCRIPTION
## Summary
- capture the triggering error in AppErrorBoundary state to display dev-friendly details and reset cleanly
- add accessibility metadata to the fallback UI while keeping toast notifications for surfaced errors
- extend the AppErrorBoundary unit test to verify the fallback details render without disrupting the surrounding UI

## Testing
- npm test *(fails: requires Firebase emulators which are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db82b1aa30832187c5828a8c59fb05