### PR TITLE
Persist active store IDs via helper during onboarding

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -475,6 +475,7 @@ describe('App signup cleanup', () => {
 describe('generateUniqueStoreId', () => {
   beforeEach(() => {
     firestore.reset()
+    window.localStorage.clear()
   })
 
   it('produces distinct IDs when the preferred slug is already owned by another user', async () => {
@@ -487,6 +488,7 @@ describe('generateUniqueStoreId', () => {
       email: 'owner-one@example.com',
     })
     expect(firstStoreId).toBe('sedifex-duplicat')
+    expect(window.localStorage.getItem(getActiveStoreStorageKey(firstUid))).toBe(firstStoreId)
     firestore.docDataByPath.set(`stores/${firstStoreId}`, { ownerId: firstUid })
 
     const secondStoreId = await generateUniqueStoreId({
@@ -497,11 +499,14 @@ describe('generateUniqueStoreId', () => {
 
     expect(secondStoreId).toBe('sedifex-duplicat-2')
     expect(secondStoreId).not.toBe(firstStoreId)
+    expect(window.localStorage.getItem(getActiveStoreStorageKey(secondUid))).toBe(secondStoreId)
+    expect(window.localStorage.getItem(getActiveStoreStorageKey(firstUid))).toBe(firstStoreId)
   })
 
   it('reuses the slug when the existing store belongs to the same user', async () => {
     const uid = 'duplicate-uid-1234'
     const storeId = await generateUniqueStoreId({ uid, company: 'Sedifex', email: 'owner@example.com' })
+    expect(window.localStorage.getItem(getActiveStoreStorageKey(uid))).toBe(storeId)
     firestore.docDataByPath.set(`stores/${storeId}`, { ownerId: uid })
 
     const nextStoreId = await generateUniqueStoreId({
@@ -511,5 +516,6 @@ describe('generateUniqueStoreId', () => {
     })
 
     expect(nextStoreId).toBe(storeId)
+    expect(window.localStorage.getItem(getActiveStoreStorageKey(uid))).toBe(storeId)
   })
 })

--- a/web/src/utils/activeStoreStorage.ts
+++ b/web/src/utils/activeStoreStorage.ts
@@ -5,17 +5,34 @@ function hasWindow(): boolean {
   return typeof window !== 'undefined'
 }
 
+function normalizeUid(uid: string | null | undefined): string | null {
+  if (typeof uid !== 'string') {
+    return null
+  }
+  const trimmed = uid.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeStoreId(storeId: string | null | undefined): string | null {
+  if (typeof storeId !== 'string') {
+    return null
+  }
+  const trimmed = storeId.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
 export function getActiveStoreStorageKey(uid: string): string {
   return `${ACTIVE_STORE_STORAGE_PREFIX}${uid}`
 }
 
 export function readActiveStoreId(uid: string | null | undefined): string | null {
-  if (!uid || !hasWindow()) {
+  const normalizedUid = normalizeUid(uid)
+  if (!normalizedUid || !hasWindow()) {
     return null
   }
 
   try {
-    const value = window.localStorage.getItem(getActiveStoreStorageKey(uid))
+    const value = window.localStorage.getItem(getActiveStoreStorageKey(normalizedUid))
     return value && value.trim() ? value.trim() : null
   } catch {
     return null
@@ -23,12 +40,14 @@ export function readActiveStoreId(uid: string | null | undefined): string | null
 }
 
 export function persistActiveStoreIdForUser(uid: string | null | undefined, storeId: string | null | undefined) {
-  if (!uid || !storeId || !hasWindow()) {
+  const normalizedUid = normalizeUid(uid)
+  const normalizedStoreId = normalizeStoreId(storeId)
+  if (!normalizedUid || !normalizedStoreId || !hasWindow()) {
     return
   }
 
   try {
-    window.localStorage.setItem(getActiveStoreStorageKey(uid), storeId)
+    window.localStorage.setItem(getActiveStoreStorageKey(normalizedUid), normalizedStoreId)
     window.localStorage.removeItem(LEGACY_ACTIVE_STORE_STORAGE_KEY)
   } catch {
     /* noop */
@@ -36,12 +55,13 @@ export function persistActiveStoreIdForUser(uid: string | null | undefined, stor
 }
 
 export function clearActiveStoreIdForUser(uid: string | null | undefined) {
-  if (!uid || !hasWindow()) {
+  const normalizedUid = normalizeUid(uid)
+  if (!normalizedUid || !hasWindow()) {
     return
   }
 
   try {
-    window.localStorage.removeItem(getActiveStoreStorageKey(uid))
+    window.localStorage.removeItem(getActiveStoreStorageKey(normalizedUid))
   } catch {
     /* noop */
   }


### PR DESCRIPTION
## Summary
- persist resolved store IDs through `persistActiveStoreIdForUser` in the onboarding controller
- harden the active store storage helper to no-op when the UID, store ID, or window object is unavailable
- extend signup onboarding tests to assert that store IDs are written under the `activeStoreId:{uid}` key

## Testing
- npm test *(fails: `src/pages/__tests__/Today.test.tsx` references undefined `formatDailySummaryKey`)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd335ff7c832190283a8edc3b9f07