### PR TITLE
Update Firestore emulator project ID fallback

### DIFF
--- a/web/tests/firestore.rules.emulator.test.ts
+++ b/web/tests/firestore.rules.emulator.test.ts
@@ -22,7 +22,7 @@ import {
   type Auth,
 } from 'firebase/auth'
 
-const projectId = process.env.GCLOUD_PROJECT ?? 'demo-sedifex'
+const projectId = process.env.GCLOUD_PROJECT ?? 'sedifex-ac2b0'
 const firestoreHost = process.env.FIRESTORE_EMULATOR_HOST ?? '127.0.0.1:8080'
 const authHost = process.env.FIREBASE_AUTH_EMULATOR_HOST ?? '127.0.0.1:9099'
 const shouldRunEmulatorSuite = process.env.RUN_FIRESTORE_EMULATOR_TESTS === '1'


### PR DESCRIPTION
## Summary
- update the Firestore emulator test suite to default to the sedifex-ac2b0 project ID

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68de948958608321b5e9d7aa593ac543