### PR TITLE
Add Supabase auth screen and session persistence

### DIFF
--- a/web/src/components/auth/AuthForm.tsx
+++ b/web/src/components/auth/AuthForm.tsx
@@ -1,0 +1,170 @@
+import type { CSSProperties, FormEventHandler, ReactNode } from 'react'
+
+type AuthFormProps = {
+  title: string
+  description?: string
+  onSubmit: FormEventHandler<HTMLFormElement>
+  submitLabel: string
+  loading?: boolean
+  error?: string | null
+  footer?: ReactNode
+  children: ReactNode
+}
+
+export function AuthForm({
+  title,
+  description,
+  onSubmit,
+  submitLabel,
+  loading = false,
+  error,
+  footer,
+  children,
+}: AuthFormProps) {
+  return (
+    <form onSubmit={onSubmit} style={formStyle} noValidate data-auth-form>
+      <div style={headerStyle}>
+        <h1 style={titleStyle}>{title}</h1>
+        {description ? <p style={descriptionStyle}>{description}</p> : null}
+      </div>
+
+      <div style={bodyStyle}>{children}</div>
+
+      {error ? (
+        <p role="alert" style={errorStyle}>
+          {error}
+        </p>
+      ) : null}
+
+      <button type="submit" style={submitStyle} disabled={loading}>
+        {loading ? 'Please wait…' : submitLabel}
+      </button>
+
+      {footer ? <div style={footerStyle}>{footer}</div> : null}
+    </form>
+  )
+}
+
+const formStyle: CSSProperties = {
+  width: '100%',
+  maxWidth: '420px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  backgroundColor: '#ffffff',
+  borderRadius: '16px',
+  padding: '2.5rem',
+  boxShadow: '0 18px 45px rgba(15, 23, 42, 0.12)',
+}
+
+const headerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+}
+
+const titleStyle: CSSProperties = {
+  fontSize: '1.75rem',
+  fontWeight: 700,
+  margin: 0,
+  color: '#0f172a',
+}
+
+const descriptionStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '1rem',
+  lineHeight: 1.5,
+  color: '#475569',
+}
+
+const bodyStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+}
+
+const submitStyle: CSSProperties = {
+  appearance: 'none',
+  border: 'none',
+  borderRadius: '999px',
+  background: 'linear-gradient(135deg, #2563eb, #7c3aed)',
+  color: '#fff',
+  fontSize: '1rem',
+  fontWeight: 600,
+  padding: '0.85rem 1.5rem',
+  cursor: 'pointer',
+  transition: 'filter 150ms ease, transform 150ms ease',
+  boxShadow: '0 14px 30px rgba(37, 99, 235, 0.35)',
+}
+
+const errorStyle: CSSProperties = {
+  margin: 0,
+  padding: '0.75rem 1rem',
+  borderRadius: '0.75rem',
+  backgroundColor: '#fef2f2',
+  color: '#b91c1c',
+  fontSize: '0.95rem',
+  border: '1px solid rgba(248, 113, 113, 0.4)',
+}
+
+const footerStyle: CSSProperties = {
+  textAlign: 'center',
+  fontSize: '0.95rem',
+  color: '#475569',
+}
+
+if (typeof window !== 'undefined') {
+  const styleId = 'auth-form-hover-style'
+  if (!document.getElementById(styleId)) {
+    const style = document.createElement('style')
+    style.id = styleId
+    style.textContent = `
+      @media (hover: hover) and (pointer: fine) {
+        form[data-auth-form] button[type="submit"]:not(:disabled) {
+          transition: filter 150ms ease, transform 150ms ease;
+        }
+        form[data-auth-form] button[type="submit"]:not(:disabled):hover {
+          filter: brightness(0.92);
+          transform: translateY(1px);
+        }
+        form[data-auth-form] button[type="submit"]:not(:disabled):active {
+          filter: brightness(0.88);
+          transform: translateY(2px);
+        }
+        form[data-auth-form] button[type="submit"]:disabled {
+          opacity: 0.65;
+          cursor: not-allowed;
+        }
+      }
+    `
+    document.head.appendChild(style)
+  }
+}
+
+export const inputGroupStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.4rem',
+}
+
+export const labelStyle: CSSProperties = {
+  fontWeight: 600,
+  fontSize: '0.95rem',
+  color: '#1e293b',
+}
+
+export const inputStyle: CSSProperties = {
+  borderRadius: '0.75rem',
+  border: '1px solid rgba(148, 163, 184, 0.6)',
+  padding: '0.85rem 1rem',
+  fontSize: '1rem',
+  backgroundColor: '#f8fafc',
+  color: '#0f172a',
+  transition: 'border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease',
+}
+
+export const noteStyle: CSSProperties = {
+  fontSize: '0.85rem',
+  color: '#64748b',
+  margin: 0,
+}

