### PR TITLE
Add selector helpers and tests for key pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ This repo is a drop-in starter for **Sedifex** (inventory & POS). It ships as a 
 - Enable **Firestore** and publish `firestore.rules`.
 - Create a second project for production later (e.g., `sedifex-prod`).
 
+## Testing
+- Run unit and integration tests from the `web/` directory with `npm run test`.
+- Firestore emulator rules tests are skipped by default. To execute them, start the local Firebase emulators and run tests with
+  `RUN_FIRESTORE_EMULATOR_TESTS=1 npm run test` so the suite can connect to the emulator endpoints.
+
 ### Workspace access spreadsheet
 - The onboarding Google Sheet should include workspace metadata columns such as `contractStart`, `contractEnd`, `paymentStatus`, `amountPaid`, and `company` for each store row.
 - Date columns can be provided as ISO-like strings (e.g., `2024-01-15`) or spreadsheet serial numbers; payment amounts can include currency symbols and will be normalized automatically.

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,5 +1,12 @@
 import '@testing-library/jest-dom/vitest'
 
+vi.stubEnv('VITE_FB_API_KEY', 'test-api-key')
+vi.stubEnv('VITE_FB_AUTH_DOMAIN', 'sedifex.test.local')
+vi.stubEnv('VITE_FB_PROJECT_ID', 'sedifex-test')
+vi.stubEnv('VITE_FB_STORAGE_BUCKET', 'sedifex-test.appspot.com')
+vi.stubEnv('VITE_FB_APP_ID', '1:1234567890:web:test')
+vi.stubEnv('VITE_FB_FUNCTIONS_REGION', 'us-central1')
+
 beforeEach(() => {
   // Ensure print is stubbed so tests can observe invocations without touching the real browser API.
   Object.defineProperty(window, 'print', {

--- a/web/tests/selectors/receive.selectors.test.tsx
+++ b/web/tests/selectors/receive.selectors.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createReceiveSelectors } from './receive'
+
+const mockUseActiveStoreContext = vi.fn(() => ({
+  storeId: 'store-1',
+  storeChangeToken: 0,
+}))
+
+const mockPublish = vi.fn()
+
+const mockLoadCachedProducts = vi.fn(async () => [
+  { id: 'prod-1', name: 'Widget', stockCount: 10 },
+])
+const mockSaveCachedProducts = vi.fn(async () => {})
+
+const queueCallableRequestMock = vi.fn(async () => true)
+const receiveStockMock = vi.fn(async () => undefined)
+const httpsCallableMock = vi.fn(() => receiveStockMock)
+const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
+const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[]) => ({
+  collection: collectionRef,
+  clauses,
+}))
+const orderByMock = vi.fn((field: string, direction?: string) => ({ field, direction }))
+const limitMock = vi.fn((value: number) => ({ value }))
+const whereMock = vi.fn((field: string, op: string, value: unknown) => ({ field, op, value }))
+const onSnapshotMock = vi.fn(
+  (
+    queryRef: { collection: { path: string } },
+    onNext: (snapshot: { docs: Array<{ id: string; data: () => Record<string, unknown> }> }) => void,
+  ) => {
+    queueMicrotask(() => {
+      onNext({
+        docs: [
+          {
+            id: 'prod-1',
+            data: () => ({ id: 'prod-1', name: 'Widget', stockCount: 10 }),
+          },
+        ],
+      })
+    })
+    return () => {}
+  },
+)
+
+let Receive: typeof import('../../src/pages/Receive').default
+
+describe('Receive page selectors', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+
+    mockUseActiveStoreContext.mockClear()
+    mockUseActiveStoreContext.mockReturnValue({ storeId: 'store-1', storeChangeToken: 0 })
+    mockPublish.mockClear()
+    mockLoadCachedProducts.mockClear()
+    mockLoadCachedProducts.mockResolvedValue([{ id: 'prod-1', name: 'Widget', stockCount: 10 }])
+    mockSaveCachedProducts.mockClear()
+    queueCallableRequestMock.mockClear()
+    receiveStockMock.mockClear()
+    httpsCallableMock.mockClear()
+    httpsCallableMock.mockReturnValue(receiveStockMock)
+    collectionMock.mockClear()
+    queryMock.mockClear()
+    orderByMock.mockClear()
+    limitMock.mockClear()
+    whereMock.mockClear()
+    onSnapshotMock.mockClear()
+
+    vi.doMock('../../src/context/ActiveStoreProvider', () => ({
+      useActiveStoreContext: () => mockUseActiveStoreContext(),
+    }))
+
+    vi.doMock('../../src/components/ToastProvider', () => ({
+      useToast: () => ({ publish: mockPublish }),
+    }))
+
+    vi.doMock('../../src/firebase', () => ({
+      db: {},
+      functions: {},
+    }))
+
+    vi.doMock('../../src/utils/offlineCache', () => ({
+      PRODUCT_CACHE_LIMIT: 200,
+      loadCachedProducts: (...args: Parameters<typeof mockLoadCachedProducts>) =>
+        mockLoadCachedProducts(...args),
+      saveCachedProducts: (...args: Parameters<typeof mockSaveCachedProducts>) =>
+        mockSaveCachedProducts(...args),
+    }))
+
+    vi.doMock('../../src/utils/offlineQueue', () => ({
+      queueCallableRequest: (...args: Parameters<typeof queueCallableRequestMock>) =>
+        queueCallableRequestMock(...args),
+    }))
+
+    vi.doMock('firebase/functions', () => ({
+      httpsCallable: (...args: Parameters<typeof httpsCallableMock>) => httpsCallableMock(...args),
+    }))
+
+    vi.doMock('firebase/firestore', () => ({
+      collection: (...args: Parameters<typeof collectionMock>) => collectionMock(...args),
+      query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
+      orderBy: (...args: Parameters<typeof orderByMock>) => orderByMock(...args),
+      limit: (...args: Parameters<typeof limitMock>) => limitMock(...args),
+      where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
+      onSnapshot: (...args: Parameters<typeof onSnapshotMock>) => onSnapshotMock(...args),
+    }))
+
+    ;({ default: Receive } = await import('../../src/pages/Receive'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('provides handles for the receive form fields', async () => {
+    render(
+      <MemoryRouter>
+        <Receive />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => expect(onSnapshotMock).toHaveBeenCalled())
+    await screen.findByRole('option', { name: 'Widget (Stock 10)' })
+
+    const selectors = createReceiveSelectors()
+
+    expect(selectors.heading()).toHaveTextContent('Receive stock')
+    expect(selectors.productSelect()).toHaveValue('')
+    expect(selectors.quantityInput()).toHaveAttribute('type', 'number')
+    expect(selectors.supplierInput()).toHaveAttribute('placeholder', 'Acme Distribution')
+    expect(selectors.referenceInput()).toHaveAttribute('placeholder', 'PO-12345 or packing slip')
+    expect(selectors.unitCostInput()).toHaveAttribute('step', '0.01')
+
+    const options = within(selectors.productSelect()).getAllByRole('option')
+    expect(options).toHaveLength(2)
+
+    expect(selectors.addStockButton()).toBeDisabled()
+    expect(selectors.statusMessage()).toBeNull()
+  })
+})

--- a/web/tests/selectors/receive.ts
+++ b/web/tests/selectors/receive.ts
@@ -1,0 +1,31 @@
+import { within } from '@testing-library/react'
+
+function resolveReceivePageRoot(root: HTMLElement) {
+  const { getByRole } = within(root)
+  const heading = getByRole('heading', { level: 2, name: /receive stock/i })
+  const pageRoot = heading.closest('.page')
+  if (!pageRoot) {
+    throw new Error('Unable to locate receive page root')
+  }
+  return { heading, pageRoot: pageRoot as HTMLElement }
+}
+
+export function createReceiveSelectors(root: HTMLElement = document.body) {
+  const { heading, pageRoot } = resolveReceivePageRoot(root)
+  const queries = within(pageRoot)
+
+  return {
+    heading: () => heading,
+    productSelect: () => queries.getByLabelText('Product') as HTMLSelectElement,
+    quantityInput: () => queries.getByLabelText('Quantity received') as HTMLInputElement,
+    supplierInput: () => queries.getByLabelText('Supplier') as HTMLInputElement,
+    referenceInput: () => queries.getByLabelText('Reference number') as HTMLInputElement,
+    unitCostInput: () => queries.getByLabelText('Unit cost (optional)') as HTMLInputElement,
+    addStockButton: () => queries.getByRole('button', { name: /add stock/i }),
+    statusMessage: () => queries.queryByRole('status') ?? queries.queryByRole('alert'),
+  }
+}
+
+export const receiveSelectors = createReceiveSelectors
+
+export type ReceiveSelectors = ReturnType<typeof createReceiveSelectors>

--- a/web/tests/selectors/sell.selectors.test.tsx
+++ b/web/tests/selectors/sell.selectors.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createSellSelectors } from './sell'
+
+const mockUseAuthUser = vi.fn(() => ({ uid: 'user-1', email: 'cashier@example.com' }))
+const mockUseActiveStoreContext = vi.fn(() => ({
+  storeId: 'store-1',
+  isLoading: false,
+  error: null,
+  memberships: [],
+  membershipsLoading: false,
+  setActiveStoreId: vi.fn(),
+  storeChangeToken: 0,
+}))
+
+const mockLoadCachedProducts = vi.fn(async () => [
+  { id: 'product-1', name: 'Iced Coffee', price: 12, stockCount: 5 },
+])
+const mockSaveCachedProducts = vi.fn(async () => {})
+const mockLoadCachedCustomers = vi.fn(async () => [])
+const mockSaveCachedCustomers = vi.fn(async () => {})
+const collectionMock = vi.fn((_db: unknown, path: string) => ({ type: 'collection', path }))
+const whereMock = vi.fn((field: string, op: string, value: unknown) => ({ field, op, value }))
+const orderByMock = vi.fn((field: string, direction?: string) => ({ field, direction }))
+const limitMock = vi.fn((value: number) => ({ value }))
+const queryMock = vi.fn((collectionRef: { path: string }, ...clauses: unknown[]) => ({
+  collection: collectionRef,
+  clauses,
+}))
+const onSnapshotMock = vi.fn(
+  (
+    queryRef: { collection: { path: string } },
+    onNext: (snapshot: { docs: Array<{ id: string; data: () => Record<string, unknown> }> }) => void,
+  ) => {
+    queueMicrotask(() => {
+      if (queryRef.collection.path === 'products') {
+        onNext({
+          docs: [
+            {
+              id: 'product-1',
+              data: () => ({ id: 'product-1', name: 'Iced Coffee', price: 12, stockCount: 5 }),
+            },
+          ],
+        })
+      } else if (queryRef.collection.path === 'customers') {
+        onNext({ docs: [] })
+      }
+    })
+    return () => {}
+  },
+)
+const docMock = vi.fn(() => ({ type: 'doc' }))
+const runTransactionMock = vi.fn(async () => undefined)
+const serverTimestampMock = vi.fn(() => 'server-timestamp')
+
+let Sell: typeof import('../../src/pages/Sell').default
+
+describe('Sell page selectors', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+
+    mockUseAuthUser.mockClear()
+    mockUseActiveStoreContext.mockClear()
+    mockLoadCachedProducts.mockClear()
+    mockSaveCachedProducts.mockClear()
+    mockLoadCachedCustomers.mockClear()
+    mockSaveCachedCustomers.mockClear()
+    collectionMock.mockClear()
+    queryMock.mockClear()
+    whereMock.mockClear()
+    orderByMock.mockClear()
+    limitMock.mockClear()
+    onSnapshotMock.mockClear()
+    docMock.mockClear()
+    runTransactionMock.mockClear()
+    serverTimestampMock.mockClear()
+
+    mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'cashier@example.com' })
+    mockUseActiveStoreContext.mockReturnValue({
+      storeId: 'store-1',
+      isLoading: false,
+      error: null,
+      memberships: [],
+      membershipsLoading: false,
+      setActiveStoreId: vi.fn(),
+      storeChangeToken: 0,
+    })
+
+    mockLoadCachedProducts.mockResolvedValue([
+      { id: 'product-1', name: 'Iced Coffee', price: 12, stockCount: 5 },
+    ])
+    mockLoadCachedCustomers.mockResolvedValue([])
+
+    if (typeof URL.createObjectURL !== 'function') {
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: vi.fn(() => 'blob:mock-url'),
+      })
+    }
+    if (typeof URL.revokeObjectURL !== 'function') {
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: vi.fn(),
+      })
+    }
+
+    vi.doMock('../../src/hooks/useAuthUser', () => ({
+      useAuthUser: () => mockUseAuthUser(),
+    }))
+
+    vi.doMock('../../src/context/ActiveStoreProvider', () => ({
+      useActiveStoreContext: () => mockUseActiveStoreContext(),
+    }))
+
+    vi.doMock('../../src/utils/offlineCache', () => ({
+      PRODUCT_CACHE_LIMIT: 200,
+      CUSTOMER_CACHE_LIMIT: 200,
+      loadCachedProducts: (...args: Parameters<typeof mockLoadCachedProducts>) =>
+        mockLoadCachedProducts(...args),
+      saveCachedProducts: (...args: Parameters<typeof mockSaveCachedProducts>) =>
+        mockSaveCachedProducts(...args),
+      loadCachedCustomers: (...args: Parameters<typeof mockLoadCachedCustomers>) =>
+        mockLoadCachedCustomers(...args),
+      saveCachedCustomers: (...args: Parameters<typeof mockSaveCachedCustomers>) =>
+        mockSaveCachedCustomers(...args),
+    }))
+
+    vi.doMock('../../src/utils/pdf', () => ({
+      buildSimplePdf: vi.fn(() => new Uint8Array([0, 1, 2, 3])),
+    }))
+
+    vi.doMock('../../src/firebase', () => ({
+      db: {},
+    }))
+
+    vi.doMock('firebase/firestore', () => ({
+      collection: (...args: Parameters<typeof collectionMock>) => collectionMock(...args),
+      query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
+      where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
+      orderBy: (...args: Parameters<typeof orderByMock>) => orderByMock(...args),
+      limit: (...args: Parameters<typeof limitMock>) => limitMock(...args),
+      onSnapshot: (...args: Parameters<typeof onSnapshotMock>) => onSnapshotMock(...args),
+      doc: (...args: Parameters<typeof docMock>) => docMock(...args),
+      runTransaction: (...args: Parameters<typeof runTransactionMock>) => runTransactionMock(...args),
+      serverTimestamp: () => serverTimestampMock(),
+    }))
+
+    ;({ default: Sell } = await import('../../src/pages/Sell'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('locates core sell page controls', async () => {
+    render(
+      <MemoryRouter>
+        <Sell />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => expect(onSnapshotMock).toHaveBeenCalled())
+    const catalogRegion = await screen.findByRole('region', { name: 'Product list' })
+    const addButton = within(catalogRegion).getByRole('button', { name: /Iced Coffee/ })
+    const user = userEvent.setup()
+    await user.click(addButton)
+    await screen.findByLabelText('Payment method')
+
+    const selectors = createSellSelectors()
+
+    expect(selectors.heading()).toHaveTextContent('Sell')
+    expect(selectors.searchField()).toHaveAttribute('placeholder', 'Search by name')
+
+    const catalog = selectors.productCatalogSection()
+    expect(catalog).toBeInTheDocument()
+    expect(within(catalog).getByText('Iced Coffee')).toBeInTheDocument()
+
+    const cart = selectors.cartSection()
+    expect(cart).toBeInTheDocument()
+    expect(within(cart).getByRole('table')).toBeInTheDocument()
+    expect(within(cart).getByText('Iced Coffee')).toBeInTheDocument()
+
+    expect(selectors.paymentMethodSelect()).toHaveValue('cash')
+    expect(selectors.cashReceivedInput()).toBeInTheDocument()
+
+    const subtotal = selectors.subtotalDisplay()
+    expect(within(subtotal).getByText('GHS 12.00')).toBeInTheDocument()
+
+    expect(selectors.recordSaleButton()).not.toBeDisabled()
+    expect(selectors.loyaltyNotice()).toBeNull()
+  })
+})

