### PR TITLE
Redirect users without memberships to onboarding

### DIFF
--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -32,7 +32,7 @@ function parseQuantity(input: string): number {
 
 export default function CloseDay() {
   const user = useAuthUser()
-  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken, isLoading: storeLoading } = useActiveStoreContext()
 
   const [total, setTotal] = useState(0)
   const [cashCounts, setCashCounts] = useState<CashCountState>(() => createInitialCashCountState())
@@ -276,18 +276,14 @@ export default function CloseDay() {
 
 
 
-  const workspaceEmptyState = (
-    <div className="empty-state">
-      <h3 className="empty-state__title">Select a workspace…</h3>
-      <p>Choose a workspace from the switcher above to continue.</p>
-    </div>
-  )
-
-  if (!activeStoreId) {
+  if (storeLoading) {
     return (
       <div className="print-summary" style={{ maxWidth: 760 }}>
         <h2 style={{ color: '#4338CA' }}>Close Day</h2>
-        {workspaceEmptyState}
+        <div className="empty-state">
+          <h3 className="empty-state__title">Loading workspace…</h3>
+          <p>Please wait while we get things ready.</p>
+        </div>
       </div>
     )
   }

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -174,7 +174,7 @@ function buildCsvValue(value: string): string {
 }
 
 export default function Customers() {
-  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken, isLoading: storeLoading } = useActiveStoreContext()
   const [customers, setCustomers] = useState<Customer[]>([])
   const [name, setName] = useState('')
   const [phone, setPhone] = useState('')
@@ -832,13 +832,6 @@ export default function Customers() {
     { id: 'untagged', label: 'Untagged' },
   ]
 
-  const workspaceEmptyState = (
-    <div className="empty-state">
-      <h3 className="empty-state__title">Select a workspace…</h3>
-      <p>Choose a workspace from the switcher above to continue.</p>
-    </div>
-  )
-
   const pageHeader = (
     <header className="page__header">
       <div>
@@ -853,11 +846,16 @@ export default function Customers() {
     </header>
   )
 
-  if (!activeStoreId) {
+  if (storeLoading) {
     return (
       <div className="page customers-page">
         {pageHeader}
-        <section className="card">{workspaceEmptyState}</section>
+        <section className="card">
+          <div className="empty-state">
+            <h3 className="empty-state__title">Loading workspace…</h3>
+            <p>Please wait while we get things ready.</p>
+          </div>
+        </section>
       </div>
     )
   }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -44,7 +44,7 @@ function formatPercent(value: number) {
 }
 
 export default function Dashboard() {
-  const { storeId, isLoading: storeLoading } = useActiveStoreContext()
+  const { isLoading: storeLoading } = useActiveStoreContext()
   const {
     rangePresets,
     selectedRangeId,
@@ -73,15 +73,6 @@ export default function Dashboard() {
       <div>
         <h2 style={{ color: '#4338CA', marginBottom: 8 }}>Dashboard</h2>
         <p style={{ color: '#475569' }}>Loading your workspace…</p>
-      </div>
-    )
-  }
-
-  if (!storeId) {
-    return (
-      <div>
-        <h2 style={{ color: '#4338CA', marginBottom: 8 }}>Dashboard</h2>
-        <p style={{ color: '#475569' }}>Select a workspace to see your dashboard.</p>
       </div>
     )
   }

--- a/web/src/pages/Gate.test.tsx
+++ b/web/src/pages/Gate.test.tsx
@@ -1,10 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import Gate from './Gate';
 
 const mockUseActiveStoreContext = vi.fn();
 const mockUseMemberships = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
 
 vi.mock('../context/ActiveStoreProvider', () => ({
   useActiveStoreContext: () => mockUseActiveStoreContext(),
@@ -16,16 +26,48 @@ vi.mock('../hooks/useMemberships', () => ({
 
 describe('Gate', () => {
   beforeEach(() => {
+    navigateMock.mockReset();
     mockUseActiveStoreContext.mockReset();
     mockUseMemberships.mockReset();
     mockUseActiveStoreContext.mockReturnValue({
       storeId: 'store-1',
       isLoading: false,
       error: null,
-      memberships: [],
+      memberships: [
+        {
+          id: 'membership-1',
+          uid: 'user-1',
+          role: 'owner' as const,
+          storeId: 'store-1',
+          email: null,
+          phone: null,
+          invitedBy: null,
+          firstSignupEmail: null,
+          createdAt: null,
+          updatedAt: null,
+        },
+      ],
       membershipsLoading: false,
       setActiveStoreId: vi.fn(),
       storeChangeToken: 0,
+    });
+    mockUseMemberships.mockReturnValue({
+      loading: false,
+      error: null,
+      memberships: [
+        {
+          id: 'membership-1',
+          uid: 'user-1',
+          role: 'owner' as const,
+          storeId: 'store-1',
+          email: null,
+          phone: null,
+          invitedBy: null,
+          firstSignupEmail: null,
+          createdAt: null,
+          updatedAt: null,
+        },
+      ],
     });
   });
 
@@ -34,29 +76,48 @@ describe('Gate', () => {
       storeId,
       loading: true,
       error: null,
+      memberships: [],
     }));
 
     render(<Gate />);
 
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 
   it("renders an error message when memberships can't be fetched", () => {
     const error = new Error('Failed to load memberships');
-    mockUseMemberships.mockReturnValue({ loading: false, error });
+    mockUseMemberships.mockReturnValue({ loading: false, error, memberships: [] });
 
     render(<Gate />);
 
     expect(screen.getByRole('heading', { name: /couldn't load your workspace/i })).toBeInTheDocument();
     expect(screen.getByText(/failed to load memberships/i)).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('navigates to onboarding when there are no memberships', async () => {
+    mockUseMemberships.mockReturnValue({ loading: false, error: null, memberships: [] });
+
+    render(
+      <Gate>
+        <div data-testid="protected">Content</div>
+      </Gate>,
+    );
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/onboarding', { replace: true });
+    });
+
+    expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
   });
 
   it('renders children once memberships load successfully', () => {
-    mockUseMemberships.mockReturnValue({ loading: false, error: null });
     const child = <div data-testid="app">App</div>;
 
     render(<Gate>{child}</Gate>);
 
     expect(screen.getByTestId('app')).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/Gate.tsx
+++ b/web/src/pages/Gate.tsx
@@ -1,5 +1,7 @@
 // web/src/pages/Gate.tsx
 import type { ReactNode } from 'react'
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useActiveStoreContext } from '../context/ActiveStoreProvider'
 import { useMemberships } from '../hooks/useMemberships'
 
@@ -14,9 +16,28 @@ function toErrorMessage(error: unknown) {
 }
 
 export default function Gate({ children }: { children?: ReactNode }) {
+  const navigate = useNavigate()
   const { storeId, isLoading: storeLoading } = useActiveStoreContext()
   const membershipsStoreId = storeLoading ? undefined : storeId ?? null
-  const { loading, error } = useMemberships(membershipsStoreId)
+  const { loading, error, memberships } = useMemberships(membershipsStoreId)
+
+  useEffect(() => {
+    if (storeLoading || loading) {
+      return
+    }
+
+    if (membershipsStoreId === undefined) {
+      return
+    }
+
+    if (error) {
+      return
+    }
+
+    if (memberships.length === 0) {
+      navigate('/onboarding', { replace: true })
+    }
+  }, [error, loading, memberships.length, membershipsStoreId, navigate, storeLoading])
 
   if (storeLoading || loading) {
     return <div className="p-6">Loading…</div>
@@ -29,6 +50,10 @@ export default function Gate({ children }: { children?: ReactNode }) {
         <p className="text-sm text-red-600">{toErrorMessage(error)}</p>
       </div>
     )
+  }
+
+  if (membershipsStoreId !== undefined && memberships.length === 0) {
+    return null
   }
 
   return <>{children}</>

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -158,7 +158,7 @@ function isOfflineError(error: unknown) {
 }
 
 export default function Products() {
-  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken, isLoading: storeLoading } = useActiveStoreContext()
   const [products, setProducts] = useState<ProductRecord[]>([])
   const [isLoadingProducts, setIsLoadingProducts] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -742,13 +742,6 @@ export default function Products() {
     )
   }
 
-  const workspaceEmptyState = (
-    <div className="empty-state">
-      <h3 className="empty-state__title">Select a workspace…</h3>
-      <p>Choose a workspace from the switcher above to continue.</p>
-    </div>
-  )
-
   const pageHeader = (
     <header className="page__header">
       <div>
@@ -763,11 +756,16 @@ export default function Products() {
     </header>
   )
 
-  if (!activeStoreId) {
+  if (storeLoading) {
     return (
       <div className="page products-page">
         {pageHeader}
-        <section className="card products-page__card">{workspaceEmptyState}</section>
+        <section className="card products-page__card">
+          <div className="empty-state">
+            <h3 className="empty-state__title">Loading workspace…</h3>
+            <p>Please wait while we get things ready.</p>
+          </div>
+        </section>
       </div>
     )
   }

--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -42,7 +42,7 @@ function isOfflineError(error: unknown) {
 }
 
 export default function Receive() {
-  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken, isLoading: storeLoading } = useActiveStoreContext()
   const [products, setProducts] = useState<Product[]>([])
   const [selected, setSelected] = useState<string>('')
   const [qty, setQty] = useState<string>('')
@@ -275,13 +275,6 @@ export default function Receive() {
 
 
 
-  const workspaceEmptyState = (
-    <div className="empty-state">
-      <h3 className="empty-state__title">Select a workspace…</h3>
-      <p>Choose a workspace from the switcher above to continue.</p>
-    </div>
-  )
-
   const pageHeader = (
     <header className="page__header">
       <div>
@@ -291,11 +284,16 @@ export default function Receive() {
     </header>
   )
 
-  if (!activeStoreId) {
+  if (storeLoading) {
     return (
       <div className="page receive-page">
         {pageHeader}
-        <section className="card receive-page__card">{workspaceEmptyState}</section>
+        <section className="card receive-page__card">
+          <div className="empty-state">
+            <h3 className="empty-state__title">Loading workspace…</h3>
+            <p>Please wait while we get things ready.</p>
+          </div>
+        </section>
       </div>
     )
   }

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -199,7 +199,7 @@ function calculateEarnedLoyaltyPoints(total: number): number {
 
 export default function Sell() {
   const user = useAuthUser()
-  const { storeId: activeStoreId, storeChangeToken } = useActiveStoreContext()
+  const { storeId: activeStoreId, storeChangeToken, isLoading: storeLoading } = useActiveStoreContext()
 
   const [products, setProducts] = useState<Product[]>([])
   const [customers, setCustomers] = useState<Customer[]>([])
@@ -797,13 +797,6 @@ export default function Sell() {
 
   const filtered = products.filter(p => p.name.toLowerCase().includes(queryText.toLowerCase()))
 
-  const workspaceEmptyState = (
-    <div className="empty-state">
-      <h3 className="empty-state__title">Select a workspace…</h3>
-      <p>Choose a workspace from the switcher above to continue.</p>
-    </div>
-  )
-
   const pageHeader = (
     <header className="page__header">
       <div>
@@ -817,11 +810,16 @@ export default function Sell() {
     </header>
   )
 
-  if (!activeStoreId) {
+  if (storeLoading) {
     return (
       <div className="page sell-page">
         {pageHeader}
-        <section className="card">{workspaceEmptyState}</section>
+        <section className="card">
+          <div className="empty-state">
+            <h3 className="empty-state__title">Loading workspace…</h3>
+            <p>Please wait while we get things ready.</p>
+          </div>
+        </section>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- redirect Gate to onboarding when memberships resolve with no entries and avoid rendering protected children in that state
- cover the onboarding redirect in Gate tests while ensuring existing loading and error flows remain intact
- let Dashboard, Sell, Receive, Products, Customers, and Close Day rely on the gate instead of workspace placeholder UI, showing a loading state only while the store context resolves

## Testing
- npm test -- Gate

------
https://chatgpt.com/codex/tasks/task_e_68dc128df6e08321b485fa4543cf8e83