### PR TITLE
Add staff access revocation flow

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "serve": "firebase emulators:start --only functions,firestore",
     "deploy": "npm run build && firebase deploy --only functions",
-    "test": "npm run build && node ./test/resolveStoreAccess.test.js && node ./test/dailySummaries.test.js && node ./test/callablesLogging.test.js && node ./test/updateStoreProfile.test.js",
+    "test": "npm run build && node ./test/resolveStoreAccess.test.js && node ./test/dailySummaries.test.js && node ./test/callablesLogging.test.js && node ./test/updateStoreProfile.test.js && node ./test/revokeStaffAccess.test.js",
     "backfill-store": "ts-node ./scripts/backfillStoreIds.ts"
   },
   "dependencies": {

--- a/functions/test/helpers/mockFirestore.js
+++ b/functions/test/helpers/mockFirestore.js
@@ -134,6 +134,10 @@ class MockDocumentReference {
     }
     this._db.setRaw(this.path, applyMerge(existing, data))
   }
+
+  async delete() {
+    this._db.deleteRaw(this.path)
+  }
 }
 
 class MockCollectionReference {
@@ -216,6 +220,10 @@ class MockFirestore {
 
   setRaw(path, data) {
     this._store.set(path, clone(data))
+  }
+
+  deleteRaw(path) {
+    this._store.delete(path)
   }
 
   getDoc(path) {

--- a/functions/test/revokeStaffAccess.test.js
+++ b/functions/test/revokeStaffAccess.test.js
@@ -1,0 +1,134 @@
+const assert = require('assert')
+const Module = require('module')
+const { MockFirestore, MockTimestamp } = require('./helpers/mockFirestore')
+
+let currentDefaultDb
+const apps = []
+let claimsUpdates
+
+const originalLoad = Module._load
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'firebase-admin') {
+    const firestore = () => currentDefaultDb
+    firestore.FieldValue = {
+      serverTimestamp: () => MockTimestamp.now(),
+      increment: amount => ({ __mockIncrement: amount }),
+    }
+    firestore.Timestamp = MockTimestamp
+
+    return {
+      initializeApp: () => {
+        const app = { name: 'mock-app' }
+        apps[0] = app
+        return app
+      },
+      app: () => apps[0] || null,
+      apps,
+      firestore,
+      auth: () => ({
+        getUser: async () => ({ customClaims: undefined }),
+        getUserByEmail: async email => ({ uid: `uid-for-${email}` }),
+        updateUser: async () => {},
+        createUser: async () => ({ uid: 'new-user' }),
+        setCustomUserClaims: async (uid, claims) => {
+          claimsUpdates.push({ uid, claims })
+        },
+      }),
+    }
+  }
+
+  if (request === 'firebase-admin/firestore') {
+    return {
+      getFirestore: () => currentDefaultDb,
+    }
+  }
+
+  return originalLoad(request, parent, isMain)
+}
+
+function clearModuleCache(modulePath) {
+  try {
+    delete require.cache[require.resolve(modulePath)]
+  } catch (error) {
+    if (!error || error.code !== 'MODULE_NOT_FOUND') {
+      throw error
+    }
+  }
+}
+
+function loadFunctionsModule() {
+  apps.length = 0
+  claimsUpdates = []
+  clearModuleCache('../lib/firestore.js')
+  clearModuleCache('../lib/telemetry.js')
+  clearModuleCache('../lib/index.js')
+  return require('../lib/index.js')
+}
+
+async function runRevocationSuccessTest() {
+  currentDefaultDb = new MockFirestore({
+    'teamMembers/member-2': {
+      uid: 'member-2',
+      email: 'staff@example.com',
+      storeId: 'store-123',
+      role: 'staff',
+      invitedBy: 'owner-1',
+    },
+  })
+
+  const { revokeStaffAccess } = loadFunctionsModule()
+  const context = {
+    auth: {
+      uid: 'owner-1',
+      token: { role: 'owner', activeStoreId: 'store-123' },
+    },
+  }
+
+  const result = await revokeStaffAccess.run({ storeId: 'store-123', uid: 'member-2' }, context)
+
+  assert.deepStrictEqual(result, { ok: true, storeId: 'store-123', uid: 'member-2' })
+  assert.strictEqual(currentDefaultDb.getDoc('teamMembers/member-2'), undefined)
+  assert.deepStrictEqual(claimsUpdates, [{ uid: 'member-2', claims: {} }])
+}
+
+async function runOwnerProtectionTest() {
+  currentDefaultDb = new MockFirestore({
+    'teamMembers/owner-1': {
+      uid: 'owner-1',
+      email: 'owner@example.com',
+      storeId: 'store-123',
+      role: 'owner',
+      invitedBy: 'owner-1',
+    },
+  })
+
+  const { revokeStaffAccess } = loadFunctionsModule()
+  const context = {
+    auth: {
+      uid: 'owner-1',
+      token: { role: 'owner', activeStoreId: 'store-123' },
+    },
+  }
+
+  let error
+  try {
+    await revokeStaffAccess.run({ storeId: 'store-123', uid: 'owner-1' }, context)
+  } catch (err) {
+    error = err
+  }
+
+  assert.ok(error, 'Expected revoking owner access to throw')
+  assert.strictEqual(error.code, 'failed-precondition')
+  assert.ok(currentDefaultDb.getDoc('teamMembers/owner-1'), 'Owner document should remain')
+}
+
+async function main() {
+  await runRevocationSuccessTest()
+  await runOwnerProtectionTest()
+  console.log('revokeStaffAccess tests passed')
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/web/src/controllers/storeController.ts
+++ b/web/src/controllers/storeController.ts
@@ -30,6 +30,17 @@ type UpdateStoreProfileResult = {
   storeId: string
 }
 
+type RevokeStaffAccessPayload = {
+  storeId: string
+  uid: string
+}
+
+type RevokeStaffAccessResult = {
+  ok: boolean
+  storeId: string
+  uid: string
+}
+
 export async function manageStaffAccount(payload: ManageStaffAccountPayload) {
   const callable = httpsCallable<ManageStaffAccountPayload, ManageStaffAccountResult>(
     functions,
@@ -43,6 +54,15 @@ export async function updateStoreProfile(payload: UpdateStoreProfilePayload) {
   const callable = httpsCallable<UpdateStoreProfilePayload, UpdateStoreProfileResult>(
     functions,
     'updateStoreProfile',
+  )
+  const response = await callable(payload)
+  return response.data
+}
+
+export async function revokeStaffAccess(payload: RevokeStaffAccessPayload) {
+  const callable = httpsCallable<RevokeStaffAccessPayload, RevokeStaffAccessResult>(
+    functions,
+    'revokeStaffAccess',
   )
   const response = await callable(payload)
   return response.data


### PR DESCRIPTION
## Summary
- add a revoke action for non-owner team members in the account overview with confirmation and toast feedback
- expose a `revokeStaffAccess` controller and callable that validates ownership, removes roster entries, and clears custom claims
- extend the test suite with UI coverage, callable tests, and mock Firestore support for document deletion

## Testing
- npm test -- src/pages/__tests__/AccountOverview.test.tsx
- (functions) npm test

------
https://chatgpt.com/codex/tasks/task_e_68db90e3408c8321bd4e29cc87611863