### PR TITLE
Enforce store-scoped Firestore access

### DIFF
--- a/functions/src/firestore.ts
+++ b/functions/src/firestore.ts
@@ -1,5 +1,6 @@
 import * as admin from 'firebase-admin'
 import { getFirestore } from 'firebase-admin/firestore'
+import * as functions from 'firebase-functions'
 
 if (!admin.apps.length) {
   admin.initializeApp()
@@ -9,3 +10,44 @@ export const defaultDb = getFirestore()
 export const rosterDb = defaultDb
 
 export { admin }
+
+const SUPPORTED_ROLES = new Set<'owner' | 'staff'>(['owner', 'staff'])
+
+export type StoreContext = {
+  storeId: string
+  role: 'owner' | 'staff'
+}
+
+export async function getStoreContext(authUid: string): Promise<StoreContext> {
+  if (!authUid) {
+    throw new functions.https.HttpsError('unauthenticated', 'Login required')
+  }
+
+  const memberSnap = await rosterDb.collection('teamMembers').doc(authUid).get()
+  if (!memberSnap.exists) {
+    throw new functions.https.HttpsError(
+      'permission-denied',
+      'Workspace membership required to access this resource.',
+    )
+  }
+
+  const data = memberSnap.data() ?? {}
+  const storeIdRaw = typeof data.storeId === 'string' ? data.storeId.trim() : ''
+  if (!storeIdRaw) {
+    throw new functions.https.HttpsError(
+      'failed-precondition',
+      'Workspace membership is missing a store assignment.',
+    )
+  }
+
+  const roleRaw = typeof data.role === 'string' ? data.role.trim().toLowerCase() : ''
+  if (!SUPPORTED_ROLES.has(roleRaw as 'owner' | 'staff')) {
+    throw new functions.https.HttpsError(
+      'permission-denied',
+      'Workspace membership role is not permitted for this operation.',
+    )
+  }
+
+  const role = roleRaw as 'owner' | 'staff'
+  return { storeId: storeIdRaw, role }
+}

--- a/functions/test/callablesLogging.test.js
+++ b/functions/test/callablesLogging.test.js
@@ -119,7 +119,13 @@ async function runBackfillLoggingTest() {
 }
 
 async function runManageStaffLoggingTest() {
-  currentDefaultDb = new MockFirestore()
+  currentDefaultDb = new MockFirestore({
+    'teamMembers/owner-1': {
+      uid: 'owner-1',
+      storeId: 'store-abc',
+      role: 'owner',
+    },
+  })
   const { manageStaffAccount } = loadIndexModule()
 
   const context = {

--- a/functions/test/revokeStaffAccess.test.js
+++ b/functions/test/revokeStaffAccess.test.js
@@ -67,6 +67,11 @@ function loadFunctionsModule() {
 
 async function runRevocationSuccessTest() {
   currentDefaultDb = new MockFirestore({
+    'teamMembers/owner-1': {
+      uid: 'owner-1',
+      storeId: 'store-123',
+      role: 'owner',
+    },
     'teamMembers/member-2': {
       uid: 'member-2',
       email: 'staff@example.com',


### PR DESCRIPTION
## Summary
- add a Firestore helper that resolves a team member's store context and validates membership
- require callable handlers to load the store context once, enforcing workspace ownership on management actions and inventory writes
- extend unit tests to cover store membership lookups, missing assignments, and logging for the new store-aware flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc05540ef48321b8a105625952dee3