--- a/web/tests/selectors/sell.ts
+++ b/web/tests/selectors/sell.ts
@@ -1,0 +1,42 @@
+import { within } from '@testing-library/react'
+
+function resolveSellPageRoot(root: HTMLElement) {
+  const { getByRole } = within(root)
+  const heading = getByRole('heading', { level: 2, name: /sell/i })
+  const pageRoot = heading.closest('.page')
+  if (!pageRoot) {
+    throw new Error('Unable to locate sell page root')
+  }
+  return { heading, pageRoot: pageRoot as HTMLElement }
+}
+
+export function createSellSelectors(root: HTMLElement = document.body) {
+  const { heading, pageRoot } = resolveSellPageRoot(root)
+  const queries = within(pageRoot)
+
+  return {
+    heading: () => heading,
+    searchField: () => queries.getByLabelText('Find a product'),
+    productCatalogSection: () => queries.getByRole('region', { name: 'Product list' }),
+    cartSection: () => queries.getByRole('region', { name: 'Cart' }),
+    paymentMethodSelect: () => queries.getByLabelText('Payment method'),
+    cashReceivedInput: () => queries.getByLabelText('Cash received'),
+    recordSaleButton: () => queries.getByRole('button', { name: /record sale/i }),
+    subtotalDisplay: () => {
+      const subtotalLabel = queries.getByText('Subtotal')
+      const subtotalContainer = subtotalLabel.closest('div')
+      if (!subtotalContainer) {
+        throw new Error('Unable to locate subtotal container')
+      }
+      return subtotalContainer as HTMLElement
+    },
+    loyaltyNotice: () =>
+      queries.queryByRole('status', {
+        name: /keep .* coming back/i,
+      }),
+  }
+}
+
+export const sellSelectors = createSellSelectors
+
+export type SellSelectors = ReturnType<typeof createSellSelectors>

