### PR TITLE
Add PageSection wrapper for workspace routes

### DIFF
--- a/web/src/layout/PageSection.tsx
+++ b/web/src/layout/PageSection.tsx
@@ -1,0 +1,36 @@
+import type { ReactElement, ReactNode } from 'react'
+import './Workspace.css'
+
+type PageSectionProps = {
+  title: string
+  subtitle?: string
+  actions?: ReactNode
+  children?: ReactNode
+  className?: string
+  cardClassName?: string
+}
+
+export default function PageSection({
+  title,
+  subtitle,
+  actions,
+  children,
+  className,
+  cardClassName,
+}: PageSectionProps): ReactElement {
+  const pageClassName = className ? `page ${className}` : 'page'
+  const cardClasses = cardClassName ? `card ${cardClassName}` : 'card'
+
+  return (
+    <div className={pageClassName}>
+      <header className="page__header">
+        <div>
+          <h2 className="page__title">{title}</h2>
+          {subtitle ? <p className="page__subtitle">{subtitle}</p> : null}
+        </div>
+        {actions ? <div className="page__actions">{actions}</div> : null}
+      </header>
+      <section className={cardClasses}>{children}</section>
+    </div>
+  )
+}

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -1,10 +1,18 @@
 import type { ReactElement } from 'react'
+import PageSection from '../layout/PageSection'
 
 export default function AccountOverview(): ReactElement {
   return (
-    <main>
-      <h1>Account Overview</h1>
-      <p>Review your business settings and subscription details.</p>
-    </main>
+    <PageSection
+      title="Account Overview"
+      subtitle="Review your business settings and subscription details."
+    >
+      <div className="empty-state" role="status" aria-live="polite">
+        <h3 className="empty-state__title">Account controls are being crafted</h3>
+        <p>
+          Manage billing, team access, and locations from here once configuration panels are ready.
+        </p>
+      </div>
+    </PageSection>
   )
 }

--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -1,10 +1,19 @@
 import type { ReactElement } from 'react'
+import PageSection from '../layout/PageSection'
 
 export default function CloseDay(): ReactElement {
   return (
-    <main>
-      <h1>Close Day</h1>
-      <p>Review the day&rsquo;s activity before closing the books.</p>
-    </main>
+    <PageSection
+      title="Close Day"
+      subtitle="Review the day’s activity before closing the books."
+    >
+      <div className="empty-state" role="status" aria-live="polite">
+        <h3 className="empty-state__title">Closing checklist is in progress</h3>
+        <p>
+          We&rsquo;re building a guided checklist to reconcile drawers, verify deposits, and finalize end-of-day
+          reporting.
+        </p>
+      </div>
+    </PageSection>
   )
 }

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -1,10 +1,19 @@
 import type { ReactElement } from 'react'
+import PageSection from '../layout/PageSection'
 
 export default function Customers(): ReactElement {
   return (
-    <main>
-      <h1>Customers</h1>
-      <p>Look up customer profiles and manage loyalty information.</p>
-    </main>
+    <PageSection
+      title="Customers"
+      subtitle="Look up customer profiles and manage loyalty information."
+    >
+      <div className="empty-state" role="status" aria-live="polite">
+        <h3 className="empty-state__title">Customer directory not yet available</h3>
+        <p>
+          Soon you&rsquo;ll be able to search customers, review visit history, and update loyalty rewards in
+          one place.
+        </p>
+      </div>
+    </PageSection>
   )
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,10 +1,19 @@
 import type { ReactElement } from 'react'
+import PageSection from '../layout/PageSection'
 
 export default function Dashboard(): ReactElement {
   return (
-    <main>
-      <h1>Dashboard</h1>
-      <p>Welcome back! Choose an option from the navigation to get started.</p>
-    </main>
+    <PageSection
+      title="Dashboard"
+      subtitle="Welcome back! Choose an option from the navigation to get started."
+    >
+      <div className="empty-state" role="status" aria-live="polite">
+        <h3 className="empty-state__title">Insights are on the way</h3>
+        <p>
+          We&rsquo;re preparing daily sales summaries and quick metrics to help you monitor performance at a
+          glance.
+        </p>
+      </div>
+    </PageSection>
   )
 }

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -1,10 +1,18 @@
 import type { ReactElement } from 'react'
+import PageSection from '../layout/PageSection'
 
 export default function Products(): ReactElement {
   return (
-    <main>
-      <h1>Products</h1>
-      <p>Manage your product catalog from here.</p>
-    </main>
+    <PageSection
+      title="Products"
+      subtitle="Manage your product catalog from here."
+    >
+      <div className="empty-state" role="status" aria-live="polite">
+        <h3 className="empty-state__title">Product manager under construction</h3>
+        <p>
+          We&rsquo;re polishing tools to add items, adjust pricing, and sync inventory with your registers.
+        </p>
+      </div>
+    </PageSection>
   )
 }

--- a/web/src/pages/Receive.tsx
+++ b/web/src/pages/Receive.tsx
@@ -1,10 +1,18 @@
 import type { ReactElement } from 'react'
+import PageSection from '../layout/PageSection'
 
 export default function Receive(): ReactElement {
   return (
-    <main>
-      <h1>Receive Stock</h1>
-      <p>Log incoming shipments and update inventory levels.</p>
-    </main>
+    <PageSection
+      title="Receive Stock"
+      subtitle="Log incoming shipments and update inventory levels."
+    >
+      <div className="empty-state" role="status" aria-live="polite">
+        <h3 className="empty-state__title">Receiving workflow coming soon</h3>
+        <p>
+          Track purchase orders, reconcile deliveries, and update counts without leaving this screen.
+        </p>
+      </div>
+    </PageSection>
   )
 }

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -1,10 +1,19 @@
 import type { ReactElement } from 'react'
+import PageSection from '../layout/PageSection'
 
 export default function Today(): ReactElement {
   return (
-    <main>
-      <h1>Today</h1>
-      <p>Track today&rsquo;s performance and quick actions.</p>
-    </main>
+    <PageSection
+      title="Today"
+      subtitle="Track today’s performance and quick actions."
+    >
+      <div className="empty-state" role="status" aria-live="polite">
+        <h3 className="empty-state__title">Today’s snapshot is coming soon</h3>
+        <p>
+          Soon you&rsquo;ll see live sales, top products, and urgent follow-ups for the day in one convenient
+          spot.
+        </p>
+      </div>
+    </PageSection>
   )
 }


### PR DESCRIPTION
## Summary
- add a reusable PageSection component that applies the shared workspace page and card styles
- refactor the dashboard, today, products, receive, customers, close day, and account overview routes to render through PageSection
- provide interim empty states so each screen keeps consistent spacing and typography until data is connected

## Testing
- npm install *(fails: 403 Forbidden while fetching @supabase/supabase-js)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ad21f10883219da6c4917eea8076