### PR TITLE
Import Vitest globals in test setup

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom/vitest'
+import { beforeEach, vi } from 'vitest'
 
 vi.stubEnv('VITE_FB_API_KEY', 'test-api-key')
 vi.stubEnv('VITE_FB_AUTH_DOMAIN', 'sedifex-ac2b0.firebaseapp.com')


### PR DESCRIPTION
## Summary
- import the beforeEach and vi helpers from vitest in the shared test setup file

## Testing
- npm run build *(fails: existing TypeScript errors about missing exports and modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e02f5e6d808321b2d61c0e1f503678