### PR TITLE
Add phone country code support to signup flow

### DIFF
--- a/functions/src/callables.ts
+++ b/functions/src/callables.ts
@@ -8,6 +8,8 @@ const db = defaultDb
 
 type ContactPayload = {
   phone?: unknown
+  phoneCountryCode?: unknown
+  phoneLocalNumber?: unknown
   firstSignupEmail?: unknown
 }
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -69,6 +69,18 @@ body {
   width: 100vw;                /* ensure background spans full width */
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .app::before,
 .app::after {
   content: "";
@@ -597,6 +609,24 @@ body {
   gap: 10px;
 }
 
+.form__phone-row {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.form__phone-country {
+  flex: 0 0 180px;
+}
+
+.form__phone-country select {
+  width: 100%;
+}
+
+.form__phone-row input[type="tel"] {
+  flex: 1;
+}
+
 .form__hint {
   color: var(--color-text-muted);
   font-size: 14px;
@@ -647,7 +677,10 @@ label {
 }
 
 input[type="email"],
-input[type="password"] {
+input[type="password"],
+input[type="text"],
+input[type="tel"],
+select {
   padding: 15px 18px;
   border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.45);
@@ -663,7 +696,10 @@ input::placeholder {
 }
 
 input[type="email"]:focus-visible,
-input[type="password"]:focus-visible {
+input[type="password"]:focus-visible,
+input[type="text"]:focus-visible,
+input[type="tel"]:focus-visible,
+select:focus-visible {
   outline: none;
   border-color: var(--color-border-strong);
   box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.25);
@@ -671,6 +707,11 @@ input[type="password"]:focus-visible {
 }
 
 input[disabled] {
+  background-color: rgba(15, 23, 42, 0.35);
+  color: rgba(148, 163, 184, 0.6);
+}
+
+select[disabled] {
   background-color: rgba(15, 23, 42, 0.35);
   color: rgba(148, 163, 184, 0.6);
 }

--- a/web/src/controllers/accessController.ts
+++ b/web/src/controllers/accessController.ts
@@ -81,6 +81,8 @@ type ResolveStoreAccessPayload = {
 
 type ContactPayload = {
   phone?: string | null
+  phoneCountryCode?: string | null
+  phoneLocalNumber?: string | null
   firstSignupEmail?: string | null
   company?: string | null
   ownerName?: string | null
@@ -188,6 +190,14 @@ export async function afterSignupBootstrap(payload?: AfterSignupBootstrapPayload
 
     if (payload.contact.phone !== undefined) {
       contact.phone = payload.contact.phone
+    }
+
+    if (payload.contact.phoneCountryCode !== undefined) {
+      contact.phoneCountryCode = payload.contact.phoneCountryCode
+    }
+
+    if (payload.contact.phoneLocalNumber !== undefined) {
+      contact.phoneLocalNumber = payload.contact.phoneLocalNumber
     }
 
     if (payload.contact.firstSignupEmail !== undefined) {


### PR DESCRIPTION
## Summary
- add a country code selector and compose E.164 phone values during signup
- persist the selected country metadata alongside phone numbers across team member bootstrap helpers
- expand signup tests to cover selecting a dialing code and verifying payload contents

## Testing
- npm test -- App.signup

------
https://chatgpt.com/codex/tasks/task_e_68dbb052cb8c83218c267de5b841e7f7