### PR TITLE
Add Firestore rules for closeouts collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -201,6 +201,11 @@ service cloud.firestore {
       allow create, update, delete: if isServiceAccountRequest();
     }
 
+    match /closeouts/{closeoutId} {
+      allow read: if canReadStoreResource() || isServiceAccountRequest();
+      allow create, update, delete: if isServiceAccountRequest();
+    }
+
     match /products/{productId} {
       allow read: if canReadStoreResource();
       allow create: if canOwnerCreateStoreResource();


### PR DESCRIPTION
## Summary
- allow read access to closeout documents using existing store-based access rules
- restrict closeout writes to service account requests, matching daily summary and activity rules

## Testing
- firebase deploy --only firestore:rules *(fails: firebase CLI not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db86d71ed083219dd6e1f081a09b7e