### PR TITLE
Refactor auth UI to use shared styles

### DIFF
--- a/web/src/components/auth/AuthForm.css
+++ b/web/src/components/auth/AuthForm.css
@@ -1,0 +1,132 @@
+:root {
+  --auth-surface: #ffffff;
+  --auth-surface-radius: 16px;
+  --auth-surface-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+  --auth-heading-color: #0f172a;
+  --auth-text-muted: #475569;
+  --auth-muted-strong: #1e293b;
+  --auth-input-border: rgba(148, 163, 184, 0.6);
+  --auth-input-background: #f8fafc;
+  --auth-input-text: #0f172a;
+  --auth-accent-start: #2563eb;
+  --auth-accent-end: #7c3aed;
+  --auth-accent-shadow: 0 14px 30px rgba(37, 99, 235, 0.35);
+  --auth-error-background: #fef2f2;
+  --auth-error-text: #b91c1c;
+  --auth-error-border: 1px solid rgba(248, 113, 113, 0.4);
+  --auth-footer-text: #475569;
+  --auth-note-text: #64748b;
+}
+
+.auth-form {
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background-color: var(--auth-surface);
+  border-radius: var(--auth-surface-radius);
+  padding: 2.5rem;
+  box-shadow: var(--auth-surface-shadow);
+}
+
+.auth-form__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.auth-form__title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--auth-heading-color);
+}
+
+.auth-form__description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--auth-text-muted);
+}
+
+.auth-form__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-form__submit {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--auth-accent-start), var(--auth-accent-end));
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.85rem 1.5rem;
+  cursor: pointer;
+  transition: filter 150ms ease, transform 150ms ease;
+  box-shadow: var(--auth-accent-shadow);
+}
+
+.auth-form__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background-color: var(--auth-error-background);
+  color: var(--auth-error-text);
+  font-size: 0.95rem;
+  border: var(--auth-error-border);
+}
+
+.auth-form__footer {
+  text-align: center;
+  font-size: 0.95rem;
+  color: var(--auth-footer-text);
+}
+
+.auth-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.auth-form__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--auth-muted-strong);
+}
+
+.auth-form__input {
+  border-radius: 0.75rem;
+  border: 1px solid var(--auth-input-border);
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  background-color: var(--auth-input-background);
+  color: var(--auth-input-text);
+  transition: border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+}
+
+.auth-form__note {
+  font-size: 0.85rem;
+  color: var(--auth-note-text);
+  margin: 0;
+}
+
+.auth-form__submit:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .auth-form__submit:not(:disabled):hover {
+    filter: brightness(0.92);
+    transform: translateY(1px);
+  }
+
+  .auth-form__submit:not(:disabled):active {
+    filter: brightness(0.88);
+    transform: translateY(2px);
+  }
+}

--- a/web/src/components/auth/AuthForm.tsx
+++ b/web/src/components/auth/AuthForm.tsx
@@ -1,4 +1,5 @@
-import type { CSSProperties, FormEventHandler, ReactNode } from 'react'
+import type { FormEventHandler, ReactNode } from 'react'
+import './AuthForm.css'
 
 type AuthFormProps = {
   title: string
@@ -22,149 +23,32 @@ export function AuthForm({
   children,
 }: AuthFormProps) {
   return (
-    <form onSubmit={onSubmit} style={formStyle} noValidate data-auth-form>
-      <div style={headerStyle}>
-        <h1 style={titleStyle}>{title}</h1>
-        {description ? <p style={descriptionStyle}>{description}</p> : null}
+    <form onSubmit={onSubmit} className="auth-form" noValidate data-auth-form>
+      <div className="auth-form__header">
+        <h1 className="auth-form__title">{title}</h1>
+        {description ? <p className="auth-form__description">{description}</p> : null}
       </div>
 
-      <div style={bodyStyle}>{children}</div>
+      <div className="auth-form__body">{children}</div>
 
       {error ? (
-        <p role="alert" style={errorStyle}>
+        <p role="alert" className="auth-form__error">
           {error}
         </p>
       ) : null}
 
-      <button type="submit" style={submitStyle} disabled={loading}>
+      <button type="submit" className="auth-form__submit" disabled={loading}>
         {loading ? 'Please wait…' : submitLabel}
       </button>
 
-      {footer ? <div style={footerStyle}>{footer}</div> : null}
+      {footer ? <div className="auth-form__footer">{footer}</div> : null}
     </form>
   )
 }
+export const authFormInputGroupClass = 'auth-form__field'
 
-const formStyle: CSSProperties = {
-  width: '100%',
-  maxWidth: '420px',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '1.5rem',
-  backgroundColor: '#ffffff',
-  borderRadius: '16px',
-  padding: '2.5rem',
-  boxShadow: '0 18px 45px rgba(15, 23, 42, 0.12)',
-}
+export const authFormLabelClass = 'auth-form__label'
 
-const headerStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '0.5rem',
-}
+export const authFormInputClass = 'auth-form__input'
 
