### PR TITLE
Ensure owner fallback name persists during signup

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -363,6 +363,7 @@ describe('App signup cleanup', () => {
         storeId,
         role: 'owner',
         email: 'owner@example.com',
+        name: 'Owner account',
         createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
         updatedAt: expect.objectContaining({ __type: 'serverTimestamp' }),
       }),
@@ -376,6 +377,7 @@ describe('App signup cleanup', () => {
     const [, ownerContactPayload, ownerContactOptions] = ownerContactCall!
     expect(ownerContactPayload).toEqual(
       expect.objectContaining({
+        name: 'Owner account',
         company: 'Sedifex',
         phone: '+445551234567',
         phoneCountryCode: '+44',
@@ -449,6 +451,7 @@ describe('App signup cleanup', () => {
         ...seededTeamMember,
         uid: createdUser.uid,
         storeId,
+        name: 'Owner account',
       }),
     )
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -528,6 +528,7 @@ export default function App() {
         const ownerName = resolveOwnerName(nextUser)
         const activityTimestamp = serverTimestamp()
         const teamMemberContactPayload = {
+          name: ownerName,
           phone: sanitizedPhone || null,
           phoneCountryCode: phoneDetails.countryCode || null,
           phoneLocalNumber: phoneDetails.localNumber || null,

--- a/web/src/controllers/onboarding.ts
+++ b/web/src/controllers/onboarding.ts
@@ -7,6 +7,7 @@ import { persistActiveStoreIdForUser } from '../utils/activeStoreStorage'
 const MAX_BASE_SLUG_LENGTH = 32
 const UID_SUFFIX_LENGTH = 8
 const MAX_COLLISION_ATTEMPTS = 10
+const OWNER_NAME_FALLBACK = 'Owner account'
 
 function slugify(value: string | null | undefined): string {
   if (!value) {
@@ -135,7 +136,7 @@ export async function createInitialOwnerAndStore(
   const uid = user.uid
   const company = companyOverride ?? null
   const resolvedEmail = emailOverride ?? user.email ?? null
-  const ownerName = user.displayName?.trim() || null
+  const ownerName = user.displayName?.trim() || OWNER_NAME_FALLBACK
 
   const baseSlug = resolveBaseSlug(company, resolvedEmail)
   const uidSuffix = buildUidSuffix(uid)


### PR DESCRIPTION
## Summary
- ensure onboarding sets a fallback owner name on initial team member creation
- include the resolved owner name when merging signup contact details
- extend the signup flow test to assert the fallback name is persisted

## Testing
- npm --prefix web run test -- App.signup.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc102d258c8321b0518e594f5017fb