### PR TITLE
Add shared override support for team member lookup

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,10 +28,9 @@ import {
 } from './utils/activeStoreStorage'
 import { getOnboardingStatus, setOnboardingStatus } from './utils/onboarding'
 import type { QueueRequestType } from './utils/offlineQueue'
+import { OVERRIDE_TEAM_MEMBER_DOC_ID } from './config/teamMembers'
 
 /* ------------------------------ config ------------------------------ */
-/** If you want to ALSO mirror the team member to a fixed doc id, put it here. */
-const OVERRIDE_MEMBER_DOC_ID = 'l8Rbmym8aBVMwL6NpZHntjBHmCo2' // set '' to disable
 const LEGACY_STORE_BACKFILL_KEY_PREFIX = 'legacy-store-backfill/'
 
 /* ------------------------------ constants ------------------------------ */
@@ -191,9 +190,9 @@ async function upsertTeamMemberDocs(params: {
         await setDoc(uidRef, { lastSeenAt }, { merge: true })
         persistActiveStoreId(existingStoreId, user.uid)
         // Optionally mirror to fixed doc for your analytics/admin
-        if (OVERRIDE_MEMBER_DOC_ID) {
+        if (OVERRIDE_TEAM_MEMBER_DOC_ID) {
           await setDoc(
-            doc(db, 'teamMembers', OVERRIDE_MEMBER_DOC_ID),
+            doc(db, 'teamMembers', OVERRIDE_TEAM_MEMBER_DOC_ID),
             { ...snap.data(), lastSeenAt, updatedAt: serverTimestamp() },
             { merge: true },
           )
@@ -228,8 +227,8 @@ async function upsertTeamMemberDocs(params: {
 
   await setDoc(uidRef, payload, { merge: true })
 
-  if (OVERRIDE_MEMBER_DOC_ID) {
-    await setDoc(doc(db, 'teamMembers', OVERRIDE_MEMBER_DOC_ID), payload, { merge: true })
+  if (OVERRIDE_TEAM_MEMBER_DOC_ID) {
+    await setDoc(doc(db, 'teamMembers', OVERRIDE_TEAM_MEMBER_DOC_ID), payload, { merge: true })
   }
 
   await ensureLegacyStoreDoc({ storeId, user, timestamp })
@@ -540,9 +539,9 @@ export default function App() {
 
         await setDoc(doc(db, 'teamMembers', nextUser.uid), teamMemberContactPayload, { merge: true })
 
-        if (OVERRIDE_MEMBER_DOC_ID) {
+        if (OVERRIDE_TEAM_MEMBER_DOC_ID) {
           await setDoc(
-            doc(db, 'teamMembers', OVERRIDE_MEMBER_DOC_ID),
+            doc(db, 'teamMembers', OVERRIDE_TEAM_MEMBER_DOC_ID),
             {
               ...teamMemberContactPayload,
               uid: nextUser.uid,

--- a/web/src/SheetAccessGuard.test.tsx
+++ b/web/src/SheetAccessGuard.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { User } from 'firebase/auth'
+import SheetAccessGuard from './SheetAccessGuard'
+import { OVERRIDE_TEAM_MEMBER_DOC_ID } from './config/teamMembers'
+
+const authMocks = vi.hoisted(() => {
+  const state = {
+    listeners: [] as Array<(user: User | null) => void>,
+    auth: { currentUser: null as User | null },
+    signOut: vi.fn(async () => {}),
+  }
+  return state
+})
+
+const firestoreMocks = vi.hoisted(() => {
+  const dataByPath = new Map<string, Record<string, unknown>>()
+
+  const docMock = vi.fn((_: unknown, collection: string, id: string) => ({
+    path: `${collection}/${id}`,
+  }))
+
+  const getDocMock = vi.fn(async (ref: { path: string }) => {
+    const data = dataByPath.get(ref.path)
+    return {
+      exists: () => data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+    }
+  })
+
+  return {
+    docMock,
+    getDocMock,
+    dataByPath,
+    reset() {
+      docMock.mockClear()
+      getDocMock.mockClear()
+      dataByPath.clear()
+    },
+  }
+})
+
+const activeStoreMocks = vi.hoisted(() => ({
+  persistActiveStoreIdForUser: vi.fn(),
+  clearActiveStoreIdForUser: vi.fn(),
+}))
+
+vi.mock('./firebase', () => ({
+  auth: authMocks.auth,
+  db: {},
+}))
+
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: (_auth: unknown, callback: (user: User | null) => void) => {
+    authMocks.listeners.push(callback)
+    callback(authMocks.auth.currentUser)
+    return () => {}
+  },
+  signOut: (...args: unknown[]) => authMocks.signOut(...args),
+}))
+
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: Parameters<typeof firestoreMocks.docMock>) =>
+    firestoreMocks.docMock(...args),
+  getDoc: (...args: Parameters<typeof firestoreMocks.getDocMock>) =>
+    firestoreMocks.getDocMock(...args),
+  collection: vi.fn(),
+  getDocs: vi.fn(async () => ({ docs: [] })),
+  query: vi.fn(),
+  where: vi.fn(),
+}))
+
+vi.mock('./utils/activeStoreStorage', () => ({
+  persistActiveStoreIdForUser: (...args: unknown[]) =>
+    activeStoreMocks.persistActiveStoreIdForUser(...args),
+  clearActiveStoreIdForUser: (...args: unknown[]) =>
+    activeStoreMocks.clearActiveStoreIdForUser(...args),
+}))
+
+function createUser(): User {
+  return {
+    uid: 'test-user',
+    email: 'user@example.com',
+  } as unknown as User
+}
+
+describe('SheetAccessGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authMocks.listeners.splice(0, authMocks.listeners.length)
+    firestoreMocks.reset()
+    authMocks.auth.currentUser = null
+  })
+
+  it('grants access when the override document contains the workspace assignment', async () => {
+    const user = createUser()
+    authMocks.auth.currentUser = user
+
+    if (!OVERRIDE_TEAM_MEMBER_DOC_ID) {
+      throw new Error('Test requires a non-empty override document id')
+    }
+
+    firestoreMocks.dataByPath.set(`teamMembers/${OVERRIDE_TEAM_MEMBER_DOC_ID}`, {
+      storeId: 'store-123',
+      status: 'active',
+      contractStatus: 'signed',
+    })
+
+    render(
+      <SheetAccessGuard>
+        <p>Child content</p>
+      </SheetAccessGuard>,
+    )
+
+    await waitFor(() =>
+      expect(screen.queryByText('Checking workspace access…')).not.toBeInTheDocument(),
+    )
+
+    expect(screen.getByText('Child content')).toBeInTheDocument()
+    expect(authMocks.signOut).not.toHaveBeenCalled()
+    expect(activeStoreMocks.persistActiveStoreIdForUser).toHaveBeenCalledWith(
+      user.uid,
+      'store-123',
+    )
+  })
+})

--- a/web/src/SheetAccessGuard.tsx
+++ b/web/src/SheetAccessGuard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { onAuthStateChanged, signOut, type User } from 'firebase/auth'
 import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore'
 import { auth, db } from './firebase'
+import { OVERRIDE_TEAM_MEMBER_DOC_ID } from './config/teamMembers'
 import { clearActiveStoreIdForUser, persistActiveStoreIdForUser } from './utils/activeStoreStorage'
 
 type TeamMemberSnapshot = {
@@ -46,6 +47,14 @@ async function loadTeamMember(user: User): Promise<TeamMemberSnapshot> {
 
   if (uidSnapshot.exists()) {
     return snapshotFromData(uidSnapshot.data())
+  }
+
+  if (OVERRIDE_TEAM_MEMBER_DOC_ID) {
+    const overrideRef = doc(db, 'teamMembers', OVERRIDE_TEAM_MEMBER_DOC_ID)
+    const overrideSnapshot = await getDoc(overrideRef)
+    if (overrideSnapshot.exists()) {
+      return snapshotFromData(overrideSnapshot.data())
+    }
   }
 
   const email = normalizeString(user.email)

--- a/web/src/config/teamMembers.ts
+++ b/web/src/config/teamMembers.ts
@@ -1,0 +1,5 @@
+/**
+ * When set, team member workspace updates will also be mirrored to this shared document ID.
+ * Set to an empty string to disable the shared override document.
+ */
+export const OVERRIDE_TEAM_MEMBER_DOC_ID = 'l8Rbmym8aBVMwL6NpZHntjBHmCo2'


### PR DESCRIPTION
## Summary
- expose the override team member document ID through a shared config module
- allow the sheet access guard to fall back to the shared override document when the per-user doc is missing
- cover the shared document fallback with a dedicated SheetAccessGuard unit test

## Testing
- npm test -- SheetAccessGuard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dbf88457f0832198f07d6b491224c5