-const titleStyle: CSSProperties = {
-  fontSize: '1.75rem',
-  fontWeight: 700,
-  margin: 0,
-  color: '#0f172a',
-}
-
-const descriptionStyle: CSSProperties = {
-  margin: 0,
-  fontSize: '1rem',
-  lineHeight: 1.5,
-  color: '#475569',
-}
-
-const bodyStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '1rem',
-}
-
-const submitStyle: CSSProperties = {
-  appearance: 'none',
-  border: 'none',
-  borderRadius: '999px',
-  background: 'linear-gradient(135deg, #2563eb, #7c3aed)',
-  color: '#fff',
-  fontSize: '1rem',
-  fontWeight: 600,
-  padding: '0.85rem 1.5rem',
-  cursor: 'pointer',
-  transition: 'filter 150ms ease, transform 150ms ease',
-  boxShadow: '0 14px 30px rgba(37, 99, 235, 0.35)',
-}
-
-const errorStyle: CSSProperties = {
-  margin: 0,
-  padding: '0.75rem 1rem',
-  borderRadius: '0.75rem',
-  backgroundColor: '#fef2f2',
-  color: '#b91c1c',
-  fontSize: '0.95rem',
-  border: '1px solid rgba(248, 113, 113, 0.4)',
-}
-
-const footerStyle: CSSProperties = {
-  textAlign: 'center',
-  fontSize: '0.95rem',
-  color: '#475569',
-}
-
-if (typeof window !== 'undefined') {
-  const styleId = 'auth-form-hover-style'
-  if (!document.getElementById(styleId)) {
-    const style = document.createElement('style')
-    style.id = styleId
-    style.textContent = `
-      @media (hover: hover) and (pointer: fine) {
-        form[data-auth-form] button[type="submit"]:not(:disabled) {
-          transition: filter 150ms ease, transform 150ms ease;
-        }
-        form[data-auth-form] button[type="submit"]:not(:disabled):hover {
-          filter: brightness(0.92);
-          transform: translateY(1px);
-        }
-        form[data-auth-form] button[type="submit"]:not(:disabled):active {
-          filter: brightness(0.88);
-          transform: translateY(2px);
-        }
-        form[data-auth-form] button[type="submit"]:disabled {
-          opacity: 0.65;
-          cursor: not-allowed;
-        }
-      }
-    `
-    document.head.appendChild(style)
-  }
-}
-
-export const inputGroupStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '0.4rem',
-}
-
-export const labelStyle: CSSProperties = {
-  fontWeight: 600,
-  fontSize: '0.95rem',
-  color: '#1e293b',
-}
-
-export const inputStyle: CSSProperties = {
-  borderRadius: '0.75rem',
-  border: '1px solid rgba(148, 163, 184, 0.6)',
-  padding: '0.85rem 1rem',
-  fontSize: '1rem',
-  backgroundColor: '#f8fafc',
-  color: '#0f172a',
-  transition: 'border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease',
-}
-
-export const noteStyle: CSSProperties = {
-  fontSize: '0.85rem',
-  color: '#64748b',
-  margin: 0,
-}
+export const authFormNoteClass = 'auth-form__note'

