### PR TITLE
Remove toast provider usage

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,41 +4,9 @@ import { onAuthStateChanged } from 'firebase/auth'
 import { Outlet } from 'react-router-dom'
 import { auth } from './firebase'
 import './pwa'
-import { useToast } from './components/ToastProvider'
 import { configureAuthPersistence, refreshSessionHeartbeat } from './controllers/sessionController'
 import { AuthUserContext } from './hooks/useAuthUser'
 import { clearActiveStoreIdForUser, clearLegacyActiveStoreId } from './utils/activeStoreStorage'
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-}
-
-type QueueCompletedMessage = { type: 'QUEUE_REQUEST_COMPLETED'; requestType?: unknown }
-type QueueFailedMessage = { type: 'QUEUE_REQUEST_FAILED'; requestType?: unknown; error?: unknown }
-
-function isQueueCompletedMessage(value: unknown): value is QueueCompletedMessage {
-  return isRecord(value) && (value as QueueCompletedMessage).type === 'QUEUE_REQUEST_COMPLETED'
-}
-
-function isQueueFailedMessage(value: unknown): value is QueueFailedMessage {
-  return isRecord(value) && (value as QueueFailedMessage).type === 'QUEUE_REQUEST_FAILED'
-}
-
-function getQueueRequestLabel(requestType: unknown): string {
-  return requestType === 'receipt' ? 'stock receipt' : 'sale'
-}
-
-function normalizeQueueError(value: unknown): string | null {
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (trimmed) return trimmed
-  }
-  if (value instanceof Error) {
-    const message = value.message.trim()
-    if (message) return message
-  }
-  return null
-}
 
 const loadingStyle: CSSProperties = {
   minHeight: '100dvh',
@@ -52,7 +20,6 @@ export default function App() {
   const [user, setUser] = useState<User | null>(null)
   const previousUidRef = useRef<string | null>(null)
   const [isAuthReady, setIsAuthReady] = useState(false)
-  const { publish } = useToast()
 
   useEffect(() => {
     configureAuthPersistence(auth).catch(() => {})
@@ -79,31 +46,6 @@ export default function App() {
     if (!user) return
     refreshSessionHeartbeat(user).catch(() => {})
   }, [user])
-
-  useEffect(() => {
-    if (!('serviceWorker' in navigator)) return
-    const handleMessage = (event: MessageEvent) => {
-      const data = event.data
-      if (isQueueCompletedMessage(data)) {
-        const label = getQueueRequestLabel((data as QueueCompletedMessage).requestType)
-        publish({ message: `Queued ${label} synced successfully.`, tone: 'success' })
-        return
-      }
-      if (isQueueFailedMessage(data)) {
-        const label = getQueueRequestLabel((data as QueueFailedMessage).requestType)
-        const detail = normalizeQueueError((data as QueueFailedMessage).error)
-        publish({
-          message: detail
-            ? `We couldn't sync the queued ${label}. ${detail}`
-            : `We couldn't sync the queued ${label}. Please try again.`,
-          tone: 'error',
-          duration: 8000,
-        })
-      }
-    }
-    navigator.serviceWorker.addEventListener('message', handleMessage)
-    return () => navigator.serviceWorker.removeEventListener('message', handleMessage)
-  }, [publish])
 
   if (!isAuthReady) {
     return (

--- a/web/src/hooks/useStoreMetrics.ts
+++ b/web/src/hooks/useStoreMetrics.ts
@@ -21,7 +21,6 @@ import { db } from '../firebase'
 import { ensureCustomerLoyalty, type CustomerLoyalty } from '../utils/customerLoyalty'
 import { useAuthUser } from './useAuthUser'
 import { useActiveStoreContext } from '../context/ActiveStoreProvider'
-import { useToast } from '../components/ToastProvider'
 import { formatCurrency } from '@shared/currency'
 import {
   CUSTOMER_CACHE_LIMIT,
@@ -317,7 +316,6 @@ function buildDailyMetricSeries(
 export function useStoreMetrics(): UseStoreMetricsResult {
   const authUser = useAuthUser()
   const { storeId: activeStoreId } = useActiveStoreContext()
-  const { publish } = useToast()
 
   const [sales, setSales] = useState<SaleRecord[]>([])
   const [products, setProducts] = useState<ProductRecord[]>([])
@@ -502,14 +500,14 @@ export function useStoreMetrics(): UseStoreMetricsResult {
     fetchSalesForRange().catch(error => {
       if (!cancelled) {
         console.warn('[metrics] Failed to fetch sales for range', error)
-        publish({ tone: 'error', message: 'Failed to refresh sales metrics.' })
+        console.error('Failed to refresh sales metrics.')
       }
     })
 
     return () => {
       cancelled = true
     }
-  }, [activeStoreId, combinedRange.start, combinedRange.end, publish])
+  }, [activeStoreId, combinedRange.start, combinedRange.end])
 
   useEffect(() => {
     let cancelled = false
@@ -904,7 +902,7 @@ export function useStoreMetrics(): UseStoreMetricsResult {
   async function handleGoalSubmit(event: FormEvent) {
     event.preventDefault()
     if (!activeStoreId) {
-      publish({ tone: 'error', message: 'Select a store to save goals.' })
+      console.warn('Select a store to save goals.')
       return
     }
 
@@ -942,10 +940,10 @@ export function useStoreMetrics(): UseStoreMetricsResult {
         revenueTarget: String(revenueTarget),
         customerTarget: String(customerTarget),
       })
-      publish({ tone: 'success', message: `Goals updated for ${goalMonthLabel}.` })
+      console.info(`Goals updated for ${goalMonthLabel}.`)
     } catch (error) {
       console.error('[metrics] Unable to save goals', error)
-      publish({ tone: 'error', message: 'Unable to save goals right now.' })
+      console.error('Unable to save goals right now.')
     } finally {
       setIsSavingGoals(false)
     }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,7 +5,6 @@ import App from './App'
 import SheetAccessGuard from './SheetAccessGuard'
 import Shell from './layout/Shell'
 import Sell from './pages/Sell'
-import { ToastProvider } from './components/ToastProvider'
 import { AppErrorBoundary } from './components/AppErrorBoundary'
 import { ActiveStoreProvider } from './context/ActiveStoreProvider'
 
@@ -26,12 +25,10 @@ const router = createHashRouter([
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <ToastProvider>
-      <ActiveStoreProvider>
-        <AppErrorBoundary>
-          <RouterProvider router={router} />
-        </AppErrorBoundary>
-      </ActiveStoreProvider>
-    </ToastProvider>
+    <ActiveStoreProvider>
+      <AppErrorBoundary>
+        <RouterProvider router={router} />
+      </AppErrorBoundary>
+    </ActiveStoreProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- remove the toast provider wrapper from the React root and drop the unused module import
- eliminate toast-based service worker messaging helpers in the app shell
- replace toast usage in the store metrics hook with console logging for success and error states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0002f63b88321b88cee9e4f4e812c