### PR TITLE
Adjust Firestore indexes for product updatedAt query

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -22,8 +22,7 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "storeId", "order": "ASCENDING" },
-        { "fieldPath": "updatedAt", "order": "DESCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- update the products composite index to cover storeId and updatedAt for the desired query pattern

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db814ae22c83218da74acbb4755164