### PR TITLE
Simplify router to sell page

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,14 +4,7 @@ import { createHashRouter, RouterProvider } from 'react-router-dom'
 import App from './App'
 import SheetAccessGuard from './SheetAccessGuard'
 import Shell from './layout/Shell'
-import Dashboard from './pages/Dashboard'
-import Products from './pages/Products'
 import Sell from './pages/Sell'
-import Receive from './pages/Receive'
-import CloseDay from './pages/CloseDay'
-import Customers from './pages/Customers'
-import Today from './pages/Today'
-import AccountOverview from './pages/AccountOverview'
 import Gate from './pages/Gate'
 import { ToastProvider } from './components/ToastProvider'
 import { AppErrorBoundary } from './components/AppErrorBoundary'
@@ -26,14 +19,7 @@ const router = createHashRouter([
       </SheetAccessGuard>
     ),
     children: [
-      { index: true, element: <Shell><Gate><Dashboard /></Gate></Shell> },
-      { path: 'today',    element: <Shell><Gate><Today /></Gate></Shell> },
-      { path: 'products',  element: <Shell><Gate><Products /></Gate></Shell> },
-      { path: 'sell',      element: <Shell><Gate><Sell /></Gate></Shell> },
-      { path: 'receive',   element: <Shell><Gate><Receive /></Gate></Shell> },
-      { path: 'customers', element: <Shell><Gate><Customers /></Gate></Shell> },
-      { path: 'close-day', element: <Shell><Gate><CloseDay /></Gate></Shell> },
-      { path: 'account',   element: <Shell><Gate><AccountOverview /></Gate></Shell> },
+      { index: true, element: <Shell><Gate><Sell /></Gate></Shell> },
     ],
   },
 ])


### PR DESCRIPTION
## Summary
- remove unused page imports from the router entry point
- update the hash router to render the Sell page as the sole child route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa394e37c832197426f17a8968372