### PR TITLE
Add store ID to Receive stock payload

### DIFF
--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -215,6 +215,7 @@ export default function Receive() {
       supplier: supplierName,
       reference: referenceNumber,
       unitCost: parsedCost,
+      storeId: activeStoreId,
     }
 
     try {

--- a/web/src/pages/__tests__/Receive.test.tsx
+++ b/web/src/pages/__tests__/Receive.test.tsx
@@ -132,7 +132,7 @@ describe('Receive', () => {
     await waitFor(() =>
       expect(queueCallableRequestMock).toHaveBeenCalledWith(
         FIREBASE_CALLABLES.RECEIVE_STOCK,
-        expect.objectContaining({ productId: 'prod-1', qty: 5 }),
+        expect.objectContaining({ productId: 'prod-1', qty: 5, storeId: 'store-123' }),
         'receipt',
       ),
     )
@@ -160,7 +160,7 @@ describe('Receive', () => {
     await waitFor(() =>
       expect(queueCallableRequestMock).toHaveBeenCalledWith(
         FIREBASE_CALLABLES.RECEIVE_STOCK,
-        expect.objectContaining({ productId: 'prod-1', qty: 5 }),
+        expect.objectContaining({ productId: 'prod-1', qty: 5, storeId: 'store-123' }),
         'receipt',
       ),
     )


### PR DESCRIPTION
## Summary
- include the active workspace ID on the receive stock payload so online and offline flows send it
- update Receive page tests to cover the new storeId field in queued requests

## Testing
- npm test -- Receive

------
https://chatgpt.com/codex/tasks/task_e_68dbe6c673f083219181e4f6b889f94a