### PR TITLE
Sign out after completing signup flow

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   createUserWithEmailAndPassword,
   onAuthStateChanged,
   signInWithEmailAndPassword,
+  signOut,
 } from 'firebase/auth'
 import { doc, getDoc, serverTimestamp, setDoc, Timestamp } from 'firebase/firestore'
 import { FirebaseError } from 'firebase/app'
@@ -572,11 +573,17 @@ export default function App() {
         await afterSignupBootstrap(storeId)
 
         setOnboardingStatus(nextUser.uid, 'pending')
+
+        await signOut(auth)
+        setMode('login')
       }
 
       setStatus({
         tone: 'success',
-        message: mode === 'login' ? 'Welcome back! Redirecting…' : 'All set! Your account is ready.',
+        message:
+          mode === 'login'
+            ? 'Welcome back! Redirecting…'
+            : 'All set! Your account is ready. Please log in to continue.',
       })
       setPassword('')
       setConfirmPassword('')


### PR DESCRIPTION
## Summary
- sign out new accounts after the signup bootstrap completes and direct users back to the login form
- update the signup flow test to cover the post-signup logout behavior and revised toast message

## Testing
- npm test *(fails: src/pages/__tests__/Today.test.tsx > Today page > renders KPI cards and activities when data is available — ReferenceError: formatDailySummaryKey is not defined)*
- npx vitest run src/App.signup.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68dc00accb9083219c67840ddfdfa9e3