### PR TITLE
Remove duplicate compilerOptions entries in web tsconfig

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -14,10 +14,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
-    "paths": {
-      "@shared/*": ["../shared/*"]
-    },
     "types": [
       "vite/client",
       "vitest/globals"


### PR DESCRIPTION
## Summary
- remove the duplicate `baseUrl` and `paths` entries from `web/tsconfig.json` so only the intended values remain

## Testing
- pnpm run build *(fails: existing TypeScript errors in the project unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68df0c36f41c83219573294addc9252b