### PR TITLE
Refine signup bootstrap test mocks

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -195,14 +195,16 @@ describe('App signup cleanup', () => {
     mocks.listeners.splice(0, mocks.listeners.length)
     firestore.reset()
     access.afterSignupBootstrap.mockReset()
+    let bootstrapCallCount = 0
     access.afterSignupBootstrap.mockImplementation(async (rawPayload?: unknown) => {
-      if (typeof rawPayload === 'string') {
-        if (!rawPayload.trim()) {
-          throw new Error('storeId required for bootstrap')
-        }
-        return
+      bootstrapCallCount += 1
+      if (bootstrapCallCount > 1) {
+        throw new Error('afterSignupBootstrap should only be called once')
       }
-      const payload = (rawPayload ?? {}) as {
+      if (!rawPayload || typeof rawPayload !== 'object' || Array.isArray(rawPayload)) {
+        throw new Error('afterSignupBootstrap payload must be an object')
+      }
+      const payload = rawPayload as {
         storeId?: string
         contact?: { ownerName?: string | null; company?: string | null }
       }


### PR DESCRIPTION
## Summary
- tighten the signup test mock for `afterSignupBootstrap` to enforce a single structured payload invocation

## Testing
- `npm --prefix web run test -- App.signup.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68dc28d98c648321acc31fee25535700