### PR TITLE
Ensure customer loyalty updates include store context

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -60,6 +60,10 @@ service cloud.firestore {
         && (resource == null || storeIdFromData(resource.data) == storeIdFromData(request.resource.data));
     }
 
+    function requestHasStoreId() {
+      return request.resource != null && storeIdFromData(request.resource.data) != null;
+    }
+
     function requestHasValidRole() {
       return request.resource != null
         && request.resource.data.keys().hasAny(['role'])
@@ -178,7 +182,8 @@ service cloud.firestore {
 
     match /customers/{customerId} {
       allow read: if canReadStoreDocument();
-      allow create, update, delete: if canOwnerModifyStoreDocument();
+      allow create, update: if canOwnerModifyStoreDocument() && requestHasStoreId();
+      allow delete: if canOwnerModifyStoreDocument();
     }
 
     match /sales/{saleId} {

--- a/web/src/hooks/useStoreMetrics.ts
+++ b/web/src/hooks/useStoreMetrics.ts
@@ -63,7 +63,7 @@ type CustomerRecord = {
   name: string
   displayName?: string
   createdAt?: Timestamp | Date | null
-  storeId?: string | null
+  storeId: string
   loyalty: CustomerLoyalty
 }
 

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -38,6 +38,7 @@ import { parseCsv } from '../utils/csv'
 type Customer = {
   id: string
   name: string
+  storeId: string
   displayName?: string
   phone?: string
   email?: string

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -42,6 +42,7 @@ type CartLine = { productId: string; name: string; price: number; qty: number }
 type Customer = {
   id: string
   name: string
+  storeId: string
   displayName?: string
   phone?: string
   email?: string
@@ -748,12 +749,14 @@ export default function Sell() {
 
           if (customerExists) {
             transaction.update(customerRef, {
+              storeId: activeStoreId,
               'loyalty.lastVisitAt': timestamp,
               'loyalty.points': nextPoints,
               updatedAt: timestamp,
             })
           } else {
             transaction.set(customerRef, {
+              storeId: activeStoreId,
               loyalty: {
                 points: nextPoints,
                 lastVisitAt: timestamp,


### PR DESCRIPTION
## Summary
- include the active store ID when updating or creating customer loyalty entries from the Sell flow
- require customer documents to expose a storeId in web typings and Firestore rules

## Testing
- npm --prefix web run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe82e98588321b5aa852b0dc06fe9