--- a/web/tests/selectors/today.selectors.test.tsx
+++ b/web/tests/selectors/today.selectors.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTodaySelectors } from './today'
+
+const mockUseActiveStoreContext = vi.fn(() => ({
+  storeId: 'store-1',
+  isLoading: false,
+  storeChangeToken: 0,
+  error: null,
+  memberships: [],
+  membershipsLoading: false,
+  setActiveStoreId: vi.fn(),
+}))
+
+const collectionMock = vi.fn((db: unknown, path: string) => ({ type: 'collection', db, path }))
+const docMock = vi.fn((db: unknown, path: string, id: string) => ({ type: 'doc', db, path, id }))
+const getDocMock = vi.fn()
+const getDocsMock = vi.fn()
+const limitMock = vi.fn((count: number) => ({ type: 'limit', count }))
+const orderByMock = vi.fn((field: string, direction: string) => ({ type: 'orderBy', field, direction }))
+const queryMock = vi.fn((ref: unknown, ...constraints: unknown[]) => ({
+  type: 'query',
+  ref,
+  constraints,
+}))
+const startAfterMock = vi.fn((...args: unknown[]) => ({ type: 'startAfter', args }))
+const whereMock = vi.fn((field: string, op: string, value: unknown) => ({
+  type: 'where',
+  field,
+  op,
+  value,
+}))
+
+let Today: typeof import('../../src/pages/Today').default
+
+describe('Today page selectors', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+
+    mockUseActiveStoreContext.mockReset()
+    mockUseActiveStoreContext.mockReturnValue({
+      storeId: 'store-1',
+      isLoading: false,
+      storeChangeToken: 0,
+      error: null,
+      memberships: [],
+      membershipsLoading: false,
+      setActiveStoreId: vi.fn(),
+    })
+
+    getDocMock.mockReset()
+    getDocsMock.mockReset()
+
+    getDocMock
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({
+          message: 'Sold Cold Brew',
+          salesTotal: 480.5,
+          salesCount: 8,
+          cardTotal: 320,
+          cashTotal: 160.5,
+          receiptCount: 6,
+          receiptUnits: 18,
+          newCustomers: 2,
+          topProducts: [
+            { id: 'prod-2', name: 'Cold Brew', unitsSold: 18, salesTotal: 220 },
+            { id: 'prod-3', name: 'Croissant', unitsSold: 25, salesTotal: 125 },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({
+          salesTotal: 460,
+          salesCount: 10,
+        }),
+      })
+
+    getDocsMock.mockResolvedValue({
+      docs: [
+        {
+          id: 'activity-1',
+          data: () => ({
+            message: 'Sold Cold Brew',
+            type: 'sale',
+            title: 'Sold Cold Brew',
+            description: '2 units sold to walk-in customer',
+            at: { toDate: () => new Date('2023-05-01T10:15:00Z') },
+          }),
+        },
+      ],
+    })
+
+    vi.doMock('../../src/context/ActiveStoreProvider', () => ({
+      useActiveStoreContext: () => mockUseActiveStoreContext(),
+    }))
+
+    vi.doMock('../../src/firebase', () => ({
+      db: {},
+    }))
+
+    vi.doMock('firebase/firestore', () => ({
+      collection: (...args: Parameters<typeof collectionMock>) => collectionMock(...args),
+      doc: (...args: Parameters<typeof docMock>) => docMock(...args),
+      getDoc: (...args: Parameters<typeof getDocMock>) => getDocMock(...args),
+      getDocs: (...args: Parameters<typeof getDocsMock>) => getDocsMock(...args),
+      limit: (...args: Parameters<typeof limitMock>) => limitMock(...args),
+      orderBy: (...args: Parameters<typeof orderByMock>) => orderByMock(...args),
+      query: (...args: Parameters<typeof queryMock>) => queryMock(...args),
+      startAfter: (...args: Parameters<typeof startAfterMock>) => startAfterMock(...args),
+      where: (...args: Parameters<typeof whereMock>) => whereMock(...args),
+    }))
+
+    ;({ default: Today } = await import('../../src/pages/Today'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('surfaces navigation, summary, and activity handles', async () => {
+    render(
+      <MemoryRouter>
+        <Today />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => expect(getDocMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(getDocsMock).toHaveBeenCalledTimes(1))
+
+    const selectors = createTodaySelectors()
+
+    expect(selectors.heading()).toHaveTextContent('Today')
+
+    const quickNav = selectors.quickActionsNav()
+    expect(quickNav).toBeInTheDocument()
+    expect(selectors.quickActionLink('Receive Stock')).toHaveAttribute('href', '/receive')
+
+    const kpiSection = selectors.kpiSection()
+    expect(kpiSection).toBeInTheDocument()
+    await waitFor(() => expect(selectors.kpiCards().length).toBeGreaterThan(0))
+
+    const activitySection = selectors.activitySection()
+    expect(activitySection).toBeInTheDocument()
+    expect(selectors.activityFilterGroup()).toBeInTheDocument()
+    expect(selectors.activityFilterButton('All')).toHaveAttribute('type', 'button')
+
+    await waitFor(() => expect(selectors.activityItems().length).toBeGreaterThan(0))
+    const activityItems = selectors.activityItems()
+    expect(activityItems[0]).toHaveTextContent('Sold Cold Brew')
+    expect(activityItems[0]).toHaveTextContent(/sale/i)
+  })
+})

--- a/web/tests/selectors/today.ts
+++ b/web/tests/selectors/today.ts
@@ -1,0 +1,81 @@
+import { within } from '@testing-library/react'
+
+function resolveTodayPageRoot(root: HTMLElement) {
+  const { getByRole } = within(root)
+  const heading = getByRole('heading', { level: 2, name: /today/i })
+  const header = heading.closest('header')
+  const pageRoot =
+    (header?.parentElement as HTMLElement | null) ??
+    (heading.closest('main') as HTMLElement | null) ??
+    root
+  if (!pageRoot) {
+    throw new Error('Unable to locate today page root')
+  }
+  return { heading, pageRoot: pageRoot as HTMLElement }
+}
+
+export function createTodaySelectors(root: HTMLElement = document.body) {
+  const { heading, pageRoot } = resolveTodayPageRoot(root)
+  const queries = within(pageRoot)
+
+  const quickActionsNav = () => queries.getByRole('navigation', { name: 'Quick actions' })
+  const quickActionLink = (label: string) => {
+    const nav = quickActionsNav()
+    try {
+      return within(nav).getByRole('link', { name: label })
+    } catch (error) {
+      const links = within(nav).getAllByRole('link')
+      const match = links.find(link => link.textContent?.trim() === label)
+      if (match) {
+        return match
+      }
+      throw new Error(`Quick action link "${label}" not found`)
+    }
+  }
+
+  const kpiHeading = () => queries.getByRole('heading', { name: 'Key performance indicators' })
+  const kpiSection = () => {
+    const section = kpiHeading().closest('section')
+    if (!section) {
+      throw new Error('Unable to locate KPI section')
+    }
+    return section as HTMLElement
+  }
+  const kpiCards = () => within(kpiSection()).queryAllByRole('article')
+
+  const activityHeading = () => queries.getByRole('heading', { name: 'Activity feed' })
+  const activitySection = () => {
+    const section = activityHeading().closest('section')
+    if (!section) {
+      throw new Error('Unable to locate activity section')
+    }
+    return section as HTMLElement
+  }
+  const activityFilterGroup = () => queries.getByRole('group', { name: 'Filter activity feed' })
+  const activityFilterButton = (label: string) =>
+    within(activityFilterGroup()).getByRole('button', { name: label })
+  const activityList = () => within(activitySection()).queryByRole('list')
+  const activityItems = () => {
+    const list = activityList()
+    return list ? within(list).queryAllByRole('listitem') : []
+  }
+
+  return {
+    heading: () => heading,
+    quickActionsNav,
+    quickActionLink,
+    kpiHeading,
+    kpiSection,
+    kpiCards,
+    activityHeading,
+    activitySection,
+    activityFilterGroup,
+    activityFilterButton,
+    activityList,
+    activityItems,
+  }
+}
+
+export const todaySelectors = createTodaySelectors
+
+export type TodaySelectors = ReturnType<typeof createTodaySelectors>


### PR DESCRIPTION
## Summary
- add selector helper modules for the Sell, Receive, and Today pages to centralize DOM queries
- exercise the selectors with new Vitest suites that render each page and assert the key controls are discoverable
- stub Firebase environment variables for Vitest and document how to run Firestore emulator tests conditionally

## Testing
- `npm run test` *(fails: src/App.signup.test.tsx > App signup cleanup > creates team member and customer records after a successful signup)*

------
https://chatgpt.com/codex/tasks/task_e_68dba53662b483219261928f94066735