### PR TITLE
Ensure signup cleanup logs new accounts out

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -273,12 +273,19 @@ describe('App signup cleanup', () => {
     await waitFor(() => expect(mocks.persistSession).toHaveBeenCalled())
 
     expect(deleteFn).not.toHaveBeenCalled()
-    expect(mocks.auth.signOut).not.toHaveBeenCalled()
-    expect(mocks.auth.currentUser).toBe(createdUser)
+
+    await waitFor(() => expect(mocks.auth.signOut).toHaveBeenCalled())
+    expect(mocks.auth.currentUser).toBeNull()
+
     expect(mocks.publish).toHaveBeenCalledWith(
       expect.objectContaining({ tone: 'error', message: 'Unable to persist session' }),
     )
     expect(localStorageSetItemSpy).not.toHaveBeenCalled()
+
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: /Log in/i })).toHaveAttribute('aria-selected', 'true'),
+    )
+    expect(screen.queryByRole('button', { name: /Create account/i })).not.toBeInTheDocument()
   })
 
   it('creates team member and customer records after a successful signup', async () => {


### PR DESCRIPTION
## Summary
- ensure the signup flow tracks the created user so cleanup can always sign out
- run signup cleanup in a finally block to restore login mode even on errors
- extend the signup tests to assert logout occurs after failures

## Testing
- npm test -- App.signup.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc37392554832196ceb3a749ab3a7f