### PR TITLE
Add config module for override team member doc ID

### DIFF
--- a/web/src/config/teamMembers.ts
+++ b/web/src/config/teamMembers.ts
@@ -1,0 +1,11 @@
+const rawOverride = import.meta.env?.VITE_OVERRIDE_TEAM_MEMBER_DOC_ID
+
+function normalizeOverride(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : ''
+}
+
+export const OVERRIDE_TEAM_MEMBER_DOC_ID = normalizeOverride(rawOverride)
+
+export type TeamMemberOverrideDocId = typeof OVERRIDE_TEAM_MEMBER_DOC_ID


### PR DESCRIPTION
## Summary
- add a config module that surfaces the override team member doc id constant for App.tsx
- normalize the optional Vite environment variable to an empty string when unset

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df0c2466e4832188ccf9ca423c43d2