### PR TITLE
Use Firestore membership for resolveStoreAccess

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,7 +1,6 @@
 import * as functions from 'firebase-functions'
 import { applyRoleClaims } from './customClaims'
 import { admin, defaultDb, getStoreContext, rosterDb, type StoreContext } from './firestore'
-import { fetchClientRowByEmail, getDefaultSpreadsheetId, normalizeHeader } from './googleSheets'
 import { deriveStoreIdFromContext, withCallableErrorLogging } from './telemetry'
 
 import { FIREBASE_CALLABLES } from '../../shared/firebaseCallables'
@@ -36,6 +35,38 @@ async function getStoreTimezone(storeId: string): Promise<string> {
   }
   storeTimezoneCache.set(storeId, 'UTC')
   return 'UTC'
+}
+
+function parseDateValue(value: unknown): admin.firestore.Timestamp | null {
+  if (value instanceof admin.firestore.Timestamp) {
+    return value
+  }
+
+  let candidate: number | null = null
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const parsed = Date.parse(trimmed)
+    if (!Number.isNaN(parsed)) {
+      candidate = parsed
+    }
+  } else if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value > 10_000_000_000) {
+      candidate = value
+    } else if (value > 1_000_000_000) {
+      candidate = value * 1000
+    } else if (value > 0) {
+      const serialEpoch = Date.UTC(1899, 11, 30)
+      candidate = serialEpoch + value * 24 * 60 * 60 * 1000
+    }
+  }
+
+  if (candidate === null) {
+    return null
+  }
+
+  return admin.firestore.Timestamp.fromMillis(candidate)
 }
 
 function parseTimestampValue(value: unknown): admin.firestore.Timestamp | null {
@@ -1022,288 +1053,6 @@ async function ensureAuthUser(email: string, password?: string) {
   }
 }
 
