### PR TITLE
Refine resolveStoreAccess Firestore tests

### DIFF
--- a/functions/test/callablesLogging.test.js
+++ b/functions/test/callablesLogging.test.js
@@ -1,6 +1,5 @@
 const assert = require('assert')
 const Module = require('module')
-const path = require('path')
 const { MockFirestore, MockTimestamp } = require('./helpers/mockFirestore')
 const { FIREBASE_CALLABLES } = require('../lib/shared/firebaseCallables.js')
 
@@ -39,14 +38,6 @@ Module._load = function patchedLoad(request, parent, isMain) {
   if (request === 'firebase-admin/firestore') {
     return {
       getFirestore: () => currentDefaultDb,
-    }
-  }
-
-  if (request === './googleSheets' || request.endsWith(`${path.sep}googleSheets`)) {
-    return {
-      fetchClientRowByEmail: async () => null,
-      getDefaultSpreadsheetId: () => 'sheet-123',
-      normalizeHeader: value => (typeof value === 'string' ? value.trim().toLowerCase() : ''),
     }
   }
 

--- a/functions/test/resolveStoreAccess.test.js
+++ b/functions/test/resolveStoreAccess.test.js
@@ -56,7 +56,7 @@ function loadFunctionsModule() {
 
 async function runSuccessTest() {
   currentDefaultDb = new MockFirestore({
-    'teamMembers/user-1': { storeId: 'store-123', role: 'owner' },
+    'teamMembers/user-1': { storeId: ' store-123 ', role: ' Owner ' },
   })
 
   const { resolveStoreAccess } = loadFunctionsModule()
@@ -106,10 +106,29 @@ async function runInvalidMembershipTest() {
   assert.deepStrictEqual(result, { ok: false, error: 'NO_MEMBERSHIP' })
 }
 
+async function runInvalidRoleTest() {
+  currentDefaultDb = new MockFirestore({
+    'teamMembers/user-4': { storeId: 'store-xyz', role: 'manager' },
+  })
+
+  const { resolveStoreAccess } = loadFunctionsModule()
+  const context = {
+    auth: {
+      uid: 'user-4',
+      token: {},
+    },
+  }
+
+  const result = await resolveStoreAccess.run({}, context)
+
+  assert.deepStrictEqual(result, { ok: false, error: 'NO_MEMBERSHIP' })
+}
+
 async function run() {
   await runSuccessTest()
   await runMissingMembershipTest()
   await runInvalidMembershipTest()
+  await runInvalidRoleTest()
   console.log('resolveStoreAccess tests passed')
 }
 


### PR DESCRIPTION
## Summary
- expand resolveStoreAccess tests to validate Firestore membership handling
- remove unused Google Sheets stub from the callable logging tests

## Testing
- npm run build
- node ./test/resolveStoreAccess.test.js
- node ./test/callablesLogging.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc190087d88321a263ebfb5fb42a87