### PR TITLE
Fix Supabase session rehydration logic

### DIFF
--- a/web/src/controllers/sessionController.ts
+++ b/web/src/controllers/sessionController.ts
@@ -14,7 +14,21 @@ export async function configureAuthPersistence(client: SupabaseClient) {
   }
 
   try {
-    await client.auth.setSession()
+    const { data, error } = await client.auth.getSession()
+    if (error) {
+      throw error
+    }
+
+    const session = data.session
+    const accessToken = session?.access_token
+    const refreshToken = session?.refresh_token
+
+    if (accessToken && refreshToken) {
+      await client.auth.setSession({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+      })
+    }
   } catch (error) {
     console.warn('[auth] Failed to synchronise Supabase session state', error)
   }


### PR DESCRIPTION
## Summary
- rehydrate Supabase auth by reading the persisted session before calling setSession
- guard against missing tokens to avoid invalid zero-argument setSession invocations

## Testing
- npm run build *(fails: missing @types from npm registry access restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68e035d14b6c8321af6835fffe243d2d