### PR TITLE
Force owner role during initial signup

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -329,7 +329,6 @@ export default function App() {
   const [confirmPassword, setConfirmPassword] = useState('')
 
   // new fields
-  const [role, setRole] = useState<'owner' | 'staff'>('owner')
   const [company, setCompany] = useState('')
   const [country, setCountry] = useState('')
   const [city, setCity] = useState('')
@@ -551,7 +550,6 @@ export default function App() {
         // Create team member + store record and refresh auth token before continuing
         const storeId = await createInitialOwnerAndStore({
           user: nextUser,
-          role,
           company: sanitizedCompany,
           email: sanitizedEmail,
           country: sanitizedCountry,
@@ -618,7 +616,6 @@ export default function App() {
       setCompany('')
       setCountry('')
       setCity('')
-      setRole('owner')
       setNormalizedPhone('')
       setDialingCode(DEFAULT_DIALING_CODE)
 
@@ -642,7 +639,6 @@ export default function App() {
     setCompany('')
     setCountry('')
     setCity('')
-    setRole('owner')
     setNormalizedPhone('')
     setDialingCode(DEFAULT_DIALING_CODE)
   }
@@ -729,17 +725,7 @@ export default function App() {
               {isSignup && (
                 <>
                   <div className="form__field">
-                    <label htmlFor="role">Role</label>
-                    <select
-                      id="role"
-                      value={role}
-                      onChange={e => setRole(e.target.value as 'owner' | 'staff')}
-                      disabled={isLoading}
-                    >
-                      <option value="owner">Owner</option>
-                      <option value="staff">Staff</option>
-                    </select>
-                    <p className="form__hint">We’ll use this to set your workspace permissions.</p>
+                    <p className="form__hint">We’ll set you up as the workspace owner.</p>
                   </div>
 
                   <div className="form__field">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -324,7 +324,6 @@ export default function App() {
   const [confirmPassword, setConfirmPassword] = useState('')
 
   // new fields
-  const [role, setRole] = useState<'owner' | 'staff'>('owner')
   const [company, setCompany] = useState('')
   const [country, setCountry] = useState('')
   const [city, setCity] = useState('')
@@ -547,7 +546,6 @@ export default function App() {
         // 1) Create the store and get the id
         const storeId = await createInitialOwnerAndStore({
           user: nextUser,
-          role,
           company: sanitizedCompany,
           email: sanitizedEmail,
           country: sanitizedCountry,
@@ -564,7 +562,7 @@ export default function App() {
             uid: nextUser.uid,
             email: (nextUser.email ?? '').toLowerCase(),
             name: ownerName,
-            role,            // 'owner' | 'staff'
+            role: 'owner',
             storeId,         // REQUIRED
             invitedBy: nextUser.uid,
             createdAt: now,
@@ -582,7 +580,7 @@ export default function App() {
               uid: nextUser.uid,
               email: (nextUser.email ?? '').toLowerCase(),
               name: ownerName,
-              role,
+              role: 'owner',
               storeId,
               invitedBy: nextUser.uid,
               updatedAt: serverTimestamp(),
@@ -650,7 +648,6 @@ export default function App() {
       setCompany('')
       setCountry('')
       setCity('')
-      setRole('owner')
       setNormalizedPhone('')
       setDialingCode(DEFAULT_DIALING_CODE)
 
@@ -684,7 +681,6 @@ export default function App() {
     setCompany('')
     setCountry('')
     setCity('')
-    setRole('owner')
     setNormalizedPhone('')
     setDialingCode(DEFAULT_DIALING_CODE)
   }
@@ -771,17 +767,7 @@ export default function App() {
               {isSignup && (
                 <>
                   <div className="form__field">
-                    <label htmlFor="role">Role</label>
-                    <select
-                      id="role"
-                      value={role}
-                      onChange={e => setRole(e.target.value as 'owner' | 'staff')}
-                      disabled={isLoading}
-                    >
-                      <option value="owner">Owner</option>
-                      <option value="staff">Staff</option>
-                    </select>
-                    <p className="form__hint">We’ll use this to set your workspace permissions.</p>
+                    <p className="form__hint">We’ll set you up as the workspace owner.</p>
                   </div>
 
                   <div className="form__field">

--- a/web/src/controllers/onboarding.test.ts
+++ b/web/src/controllers/onboarding.test.ts
@@ -89,7 +89,6 @@ describe('createInitialOwnerAndStore', () => {
     const storeId = await createInitialOwnerAndStore({
       user,
       email: 'custom-owner@example.com',
-      role: 'staff',
       company: 'Sedifex Incorporated',
       country: 'Canada',
       city: 'Toronto',
@@ -103,7 +102,7 @@ describe('createInitialOwnerAndStore', () => {
     expect(teamMemberDoc).toMatchObject({
       uid: user.uid,
       storeId,
-      role: 'staff',
+      role: 'owner',
       email: 'custom-owner@example.com',
       company: 'Sedifex Incorporated',
       name: 'Store Owner',

--- a/web/src/controllers/onboarding.ts
+++ b/web/src/controllers/onboarding.ts
@@ -119,7 +119,6 @@ export async function generateUniqueStoreId(params: {
 type CreateInitialOwnerAndStoreParams = {
   user: Pick<User, 'uid' | 'email' | 'displayName'>
   email?: string | null
-  role?: string
   company?: string | null
   country?: string | null
   city?: string | null
@@ -132,7 +131,6 @@ export async function createInitialOwnerAndStore(
   const {
     user,
     email: emailOverride = null,
-    role = 'owner',
     company: companyOverride = null,
     country: countryOverride = null,
     city: cityOverride = null,
@@ -157,7 +155,7 @@ export async function createInitialOwnerAndStore(
   const teamMemberPayload: Record<string, unknown> = {
     uid,
     storeId,
-    role,
+    role: 'owner',
     email: resolvedEmail,
     updatedAt,
     createdAt,


### PR DESCRIPTION
## Summary
- remove the staff role selector during signup and update the helper text
- ensure initial owner provisioning always writes the owner role to Firestore
- update onboarding tests to reflect the owner-only role handling

## Testing
- pnpm vitest run src/controllers/onboarding.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ded764db648321b6a441529d6e7b8d