### PR TITLE
Ensure onAuthCreate seeds deterministic workspace metadata

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && node ./scripts/postbuild.js",
     "serve": "firebase emulators:start --only functions,firestore",
     "deploy": "npm run build && firebase deploy --only functions",
-    "test": "npm run build && node ./test/resolveStoreAccess.test.js && node ./test/dailySummaries.test.js && node ./test/callablesLogging.test.js && node ./test/updateStoreProfile.test.js && node ./test/revokeStaffAccess.test.js && node ./test/nightlyDataHygiene.test.js",
+    "test": "npm run build && node ./test/onAuthCreate.test.js && node ./test/resolveStoreAccess.test.js && node ./test/dailySummaries.test.js && node ./test/callablesLogging.test.js && node ./test/updateStoreProfile.test.js && node ./test/revokeStaffAccess.test.js && node ./test/nightlyDataHygiene.test.js",
     "backfill-store": "ts-node ./scripts/backfillStoreIds.ts",
     "migrate-missing-members": "ts-node ./scripts/migrateMissingMemberships.ts"
   },

--- a/functions/src/onAuthCreate.ts
+++ b/functions/src/onAuthCreate.ts
@@ -4,18 +4,29 @@ import { admin, rosterDb } from './firestore'
 export const onAuthCreate = functions.auth.user().onCreate(async user => {
   const uid = user.uid
   const timestamp = admin.firestore.FieldValue.serverTimestamp()
+  const memberRef = rosterDb.collection('teamMembers').doc(uid)
+  const existingSnap = await memberRef.get()
+  const existingData = existingSnap.data() ?? {}
 
-  await rosterDb
-    .collection('teamMembers')
-    .doc(uid)
-    .set(
-      {
-        uid,
-        email: user.email ?? null,
-        phone: user.phoneNumber ?? null,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      },
-      { merge: true },
-    )
+  const existingStoreId =
+    typeof existingData.storeId === 'string' ? existingData.storeId.trim() : ''
+  const resolvedStoreId = existingStoreId || uid
+
+  const existingRoleRaw =
+    typeof existingData.role === 'string' ? existingData.role.trim().toLowerCase() : ''
+  const resolvedRole =
+    existingRoleRaw === 'owner' || existingRoleRaw === 'staff' ? existingRoleRaw : 'owner'
+
+  await memberRef.set(
+    {
+      uid,
+      storeId: resolvedStoreId,
+      role: resolvedRole,
+      email: user.email ?? null,
+      phone: user.phoneNumber ?? null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+    { merge: true },
+  )
 })

--- a/functions/test/onAuthCreate.test.js
+++ b/functions/test/onAuthCreate.test.js
@@ -1,0 +1,116 @@
+const assert = require('assert')
+const Module = require('module')
+const { MockFirestore, MockTimestamp } = require('./helpers/mockFirestore')
+
+let currentRosterDb
+const apps = []
+
+const originalLoad = Module._load
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'firebase-admin') {
+    const firestore = () => currentRosterDb
+    firestore.FieldValue = {
+      serverTimestamp: () => MockTimestamp.now(),
+      increment: amount => ({ __mockIncrement: amount }),
+    }
+    firestore.Timestamp = MockTimestamp
+
+    return {
+      initializeApp: () => {
+        const app = { name: 'mock-app' }
+        apps[0] = app
+        return app
+      },
+      app: () => apps[0] || null,
+      apps,
+      firestore,
+      auth: () => ({
+        getUser: async () => ({ customClaims: undefined }),
+        getUserByEmail: async () => {
+          const err = new Error('not found')
+          err.code = 'auth/user-not-found'
+          throw err
+        },
+        updateUser: async () => {},
+        createUser: async () => ({ uid: 'new-user' }),
+        setCustomUserClaims: async () => {},
+      }),
+    }
+  }
+
+  if (request === 'firebase-admin/firestore') {
+    return {
+      getFirestore: () => currentRosterDb,
+    }
+  }
+
+  return originalLoad(request, parent, isMain)
+}
+
+function loadOnAuthCreate() {
+  apps.length = 0
+  delete require.cache[require.resolve('../lib/firestore.js')]
+  delete require.cache[require.resolve('../lib/onAuthCreate.js')]
+  return require('../lib/onAuthCreate.js')
+}
+
+async function runCreatesMembershipTest() {
+  currentRosterDb = new MockFirestore()
+  const { onAuthCreate } = loadOnAuthCreate()
+
+  const user = {
+    uid: 'owner-1234',
+    email: 'owner@example.com',
+    phoneNumber: '+15555550123',
+  }
+
+  await onAuthCreate.run(user, {})
+
+  const record = currentRosterDb.getDoc('teamMembers/owner-1234')
+  assert.strictEqual(record.uid, 'owner-1234')
+  assert.strictEqual(record.storeId, 'owner-1234')
+  assert.strictEqual(record.role, 'owner')
+  assert.strictEqual(record.email, 'owner@example.com')
+  assert.strictEqual(record.phone, '+15555550123')
+  assert(record.createdAt)
+  assert(record.updatedAt)
+}
+
+async function runPreservesExistingMetadataTest() {
+  currentRosterDb = new MockFirestore({
+    'teamMembers/staff-1': {
+      storeId: 'store-xyz',
+      role: 'staff',
+      name: 'Invited Staff',
+    },
+  })
+  const { onAuthCreate } = loadOnAuthCreate()
+
+  const user = {
+    uid: 'staff-1',
+    email: 'staff@example.com',
+  }
+
+  await onAuthCreate.run(user, {})
+
+  const record = currentRosterDb.getDoc('teamMembers/staff-1')
+  assert.strictEqual(record.storeId, 'store-xyz')
+  assert.strictEqual(record.role, 'staff')
+  assert.strictEqual(record.email, 'staff@example.com')
+  assert.strictEqual(record.name, 'Invited Staff')
+}
+
+async function run() {
+  await runCreatesMembershipTest()
+  await runPreservesExistingMetadataTest()
+  console.log('onAuthCreate tests passed')
+}
+
+run()
+  .catch(err => {
+    console.error(err)
+    process.exitCode = 1
+  })
+  .finally(() => {
+    Module._load = originalLoad
+  })


### PR DESCRIPTION
## Summary
- resolve an initial storeId and role when onAuthCreate seeds a teamMembers document while preserving invited metadata
- add targeted unit tests that cover the new onAuthCreate behavior
- wire the new test into the npm test script

## Testing
- npm --prefix functions test

------
https://chatgpt.com/codex/tasks/task_e_68de988c155c8321b5d6f7cc0b89f0dc