### PR TITLE
Add signup location fields and propagate to backend

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -206,7 +206,13 @@ describe('App signup cleanup', () => {
       }
       const payload = rawPayload as {
         storeId?: string
-        contact?: { ownerName?: string | null; company?: string | null }
+        contact?: {
+          ownerName?: string | null
+          company?: string | null
+          country?: string | null
+          city?: string | null
+          phoneCountryCode?: string | null
+        }
       }
       if (typeof payload.storeId !== 'string' || !payload.storeId) {
         throw new Error('storeId required for bootstrap')
@@ -221,6 +227,9 @@ describe('App signup cleanup', () => {
           ownerId: mocks.auth.currentUser?.uid ?? null,
           ownerName: payload.contact?.ownerName ?? null,
           company: payload.contact?.company ?? null,
+          country: payload.contact?.country ?? null,
+          city: payload.contact?.city ?? null,
+          phoneCountryCode: payload.contact?.phoneCountryCode ?? null,
           createdAt,
           updatedAt,
         },
@@ -262,9 +271,14 @@ describe('App signup cleanup', () => {
       await user.type(screen.getByLabelText(/Email/i), 'owner@example.com')
       await user.selectOptions(screen.getByLabelText(/Role/i), 'owner')
       await user.type(screen.getByLabelText(/Company/i), 'Sedifex')
-      await user.selectOptions(screen.getByLabelText(/Country code/i), '+44')
-      expect((screen.getByLabelText(/Country code/i) as HTMLSelectElement).value).toBe('+44')
-      await user.type(screen.getByLabelText(/Phone/i), ' (555) 123-4567 ')
+      await user.type(screen.getByLabelText(/^Country$/i), ' United Kingdom ')
+      await user.type(screen.getByLabelText(/^City$/i), ' London ')
+      const dialingInput = screen.getByLabelText(/Country code/i)
+      await user.clear(dialingInput)
+      await user.type(dialingInput, ' 0044 ')
+      const phoneInput = screen.getByLabelText(/Phone/i)
+      await user.click(phoneInput)
+      await user.type(phoneInput, ' (555) 123-4567 ')
       await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
       await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
       await user.click(screen.getByRole('button', { name: /Create account/i }))
@@ -337,9 +351,14 @@ describe('App signup cleanup', () => {
       await user.type(screen.getByLabelText(/Email/i), 'owner@example.com')
       await user.selectOptions(screen.getByLabelText(/Role/i), 'owner')
       await user.type(screen.getByLabelText(/Company/i), 'Sedifex')
-      await user.selectOptions(screen.getByLabelText(/Country code/i), '+44')
-      expect((screen.getByLabelText(/Country code/i) as HTMLSelectElement).value).toBe('+44')
-      await user.type(screen.getByLabelText(/Phone/i), ' (555) 123-4567 ')
+      await user.type(screen.getByLabelText(/^Country$/i), ' United Kingdom ')
+      await user.type(screen.getByLabelText(/^City$/i), ' London ')
+      const dialingInput = screen.getByLabelText(/Country code/i)
+      await user.clear(dialingInput)
+      await user.type(dialingInput, ' 0044 ')
+      const phoneInput = screen.getByLabelText(/Phone/i)
+      await user.click(phoneInput)
+      await user.type(phoneInput, ' (555) 123-4567 ')
       await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
       await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
       await user.click(screen.getByRole('button', { name: /Create account/i }))
@@ -373,6 +392,10 @@ describe('App signup cleanup', () => {
         role: 'owner',
         email: 'owner@example.com',
         name: 'Owner account',
+        company: 'Sedifex',
+        country: 'United Kingdom',
+        city: 'London',
+        phoneCountryCode: '+44',
         createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
         updatedAt: expect.objectContaining({ __type: 'serverTimestamp' }),
       }),
@@ -388,6 +411,8 @@ describe('App signup cleanup', () => {
       expect.objectContaining({
         name: 'Owner account',
         company: 'Sedifex',
+        country: 'United Kingdom',
+        city: 'London',
         phone: '+445551234567',
         phoneCountryCode: '+44',
         phoneLocalNumber: '5551234567',
@@ -414,6 +439,8 @@ describe('App signup cleanup', () => {
         phone: '+445551234567',
         phoneCountryCode: '+44',
         phoneLocalNumber: '5551234567',
+        country: 'United Kingdom',
+        city: 'London',
         status: 'active',
         role: 'client',
         createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
@@ -431,6 +458,10 @@ describe('App signup cleanup', () => {
         storeId,
         ownerId: createdUser.uid,
         ownerEmail: 'owner@example.com',
+        company: 'Sedifex',
+        country: 'United Kingdom',
+        city: 'London',
+        phoneCountryCode: '+44',
         createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
         updatedAt: expect.objectContaining({ __type: 'serverTimestamp' }),
       }),
@@ -448,6 +479,9 @@ describe('App signup cleanup', () => {
         ownerId: createdUser.uid,
         ownerName: 'Owner account',
         company: 'Sedifex',
+        country: 'United Kingdom',
+        city: 'London',
+        phoneCountryCode: '+44',
         createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
         updatedAt: expect.objectContaining({ __type: 'serverTimestamp' }),
       }),
@@ -461,6 +495,12 @@ describe('App signup cleanup', () => {
         uid: createdUser.uid,
         storeId,
         name: 'Owner account',
+        company: 'Sedifex',
+        country: 'United Kingdom',
+        city: 'London',
+        phone: '+445551234567',
+        phoneCountryCode: '+44',
+        phoneLocalNumber: '5551234567',
       }),
     )
 
@@ -470,6 +510,10 @@ describe('App signup cleanup', () => {
         ...seededStore,
         storeId,
         ownerId: createdUser.uid,
+        company: 'Sedifex',
+        country: 'United Kingdom',
+        city: 'London',
+        phoneCountryCode: '+44',
       }),
     )
 
@@ -481,6 +525,8 @@ describe('App signup cleanup', () => {
         phoneLocalNumber: '5551234567',
         firstSignupEmail: 'owner@example.com',
         company: 'Sedifex',
+        country: 'United Kingdom',
+        city: 'London',
         ownerName: 'Owner account',
       },
     })
@@ -529,16 +575,11 @@ describe('App signup cleanup', () => {
     await waitFor(() => expect(mocks.persistSession).toHaveBeenCalled())
 
     const storeId = 'owner-example-com-test-use'
-    const { docRefByPath, setDocMock } = firestore
-    const profileDocRef = docRefByPath.get(`teamMembers/${existingUser.uid}`)
-    const overrideDocRef = docRefByPath.get('teamMembers/l8Rbmym8aBVMwL6NpZHntjBHmCo2')
-    const storeDocRef = docRefByPath.get(`stores/${storeId}`)
+    const { setDocMock } = firestore
 
-    expect(profileDocRef).toBeDefined()
-    expect(overrideDocRef).toBeDefined()
-    expect(storeDocRef).toBeDefined()
-
-    const profileCall = setDocMock.mock.calls.find(([ref]) => ref === profileDocRef)
+    const profileCall = setDocMock.mock.calls.find(
+      ([ref]) => (ref as { path?: string } | undefined)?.path === `teamMembers/${existingUser.uid}`,
+    )
     expect(profileCall).toBeDefined()
     const [, profilePayload, profileOptions] = profileCall!
     expect(profilePayload).toEqual(
@@ -550,11 +591,15 @@ describe('App signup cleanup', () => {
     )
     expect(profileOptions).toEqual({ merge: true })
 
-    const overrideCall = setDocMock.mock.calls.find(([ref]) => ref === overrideDocRef)
+    const overrideCall = setDocMock.mock.calls.find(
+      ([ref]) => (ref as { path?: string } | undefined)?.path === 'teamMembers/l8Rbmym8aBVMwL6NpZHntjBHmCo2',
+    )
     expect(overrideCall).toBeDefined()
     expect(overrideCall?.[1]).toEqual(expect.objectContaining({ storeId }))
 
-    const storeCall = setDocMock.mock.calls.find(([ref]) => ref === storeDocRef)
+    const storeCall = setDocMock.mock.calls.find(
+      ([ref]) => (ref as { path?: string } | undefined)?.path === `stores/${storeId}`,
+    )
     expect(storeCall).toBeDefined()
     const [, storePayload, storeOptions] = storeCall!
     expect(storePayload).toEqual(

--- a/web/src/controllers/accessController.ts
+++ b/web/src/controllers/accessController.ts
@@ -26,6 +26,8 @@ type ContactPayload = {
   firstSignupEmail?: string | null
   company?: string | null
   ownerName?: string | null
+  country?: string | null
+  city?: string | null
 }
 
 type AfterSignupBootstrapPayload = {
@@ -109,6 +111,14 @@ export async function afterSignupBootstrap(payload?: AfterSignupBootstrapPayload
 
     if (payload.contact.ownerName !== undefined) {
       contact.ownerName = payload.contact.ownerName
+    }
+
+    if (payload.contact.country !== undefined) {
+      contact.country = payload.contact.country
+    }
+
+    if (payload.contact.city !== undefined) {
+      contact.city = payload.contact.city
     }
 
     if (Object.keys(contact).length > 0) {

--- a/web/src/controllers/onboarding.test.ts
+++ b/web/src/controllers/onboarding.test.ts
@@ -91,6 +91,9 @@ describe('createInitialOwnerAndStore', () => {
       email: 'custom-owner@example.com',
       role: 'staff',
       company: 'Sedifex Incorporated',
+      country: 'Canada',
+      city: 'Toronto',
+      phoneCountryCode: '+1',
     })
 
     expect(storeId).toBe('sedifex-incorporated-owner-12')
@@ -104,6 +107,9 @@ describe('createInitialOwnerAndStore', () => {
       email: 'custom-owner@example.com',
       company: 'Sedifex Incorporated',
       name: 'Store Owner',
+      country: 'Canada',
+      city: 'Toronto',
+      phoneCountryCode: '+1',
     })
 
     const storeDoc = firestore.docDataByPath.get(`stores/${storeId}`)
@@ -113,6 +119,9 @@ describe('createInitialOwnerAndStore', () => {
       ownerEmail: 'custom-owner@example.com',
       ownerName: 'Store Owner',
       company: 'Sedifex Incorporated',
+      country: 'Canada',
+      city: 'Toronto',
+      phoneCountryCode: '+1',
     })
   })
 

--- a/web/src/controllers/onboarding.ts
+++ b/web/src/controllers/onboarding.ts
@@ -121,6 +121,9 @@ type CreateInitialOwnerAndStoreParams = {
   email?: string | null
   role?: string
   company?: string | null
+  country?: string | null
+  city?: string | null
+  phoneCountryCode?: string | null
 }
 
 export async function createInitialOwnerAndStore(
@@ -131,10 +134,16 @@ export async function createInitialOwnerAndStore(
     email: emailOverride = null,
     role = 'owner',
     company: companyOverride = null,
+    country: countryOverride = null,
+    city: cityOverride = null,
+    phoneCountryCode: phoneCountryCodeOverride = null,
   } = params
 
   const uid = user.uid
   const company = companyOverride ?? null
+  const country = countryOverride ?? null
+  const city = cityOverride ?? null
+  const phoneCountryCode = phoneCountryCodeOverride ?? null
   const resolvedEmail = emailOverride ?? user.email ?? null
   const ownerName = user.displayName?.trim() || OWNER_NAME_FALLBACK
 
@@ -162,6 +171,18 @@ export async function createInitialOwnerAndStore(
     teamMemberPayload.company = company
   }
 
+  if (country !== null) {
+    teamMemberPayload.country = country
+  }
+
+  if (city !== null) {
+    teamMemberPayload.city = city
+  }
+
+  if (phoneCountryCode !== null) {
+    teamMemberPayload.phoneCountryCode = phoneCountryCode
+  }
+
   await setDoc(doc(db, 'teamMembers', uid), teamMemberPayload, { merge: true })
 
   const storePayload: Record<string, unknown> = {
@@ -178,6 +199,18 @@ export async function createInitialOwnerAndStore(
 
   if (company !== null) {
     storePayload.company = company
+  }
+
+  if (country !== null) {
+    storePayload.country = country
+  }
+
+  if (city !== null) {
+    storePayload.city = city
+  }
+
+  if (phoneCountryCode !== null) {
+    storePayload.phoneCountryCode = phoneCountryCode
   }
 
   await setDoc(doc(db, 'stores', storeId), storePayload, { merge: true })

--- a/web/src/pages/__tests__/Today.test.tsx
+++ b/web/src/pages/__tests__/Today.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom'
 
 
 import { formatCurrency } from '@shared/currency'
+import { formatDailySummaryKey } from '../../../../shared/dateKeys'
 import Today, { formatDateKey } from '../Today'
 
 


### PR DESCRIPTION
## Summary
- capture country, city, and dialing code in the signup form and validation flow
- propagate the new contact fields through onboarding payloads and Cloud Functions
- update related tests and fixtures for manual dialing code entry and Firestore expectations

## Testing
- npm test (web)
- npm test (functions)


------
https://chatgpt.com/codex/tasks/task_e_68dcec98d17883218b12967def33a169