### PR TITLE
Switch membership access from Firestore to Supabase

### DIFF
--- a/supabase/migrations/0001_team_members.sql
+++ b/supabase/migrations/0001_team_members.sql
@@ -1,0 +1,136 @@
+-- supabase/migrations/0001_team_members.sql
+--
+-- Schema objects required for workspace memberships in Supabase.
+-- The objects below provide:
+--   * Workspace stores (`stores`)
+--   * Team member assignments (`team_members`)
+--   * Contract/payment tracking per store (`store_contracts`)
+--   * A read-optimised view (`team_memberships_view`) that joins the
+--     tables and exposes contract fields used by the frontend.
+--   * RPC helpers so the web client can resolve memberships via UID
+--     or email without exposing the full tables.
+
+set search_path to public;
+
+create extension if not exists "uuid-ossp";
+create extension if not exists pgcrypto;
+
+create table if not exists public.stores (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique,
+  name text not null,
+  company text,
+  status text not null default 'active',
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.store_contracts (
+  id uuid primary key default gen_random_uuid(),
+  store_id uuid not null references public.stores(id) on delete cascade,
+  status text not null default 'active',
+  contract_start date,
+  contract_end date,
+  payment_status text,
+  amount_paid numeric(12, 2),
+  currency text default 'USD',
+  is_current boolean not null default true,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.team_members (
+  id uuid primary key default gen_random_uuid(),
+  store_id uuid not null references public.stores(id) on delete cascade,
+  uid text,
+  email text,
+  role text not null default 'staff',
+  status text default 'active',
+  contract_status text,
+  phone text,
+  invited_by text,
+  first_signup_email text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint team_members_role_check check (role in ('owner', 'staff')),
+  constraint team_members_identity_check check (uid is not null or email is not null)
+);
+
+create index if not exists team_members_uid_idx on public.team_members (uid);
+create index if not exists team_members_email_idx on public.team_members (email);
+create index if not exists team_members_store_idx on public.team_members (store_id);
+
+create or replace view public.team_memberships_view as
+select
+  tm.id,
+  tm.store_id,
+  tm.uid,
+  tm.email,
+  tm.role,
+  tm.status,
+  coalesce(tm.contract_status, sc.status) as contract_status,
+  tm.phone,
+  tm.invited_by,
+  tm.first_signup_email,
+  tm.created_at,
+  tm.updated_at,
+  sc.contract_start,
+  sc.contract_end,
+  sc.payment_status,
+  sc.amount_paid,
+  sc.currency,
+  s.company,
+  s.name as store_name
+from public.team_members tm
+join public.stores s on s.id = tm.store_id
+left join public.store_contracts sc
+  on sc.store_id = tm.store_id and sc.is_current = true;
+
+create type public.active_team_member_result as (
+  member_id uuid,
+  store_id uuid,
+  status text,
+  contract_status text,
+  role text,
+  email text,
+  uid text
+);
+
+create or replace function public.get_active_team_membership(
+  p_uid text,
+  p_email text default null
+) returns public.active_team_member_result
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  result public.active_team_member_result;
+begin
+  select
+    tm.id,
+    tm.store_id,
+    tm.status,
+    coalesce(tm.contract_status, sc.status),
+    tm.role,
+    tm.email,
+    tm.uid
+  into result
+  from public.team_members tm
+  join public.stores s on s.id = tm.store_id
+  left join public.store_contracts sc
+    on sc.store_id = tm.store_id and sc.is_current = true
+  where
+    (p_uid is not null and tm.uid = p_uid)
+    or (p_email is not null and tm.email = p_email)
+  order by
+    case when p_uid is not null and tm.uid = p_uid then 0 else 1 end,
+    tm.updated_at desc
+  limit 1;
+
+  return result;
+end;
+$$;
+
+comment on view public.team_memberships_view is 'Join of team member assignments and current contract metadata for storefronts.';
+comment on function public.get_active_team_membership(text, text) is 'Resolve the most relevant membership for a user by UID/email including contract status.';

--- a/web/src/config/supabaseEnv.ts
+++ b/web/src/config/supabaseEnv.ts
@@ -1,0 +1,28 @@
+// web/src/config/supabaseEnv.ts
+const requiredSupabaseEnvKeys = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY'] as const
+
+type RequiredSupabaseEnvKey = (typeof requiredSupabaseEnvKeys)[number]
+
+type SupabaseEnvConfig = {
+  url: string
+  anonKey: string
+}
+
+function getRequiredEnv(key: RequiredSupabaseEnvKey): string {
+  const value = import.meta.env[key]
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value.trim().replace(/\/$/, '')
+  }
+
+  throw new Error(
+    `[supabase-env] Missing required environment variable "${key}". ` +
+      'Ensure the Supabase URL and anon key are configured for this deployment.'
+  )
+}
+
+export const supabaseEnv: SupabaseEnvConfig = {
+  url: getRequiredEnv('VITE_SUPABASE_URL'),
+  anonKey: getRequiredEnv('VITE_SUPABASE_ANON_KEY'),
+}
+
+export type { SupabaseEnvConfig }

--- a/web/src/config/teamMembers.ts
+++ b/web/src/config/teamMembers.ts
@@ -1,4 +1,6 @@
-const rawOverride = import.meta.env?.VITE_OVERRIDE_TEAM_MEMBER_DOC_ID
+const rawOverride =
+  import.meta.env?.VITE_OVERRIDE_TEAM_MEMBER_ID ??
+  import.meta.env?.VITE_OVERRIDE_TEAM_MEMBER_DOC_ID
 
 function normalizeOverride(value: unknown): string {
   if (typeof value !== 'string') return ''
@@ -6,6 +8,9 @@ function normalizeOverride(value: unknown): string {
   return trimmed.length > 0 ? trimmed : ''
 }
 
-export const OVERRIDE_TEAM_MEMBER_DOC_ID = normalizeOverride(rawOverride)
+export const OVERRIDE_TEAM_MEMBER_ID = normalizeOverride(rawOverride)
 
-export type TeamMemberOverrideDocId = typeof OVERRIDE_TEAM_MEMBER_DOC_ID
+export type TeamMemberOverrideId = typeof OVERRIDE_TEAM_MEMBER_ID
+
+export const OVERRIDE_TEAM_MEMBER_DOC_ID = OVERRIDE_TEAM_MEMBER_ID
+export type TeamMemberOverrideDocId = TeamMemberOverrideId

--- a/web/src/supabaseClient.ts
+++ b/web/src/supabaseClient.ts
@@ -1,0 +1,101 @@
+// web/src/supabaseClient.ts
+import { supabaseEnv } from './config/supabaseEnv'
+
+type SupabaseRequestOptions = RequestInit & {
+  searchParams?: URLSearchParams | Record<string, string | string[] | undefined>
+}
+
+function buildSearchParams(
+  params: URLSearchParams | Record<string, string | string[] | undefined> | undefined,
+): string {
+  if (!params) {
+    return ''
+  }
+
+  if (params instanceof URLSearchParams) {
+    const serialized = params.toString()
+    return serialized ? `?${serialized}` : ''
+  }
+
+  const searchParams = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (typeof entry === 'string') {
+          searchParams.append(key, entry)
+        }
+      }
+    } else if (typeof value === 'string') {
+      searchParams.set(key, value)
+    }
+  }
+
+  const serialized = searchParams.toString()
+  return serialized ? `?${serialized}` : ''
+}
+
+async function supabaseRequest(path: string, options: SupabaseRequestOptions = {}) {
+  const headers = new Headers(options.headers)
+  headers.set('apikey', supabaseEnv.anonKey)
+  headers.set('Authorization', `Bearer ${supabaseEnv.anonKey}`)
+
+  if (options.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  const search = buildSearchParams(options.searchParams)
+  const response = await fetch(`${supabaseEnv.url}${path}${search}`, {
+    ...options,
+    headers,
+  })
+
+  if (!response.ok) {
+    let message = `${response.status} ${response.statusText}`
+    try {
+      const payload = await response.json()
+      if (payload && typeof payload.error === 'string') {
+        message = payload.error
+      } else if (payload && typeof payload.message === 'string') {
+        message = payload.message
+      }
+    } catch {
+      // Ignore JSON parsing errors and fall back to status text.
+    }
+    throw new Error(`[supabase] ${message}`)
+  }
+
+  return response
+}
+
+export async function callSupabaseRpc<T>(
+  fn: string,
+  args: Record<string, unknown>,
+): Promise<T | null> {
+  const response = await supabaseRequest(`/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    body: JSON.stringify(args ?? {}),
+  })
+
+  if (response.status === 204) {
+    return null
+  }
+
+  const data = (await response.json()) as T | null
+  return data
+}
+
+export async function querySupabase<T>(
+  resource: string,
+  params?: URLSearchParams | Record<string, string | string[] | undefined>,
+): Promise<T[]> {
+  const response = await supabaseRequest(`/rest/v1/${resource}`, {
+    method: 'GET',
+    searchParams: params,
+    headers: {
+      Prefer: 'return=representation',
+    },
+  })
+
+  const data = (await response.json()) as T[] | null
+  return Array.isArray(data) ? data : []
+}

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -6,6 +6,8 @@ vi.stubEnv('VITE_FB_PROJECT_ID', 'sedifex-ac2b0')
 vi.stubEnv('VITE_FB_STORAGE_BUCKET', 'sedifex-ac2b0.appspot.com')
 vi.stubEnv('VITE_FB_APP_ID', '1:1234567890:web:test')
 vi.stubEnv('VITE_FB_FUNCTIONS_REGION', 'us-central1')
+vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co')
+vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'supabase-anon-key')
 
 beforeEach(() => {
   // Ensure print is stubbed so tests can observe invocations without touching the real browser API.


### PR DESCRIPTION
## Summary
- add Supabase schema objects for stores, team members, and active membership RPC lookups
- replace SheetAccessGuard Firestore lookups with Supabase RPC calls and retry logic
- rewrite useMemberships hook and tests to read team memberships from Supabase via REST helper utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e00b286fd88321baab21c794df4a8d