--- a/web/src/pages/AuthScreen.css
+++ b/web/src/pages/AuthScreen.css
@@ -1,0 +1,83 @@
+.auth-screen {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: radial-gradient(circle at top, rgba(37, 99, 235, 0.08), transparent 55%), #f8fafc;
+}
+
+.auth-screen__panel {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.auth-screen__brand {
+  text-align: center;
+  color: var(--auth-heading-color);
+}
+
+.auth-screen__logo {
+  font-weight: 800;
+  font-size: 2.5rem;
+  letter-spacing: -0.04em;
+}
+
+.auth-screen__tagline {
+  margin: 0.5rem 0 0;
+  font-size: 1rem;
+  color: var(--auth-text-muted);
+}
+
+.auth-screen__mode-toggle {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  background-color: rgba(148, 163, 184, 0.14);
+  border-radius: 999px;
+  padding: 0.25rem;
+  gap: 0.25rem;
+}
+
+.auth-screen__mode-button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background-color: transparent;
+  color: var(--auth-text-muted);
+  cursor: pointer;
+  transition: background-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
+}
+
+.auth-screen__mode-button.is-active {
+  background-color: #ffffff;
+  color: #1d4ed8;
+  box-shadow: 0 10px 25px rgba(30, 64, 175, 0.18);
+}
+
+.auth-screen__footer-button {
+  appearance: none;
+  background: none;
+  border: none;
+  color: var(--auth-accent-start);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .auth-screen__mode-button:not(:disabled):hover {
+    background-color: rgba(255, 255, 255, 0.7);
+    color: #1d4ed8;
+  }
+
+  .auth-screen__footer-button:not(:disabled):hover {
+    text-decoration: underline;
+  }
+}

--- a/web/src/pages/AuthScreen.tsx
+++ b/web/src/pages/AuthScreen.tsx
@@ -1,9 +1,16 @@
-import { useCallback, useMemo, useState, type CSSProperties, type FormEvent } from 'react'
+import { useCallback, useMemo, useState, type FormEvent } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { AuthForm, inputGroupStyle, inputStyle, labelStyle, noteStyle } from '../components/auth/AuthForm'
+import {
+  AuthForm,
+  authFormInputClass,
+  authFormInputGroupClass,
+  authFormLabelClass,
+  authFormNoteClass,
+} from '../components/auth/AuthForm'
 import { useToast } from '../components/ToastProvider'
 import { afterSignupBootstrap } from '../controllers/accessController'
 import { supabase } from '../supabaseClient'
+import './AuthScreen.css'
 
 type AuthMode = 'sign-in' | 'sign-up'
 
