### PR TITLE
Adjust BarcodeScanner props typing

### DIFF
--- a/web/src/components/BarcodeScanner.tsx
+++ b/web/src/components/BarcodeScanner.tsx
@@ -7,13 +7,15 @@ export type ScanResult = {
   source: ScanResultSource
 }
 
-export type BarcodeScannerProps = {
+type DivProps = Omit<ComponentPropsWithoutRef<'div'>, 'onError'>
+
+export type BarcodeScannerProps = DivProps & {
   className?: string
   enableCameraFallback?: boolean
   manualEntryLabel?: string
   onScan?: (result: ScanResult) => void
   onError?: (message: string) => void
-} & ComponentPropsWithoutRef<'div'>
+}
 
 export default function BarcodeScanner(_props: BarcodeScannerProps) {
   return null


### PR DESCRIPTION
## Summary
- omit the div `onError` prop before defining the component-specific handler signature for `BarcodeScanner`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e02f5d5bd48321b03b7c5c9a06d870