-type SheetRecord = Record<string, string>
-
-type SeededDocument = {
-  id: string
-  data: admin.firestore.DocumentData
-}
-
-function getOptionalString(value: unknown): string | null {
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (trimmed.length > 0) {
-      return trimmed
-    }
-  }
-  return null
-}
-
-function getOptionalEmail(value: unknown): string | null {
-  const candidate = getOptionalString(value)
-  return candidate ? candidate.toLowerCase() : null
-}
-
-function getValueFromRecord(record: SheetRecord, keys: string[]): string | null {
-  for (const key of keys) {
-    const normalizedKey = normalizeHeader(key)
-    if (!normalizedKey) continue
-    const value = record[normalizedKey]
-    const resolved = getOptionalString(value)
-    if (resolved) return resolved
-  }
-  return null
-}
-
-function getEmailFromRecord(record: SheetRecord, keys: string[]): string | null {
-  for (const key of keys) {
-    const normalizedKey = normalizeHeader(key)
-    if (!normalizedKey) continue
-    const value = record[normalizedKey]
-    const resolved = getOptionalEmail(value)
-    if (resolved) return resolved
-  }
-  return null
-}
-
-function isInactiveContractStatus(value: string | null): boolean {
-  if (!value) return false
-  const normalized = value.trim().toLowerCase()
-  if (!normalized) return false
-  const tokens = normalized.split(/[^a-z0-9]+/).filter(Boolean)
-  const tokenSet = new Set(tokens)
-  const inactiveTokens = [
-    'inactive',
-    'terminated',
-    'termination',
-    'cancelled',
-    'canceled',
-    'suspended',
-    'paused',
-    'hold',
-    'closed',
-    'ended',
-    'deactivated',
-    'disabled',
-  ]
-  return inactiveTokens.some(token => tokenSet.has(token))
-}
-
-function parseNumberValue(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value
-  }
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) return null
-    const normalized = trimmed.replace(/[^0-9.+-]/g, '')
-    if (!normalized) return null
-    const parsed = Number(normalized)
-    return Number.isFinite(parsed) ? parsed : null
-  }
-  return null
-}
-
-function parseDateValue(value: unknown): admin.firestore.Timestamp | null {
-  if (value instanceof admin.firestore.Timestamp) {
-    return value
-  }
-
-  let candidate: number | null = null
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) return null
-    const parsed = Date.parse(trimmed)
-    if (!Number.isNaN(parsed)) {
-      candidate = parsed
-    }
-  } else if (typeof value === 'number' && Number.isFinite(value)) {
-    if (value > 10_000_000_000) {
-      candidate = value
-    } else if (value > 1_000_000_000) {
-      candidate = value * 1000
-    } else if (value > 0) {
-      const serialEpoch = Date.UTC(1899, 11, 30)
-      candidate = serialEpoch + value * 24 * 60 * 60 * 1000
-    }
-  }
-
-  if (candidate === null) {
-    return null
-  }
-
-  return admin.firestore.Timestamp.fromMillis(candidate)
-}
-
-function getTimestampFromRecord(
-  record: SheetRecord,
-  keys: string[],
-): admin.firestore.Timestamp | null {
-  for (const key of keys) {
-    const normalizedKey = normalizeHeader(key)
-    if (!normalizedKey) continue
-    const raw = record[normalizedKey]
-    const parsed = parseDateValue(raw)
-    if (parsed) return parsed
-  }
-  return null
-}
-
-function getNumberFromRecord(record: SheetRecord, keys: string[]): number | null {
-  for (const key of keys) {
-    const normalizedKey = normalizeHeader(key)
-    if (!normalizedKey) continue
-    const raw = record[normalizedKey]
-    const parsed = parseNumberValue(raw)
-    if (parsed !== null) return parsed
-  }
-  return null
-}
-
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-}
-
-function buildSeedId(storeId: string, candidate: string | null, fallback: string): string {
-  const normalizedCandidate = candidate ? slugify(candidate) : ''
-  if (normalizedCandidate) {
-    return `${storeId}_${normalizedCandidate}`
-  }
-  return `${storeId}_${fallback}`
-}
-
-function parseSeedArray(record: SheetRecord, keys: string[]): Record<string, unknown>[] {
-  for (const key of keys) {
-    const value = getOptionalString(record[key])
-    if (!value) continue
-    try {
-      const parsed = JSON.parse(value) as unknown
-      if (Array.isArray(parsed)) {
-        return parsed.filter(item => typeof item === 'object' && item !== null) as Record<string, unknown>[]
-      }
-      if (parsed && typeof parsed === 'object') {
-        return Object.values(parsed as Record<string, unknown>).filter(
-          item => typeof item === 'object' && item !== null,
-        ) as Record<string, unknown>[]
-      }
-    } catch (error) {
-      functions.logger.warn('[resolveStoreAccess] Unable to parse seed data column', key, error)
-    }
-  }
-  return []
-}
-
-function parseTags(value: unknown): string[] {
-  if (Array.isArray(value)) {
-    return value
-      .map(item => getOptionalString(item))
-      .filter((item): item is string => typeof item === 'string' && item.length > 0)
-  }
-  const asString = getOptionalString(value)
-  if (!asString) return []
-  return asString
-    .split(/[,#]/)
-    .map(part => part.trim())
-    .filter(Boolean)
-}
-
-function mapProductSeeds(record: SheetRecord, storeId: string): SeededDocument[] {
-  const products = parseSeedArray(record, ['products_json', 'products'])
-  return products
-    .map((product, index) => {
-      const name = getOptionalString(product.name ?? product.product_name ?? product.title)
-      if (!name) return null
-      const sku = getOptionalString(product.sku ?? product.product_sku ?? product.code)
-      const idCandidate =
-        getOptionalString(product.id ?? product.product_id ?? product.identifier ?? sku ?? name) ?? null
-      const price =
-        parseNumberValue(product.price ?? product.unit_price ?? product.retail_price ?? product.cost_price) ?? null
-      const stockCount =
-        parseNumberValue(product.stockCount ?? product.stock_count ?? product.quantity ?? product.inventory) ?? null
-      const reorderThreshold =
-        parseNumberValue(
-          product.reorderThreshold ?? product.reorder_threshold ?? product.reorder_point ?? product.reorder,
-        ) ?? null
-
-      const seedId = buildSeedId(storeId, idCandidate, `product_${index + 1}`)
-      const data: admin.firestore.DocumentData = { storeId, name }
-      if (sku) data.sku = sku
-      if (price !== null) data.price = price
-      if (stockCount !== null) data.stockCount = stockCount
-      if (reorderThreshold !== null) data.reorderThreshold = reorderThreshold
-      return { id: seedId, data }
-    })
-    .filter((item): item is SeededDocument => item !== null)
-}
-
-function mapCustomerSeeds(record: SheetRecord, storeId: string): SeededDocument[] {
-  const customers = parseSeedArray(record, ['customers_json', 'customers'])
-  return customers
-    .map((customer, index) => {
-      const primaryName =
-        getOptionalString(customer.displayName ?? customer.display_name ?? customer.name ?? customer.customer_name) ??
-        null
-      const fallbackName =
-        getOptionalString(customer.name ?? customer.customer_name ?? customer.displayName ?? customer.display_name) ??
-        primaryName
-      const email = getOptionalEmail(customer.email ?? customer.contact_email)
-      const phone = getOptionalString(customer.phone ?? customer.phone_number ?? customer.contact_phone)
-
-      if (!primaryName && !fallbackName && !email && !phone) {
-        return null
-      }
-
-      const identifierCandidate =
-        getOptionalString(
-          customer.id ??
-            customer.customer_id ??
-            customer.identifier ??
-            customer.external_id ??
-            email ??
-            phone ??
-            primaryName ??
-            fallbackName ??
-            undefined,
-        ) ?? null
-
-      const tags = parseTags(customer.tags ?? customer.labels)
-      const notes = getOptionalString(customer.notes ?? customer.note ?? customer.summary)
-
-      const seedId = buildSeedId(storeId, identifierCandidate, `customer_${index + 1}`)
-      const data: admin.firestore.DocumentData = {
-        storeId,
-        name: fallbackName ?? primaryName ?? email ?? phone ?? seedId,
-      }
-      if (primaryName) data.displayName = primaryName
-      if (email) data.email = email
-      if (phone) data.phone = phone
-      if (notes) data.notes = notes
-      if (tags.length) data.tags = tags
-      return { id: seedId, data }
-    })
-    .filter((item): item is SeededDocument => item !== null)
-}
-
-function serializeFirestoreData(data: admin.firestore.DocumentData): Record<string, unknown> {
-  const result: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(data)) {
-    if (value instanceof admin.firestore.Timestamp) {
-      result[key] = value.toMillis()
-    } else if (Array.isArray(value)) {
-      result[key] = value.map(item =>
-        item instanceof admin.firestore.Timestamp ? item.toMillis() : item,
-      )
-    } else {
-      result[key] = value
-    }
-  }
-  return result
-}
-
 export const handleUserCreate = functions.auth.user().onCreate(async user => {
   const uid = user.uid
   const timestamp = admin.firestore.FieldValue.serverTimestamp()
@@ -1500,331 +1249,28 @@ export const afterSignupBootstrap = functions.https.onCall(
 export const resolveStoreAccess = functions.https.onCall(
   withCallableErrorLogging(
     FIREBASE_CALLABLES.RESOLVE_STORE_ACCESS,
-    async (data, context) => {
+    async (_data, context) => {
       assertAuthenticated(context)
 
-      const uid = context.auth!.uid
-      const token = context.auth!.token as Record<string, unknown>
-      const emailFromToken = typeof token.email === 'string' ? (token.email as string).toLowerCase() : null
-
-  const rawPayload = (data ?? {}) as { storeId?: unknown } | unknown
-  let requestedStoreId: string | null = null
-  if (typeof rawPayload === 'object' && rawPayload !== null && 'storeId' in rawPayload) {
-    const candidate = (rawPayload as { storeId?: unknown }).storeId
-    if (typeof candidate !== 'string') {
-      throw new functions.https.HttpsError(
-        'permission-denied',
-        'Enter the store ID assigned to your Sedifex workspace.',
-      )
-    }
-    const trimmed = candidate.trim()
-    if (!trimmed) {
-      throw new functions.https.HttpsError(
-        'permission-denied',
-        'Enter the store ID assigned to your Sedifex workspace.',
-      )
-    }
-    requestedStoreId = trimmed
-  }
-
-  if (!emailFromToken) {
-    throw new functions.https.HttpsError(
-      'failed-precondition',
-      'A verified email is required to resolve store access for this account.',
-    )
-  }
-
-  let sheetRow: Awaited<ReturnType<typeof fetchClientRowByEmail>>
-  try {
-    sheetRow = await fetchClientRowByEmail(getDefaultSpreadsheetId(), emailFromToken)
-  } catch (error) {
-    functions.logger.error('[resolveStoreAccess] Failed to query Google Sheets', error)
-    throw new functions.https.HttpsError('internal', 'Unable to verify workspace access at this time.')
-  }
-
-  if (!sheetRow) {
-    throw new functions.https.HttpsError(
-      'permission-denied',
-      'We could not find a workspace assignment for this account. Reach out to your Sedifex administrator.',
-    )
-  }
-
-  const record = sheetRow.record
-  const now = admin.firestore.Timestamp.now()
-
-  const memberRef = rosterDb.collection('teamMembers').doc(uid)
-  const memberSnap = await memberRef.get()
-  const existingMember = memberSnap.data() ?? {}
-
-  const existingStoreId =
-    typeof existingMember.storeId === 'string' && existingMember.storeId.trim() !== ''
-      ? (existingMember.storeId as string).trim()
-      : null
-
-  const sheetStoreIdValue = getValueFromRecord(record, [
-    'store_id',
-    'storeid',
-    'store_identifier',
-    'store',
-  ])
-  const normalizedSheetStoreId =
-    typeof sheetStoreIdValue === 'string' ? sheetStoreIdValue.trim() : ''
-
-  const missingStoreIdMessage =
-    'We could not confirm the store ID assigned to your Sedifex workspace. Reach out to your Sedifex administrator.'
-
-  if (requestedStoreId !== null) {
-    if (!normalizedSheetStoreId) {
-      throw new functions.https.HttpsError('failed-precondition', missingStoreIdMessage)
-    }
-    if (requestedStoreId !== normalizedSheetStoreId) {
-      throw new functions.https.HttpsError(
-        'permission-denied',
-        `Your account is assigned to store ${normalizedSheetStoreId}. Enter the correct store ID to continue.`,
-      )
-    }
-  }
-
-  const storeIdCandidate = normalizedSheetStoreId || existingStoreId || null
-
-  if (!storeIdCandidate) {
-    throw new functions.https.HttpsError('failed-precondition', missingStoreIdMessage)
-  }
-
-  const storeId = storeIdCandidate
-
-  const resolvedRoleCandidate = getValueFromRecord(record, ['role', 'member_role', 'store_role', 'workspace_role'])
-  const existingRole =
-    typeof existingMember.role === 'string' && VALID_ROLES.has(existingMember.role)
-      ? (existingMember.role as 'owner' | 'staff')
-      : null
-  let resolvedRole: 'owner' | 'staff' = existingRole ?? 'staff'
-  if (resolvedRoleCandidate) {
-    const normalizedRole = resolvedRoleCandidate.toLowerCase()
-    if (normalizedRole.includes('owner')) {
-      resolvedRole = 'owner'
-    } else if (VALID_ROLES.has(normalizedRole) && existingRole !== 'owner') {
-      resolvedRole = normalizedRole as 'owner' | 'staff'
-    }
-  }
-
-  const memberEmail =
-    getEmailFromRecord(record, ['member_email', 'email', 'primary_email', 'user_email']) ?? emailFromToken
-  const memberPhone =
-    getValueFromRecord(record, ['member_phone', 'phone', 'contact_phone', 'store_contact_phone']) ??
-    (typeof existingMember.phone === 'string' ? existingMember.phone : null)
-  const firstSignupEmail =
-    getEmailFromRecord(record, ['first_signup_email', 'signup_email']) ??
-    (typeof existingMember.firstSignupEmail === 'string'
-      ? existingMember.firstSignupEmail
-      : emailFromToken)
-  const memberName =
-    getValueFromRecord(record, ['member_name', 'contact_name', 'staff_name', 'name']) ??
-    (typeof existingMember.name === 'string' ? existingMember.name : null)
-  const invitedBy =
-    getValueFromRecord(record, ['invited_by', 'inviter_uid', 'invitedby']) ??
-    (typeof existingMember.invitedBy === 'string' ? existingMember.invitedBy : null)
-
-  const memberCreatedAt =
-    memberSnap.exists && existingMember.createdAt instanceof admin.firestore.Timestamp
-      ? (existingMember.createdAt as admin.firestore.Timestamp)
-      : now
-
-  const memberData: admin.firestore.DocumentData = {
-    uid,
-    storeId,
-    role: resolvedRole,
-    email: memberEmail,
-    updatedAt: now,
-    createdAt: memberCreatedAt,
-  }
-  if (memberPhone) memberData.phone = memberPhone
-  if (memberName) memberData.name = memberName
-  if (firstSignupEmail) memberData.firstSignupEmail = firstSignupEmail
-  if (invitedBy) memberData.invitedBy = invitedBy
-
-  await memberRef.set(memberData, { merge: true })
-  const claims = await applyRoleClaims({ uid, role: resolvedRole, storeId })
-
-  const storeRef = defaultDb.collection('stores').doc(storeId)
-  const storeSnap = await storeRef.get()
-  const existingStore = storeSnap.data() ?? {}
-  const storeCreatedAt =
-    storeSnap.exists && existingStore.createdAt instanceof admin.firestore.Timestamp
-      ? (existingStore.createdAt as admin.firestore.Timestamp)
-      : now
-
-  const storeName =
-    getValueFromRecord(record, ['store_name', 'workspace_name', 'store']) ??
-    (typeof existingStore.name === 'string' ? existingStore.name : null)
-  const storeDisplayName =
-    getValueFromRecord(record, ['store_display_name', 'display_name']) ??
-    (typeof existingStore.displayName === 'string' ? existingStore.displayName : null)
-  const storeEmail =
-    getEmailFromRecord(record, ['store_email', 'contact_email', 'store_contact_email']) ??
-    (typeof existingStore.email === 'string' ? existingStore.email : null)
-  const storePhone =
-    getValueFromRecord(record, ['store_phone', 'contact_phone', 'store_contact_phone']) ??
-    (typeof existingStore.phone === 'string' ? existingStore.phone : null)
-  const storeTimezone =
-    getValueFromRecord(record, ['store_timezone', 'timezone']) ??
-    (typeof existingStore.timezone === 'string' ? existingStore.timezone : null)
-  const storeCurrency =
-    getValueFromRecord(record, ['store_currency', 'currency']) ??
-    (typeof existingStore.currency === 'string' ? existingStore.currency : null)
-  const storeStatus =
-    getValueFromRecord(record, ['store_status', 'status']) ??
-    (typeof existingStore.status === 'string' ? existingStore.status : null)
-  const contractStart =
-    getTimestampFromRecord(record, [
-      'contractStart',
-      'contract_start',
-      'contract_start_date',
-      'contract_start_at',
-      'start_date',
-    ]) ??
-    (existingStore.contractStart instanceof admin.firestore.Timestamp
-      ? existingStore.contractStart
-      : null)
-  const contractEnd =
-    getTimestampFromRecord(record, [
-      'contractEnd',
-      'contract_end',
-      'contract_end_date',
-      'contract_end_at',
-      'end_date',
-    ]) ??
-    (existingStore.contractEnd instanceof admin.firestore.Timestamp
-      ? existingStore.contractEnd
-      : null)
-  const paymentStatus =
-    getValueFromRecord(record, ['paymentStatus', 'payment_status', 'contract_payment_status']) ??
-    (typeof existingStore.paymentStatus === 'string' ? existingStore.paymentStatus : null)
-  const amountPaid =
-    getNumberFromRecord(record, ['amountPaid', 'amount_paid', 'payment_amount', 'contract_amount_paid']) ??
-    (typeof existingStore.amountPaid === 'number' && Number.isFinite(existingStore.amountPaid)
-      ? (existingStore.amountPaid as number)
-      : null)
-  const company =
-    getValueFromRecord(record, ['company', 'company_name', 'business_name']) ??
-    (typeof existingStore.company === 'string' ? existingStore.company : null)
-
-  if (isInactiveContractStatus(storeStatus)) {
-    throw new functions.https.HttpsError('permission-denied', INACTIVE_WORKSPACE_MESSAGE)
-  }
-  const storeAddressLine1 =
-    getValueFromRecord(record, ['store_address_line1', 'address_line1', 'address_1']) ??
-    (typeof existingStore.addressLine1 === 'string' ? existingStore.addressLine1 : null)
-  const storeAddressLine2 =
-    getValueFromRecord(record, ['store_address_line2', 'address_line2', 'address_2']) ??
-    (typeof existingStore.addressLine2 === 'string' ? existingStore.addressLine2 : null)
-  const storeCity =
-    getValueFromRecord(record, ['store_city', 'city']) ??
-    (typeof existingStore.city === 'string' ? existingStore.city : null)
-  const storeRegion =
-    getValueFromRecord(record, ['store_region', 'region', 'state', 'province']) ??
-    (typeof existingStore.region === 'string' ? existingStore.region : null)
-  const storePostalCode =
-    getValueFromRecord(record, ['store_postal_code', 'postal_code', 'zip']) ??
-    (typeof existingStore.postalCode === 'string' ? existingStore.postalCode : null)
-  const storeCountry =
-    getValueFromRecord(record, ['store_country', 'country']) ??
-    (typeof existingStore.country === 'string' ? existingStore.country : null)
-
-  const storeData: admin.firestore.DocumentData = {
-    storeId,
-    updatedAt: now,
-    createdAt: storeCreatedAt,
-  }
-  if (storeName) storeData.name = storeName
-  if (storeDisplayName) storeData.displayName = storeDisplayName
-  if (storeEmail) storeData.email = storeEmail
-  if (storePhone) storeData.phone = storePhone
-  if (storeTimezone) storeData.timezone = storeTimezone
-  if (storeCurrency) storeData.currency = storeCurrency
-  if (storeStatus) storeData.status = storeStatus
-  if (storeAddressLine1) storeData.addressLine1 = storeAddressLine1
-  if (storeAddressLine2) storeData.addressLine2 = storeAddressLine2
-  if (storeCity) storeData.city = storeCity
-  if (storeRegion) storeData.region = storeRegion
-  if (storePostalCode) storeData.postalCode = storePostalCode
-  if (storeCountry) storeData.country = storeCountry
-  if (contractStart) storeData.contractStart = contractStart
-  if (contractEnd) storeData.contractEnd = contractEnd
-  if (paymentStatus) storeData.paymentStatus = paymentStatus
-  if (amountPaid !== null) storeData.amountPaid = amountPaid
-  if (company) storeData.company = company
-
-  await storeRef.set(storeData, { merge: true })
-
-  const productSeeds = mapProductSeeds(record, storeId)
-  const customerSeeds = mapCustomerSeeds(record, storeId)
-
-  const productResults = await Promise.all(
-    productSeeds.map(async seed => {
-      const ref = defaultDb.collection('products').doc(seed.id)
-      const snapshot = await ref.get()
-      const existingProduct = snapshot.data() ?? {}
-      const productCreatedAt =
-        snapshot.exists && existingProduct.createdAt instanceof admin.firestore.Timestamp
-          ? (existingProduct.createdAt as admin.firestore.Timestamp)
-          : now
-      const productData: admin.firestore.DocumentData = {
-        ...seed.data,
-        createdAt: productCreatedAt,
-        updatedAt: now,
+      const memberRef = rosterDb.collection('teamMembers').doc(context.auth!.uid)
+      const memberSnap = await memberRef.get()
+      if (!memberSnap.exists) {
+        return { ok: false as const, error: 'NO_MEMBERSHIP' as const }
       }
-      await ref.set(productData, { merge: true })
-      return { id: ref.id, data: productData }
-    }),
-  )
 
-  const customerResults = await Promise.all(
-    customerSeeds.map(async seed => {
-      const ref = defaultDb.collection('customers').doc(seed.id)
-      const snapshot = await ref.get()
-      const existingCustomer = snapshot.data() ?? {}
-      const customerCreatedAt =
-        snapshot.exists && existingCustomer.createdAt instanceof admin.firestore.Timestamp
-          ? (existingCustomer.createdAt as admin.firestore.Timestamp)
-          : now
-      const customerData: admin.firestore.DocumentData = {
-        ...seed.data,
-        createdAt: customerCreatedAt,
-        updatedAt: now,
+      const data = memberSnap.data() ?? {}
+      const storeId = typeof data.storeId === 'string' ? data.storeId.trim() : ''
+      const roleCandidate = typeof data.role === 'string' ? data.role.trim().toLowerCase() : ''
+      const role =
+        roleCandidate === 'owner' || roleCandidate === 'staff'
+          ? (roleCandidate as 'owner' | 'staff')
+          : null
+
+      if (storeId && role) {
+        return { ok: true as const, storeId, role }
       }
-      await ref.set(customerData, { merge: true })
-      return { id: ref.id, data: customerData }
-    }),
-  )
 
-  return {
-    ok: true,
-    storeId,
-    role: resolvedRole,
-    spreadsheetId: sheetRow.spreadsheetId,
-    teamMember: { id: memberRef.id, data: serializeFirestoreData(memberData) },
-    claims,
-    store: { id: storeRef.id, data: serializeFirestoreData(storeData) },
-    products: productResults.map(item => ({ id: item.id, data: serializeFirestoreData(item.data) })),
-    customers: customerResults.map(item => ({ id: item.id, data: serializeFirestoreData(item.data) })),
-  }
-    },
-    {
-      resolveStoreId: (rawData, context) => {
-        if (rawData && typeof rawData === 'object' && 'storeId' in (rawData as Record<string, unknown>)) {
-          const candidate = (rawData as { storeId?: unknown }).storeId
-          if (typeof candidate === 'string') {
-            const trimmed = candidate.trim()
-            if (trimmed) {
-              return trimmed
-            }
-          }
-        }
-        const fromContext = deriveStoreIdFromContext(context)
-        if (fromContext) return fromContext
-        return context.auth?.uid ?? null
-      },
+      return { ok: false as const, error: 'NO_MEMBERSHIP' as const }
     },
   ),
 )

--- a/functions/test/resolveStoreAccess.test.js
+++ b/functions/test/resolveStoreAccess.test.js
@@ -1,21 +1,9 @@
 const assert = require('assert')
 const Module = require('module')
-const path = require('path')
 const { MockFirestore, MockTimestamp } = require('./helpers/mockFirestore')
 
 let currentDefaultDb
-let sheetRowMock
 const apps = []
-let lastCustomClaims
-
-function normalizeHeader(header) {
-  if (typeof header !== 'string') return ''
-  return header
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-}
 
 const originalLoad = Module._load
 Module._load = function patchedLoad(request, parent, isMain) {
@@ -37,7 +25,7 @@ Module._load = function patchedLoad(request, parent, isMain) {
       apps,
       firestore,
       auth: () => ({
-        getUser: async () => ({ customClaims: lastCustomClaims || undefined }),
+        getUser: async () => ({ customClaims: undefined }),
         getUserByEmail: async () => {
           const err = new Error('not found')
           err.code = 'auth/user-not-found'
@@ -45,9 +33,7 @@ Module._load = function patchedLoad(request, parent, isMain) {
         },
         updateUser: async () => {},
         createUser: async () => ({ uid: 'new-user' }),
-        setCustomUserClaims: async (_uid, claims) => {
-          lastCustomClaims = { ...claims }
-        },
+        setCustomUserClaims: async () => {},
       }),
     }
   }
@@ -58,208 +44,72 @@ Module._load = function patchedLoad(request, parent, isMain) {
     }
   }
 
-  if (request === './googleSheets' || request.endsWith(`${path.sep}googleSheets`)) {
-    return {
-      fetchClientRowByEmail: async () => sheetRowMock,
-      getDefaultSpreadsheetId: () => 'sheet-123',
-      normalizeHeader,
-    }
-  }
-
   return originalLoad(request, parent, isMain)
 }
 
 function loadFunctionsModule() {
   apps.length = 0
-  lastCustomClaims = null
   delete require.cache[require.resolve('../lib/firestore.js')]
-  delete require.cache[require.resolve('../lib/googleSheets.js')]
   delete require.cache[require.resolve('../lib/index.js')]
   return require('../lib/index.js')
 }
 
-async function runActiveStatusTest() {
-  currentDefaultDb = new MockFirestore()
-  sheetRowMock = {
-    spreadsheetId: 'sheet-123',
-    headers: [],
-    normalizedHeaders: [],
-    values: [],
-    record: {
-      [normalizeHeader('store_id')]: 'store-001',
-      [normalizeHeader('store_status')]: 'Active',
-      [normalizeHeader('role')]: 'Owner',
-      [normalizeHeader('member_email')]: 'owner@example.com',
-      [normalizeHeader('member_name')]: 'Owner One',
-      [normalizeHeader('contractStart')]: '2024-01-15',
-      [normalizeHeader('contract_end')]: '2024-12-31',
-      [normalizeHeader('paymentStatus')]: 'Paid',
-      [normalizeHeader('amountPaid')]: '$1,234.56',
-      [normalizeHeader('company')]: 'Example Company',
-    },
-  }
+async function runSuccessTest() {
+  currentDefaultDb = new MockFirestore({
+    'teamMembers/user-1': { storeId: 'store-123', role: 'owner' },
+  })
 
   const { resolveStoreAccess } = loadFunctionsModule()
   const context = {
     auth: {
       uid: 'user-1',
-      token: { email: 'owner@example.com' },
+      token: {},
     },
   }
 
-  const result = await resolveStoreAccess.run({ storeId: 'store-001' }, context)
+  const result = await resolveStoreAccess.run({}, context)
 
-  assert.strictEqual(result.ok, true)
-  assert.strictEqual(result.storeId, 'store-001')
-  assert.strictEqual(result.role, 'owner')
-  assert.deepStrictEqual(result.claims, {
-    role: 'owner',
-    activeStoreId: 'store-001',
-  })
-  assert.deepStrictEqual(lastCustomClaims, {
-    role: 'owner',
-    activeStoreId: 'store-001',
-  })
-
-  const expectedContractStart = Date.parse('2024-01-15T00:00:00.000Z')
-  const expectedContractEnd = Date.parse('2024-12-31T00:00:00.000Z')
-
-  const rosterDoc = currentDefaultDb.getDoc('teamMembers/user-1')
-  assert.ok(rosterDoc)
-  assert.strictEqual(rosterDoc.storeId, 'store-001')
-
-  const storeDoc = currentDefaultDb.getDoc('stores/store-001')
-  assert.ok(storeDoc)
-  assert.strictEqual(storeDoc.status, 'Active')
-  assert.strictEqual(storeDoc.contractStart._millis, expectedContractStart)
-  assert.strictEqual(storeDoc.contractEnd._millis, expectedContractEnd)
-  assert.strictEqual(storeDoc.paymentStatus, 'Paid')
-  assert.strictEqual(storeDoc.amountPaid, 1234.56)
-  assert.strictEqual(storeDoc.company, 'Example Company')
-
-  assert.strictEqual(result.store.data.contractStart, expectedContractStart)
-  assert.strictEqual(result.store.data.contractEnd, expectedContractEnd)
-  assert.strictEqual(result.store.data.paymentStatus, 'Paid')
-  assert.strictEqual(result.store.data.amountPaid, 1234.56)
-  assert.strictEqual(result.store.data.company, 'Example Company')
+  assert.deepStrictEqual(result, { ok: true, storeId: 'store-123', role: 'owner' })
 }
 
-async function runInactiveStatusTest() {
+async function runMissingMembershipTest() {
   currentDefaultDb = new MockFirestore()
-  sheetRowMock = {
-    spreadsheetId: 'sheet-123',
-    headers: [],
-    normalizedHeaders: [],
-    values: [],
-    record: {
-      [normalizeHeader('store_id')]: 'store-002',
-      [normalizeHeader('status')]: 'Contract Terminated',
-      [normalizeHeader('member_email')]: 'owner@example.com',
-    },
-  }
 
   const { resolveStoreAccess } = loadFunctionsModule()
   const context = {
     auth: {
       uid: 'user-2',
-      token: { email: 'owner@example.com' },
+      token: {},
     },
   }
 
-  let error
-  try {
-    await resolveStoreAccess.run({ storeId: 'store-002' }, context)
-  } catch (err) {
-    error = err
-  }
+  const result = await resolveStoreAccess.run({}, context)
 
-  assert.ok(error, 'Expected inactive contract to throw')
-  assert.strictEqual(error.code, 'permission-denied')
-  assert.match(
-    error.message,
-    /workspace contract is not active/i,
-    'Expected inactive status rejection message',
-  )
+  assert.deepStrictEqual(result, { ok: false, error: 'NO_MEMBERSHIP' })
 }
 
-async function runStoreIdMismatchTest() {
-  currentDefaultDb = new MockFirestore()
-  sheetRowMock = {
-    spreadsheetId: 'sheet-123',
-    headers: [],
-    normalizedHeaders: [],
-    values: [],
-    record: {
-      [normalizeHeader('store_id')]: 'store-777',
-      [normalizeHeader('status')]: 'Active',
-      [normalizeHeader('member_email')]: 'owner@example.com',
-    },
-  }
+async function runInvalidMembershipTest() {
+  currentDefaultDb = new MockFirestore({
+    'teamMembers/user-3': { storeId: '', role: 'viewer' },
+  })
 
   const { resolveStoreAccess } = loadFunctionsModule()
   const context = {
     auth: {
       uid: 'user-3',
-      token: { email: 'owner@example.com' },
+      token: {},
     },
   }
 
-  let error
-  try {
-    await resolveStoreAccess.run({ storeId: 'store-abc' }, context)
-  } catch (err) {
-    error = err
-  }
+  const result = await resolveStoreAccess.run({}, context)
 
-  assert.ok(error, 'Expected mismatch to throw')
-  assert.strictEqual(error.code, 'permission-denied')
-  assert.strictEqual(
-    error.message,
-    'Your account is assigned to store store-777. Enter the correct store ID to continue.',
-  )
-}
-
-async function runMissingStoreIdTest() {
-  currentDefaultDb = new MockFirestore()
-  sheetRowMock = {
-    spreadsheetId: 'sheet-123',
-    headers: [],
-    normalizedHeaders: [],
-    values: [],
-    record: {
-      status: 'Active',
-      member_email: 'owner@example.com',
-    },
-  }
-
-  const { resolveStoreAccess } = loadFunctionsModule()
-  const context = {
-    auth: {
-      uid: 'user-4',
-      token: { email: 'owner@example.com' },
-    },
-  }
-
-  let error
-  try {
-    await resolveStoreAccess.run({ storeId: 'store-001' }, context)
-  } catch (err) {
-    error = err
-  }
-
-  assert.ok(error, 'Expected missing store ID to throw')
-  assert.strictEqual(error.code, 'failed-precondition')
-  assert.strictEqual(
-    error.message,
-    'We could not confirm the store ID assigned to your Sedifex workspace. Reach out to your Sedifex administrator.',
-  )
+  assert.deepStrictEqual(result, { ok: false, error: 'NO_MEMBERSHIP' })
 }
 
 async function run() {
-  await runActiveStatusTest()
-  await runInactiveStatusTest()
-  await runStoreIdMismatchTest()
-  await runMissingStoreIdTest()
+  await runSuccessTest()
+  await runMissingMembershipTest()
+  await runInvalidMembershipTest()
   console.log('resolveStoreAccess tests passed')
 }
 


### PR DESCRIPTION
## Summary
- replace the resolveStoreAccess callable with a simple Firestore lookup of the caller's teamMembers document
- remove spreadsheet payload parsing utilities that were only used by the old Google Sheets workflow
- add focused tests that cover Firestore-backed success and NO_MEMBERSHIP responses

## Testing
- npm --prefix functions run build
- node functions/test/resolveStoreAccess.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc158812c08321aa8d0927ea1ebc28