@@ -174,25 +181,25 @@ export default function AuthScreen() {
   const footerActionMode: AuthMode = mode === 'sign-in' ? 'sign-up' : 'sign-in'
 
   return (
-    <main style={screenStyle}>
-      <div style={panelStyle}>
-        <div style={brandStyle}>
-          <div style={logoStyle}>Sedifex</div>
-          <p style={taglineStyle}>Sell faster. Count smarter.</p>
+    <main className="auth-screen">
+      <div className="auth-screen__panel">
+        <div className="auth-screen__brand">
+          <div className="auth-screen__logo">Sedifex</div>
+          <p className="auth-screen__tagline">Sell faster. Count smarter.</p>
         </div>
 
-        <div style={modeToggleStyle}>
+        <div className="auth-screen__mode-toggle">
           <button
             type="button"
             onClick={() => toggleMode('sign-in')}
-            style={{ ...modeButtonStyle, ...(mode === 'sign-in' ? modeButtonActiveStyle : {}) }}
+            className={`auth-screen__mode-button${mode === 'sign-in' ? ' is-active' : ''}`}
           >
             Sign in
           </button>
           <button
             type="button"
             onClick={() => toggleMode('sign-up')}
-            style={{ ...modeButtonStyle, ...(mode === 'sign-up' ? modeButtonActiveStyle : {}) }}
+            className={`auth-screen__mode-button${mode === 'sign-up' ? ' is-active' : ''}`}
           >
             Create account
           </button>
@@ -211,7 +218,7 @@ export default function AuthScreen() {
               <button
                 type="button"
                 onClick={() => toggleMode(footerActionMode)}
-                style={footerActionButtonStyle}
+                className="auth-screen__footer-button"
                 disabled={loading}
               >
                 {footerActionButtonLabel}
@@ -219,10 +226,10 @@ export default function AuthScreen() {
             </div>
           }
         >
-          <label style={inputGroupStyle}>
-            <span style={labelStyle}>Email</span>
+          <label className={authFormInputGroupClass}>
+            <span className={authFormLabelClass}>Email</span>
             <input
-              style={inputStyle}
+              className={authFormInputClass}
               type="email"
               name="email"
               autoComplete="email"
@@ -234,10 +241,10 @@ export default function AuthScreen() {
             />
           </label>
 
-          <label style={inputGroupStyle}>
-            <span style={labelStyle}>Password</span>
+          <label className={authFormInputGroupClass}>
+            <span className={authFormLabelClass}>Password</span>
             <input
-              style={inputStyle}
+              className={authFormInputClass}
               type="password"
               name="password"
               autoComplete={mode === 'sign-in' ? 'current-password' : 'new-password'}
@@ -247,83 +254,10 @@ export default function AuthScreen() {
               disabled={loading}
               required
             />
-            <p style={noteStyle}>Use at least {MIN_PASSWORD_LENGTH} characters for a strong password.</p>
+            <p className={authFormNoteClass}>Use at least {MIN_PASSWORD_LENGTH} characters for a strong password.</p>
           </label>
         </AuthForm>
       </div>
     </main>
   )
-}
-
-const screenStyle: CSSProperties = {
-  minHeight: '100dvh',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: '2rem',
-  background: 'radial-gradient(circle at top, rgba(37, 99, 235, 0.08), transparent 55%), #f8fafc',
-}
-
-const panelStyle: CSSProperties = {
-  width: '100%',
-  maxWidth: '520px',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '1.5rem',
-  alignItems: 'center',
-}
-
-const brandStyle: CSSProperties = {
-  textAlign: 'center',
-  color: '#0f172a',
-}
-
-const logoStyle: CSSProperties = {
-  fontWeight: 800,
-  fontSize: '2.5rem',
-  letterSpacing: '-0.04em',
-}
-
-const taglineStyle: CSSProperties = {
-  margin: '0.5rem 0 0',
-  fontSize: '1rem',
-  color: '#475569',
-}
-
-const modeToggleStyle: CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-  backgroundColor: 'rgba(148, 163, 184, 0.14)',
-  borderRadius: '999px',
-  padding: '0.25rem',
-  gap: '0.25rem',
-}
-
-const modeButtonStyle: CSSProperties = {
-  appearance: 'none',
-  border: 'none',
-  borderRadius: '999px',
-  padding: '0.6rem 1.25rem',
-  fontSize: '0.95rem',
-  fontWeight: 600,
-  backgroundColor: 'transparent',
-  color: '#475569',
-  cursor: 'pointer',
-  transition: 'background-color 150ms ease, color 150ms ease, box-shadow 150ms ease',
-}
-
-const modeButtonActiveStyle: CSSProperties = {
-  backgroundColor: '#fff',
-  color: '#1d4ed8',
-  boxShadow: '0 10px 25px rgba(30, 64, 175, 0.18)',
-}
-
-const footerActionButtonStyle: CSSProperties = {
-  appearance: 'none',
-  background: 'none',
-  border: 'none',
-  color: '#2563eb',
-  fontWeight: 600,
-  cursor: 'pointer',
-  padding: 0,
 }


### PR DESCRIPTION
## Summary
- replace inline styling in AuthForm with semantic class names backed by theme variables
- move AuthScreen layout and toggle presentation into declarative CSS classes
- centralize hover, active, and disabled button states within the new stylesheets

## Testing
- npm run lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ad191f788321bf3e222c2edfa490