### PR TITLE
Use useActiveStore hook in ActiveStoreProvider

### DIFF
--- a/web/src/context/ActiveStoreProvider.tsx
+++ b/web/src/context/ActiveStoreProvider.tsx
@@ -1,15 +1,8 @@
-import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react'
-import { onAuthStateChanged } from 'firebase/auth'
-import { doc, getDoc } from 'firebase/firestore'
+import { createContext, ReactNode, useContext } from 'react'
 
-import { auth, db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
 
-const ACTIVE_STORE_STORAGE_KEY = 'activeStoreId'
-
-interface ActiveStoreContextValue {
-  storeId: string | null
-  setStoreId: (nextStoreId: string | null) => void
-}
+type ActiveStoreContextValue = ReturnType<typeof useActiveStore>
 
 const ActiveStoreContext = createContext<ActiveStoreContextValue | undefined>(undefined)
 
@@ -17,114 +10,8 @@ interface ActiveStoreProviderProps {
   children: ReactNode
 }
 
-function hasWindow(): boolean {
-  return typeof window !== 'undefined'
-}
-
-function readStoredStoreId(): string | null {
-  if (!hasWindow()) {
-    return null
-  }
-
-  try {
-    const value = window.localStorage.getItem(ACTIVE_STORE_STORAGE_KEY)
-    return value && value.trim() ? value.trim() : null
-  } catch {
-    return null
-  }
-}
-
-function persistStoreId(storeId: string | null) {
-  if (!hasWindow()) {
-    return
-  }
-
-  try {
-    if (storeId && storeId.trim()) {
-      window.localStorage.setItem(ACTIVE_STORE_STORAGE_KEY, storeId.trim())
-    } else {
-      window.localStorage.removeItem(ACTIVE_STORE_STORAGE_KEY)
-    }
-  } catch {
-    /* noop */
-  }
-}
-
 export function ActiveStoreProvider({ children }: ActiveStoreProviderProps) {
-  const [storeId, setStoreIdState] = useState<string | null>(() => readStoredStoreId())
-
-  useEffect(() => {
-    let isMounted = true
-
-    const unsubscribe = onAuthStateChanged(auth, user => {
-      if (!isMounted) {
-        return
-      }
-
-      if (!user) {
-        persistStoreId(null)
-        setStoreIdState(null)
-        return
-      }
-
-      const existingStoreId = readStoredStoreId()
-      if (existingStoreId) {
-        setStoreIdState(existingStoreId)
-        return
-      }
-
-      ;(async () => {
-        try {
-          const memberDoc = await getDoc(doc(db, 'teamMembers', user.uid))
-          if (!isMounted) {
-            return
-          }
-
-          if (!memberDoc.exists()) {
-            setStoreIdState(null)
-            return
-          }
-
-          const data = memberDoc.data() as { storeId?: unknown } | undefined
-          const documentStoreId =
-            typeof data?.storeId === 'string' && data.storeId.trim().length > 0
-              ? data.storeId.trim()
-              : null
-
-          if (documentStoreId) {
-            persistStoreId(documentStoreId)
-            setStoreIdState(documentStoreId)
-          } else {
-            setStoreIdState(null)
-          }
-        } catch (error) {
-          console.error('[ActiveStoreProvider] Failed to load team member document', error)
-          if (isMounted) {
-            setStoreIdState(null)
-          }
-        }
-      })()
-    })
-
-    return () => {
-      isMounted = false
-      unsubscribe()
-    }
-  }, [])
-
-  const setStoreId = useCallback((nextStoreId: string | null) => {
-    const normalized = nextStoreId && nextStoreId.trim() ? nextStoreId.trim() : null
-    setStoreIdState(normalized)
-    persistStoreId(normalized)
-  }, [])
-
-  const value = useMemo<ActiveStoreContextValue>(
-    () => ({
-      storeId,
-      setStoreId,
-    }),
-    [setStoreId, storeId],
-  )
+  const value = useActiveStore()
 
   return <ActiveStoreContext.Provider value={value}>{children}</ActiveStoreContext.Provider>
 }


### PR DESCRIPTION
## Summary
- replace the hand-rolled ActiveStoreProvider logic with the shared useActiveStore hook
- expose the hook's full return value through the context so consumers receive the complete active-store state

## Testing
- npm test *(fails: existing failures in `src/App.signup.test.tsx > App signup cleanup > creates team member and customer records after a successful signup` and `src/pages/__tests__/Today.test.tsx > Today page > renders KPI cards and activities when data is available`)*

------
https://chatgpt.com/codex/tasks/task_e_68dbeff77740832191290e89ffb780a5