### PR TITLE
Expose Supabase types from client export

### DIFF
--- a/web/src/supabaseClient.ts
+++ b/web/src/supabaseClient.ts
@@ -1,6 +1,9 @@
-
-import { createClient } from '@supabase/supabase-js'
-
+import {
+  createClient,
+  type Session,
+  type SupabaseClient,
+  type User,
+} from '@supabase/supabase-js'
 import { supabaseEnv } from './config/supabaseEnv'
 
 export const supabase = createClient(supabaseEnv.url, supabaseEnv.anonKey, {
@@ -10,3 +13,4 @@ export const supabase = createClient(supabaseEnv.url, supabaseEnv.anonKey, {
   },
 })
 
+export type { Session, SupabaseClient, User }


### PR DESCRIPTION
## Summary
- import the Session, SupabaseClient, and User types from `@supabase/supabase-js`
- re-export those types alongside the configured Supabase client

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e02f59cd30832195765dcfdfc0ec75