### PR TITLE
Restore marketing info cards on auth screen

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -224,6 +224,14 @@ body {
   z-index: 1;
 }
 
+.app__info-grid > h2 {
+  margin: 0;
+  grid-column: 1 / -1;
+  font-size: clamp(22px, 4vw, 32px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
 .info-card {
   background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(24, 33, 53, 0.9));
   border-radius: 28px;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -913,6 +913,56 @@ export default function App() {
             ))}
           </div>
         </section>
+
+        <section className="app__info-grid" aria-labelledby="app-info-heading">
+          <h2 id="app-info-heading">Why retailers choose Sedifex</h2>
+          <article className="info-card">
+            <h3>About Sedifex</h3>
+            <p>
+              Sedifex keeps fast-moving retailers aligned with a connected operating system for sales, inventory,
+              and store communication. We work with multi-location teams that need reliable insights without the
+              spreadsheets.
+            </p>
+            <p className="info-card__caption">Headquartered in Austin with teams across North America.</p>
+          </article>
+          <article className="info-card">
+            <h3>Mission &amp; values</h3>
+            <p>We believe every retail team deserves data they can trust and workflows that reduce busywork.</p>
+            <ul className="info-card__list">
+              <li>Give operators clarity in the moment they need to act.</li>
+              <li>Design software that works beautifully on any device in the store.</li>
+              <li>Earn trust with transparent pricing and accountable support.</li>
+            </ul>
+          </article>
+          <article className="info-card">
+            <h3>Implementation &amp; support</h3>
+            <p>
+              Onboarding specialists migrate your data, train your team, and monitor adoption milestones so you can
+              launch with confidence.
+            </p>
+            <ul className="info-card__list">
+              <li>Guided setup checklist and go-live review.</li>
+              <li>Role-based training sessions with recordings.</li>
+              <li>
+                Dedicated support channel with{' '}
+                <span aria-hidden="true">&lt;24 hr</span>
+                <span className="visually-hidden">under twenty-four hour</span> response.
+              </li>
+            </ul>
+            <a className="info-card__cta" href="mailto:hello@sedifex.com">Talk with our team</a>
+          </article>
+          <article className="info-card">
+            <h3>Security &amp; reliability</h3>
+            <p>
+              Enterprise-grade authentication, audit trails, and automated backups protect every transaction and
+              keep your data resilient.
+            </p>
+            <p>
+              Sedifex is hosted on SOC 2 compliant infrastructure with regional redundancy and role-based access
+              controls.
+            </p>
+          </article>
+        </section>
       </main>
     )
   }


### PR DESCRIPTION
## Summary
- restore the unauthenticated app view marketing cards with updated about, mission, support, and security copy
- add an accessible heading for the info grid and CTA link back to the support team
- adjust the info grid styling to accommodate the heading while keeping existing card spacing

## Testing
- npm run lint *(fails: existing lint rule violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dcec8fc3388321bdb33f262269f371