### PR TITLE
Add script to backfill missing memberships

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ This repo is a drop-in starter for **Sedifex** (inventory & POS). It ships as a 
 - Firestore emulator rules tests are skipped by default. To execute them, start the local Firebase emulators and run tests with
   `RUN_FIRESTORE_EMULATOR_TESTS=1 npm run test` so the suite can connect to the emulator endpoints.
 
+## Maintenance scripts
+- To backfill missing team memberships and store documents for legacy Auth accounts, run `npm run migrate-missing-members` from the
+  `functions/` directory. The script requires Firebase Admin credentials (e.g., `GOOGLE_APPLICATION_CREDENTIALS`) so it can list
+  all users and write to Firestore.
+
 ### Firestore membership documents
 - Store onboarding now relies on membership documents in Firestore. Create one document per workspace under `memberships/{workspaceId}` with fields such as `contractStart`, `contractEnd`, `paymentStatus`, `amountPaid`, and `company`.
 - Ensure date fields are stored as Firestore Timestamps (or ISO strings if ingesting via script) and normalize payment amounts to numbers so Cloud Functions can process billing logic without additional parsing.

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,8 @@
     "serve": "firebase emulators:start --only functions,firestore",
     "deploy": "npm run build && firebase deploy --only functions",
     "test": "npm run build && node ./test/resolveStoreAccess.test.js && node ./test/dailySummaries.test.js && node ./test/callablesLogging.test.js && node ./test/updateStoreProfile.test.js && node ./test/revokeStaffAccess.test.js && node ./test/nightlyDataHygiene.test.js",
-    "backfill-store": "ts-node ./scripts/backfillStoreIds.ts"
+    "backfill-store": "ts-node ./scripts/backfillStoreIds.ts",
+    "migrate-missing-members": "ts-node ./scripts/migrateMissingMemberships.ts"
   },
   "dependencies": {
     "firebase-admin": "^12.5.0",

--- a/functions/scripts/migrateMissingMemberships.ts
+++ b/functions/scripts/migrateMissingMemberships.ts
@@ -1,0 +1,111 @@
+import * as admin from 'firebase-admin'
+
+if (!admin.apps.length) {
+  admin.initializeApp()
+}
+
+const auth = admin.auth()
+const db = admin.firestore()
+
+function buildDeterministicStoreId(uid: string): string {
+  const suffix = uid.slice(0, 8) || uid
+  return `store-${suffix}`
+}
+
+function resolveDisplayName(user: admin.auth.UserRecord): string {
+  const direct = user.displayName?.trim()
+  if (direct) {
+    return direct
+  }
+
+  const email = user.email?.trim()
+  if (email) {
+    const [local] = email.split('@')
+    if (local) {
+      return local
+    }
+  }
+
+  return `Owner ${user.uid.slice(0, 6)}`
+}
+
+async function migrateUser(user: admin.auth.UserRecord): Promise<'skipped' | 'created' | 'failed'> {
+  const uid = user.uid
+  const memberRef = db.collection('teamMembers').doc(uid)
+  const existing = await memberRef.get()
+  if (existing.exists) {
+    console.log(`[migrate-missing-members] Skipping ${uid}; membership already exists`)
+    return 'skipped'
+  }
+
+  const storeId = buildDeterministicStoreId(uid)
+  const name = resolveDisplayName(user)
+  const now = admin.firestore.Timestamp.now()
+
+  const teamMemberPayload: Record<string, unknown> = {
+    uid,
+    storeId,
+    role: 'owner',
+    email: user.email ?? null,
+    phoneNumber: user.phoneNumber ?? null,
+    name,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  try {
+    const storeRef = db.collection('stores').doc(storeId)
+    const existingStore = await storeRef.get()
+
+    const storePayload: Record<string, unknown> = {
+      storeId,
+      ownerId: uid,
+      ownerEmail: user.email ?? null,
+      ownerName: name,
+      updatedAt: now,
+    }
+
+    if (!existingStore.exists) {
+      storePayload.createdAt = now
+    }
+
+    await memberRef.set(teamMemberPayload, { merge: true })
+    await storeRef.set(storePayload, { merge: true })
+    console.log(`[migrate-missing-members] Created membership and store for ${uid} -> ${storeId}`)
+    return 'created'
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`[migrate-missing-members] Failed to create membership for ${uid}: ${message}`)
+    return 'failed'
+  }
+}
+
+async function run(): Promise<void> {
+  let nextPageToken: string | undefined
+  let processed = 0
+  let created = 0
+  let failed = 0
+
+  do {
+    const result = await auth.listUsers(1000, nextPageToken)
+    for (const user of result.users) {
+      const outcome = await migrateUser(user)
+      processed += 1
+      if (outcome === 'created') {
+        created += 1
+      } else if (outcome === 'failed') {
+        failed += 1
+      }
+    }
+    nextPageToken = result.pageToken
+  } while (nextPageToken)
+
+  console.log(
+    `[migrate-missing-members] Migration complete. Processed ${processed} users, created ${created} memberships, ${failed} failures`,
+  )
+}
+
+run().catch(error => {
+  console.error('[migrate-missing-members] Migration failed', error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add a TypeScript script that backfills missing team membership and store documents for Auth users
- log per-user outcomes while creating deterministic store IDs and owner metadata
- expose the migration via an npm script and document how to run it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc1da2c60c8321b710f959de693f8d