### PR TITLE
Share daily summary date helper

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -6,7 +6,7 @@
     "node": "20"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node ./scripts/postbuild.js",
     "serve": "firebase emulators:start --only functions,firestore",
     "deploy": "npm run build && firebase deploy --only functions",
     "test": "npm run build && node ./test/resolveStoreAccess.test.js && node ./test/dailySummaries.test.js && node ./test/callablesLogging.test.js && node ./test/updateStoreProfile.test.js",

--- a/functions/scripts/postbuild.js
+++ b/functions/scripts/postbuild.js
@@ -1,0 +1,29 @@
+const fs = require('fs')
+const path = require('path')
+
+const libDir = path.join(__dirname, '..', 'lib')
+const compiledFunctionsDir = path.join(libDir, 'functions', 'src')
+
+function copyRecursive(source, destination) {
+  if (!fs.existsSync(source)) {
+    return
+  }
+  fs.mkdirSync(destination, { recursive: true })
+  const entries = fs.readdirSync(source, { withFileTypes: true })
+  for (const entry of entries) {
+    const sourcePath = path.join(source, entry.name)
+    const destPath = path.join(destination, entry.name)
+    if (entry.isDirectory()) {
+      copyRecursive(sourcePath, destPath)
+    } else {
+      fs.copyFileSync(sourcePath, destPath)
+    }
+  }
+}
+
+copyRecursive(compiledFunctionsDir, libDir)
+
+const compiledFunctionsRoot = path.join(libDir, 'functions')
+if (fs.existsSync(compiledFunctionsRoot)) {
+  fs.rmSync(compiledFunctionsRoot, { recursive: true, force: true })
+}

--- a/functions/src/telemetry.ts
+++ b/functions/src/telemetry.ts
@@ -1,22 +1,12 @@
 import * as functions from 'firebase-functions'
 import { admin, defaultDb } from './firestore'
+import { formatDailySummaryKey } from '../../shared/dateKeys'
 
 type CallableContext = functions.https.CallableContext
-
-const DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', {
-  timeZone: 'UTC',
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-})
 
 const MAX_SANITIZE_DEPTH = 4
 const MAX_ARRAY_SAMPLE = 5
 const MAX_OBJECT_KEYS = 25
-
-function formatDateKey(timestamp: admin.firestore.Timestamp): string {
-  return DATE_FORMATTER.format(timestamp.toDate())
-}
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false
@@ -145,7 +135,7 @@ export async function logCallableError<T>({
 }: CallableErrorLogInput<T>): Promise<void> {
   try {
     const timestamp = admin.firestore.Timestamp.now()
-    const dateKey = formatDateKey(timestamp)
+    const dateKey = formatDailySummaryKey(timestamp.toDate(), { timeZone: 'UTC' })
     const logDocRef = defaultDb.collection('logs').doc(dateKey)
     await logDocRef.set({ dateKey, createdAt: timestamp }, { merge: true })
     const eventsCollection = logDocRef.collection('events')

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -12,6 +12,7 @@
   },
   "compileOnSave": true,
   "include": [
-    "src"
+    "src",
+    "../shared/**/*.ts"
   ]
 }

--- a/shared/dateKeys.ts
+++ b/shared/dateKeys.ts
@@ -1,0 +1,66 @@
+const DATE_KEY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>()
+
+function getFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cacheKey = timeZone || 'UTC'
+  let formatter = formatterCache.get(cacheKey)
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-CA', {
+      timeZone: cacheKey,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    formatterCache.set(cacheKey, formatter)
+  }
+  return formatter
+}
+
+export type FormatDateKeyOptions = {
+  timeZone?: string
+  onInvalidTimeZone?: (timeZone: string, error: unknown) => void
+}
+
+export function formatDailySummaryKey(date: Date, options: FormatDateKeyOptions = {}): string {
+  const { timeZone = 'UTC', onInvalidTimeZone } = options
+
+  try {
+    return getFormatter(timeZone).format(date)
+  } catch (error) {
+    if (timeZone !== 'UTC') {
+      formatterCache.delete(timeZone)
+      onInvalidTimeZone?.(timeZone, error)
+      return getFormatter('UTC').format(date)
+    }
+    throw error
+  }
+}
+
+export function parseDailySummaryKey(value: string): Date | null {
+  if (typeof value !== 'string') return null
+  const match = value.match(DATE_KEY_REGEX)
+  if (!match) return null
+  const [, yearStr, monthStr, dayStr] = match
+  const year = Number(yearStr)
+  const monthIndex = Number(monthStr) - 1
+  const day = Number(dayStr)
+  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || !Number.isInteger(day)) {
+    return null
+  }
+  const date = new Date(Date.UTC(year, monthIndex, day))
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== monthIndex ||
+    date.getUTCDate() !== day
+  ) {
+    return null
+  }
+  return date
+}
+
+export function normalizeDailySummaryKey(value: string): string | null {
+  const parsed = parseDailySummaryKey(value)
+  if (!parsed) return null
+  return formatDailySummaryKey(parsed, { timeZone: 'UTC' })
+}

