### PR TITLE
Update account overview empty state messaging

### DIFF
--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -468,11 +468,20 @@ export default function AccountOverview() {
     return <div role="alert">{storeError}</div>
   }
 
-  if (!storeId && !storeLoading) {
+  if (!storeId) {
+    if (storeLoading) {
+      return (
+        <div className="account-overview" role="status">
+          <h1>Account overview</h1>
+          <p>Loading account details…</p>
+        </div>
+      )
+    }
+
     return (
       <div className="account-overview" role="status">
         <h1>Account overview</h1>
-        <p>Select a workspace to view account details.</p>
+        <p>Select a workspace…</p>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- show the workspace selection empty state using the shared "Select a workspace…" copy
- keep the account overview content gated behind an active workspace to preserve Firestore behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe4ed393483218ff03c35271bff0c