### PR TITLE
Capture name during signup and propagate onboarding metadata

### DIFF
--- a/web/src/controllers/accessController.ts
+++ b/web/src/controllers/accessController.ts
@@ -80,6 +80,7 @@ type ResolveStoreAccessPayload = {
 }
 
 type ContactPayload = {
+  name?: string | null
   phone?: string | null
   phoneCountryCode?: string | null
   phoneLocalNumber?: string | null
@@ -190,6 +191,10 @@ export async function afterSignupBootstrap(payload?: AfterSignupBootstrapPayload
 
     if (payload.contact.phone !== undefined) {
       contact.phone = payload.contact.phone
+    }
+
+    if (payload.contact.name !== undefined) {
+      contact.name = payload.contact.name
     }
 
     if (payload.contact.phoneCountryCode !== undefined) {

--- a/web/src/controllers/onboarding.test.ts
+++ b/web/src/controllers/onboarding.test.ts
@@ -140,4 +140,29 @@ describe('createInitialOwnerAndStore', () => {
     const storeDoc = firestore.docDataByPath.get(`stores/${storeId}`)
     expect(storeDoc).toMatchObject({ ownerId: user.uid })
   })
+
+  it('applies the provided name override when displayName is not set', async () => {
+    const user = {
+      uid: 'owner-override',
+      email: 'override@example.com',
+      displayName: undefined,
+    } as unknown as User
+
+    const storeId = await createInitialOwnerAndStore({
+      user,
+      company: 'Override Incorporated',
+      name: ' Override Name ',
+    })
+
+    const teamMemberDoc = firestore.docDataByPath.get(`teamMembers/${user.uid}`)
+    const storeDoc = firestore.docDataByPath.get(`stores/${storeId}`)
+
+    expect(teamMemberDoc).toMatchObject({
+      name: 'Override Name',
+    })
+
+    expect(storeDoc).toMatchObject({
+      ownerName: 'Override Name',
+    })
+  })
 })

--- a/web/src/controllers/onboarding.ts
+++ b/web/src/controllers/onboarding.ts
@@ -120,6 +120,7 @@ type CreateInitialOwnerAndStoreParams = {
   email?: string | null
   role?: string
   company?: string | null
+  name?: string | null
 }
 
 export async function createInitialOwnerAndStore(
@@ -130,12 +131,14 @@ export async function createInitialOwnerAndStore(
     email: emailOverride = null,
     role = 'owner',
     company: companyOverride = null,
+    name: nameOverride = null,
   } = params
 
   const uid = user.uid
   const company = companyOverride ?? null
   const resolvedEmail = emailOverride ?? user.email ?? null
-  const ownerName = user.displayName?.trim() || null
+  const trimmedNameOverride = typeof nameOverride === 'string' ? nameOverride.trim() : null
+  const ownerName = trimmedNameOverride || user.displayName?.trim() || null
 
   const baseSlug = resolveBaseSlug(company, resolvedEmail)
   const uidSuffix = buildUidSuffix(uid)

--- a/web/src/pages/__tests__/Today.test.tsx
+++ b/web/src/pages/__tests__/Today.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom'
 
 
 import { formatCurrency } from '@shared/currency'
+import { formatDailySummaryKey } from '@shared/dateKeys'
 import Today, { formatDateKey } from '../Today'
 
 


### PR DESCRIPTION
## Summary
- add a controlled name field to the signup flow, require it for validation, and propagate the sanitized value to profile updates, contact payloads, and the fixed override document
- allow createInitialOwnerAndStore to accept a name override so onboarding documents include names even before displayName resolves, and update the override document identifier
- refresh onboarding and signup tests to cover the new name handling and import the daily summary helper in the Today page test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbf880b6fc8321a6d3688cd73d0404