### PR TITLE
Update onboarding docs guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ This repo is a drop-in starter for **Sedifex** (inventory & POS). It ships as a 
 - Firestore emulator rules tests are skipped by default. To execute them, start the local Firebase emulators and run tests with
   `RUN_FIRESTORE_EMULATOR_TESTS=1 npm run test` so the suite can connect to the emulator endpoints.
 
-### Workspace access spreadsheet
-- The onboarding Google Sheet should include workspace metadata columns such as `contractStart`, `contractEnd`, `paymentStatus`, `amountPaid`, and `company` for each store row.
-- Date columns can be provided as ISO-like strings (e.g., `2024-01-15`) or spreadsheet serial numbers; payment amounts can include currency symbols and will be normalized automatically.
+### Firestore membership documents
+- Store onboarding now relies on membership documents in Firestore. Create one document per workspace under `memberships/{workspaceId}` with fields such as `contractStart`, `contractEnd`, `paymentStatus`, `amountPaid`, and `company`.
+- Ensure date fields are stored as Firestore Timestamps (or ISO strings if ingesting via script) and normalize payment amounts to numbers so Cloud Functions can process billing logic without additional parsing.
 
 ## Branding
 - Name: **Sedifex**


### PR DESCRIPTION
## Summary
- replace the workspace spreadsheet onboarding guidance with instructions for Firestore membership documents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc18fdfc38832180d8d1052484f9f9