### PR TITLE
Remove override team member doc handling

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -28,7 +28,6 @@ import {
 } from './utils/activeStoreStorage'
 import { getOnboardingStatus, setOnboardingStatus } from './utils/onboarding'
 import type { QueueRequestType } from './utils/offlineQueue'
-import { OVERRIDE_TEAM_MEMBER_DOC_ID } from './config/teamMembers'
 
 /* ------------------------------ config ------------------------------ */
 const LEGACY_STORE_BACKFILL_KEY_PREFIX = 'legacy-store-backfill/'
@@ -156,7 +155,7 @@ async function ensureLegacyStoreDoc(params: {
   }
 }
 
-/** Ensure teamMembers/{uid} exists; optionally mirror to fixed ID. */
+/** Ensure teamMembers/{uid} exists. */
 async function upsertTeamMemberDocs(params: {
   user: User
   role: 'owner' | 'staff'
@@ -190,14 +189,6 @@ async function upsertTeamMemberDocs(params: {
       if (existingStoreId) {
         await setDoc(uidRef, { lastSeenAt }, { merge: true })
         persistActiveStoreId(existingStoreId, user.uid)
-        // Optionally mirror to fixed doc for your analytics/admin
-        if (OVERRIDE_TEAM_MEMBER_DOC_ID) {
-          await setDoc(
-            doc(db, 'teamMembers', OVERRIDE_TEAM_MEMBER_DOC_ID),
-            { ...snap.data(), lastSeenAt, updatedAt: serverTimestamp() },
-            { merge: true },
-          )
-        }
         return { storeId: existingStoreId, role: (snap.get('role') as 'owner' | 'staff') || role }
       }
     }
@@ -229,10 +220,6 @@ async function upsertTeamMemberDocs(params: {
   }
 
   await setDoc(uidRef, payload, { merge: true })
-
-  if (OVERRIDE_TEAM_MEMBER_DOC_ID) {
-    await setDoc(doc(db, 'teamMembers', OVERRIDE_TEAM_MEMBER_DOC_ID), payload, { merge: true })
-  }
 
   await ensureLegacyStoreDoc({ storeId, user, timestamp })
 
@@ -595,21 +582,6 @@ export default function App() {
         }
 
         await setDoc(doc(db, 'teamMembers', nextUser.uid), teamMemberContactPayload, { merge: true })
-
-        if (OVERRIDE_TEAM_MEMBER_DOC_ID) {
-          await setDoc(
-            doc(db, 'teamMembers', OVERRIDE_TEAM_MEMBER_DOC_ID),
-            {
-              ...teamMemberContactPayload,
-              uid: nextUser.uid,
-              storeId,
-              role,
-              email: nextUser.email ?? null,
-              name: ownerName,
-            },
-            { merge: true },
-          )
-        }
 
         await afterSignupBootstrap({
           storeId,

--- a/web/src/SheetAccessGuard.tsx
+++ b/web/src/SheetAccessGuard.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 import { onAuthStateChanged, signOut, type User } from 'firebase/auth'
 import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore'
 import { auth, db } from './firebase'
-import { OVERRIDE_TEAM_MEMBER_DOC_ID } from './config/teamMembers'
 import { clearActiveStoreIdForUser, persistActiveStoreIdForUser } from './utils/activeStoreStorage'
 
 type TeamMemberSnapshot = {
@@ -47,14 +46,6 @@ async function loadTeamMember(user: User): Promise<TeamMemberSnapshot> {
 
   if (uidSnapshot.exists()) {
     return snapshotFromData(uidSnapshot.data())
-  }
-
-  if (OVERRIDE_TEAM_MEMBER_DOC_ID) {
-    const overrideRef = doc(db, 'teamMembers', OVERRIDE_TEAM_MEMBER_DOC_ID)
-    const overrideSnapshot = await getDoc(overrideRef)
-    if (overrideSnapshot.exists()) {
-      return snapshotFromData(overrideSnapshot.data())
-    }
   }
 
   const email = normalizeString(user.email)

--- a/web/src/config/teamMembers.ts
+++ b/web/src/config/teamMembers.ts
@@ -1,5 +1,0 @@
-/**
- * When set, team member workspace updates will also be mirrored to this shared document ID.
- * Set to an empty string to disable the shared override document.
- */
-export const OVERRIDE_TEAM_MEMBER_DOC_ID = 'l8Rbmym8aBVMwL6NpZHntjBHmCo2'

--- a/web/src/hooks/useMemberships.test.tsx
+++ b/web/src/hooks/useMemberships.test.tsx
@@ -29,10 +29,6 @@ vi.mock('firebase/firestore', () => ({
   getDoc: (...args: Parameters<typeof getDocMock>) => getDocMock(...args),
 }))
 
-vi.mock('../config/teamMembers', () => ({
-  OVERRIDE_TEAM_MEMBER_DOC_ID: '',
-}))
-
 describe('useMemberships', () => {
   beforeEach(() => {
     mockUseAuthUser.mockReset()

--- a/web/src/hooks/useMemberships.ts
+++ b/web/src/hooks/useMemberships.ts
@@ -14,7 +14,6 @@ import {
 } from 'firebase/firestore'
 import { db } from '../firebase'
 import { useAuthUser } from './useAuthUser'
-import { OVERRIDE_TEAM_MEMBER_DOC_ID } from '../config/teamMembers'
 
 export type Membership = {
   id: string
@@ -121,10 +120,6 @@ export function useMemberships(activeStoreId?: string | null) {
         }
 
         const fallbackRefs = [doc(db, 'teamMembers', user.uid)]
-
-        if (OVERRIDE_TEAM_MEMBER_DOC_ID) {
-          fallbackRefs.push(doc(db, 'teamMembers', OVERRIDE_TEAM_MEMBER_DOC_ID))
-        }
 
         for (const ref of fallbackRefs) {
           try {


### PR DESCRIPTION
## Summary
- remove the override team member document config and writes from the app flows
- rely on per-user team member documents in the sheet access guard and memberships hook
- update related tests to reflect the new behavior and drop override document mocks

## Testing
- npm --prefix web test -- src/hooks/useMemberships.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68deb671126083219cd40221d164612e