--- a/web/src/pages/AuthScreen.tsx
+++ b/web/src/pages/AuthScreen.tsx
@@ -1,0 +1,329 @@
+import { useCallback, useMemo, useState, type CSSProperties, type FormEvent } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { AuthForm, inputGroupStyle, inputStyle, labelStyle, noteStyle } from '../components/auth/AuthForm'
+import { useToast } from '../components/ToastProvider'
+import { afterSignupBootstrap } from '../controllers/accessController'
+import { supabase } from '../supabaseClient'
+
+type AuthMode = 'sign-in' | 'sign-up'
+
+const MIN_PASSWORD_LENGTH = 8
+
+function normalizeError(error: unknown): string {
+  if (!error) {
+    return 'Something went wrong. Please try again.'
+  }
+
+  if (typeof error === 'string') {
+    const trimmed = error.trim()
+    return trimmed || 'Something went wrong. Please try again.'
+  }
+
+  if (error instanceof Error) {
+    const trimmed = error.message.trim()
+    return trimmed || 'Something went wrong. Please try again.'
+  }
+
+  if (typeof error === 'object' && 'message' in (error as Record<string, unknown>)) {
+    const value = (error as { message?: unknown }).message
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim()
+    }
+  }
+
+  return 'Something went wrong. Please try again.'
+}
+
+function validateCredentials(email: string, password: string): string | null {
+  const trimmedEmail = email.trim()
+  if (!trimmedEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+    return 'Enter a valid email address to continue.'
+  }
+
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`
+  }
+
+  return null
+}
+
+export default function AuthScreen() {
+  const [mode, setMode] = useState<AuthMode>('sign-in')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const { publish } = useToast()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const redirectTo = useMemo(() => {
+    const state = location.state as { from?: string } | null
+    if (state?.from && typeof state.from === 'string') {
+      return state.from
+    }
+    if (location.pathname && location.pathname !== '/') {
+      return location.pathname
+    }
+    return '/'
+  }, [location.pathname, location.state])
+
+  const toggleMode = useCallback((nextMode: AuthMode) => {
+    setMode(current => {
+      if (current === nextMode) {
+        return current
+      }
+      setError(null)
+      setPassword('')
+      return nextMode
+    })
+  }, [])
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      if (loading) return
+
+      const validationError = validateCredentials(email, password)
+      if (validationError) {
+        setError(validationError)
+        publish({ message: validationError, tone: 'error' })
+        return
+      }
+
+      setLoading(true)
+      setError(null)
+
+      const trimmedEmail = email.trim()
+
+      try {
+        if (mode === 'sign-in') {
+          const { data, error: signInError } = await supabase.auth.signInWithPassword({
+            email: trimmedEmail,
+            password,
+          })
+
+          if (signInError) {
+            const message = normalizeError(signInError)
+            setError(message)
+            publish({ message, tone: 'error' })
+            return
+          }
+
+          if (!data.session) {
+            publish({ message: 'Signed in. Loading your workspace…', tone: 'info' })
+          } else {
+            publish({ message: 'Welcome back!', tone: 'success' })
+          }
+
+          navigate(redirectTo, { replace: true })
+          return
+        }
+
+        const { data, error: signUpError } = await supabase.auth.signUp({
+          email: trimmedEmail,
+          password,
+        })
+
+        if (signUpError) {
+          const message = normalizeError(signUpError)
+          setError(message)
+          publish({ message, tone: 'error' })
+          return
+        }
+
+        if (data.user?.id) {
+          try {
+            await afterSignupBootstrap()
+          } catch (bootstrapError) {
+            const message = normalizeError(bootstrapError)
+            publish({
+              message: `We created your account but hit a snag syncing workspace data. ${message}`,
+              tone: 'error',
+              duration: 8000,
+            })
+          }
+        }
+
+        const successMessage = data.session
+          ? 'Account created! Setting things up now…'
+          : 'Check your inbox to confirm your email and finish setting up your account.'
+        publish({ message: successMessage, tone: 'success' })
+
+        navigate(redirectTo, { replace: true })
+      } catch (unknownError) {
+        const message = normalizeError(unknownError)
+        setError(message)
+        publish({ message, tone: 'error' })
+      } finally {
+        setLoading(false)
+      }
+    },
+    [email, loading, mode, navigate, password, publish, redirectTo],
+  )
+
+  const formTitle = mode === 'sign-in' ? 'Welcome back' : 'Create your Sedifex account'
+  const formDescription =
+    mode === 'sign-in'
+      ? 'Sign in to manage your stores, track inventory, and keep sales in sync.'
+      : 'Start your free Sedifex workspace so your team can sell faster and count smarter.'
+
+  const footerActionLabel =
+    mode === 'sign-in' ? "Don't have an account?" : 'Already have an account?'
+  const footerActionButtonLabel = mode === 'sign-in' ? 'Create one' : 'Sign in'
+  const footerActionMode: AuthMode = mode === 'sign-in' ? 'sign-up' : 'sign-in'
+
+  return (
+    <main style={screenStyle}>
+      <div style={panelStyle}>
+        <div style={brandStyle}>
+          <div style={logoStyle}>Sedifex</div>
+          <p style={taglineStyle}>Sell faster. Count smarter.</p>
+        </div>
+
+        <div style={modeToggleStyle}>
+          <button
+            type="button"
+            onClick={() => toggleMode('sign-in')}
+            style={{ ...modeButtonStyle, ...(mode === 'sign-in' ? modeButtonActiveStyle : {}) }}
+          >
+            Sign in
+          </button>
+          <button
+            type="button"
+            onClick={() => toggleMode('sign-up')}
+            style={{ ...modeButtonStyle, ...(mode === 'sign-up' ? modeButtonActiveStyle : {}) }}
+          >
+            Create account
+          </button>
+        </div>
+
+        <AuthForm
+          title={formTitle}
+          description={formDescription}
+          onSubmit={handleSubmit}
+          submitLabel={mode === 'sign-in' ? 'Sign in' : 'Create account'}
+          loading={loading}
+          error={error}
+          footer={
+            <div>
+              {footerActionLabel}{' '}
+              <button
+                type="button"
+                onClick={() => toggleMode(footerActionMode)}
+                style={footerActionButtonStyle}
+                disabled={loading}
+              >
+                {footerActionButtonLabel}
+              </button>
+            </div>
+          }
+        >
+          <label style={inputGroupStyle}>
+            <span style={labelStyle}>Email</span>
+            <input
+              style={inputStyle}
+              type="email"
+              name="email"
+              autoComplete="email"
+              placeholder="you@company.com"
+              value={email}
+              onChange={event => setEmail(event.target.value)}
+              disabled={loading}
+              required
+            />
+          </label>
+
+          <label style={inputGroupStyle}>
+            <span style={labelStyle}>Password</span>
+            <input
+              style={inputStyle}
+              type="password"
+              name="password"
+              autoComplete={mode === 'sign-in' ? 'current-password' : 'new-password'}
+              placeholder="Enter at least 8 characters"
+              value={password}
+              onChange={event => setPassword(event.target.value)}
+              disabled={loading}
+              required
+            />
+            <p style={noteStyle}>Use at least {MIN_PASSWORD_LENGTH} characters for a strong password.</p>
+          </label>
+        </AuthForm>
+      </div>
+    </main>
+  )
+}
+
+const screenStyle: CSSProperties = {
+  minHeight: '100dvh',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '2rem',
+  background: 'radial-gradient(circle at top, rgba(37, 99, 235, 0.08), transparent 55%), #f8fafc',
+}
+
+const panelStyle: CSSProperties = {
+  width: '100%',
+  maxWidth: '520px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  alignItems: 'center',
+}
+
+const brandStyle: CSSProperties = {
+  textAlign: 'center',
+  color: '#0f172a',
+}
+
+const logoStyle: CSSProperties = {
+  fontWeight: 800,
+  fontSize: '2.5rem',
+  letterSpacing: '-0.04em',
+}
+
+const taglineStyle: CSSProperties = {
+  margin: '0.5rem 0 0',
+  fontSize: '1rem',
+  color: '#475569',
+}
+
+const modeToggleStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  backgroundColor: 'rgba(148, 163, 184, 0.14)',
+  borderRadius: '999px',
+  padding: '0.25rem',
+  gap: '0.25rem',
+}
+
+const modeButtonStyle: CSSProperties = {
+  appearance: 'none',
+  border: 'none',
+  borderRadius: '999px',
+  padding: '0.6rem 1.25rem',
+  fontSize: '0.95rem',
+  fontWeight: 600,
+  backgroundColor: 'transparent',
+  color: '#475569',
+  cursor: 'pointer',
+  transition: 'background-color 150ms ease, color 150ms ease, box-shadow 150ms ease',
+}
+
+const modeButtonActiveStyle: CSSProperties = {
+  backgroundColor: '#fff',
+  color: '#1d4ed8',
+  boxShadow: '0 10px 25px rgba(30, 64, 175, 0.18)',
+}
+
+const footerActionButtonStyle: CSSProperties = {
+  appearance: 'none',
+  background: 'none',
+  border: 'none',
+  color: '#2563eb',
+  fontWeight: 600,
+  cursor: 'pointer',
+  padding: 0,
+}


### PR DESCRIPTION
## Summary
- add a dedicated AuthScreen with Supabase email/password sign-in & sign-up flows, validation, toasts, and post-signup bootstrap
- create a shared AuthForm component to centralize authentication layout and styling
- update App to surface the auth screen when signed out and persist active sessions to Firestore metadata

## Testing
- npm run lint *(fails: missing `@eslint/js` required by the repo's eslint.config.js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a97c60e08321a2a45755ace1b51a