--- a/web/src/hooks/useStoreMetrics.ts
+++ b/web/src/hooks/useStoreMetrics.ts
@@ -16,6 +16,7 @@ import {
   type Timestamp,
 } from 'firebase/firestore'
 
+import { formatDailySummaryKey } from '../../../shared/dateKeys'
 import { db } from '../firebase'
 import { ensureCustomerLoyalty, type CustomerLoyalty } from '../utils/customerLoyalty'
 import { useAuthUser } from './useAuthUser'
@@ -241,10 +242,6 @@ function enumerateDaysBetween(start: Date, end: Date) {
   return days
 }
 
-function formatDateKey(date: Date) {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
-}
-
 function getSaleSortValue(sale: SaleRecord) {
   return asDate(sale.createdAt)?.getTime() ?? 0
 }
@@ -301,7 +298,7 @@ function buildDailyMetricSeries(
   sales.forEach(sale => {
     const created = asDate(sale.createdAt)
     if (!created) return
-    const key = formatDateKey(created)
+    const key = formatDailySummaryKey(created)
     const bucket = buckets.get(key) ?? { revenue: 0, count: 0 }
     bucket.revenue += sale.total ?? 0
     bucket.count += 1
@@ -309,7 +306,7 @@ function buildDailyMetricSeries(
   })
 
   return enumerateDaysBetween(start, end).map(day => {
-    const bucket = buckets.get(formatDateKey(day))
+    const bucket = buckets.get(formatDailySummaryKey(day))
     if (!bucket) {
       return 0
     }

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -15,15 +15,10 @@ import {
   type QueryDocumentSnapshot,
 } from 'firebase/firestore'
 
+import { Link } from 'react-router-dom'
+import { formatDailySummaryKey } from '../../../shared/dateKeys'
 import { db } from '../firebase'
 import { useActiveStoreContext } from '../context/ActiveStoreProvider'
-
-export function formatDateKey(date: Date) {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}${month}${day}`
-}
 
 type TopProduct = {
   id: string
@@ -277,11 +272,11 @@ export default function Today() {
   )
 
   const today = useMemo(() => new Date(), [])
-  const todayKey = useMemo(() => formatDateKey(today), [today])
+  const todayKey = useMemo(() => formatDailySummaryKey(today), [today])
   const previousDayKey = useMemo(() => {
     const previous = new Date(today)
     previous.setDate(previous.getDate() - 1)
-    return formatDateKey(previous)
+    return formatDailySummaryKey(previous)
   }, [today])
   const todayLabel = useMemo(
     () =>

--- a/web/src/pages/__tests__/Today.test.tsx
+++ b/web/src/pages/__tests__/Today.test.tsx
@@ -4,7 +4,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 
-import Today, { formatDateKey } from '../Today'
+import Today from '../Today'
+import { formatDailySummaryKey } from '../../../../shared/dateKeys'
 
 const mockUseActiveStoreContext = vi.fn(() => ({
   storeId: 'store-123',
@@ -222,10 +223,10 @@ describe('Today page', () => {
       </MemoryRouter>,
     )
 
-    const expectedKey = formatDateKey(new Date())
+    const expectedKey = formatDailySummaryKey(new Date())
     const previousDate = new Date()
     previousDate.setDate(previousDate.getDate() - 1)
-    const expectedPreviousKey = formatDateKey(previousDate)
+    const expectedPreviousKey = formatDailySummaryKey(previousDate)
 
     await waitFor(() => {
       expect(screen.getByText('GHS 480.50')).toBeInTheDocument()

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -21,6 +21,7 @@
   },
   "include": [
     "src",
-    "tests"
+    "tests",
+    "../shared"
   ]
 }


### PR DESCRIPTION
## Summary
- add a shared `shared/dateKeys` helper for formatting and parsing daily summary document keys and reuse it across Cloud Functions and the web app
- update the Today page, store metrics hook, and related tests to consume the shared helper so IDs match backend expectations
- adjust TypeScript configs and the functions build script to include the shared module output

## Testing
- npm --prefix functions run build
- npm --prefix web run test -- Today

------
https://chatgpt.com/codex/tasks/task_e_68db92dfc7988321922c36c7d949d6a3