### PR TITLE
Add staff-level helper for store resource creation

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -100,8 +100,7 @@ service cloud.firestore {
       return resourceStoreId != null && resourceStoreId == requestStoreId;
     }
 
-    function canCreateStoreResource() {
-
+    function canStaffCreateStoreResource() {
       let storeId = storeIdFromData(request.resource.data);
       return requestMaintainsStoreIdConsistency()
         && storeId != null


### PR DESCRIPTION
## Summary
- add a canStaffCreateStoreResource helper that uses the existing store access checks
- keep /sales and /saleItems create permissions referencing the shared staff helper

## Testing
- not run (environment does not allow installing firebase-tools to deploy rules)


------
https://chatgpt.com/codex/tasks/task_e_68db854c7dcc8321b8d0a63f8ec1f591