### PR TITLE
Add workspace empty states to transactional pages

### DIFF
--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -276,6 +276,22 @@ export default function CloseDay() {
 
 
 
+  const workspaceEmptyState = (
+    <div className="empty-state">
+      <h3 className="empty-state__title">Select a workspace…</h3>
+      <p>Choose a workspace from the switcher above to continue.</p>
+    </div>
+  )
+
+  if (!activeStoreId) {
+    return (
+      <div className="print-summary" style={{ maxWidth: 760 }}>
+        <h2 style={{ color: '#4338CA' }}>Close Day</h2>
+        {workspaceEmptyState}
+      </div>
+    )
+  }
+
   return (
     <div className="print-summary" style={{ maxWidth: 760 }}>
       <h2 style={{ color: '#4338CA' }}>Close Day</h2>

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -831,19 +831,39 @@ export default function Customers() {
     { id: 'untagged', label: 'Untagged' },
   ]
 
+  const workspaceEmptyState = (
+    <div className="empty-state">
+      <h3 className="empty-state__title">Select a workspace…</h3>
+      <p>Choose a workspace from the switcher above to continue.</p>
+    </div>
+  )
+
+  const pageHeader = (
+    <header className="page__header">
+      <div>
+        <h2 className="page__title">Customers</h2>
+        <p className="page__subtitle">
+          Keep a tidy record of your regulars and speed up checkout on the sales floor.
+        </p>
+      </div>
+      <span className="customers-page__badge" aria-live="polite">
+        {customers.length} saved • {totalShown} shown
+      </span>
+    </header>
+  )
+
+  if (!activeStoreId) {
+    return (
+      <div className="page customers-page">
+        {pageHeader}
+        <section className="card">{workspaceEmptyState}</section>
+      </div>
+    )
+  }
+
   return (
     <div className="page customers-page">
-      <header className="page__header">
-        <div>
-          <h2 className="page__title">Customers</h2>
-          <p className="page__subtitle">
-            Keep a tidy record of your regulars and speed up checkout on the sales floor.
-          </p>
-        </div>
-        <span className="customers-page__badge" aria-live="polite">
-          {customers.length} saved • {totalShown} shown
-        </span>
-      </header>
+      {pageHeader}
 
       <div className="customers-page__grid">
         <section className="card" aria-label="Add a customer">

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -742,20 +742,40 @@ export default function Products() {
     )
   }
 
+  const workspaceEmptyState = (
+    <div className="empty-state">
+      <h3 className="empty-state__title">Select a workspace…</h3>
+      <p>Choose a workspace from the switcher above to continue.</p>
+    </div>
+  )
+
+  const pageHeader = (
+    <header className="page__header">
+      <div>
+        <h2 className="page__title">Products</h2>
+        <p className="page__subtitle">
+          Review inventory, monitor low stock alerts, and keep your catalogue tidy.
+        </p>
+      </div>
+      <Link to="/receive" className="products-page__receive-link">
+        Receive stock
+      </Link>
+    </header>
+  )
+
+  if (!activeStoreId) {
+    return (
+      <div className="page products-page">
+        {pageHeader}
+        <section className="card products-page__card">{workspaceEmptyState}</section>
+      </div>
+    )
+  }
+
 
   return (
     <div className="page products-page">
-      <header className="page__header">
-        <div>
-          <h2 className="page__title">Products</h2>
-          <p className="page__subtitle">
-            Review inventory, monitor low stock alerts, and keep your catalogue tidy.
-          </p>
-        </div>
-        <Link to="/receive" className="products-page__receive-link">
-          Receive stock
-        </Link>
-      </header>
+      {pageHeader}
 
       <section className="card products-page__card">
         <div className="products-page__toolbar">

--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -274,14 +274,34 @@ export default function Receive() {
 
 
 
+  const workspaceEmptyState = (
+    <div className="empty-state">
+      <h3 className="empty-state__title">Select a workspace…</h3>
+      <p>Choose a workspace from the switcher above to continue.</p>
+    </div>
+  )
+
+  const pageHeader = (
+    <header className="page__header">
+      <div>
+        <h2 className="page__title">Receive stock</h2>
+        <p className="page__subtitle">Log deliveries against your Firestore inventory so shelves stay replenished.</p>
+      </div>
+    </header>
+  )
+
+  if (!activeStoreId) {
+    return (
+      <div className="page receive-page">
+        {pageHeader}
+        <section className="card receive-page__card">{workspaceEmptyState}</section>
+      </div>
+    )
+  }
+
   return (
     <div className="page receive-page">
-      <header className="page__header">
-        <div>
-          <h2 className="page__title">Receive stock</h2>
-          <p className="page__subtitle">Log deliveries against your Firestore inventory so shelves stay replenished.</p>
-        </div>
-      </header>
+      {pageHeader}
 
       <section className="card receive-page__card">
         <div className="receive-page__form">

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -793,18 +793,38 @@ export default function Sell() {
 
   const filtered = products.filter(p => p.name.toLowerCase().includes(queryText.toLowerCase()))
 
+  const workspaceEmptyState = (
+    <div className="empty-state">
+      <h3 className="empty-state__title">Select a workspace…</h3>
+      <p>Choose a workspace from the switcher above to continue.</p>
+    </div>
+  )
+
+  const pageHeader = (
+    <header className="page__header">
+      <div>
+        <h2 className="page__title">Sell</h2>
+        <p className="page__subtitle">Build a cart from your product list and record the sale in seconds.</p>
+      </div>
+      <div className="sell-page__total" aria-live="polite">
+        <span className="sell-page__total-label">Subtotal</span>
+        <span className="sell-page__total-value">{formatCurrency(subtotal)}</span>
+      </div>
+    </header>
+  )
+
+  if (!activeStoreId) {
+    return (
+      <div className="page sell-page">
+        {pageHeader}
+        <section className="card">{workspaceEmptyState}</section>
+      </div>
+    )
+  }
+
   return (
     <div className="page sell-page">
-      <header className="page__header">
-        <div>
-          <h2 className="page__title">Sell</h2>
-          <p className="page__subtitle">Build a cart from your product list and record the sale in seconds.</p>
-        </div>
-        <div className="sell-page__total" aria-live="polite">
-          <span className="sell-page__total-label">Subtotal</span>
-          <span className="sell-page__total-value">{formatCurrency(subtotal)}</span>
-        </div>
-      </header>
+      {pageHeader}
 
       <section className="card">
         <div className="field">


### PR DESCRIPTION
## Summary
- add a shared workspace-empty state message for the Products, Sell, Receive, Customers, and Close Day flows
- reuse the existing activeStoreId to block page rendering until a workspace is selected

## Testing
- `npm --prefix web run test` *(fails: App signup cleanup > creates team member and customer records after a successful signup; Today page > renders KPI cards and activities when data is available)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe3511f8083218b83fa310d04c82e