### PR TITLE
Centralize shared web theme

### DIFF
--- a/web/src/components/AppErrorBoundary.tsx
+++ b/web/src/components/AppErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type CSSProperties, type ErrorInfo, type ReactNode } from 'react'
+import { colors, radii } from '../styles/themeTokens'
 
 type AppErrorBoundaryProps = {
   children: ReactNode
@@ -71,9 +72,9 @@ const messageStyle: CSSProperties = {
 
 const buttonStyle: CSSProperties = {
   border: 'none',
-  borderRadius: '0.5rem',
-  backgroundColor: '#2b6cb0',
-  color: '#fff',
+  borderRadius: radii.md,
+  backgroundColor: colors.info,
+  color: colors.textInverse,
   padding: '0.75rem 1.5rem',
   fontSize: '1rem',
   fontWeight: 500,

--- a/web/src/components/ToastProvider.tsx
+++ b/web/src/components/ToastProvider.tsx
@@ -9,6 +9,7 @@ import {
   type CSSProperties,
   type ReactNode,
 } from 'react'
+import { colors, radii, shadows } from '../styles/themeTokens'
 
 type ToastTone = 'success' | 'error' | 'info'
 
@@ -114,19 +115,19 @@ const containerStyle: CSSProperties = {
 const toastStyle: CSSProperties = {
   pointerEvents: 'auto',
   border: 'none',
-  borderRadius: '0.5rem',
+  borderRadius: radii.md,
   padding: '0.75rem 1rem',
   fontSize: '0.875rem',
   fontWeight: 500,
-  color: '#fff',
-  backgroundColor: '#333',
-  boxShadow: '0 10px 30px rgba(0,0,0,0.2)',
+  color: colors.textInverse,
+  backgroundColor: colors.surfaceElevated,
+  boxShadow: shadows.overlay,
   cursor: 'pointer',
   textAlign: 'left',
 }
 
 const toneStyles: Record<ToastTone, CSSProperties> = {
-  success: { backgroundColor: '#1b873f' },
-  error: { backgroundColor: '#c53030' },
-  info: { backgroundColor: '#2b6cb0' },
+  success: { backgroundColor: colors.success },
+  error: { backgroundColor: colors.danger },
+  info: { backgroundColor: colors.info },
 }

--- a/web/src/components/auth/AuthForm.tsx
+++ b/web/src/components/auth/AuthForm.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, FormEventHandler, ReactNode } from 'react'
+import { colors, gradients, overlays, radii, shadows } from '../../styles/themeTokens'
 
 type AuthFormProps = {
   title: string
@@ -51,10 +52,10 @@ const formStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   gap: '1.5rem',
-  backgroundColor: '#ffffff',
-  borderRadius: '16px',
+  backgroundColor: colors.surface,
+  borderRadius: radii.xl,
   padding: '2.5rem',
-  boxShadow: '0 18px 45px rgba(15, 23, 42, 0.12)',
+  boxShadow: shadows.elevated,
 }
 
 const headerStyle: CSSProperties = {
@@ -67,14 +68,14 @@ const titleStyle: CSSProperties = {
   fontSize: '1.75rem',
   fontWeight: 700,
   margin: 0,
-  color: '#0f172a',
+  color: colors.textPrimary,
 }
 
 const descriptionStyle: CSSProperties = {
   margin: 0,
   fontSize: '1rem',
   lineHeight: 1.5,
-  color: '#475569',
+  color: colors.textSecondary,
 }
 
 const bodyStyle: CSSProperties = {
@@ -86,31 +87,31 @@ const bodyStyle: CSSProperties = {
 const submitStyle: CSSProperties = {
   appearance: 'none',
   border: 'none',
-  borderRadius: '999px',
-  background: 'linear-gradient(135deg, #2563eb, #7c3aed)',
-  color: '#fff',
+  borderRadius: radii.pill,
+  background: gradients.auth,
+  color: colors.textInverse,
   fontSize: '1rem',
   fontWeight: 600,
   padding: '0.85rem 1.5rem',
   cursor: 'pointer',
   transition: 'filter 150ms ease, transform 150ms ease',
-  boxShadow: '0 14px 30px rgba(37, 99, 235, 0.35)',
+  boxShadow: shadows.cta,
 }
 
 const errorStyle: CSSProperties = {
   margin: 0,
   padding: '0.75rem 1rem',
-  borderRadius: '0.75rem',
-  backgroundColor: '#fef2f2',
-  color: '#b91c1c',
+  borderRadius: radii.md,
+  backgroundColor: colors.dangerSurface,
+  color: colors.danger,
   fontSize: '0.95rem',
-  border: '1px solid rgba(248, 113, 113, 0.4)',
+  border: `1px solid ${overlays.dangerOutline}`,
 }
 
 const footerStyle: CSSProperties = {
   textAlign: 'center',
   fontSize: '0.95rem',
-  color: '#475569',
+  color: colors.textSecondary,
 }
 
 if (typeof window !== 'undefined') {
@@ -150,21 +151,21 @@ export const inputGroupStyle: CSSProperties = {
 export const labelStyle: CSSProperties = {
   fontWeight: 600,
   fontSize: '0.95rem',
-  color: '#1e293b',
+  color: colors.textPrimary,
 }
 
 export const inputStyle: CSSProperties = {
-  borderRadius: '0.75rem',
-  border: '1px solid rgba(148, 163, 184, 0.6)',
+  borderRadius: radii.md,
+  border: '1px solid rgba(var(--color-border-input-rgb, 148, 163, 184), 0.6)',
   padding: '0.85rem 1rem',
   fontSize: '1rem',
-  backgroundColor: '#f8fafc',
-  color: '#0f172a',
+  backgroundColor: colors.background,
+  color: colors.textPrimary,
   transition: 'border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease',
 }
 
 export const noteStyle: CSSProperties = {
   fontSize: '0.85rem',
-  color: '#64748b',
+  color: colors.textMuted,
   margin: 0,
 }

--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -1,17 +1,17 @@
 .shell {
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: #f8fafc;
+  font-family: var(--font-family-sans, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  background: var(--color-app-background, #f8fafc);
   min-height: 100vh;
-  color: #0f172a;
+  color: var(--color-text-primary, #0f172a);
 }
 
 .shell__header {
   position: sticky;
   top: 0;
   z-index: 10;
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--color-surface-translucent, rgba(255, 255, 255, 0.92));
   backdrop-filter: saturate(180%) blur(12px);
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-border-subtle, #e2e8f0);
 }
 
 .shell__header-inner {
@@ -33,12 +33,12 @@
 .shell__logo {
   font-size: 24px;
   font-weight: 800;
-  color: #4338ca;
+  color: var(--color-brand-500, #4338ca);
 }
 
 .shell__tagline {
   font-size: 13px;
-  color: #64748b;
+  color: var(--color-text-muted, #64748b);
   font-weight: 500;
 }
 
@@ -57,12 +57,12 @@
   justify-content: center;
   gap: 6px;
   padding: 8px 14px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill, 999px);
   text-decoration: none;
   font-size: 14px;
   font-weight: 500;
-  color: #4338ca;
-  background-color: #eef2ff;
+  color: var(--color-brand-500, #4338ca);
+  background-color: var(--color-brand-50, #eef2ff);
   border: 1px solid transparent;
   box-shadow: none;
   transition: all 0.2s ease;
@@ -70,16 +70,16 @@
 }
 
 .shell__nav-link:is(:hover, :focus-visible) {
-  border-color: rgba(67, 56, 202, 0.25);
-  box-shadow: 0 6px 18px rgba(67, 56, 202, 0.1);
+  border-color: rgba(var(--color-brand-rgb, 67, 56, 202), 0.25);
+  box-shadow: var(--shadow-brand-halo, 0 6px 18px rgba(67, 56, 202, 0.1));
 }
 
 .shell__nav-link.is-active {
   font-weight: 600;
-  color: #ffffff;
-  background-color: #4338ca;
-  border-color: #4338ca;
-  box-shadow: 0 6px 18px rgba(67, 56, 202, 0.18);
+  color: var(--color-text-inverse, #ffffff);
+  background-color: var(--color-brand-500, #4338ca);
+  border-color: var(--color-brand-500, #4338ca);
+  box-shadow: var(--shadow-brand-halo-strong, 0 6px 18px rgba(67, 56, 202, 0.18));
 }
 
 .shell__controls {
@@ -103,7 +103,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #475569;
+  color: var(--color-text-secondary, #475569);
 }
 
 .shell__store-select {
@@ -117,16 +117,16 @@
 
 .shell__store-empty {
   font-size: 13px;
-  color: #64748b;
+  color: var(--color-text-muted, #64748b);
   padding: 9px 12px;
-  border-radius: 12px;
-  border: 1px dashed #cbd5f5;
-  background: #eef2ff;
+  border-radius: var(--radius-md, 12px);
+  border: 1px dashed var(--color-border-muted, #cbd5f5);
+  background: var(--color-brand-50, #eef2ff);
 }
 
 .shell__store-status {
   font-size: 12px;
-  color: #475569;
+  color: var(--color-text-secondary, #475569);
 }
 
 .shell__account {
@@ -134,13 +134,13 @@
   align-items: center;
   gap: 10px;
   padding: 6px 10px;
-  background: #eef2ff;
-  border-radius: 999px;
+  background: var(--color-brand-50, #eef2ff);
+  border-radius: var(--radius-pill, 999px);
 }
 
 .shell__account-email {
   font-size: 13px;
-  color: #4338ca;
+  color: var(--color-brand-500, #4338ca);
   font-weight: 600;
 }
 
@@ -159,17 +159,17 @@
   font: inherit;
   color: inherit;
   padding: 10px 12px;
-  border-radius: 12px;
-  border: 1px solid #cbd5f5;
-  background: #ffffff;
+  border-radius: var(--radius-md, 12px);
+  border: 1px solid var(--color-border-muted, #cbd5f5);
+  background: var(--color-surface-base, #ffffff);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .shell input:focus,
 .shell select:focus,
 .shell textarea:focus {
-  border-color: #4338ca;
-  box-shadow: 0 0 0 3px rgba(67, 56, 202, 0.12);
+  border-color: var(--color-brand-500, #4338ca);
+  box-shadow: var(--focus-ring-primary, 0 0 0 3px rgba(67, 56, 202, 0.12));
   outline: none;
 }
 
@@ -179,7 +179,7 @@
 }
 
 .shell button:focus-visible {
-  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline: 2px solid var(--focus-outline-info, rgba(59, 130, 246, 0.6));
   outline-offset: 2px;
 }
 
@@ -188,16 +188,16 @@
 }
 
 .shell__status-badge {
-  --status-bg: #eef2ff;
-  --status-color: #4338ca;
-  --status-border: rgba(67, 56, 202, 0.2);
-  --status-dot: #4f46e5;
-  --status-glow: rgba(79, 70, 229, 0.2);
+  --status-bg: var(--color-brand-50, #eef2ff);
+  --status-color: var(--color-brand-500, #4338ca);
+  --status-border: rgba(var(--color-brand-rgb, 67, 56, 202), 0.2);
+  --status-dot: var(--color-brand-600, #4f46e5);
+  --status-glow: rgba(var(--color-brand-strong-rgb, 79, 70, 229), 0.2);
   display: inline-flex;
   align-items: center;
   gap: 6px;
   padding: 4px 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill, 999px);
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -210,43 +210,43 @@
 }
 
 .shell__status-badge[data-variant='offline'] {
-  --status-bg: #fef2f2;
-  --status-color: #b91c1c;
-  --status-border: rgba(239, 68, 68, 0.3);
-  --status-dot: #ef4444;
-  --status-glow: rgba(239, 68, 68, 0.18);
+  --status-bg: var(--color-danger-soft, #fef2f2);
+  --status-color: var(--color-danger-500, #b91c1c);
+  --status-border: rgba(var(--color-danger-rgb, 239, 68, 68), 0.3);
+  --status-dot: var(--color-danger-intense, #ef4444);
+  --status-glow: rgba(var(--color-danger-rgb, 239, 68, 68), 0.18);
 }
 
 .shell__status-badge[data-variant='degraded'] {
-  --status-bg: #fff7ed;
-  --status-color: #92400e;
-  --status-border: rgba(245, 158, 11, 0.28);
-  --status-dot: #f59e0b;
-  --status-glow: rgba(245, 158, 11, 0.18);
+  --status-bg: var(--color-warning-soft, #fff7ed);
+  --status-color: var(--color-warning-contrast, #92400e);
+  --status-border: rgba(var(--color-warning-rgb, 245, 158, 11), 0.28);
+  --status-dot: var(--color-warning-500, #f59e0b);
+  --status-glow: rgba(var(--color-warning-rgb, 245, 158, 11), 0.18);
 }
 
 .shell__status-badge[data-variant='pending'] {
-  --status-bg: #f5f3ff;
-  --status-color: #5b21b6;
-  --status-border: rgba(124, 58, 237, 0.28);
-  --status-dot: #7c3aed;
-  --status-glow: rgba(124, 58, 237, 0.18);
+  --status-bg: var(--color-brand-100, #f5f3ff);
+  --status-color: var(--color-brand-800, #5b21b6);
+  --status-border: rgba(var(--color-brand-vivid-rgb, 124, 58, 237), 0.28);
+  --status-dot: var(--color-brand-vivid, #7c3aed);
+  --status-glow: rgba(var(--color-brand-vivid-rgb, 124, 58, 237), 0.18);
 }
 
 .shell__status-badge[data-variant='processing'] {
-  --status-bg: #eff6ff;
-  --status-color: #1d4ed8;
-  --status-border: rgba(59, 130, 246, 0.25);
-  --status-dot: #3b82f6;
-  --status-glow: rgba(59, 130, 246, 0.18);
+  --status-bg: var(--color-info-soft, #eff6ff);
+  --status-color: var(--color-info-500, #1d4ed8);
+  --status-border: rgba(var(--color-info-accent-rgb, 59, 130, 246), 0.25);
+  --status-dot: var(--color-info-accent, #3b82f6);
+  --status-glow: rgba(var(--color-info-accent-rgb, 59, 130, 246), 0.18);
 }
 
 .shell__status-badge[data-variant='error'] {
-  --status-bg: #fef2f2;
-  --status-color: #7f1d1d;
-  --status-border: rgba(185, 28, 28, 0.35);
-  --status-dot: #dc2626;
-  --status-glow: rgba(220, 38, 38, 0.2);
+  --status-bg: var(--color-danger-soft, #fef2f2);
+  --status-color: var(--color-danger-strong, #7f1d1d);
+  --status-border: rgba(var(--color-danger-strong-rgb, 185, 28, 28), 0.35);
+  --status-dot: var(--color-danger-intense, #dc2626);
+  --status-glow: rgba(var(--color-danger-intense-rgb, 220, 38, 38), 0.2);
 }
 
 .shell__status-dot {

--- a/web/src/layout/Workspace.css
+++ b/web/src/layout/Workspace.css
@@ -16,12 +16,12 @@
   font-size: clamp(24px, 3vw, 30px);
   font-weight: 700;
   letter-spacing: -0.02em;
-  color: #1e293b;
+  color: var(--color-text-strong, #1e293b);
 }
 
 .page__subtitle {
   margin: 4px 0 0;
-  color: #64748b;
+  color: var(--color-text-muted, #64748b);
   font-size: 15px;
   max-width: 56ch;
 }
@@ -33,10 +33,10 @@
 }
 
 .card {
-  background: #ffffff;
-  border-radius: 20px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 24px 60px -40px rgba(15, 23, 42, 0.45);
+  background: var(--color-surface-base, #ffffff);
+  border-radius: var(--radius-2xl, 20px);
+  border: 1px solid var(--color-border-subtle, #e2e8f0);
+  box-shadow: var(--shadow-card, 0 24px 60px -40px rgba(15, 23, 42, 0.45));
   padding: 20px clamp(20px, 4vw, 28px);
   display: grid;
   gap: 18px;
@@ -50,12 +50,12 @@
   margin: 0;
   font-size: 18px;
   font-weight: 600;
-  color: #1e293b;
+  color: var(--color-text-strong, #1e293b);
 }
 
 .card__subtitle {
   margin: 0;
-  color: #64748b;
+  color: var(--color-text-muted, #64748b);
   font-size: 14px;
 }
 
@@ -67,12 +67,12 @@
 .field__label {
   font-size: 13px;
   font-weight: 600;
-  color: #475569;
+  color: var(--color-text-secondary, #475569);
 }
 
 .field__hint {
   font-size: 13px;
-  color: #94a3b8;
+  color: var(--color-text-subtle, #94a3b8);
 }
 
 .button {
@@ -80,7 +80,7 @@
   align-items: center;
   justify-content: center;
   gap: 6px;
-  border-radius: 12px;
+  border-radius: var(--radius-lg, 12px);
   padding: 10px 16px;
   font-weight: 600;
   line-height: 1.2;
@@ -94,53 +94,53 @@
 }
 
 .button--primary {
-  background: linear-gradient(135deg, #4338ca, #4f46e5);
-  color: #ffffff;
-  box-shadow: 0 18px 40px -24px rgba(67, 56, 202, 0.6);
+  background: var(--gradient-brand, linear-gradient(135deg, #4338ca, #4f46e5));
+  color: var(--color-text-inverse, #ffffff);
+  box-shadow: var(--shadow-brand-strong, 0 18px 40px -24px rgba(67, 56, 202, 0.6));
 }
 
 .button--primary:is(:hover, :focus-visible) {
-  box-shadow: 0 20px 44px -22px rgba(67, 56, 202, 0.8);
+  box-shadow: var(--shadow-brand-stronger, 0 20px 44px -22px rgba(67, 56, 202, 0.8));
 }
 
 .button--secondary {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
-  color: #ffffff;
-  box-shadow: 0 18px 40px -24px rgba(37, 99, 235, 0.6);
+  background: var(--gradient-info, linear-gradient(135deg, #2563eb, #1d4ed8));
+  color: var(--color-text-inverse, #ffffff);
+  box-shadow: var(--shadow-info-strong, 0 18px 40px -24px rgba(37, 99, 235, 0.6));
 }
 
 .button--success {
-  background: linear-gradient(135deg, #059669, #047857);
-  color: #ffffff;
-  box-shadow: 0 18px 40px -24px rgba(5, 150, 105, 0.55);
+  background: var(--gradient-success, linear-gradient(135deg, #059669, #047857));
+  color: var(--color-text-inverse, #ffffff);
+  box-shadow: var(--shadow-success, 0 18px 40px -24px rgba(5, 150, 105, 0.55));
 }
 
 .button--neutral {
-  background: #eef2ff;
-  color: #4338ca;
-  border-color: rgba(67, 56, 202, 0.18);
+  background: var(--color-brand-50, #eef2ff);
+  color: var(--color-brand-500, #4338ca);
+  border-color: rgba(var(--color-brand-rgb, 67, 56, 202), 0.18);
 }
 
 .button--outline {
-  background: #ffffff;
-  color: #4338ca;
-  border-color: #cbd5f5;
+  background: var(--color-surface-base, #ffffff);
+  color: var(--color-brand-500, #4338ca);
+  border-color: var(--color-border-muted, #cbd5f5);
 }
 
 .button--ghost {
   background: transparent;
-  color: #4338ca;
+  color: var(--color-brand-500, #4338ca);
 }
 
 .button--danger {
-  background: #fef2f2;
-  color: #b91c1c;
-  border-color: #fecaca;
+  background: var(--color-danger-soft, #fef2f2);
+  color: var(--color-danger-500, #b91c1c);
+  border-color: var(--color-danger-border, #fecaca);
 }
 
 .button--small {
   padding: 6px 12px;
-  border-radius: 10px;
+  border-radius: var(--radius-sm, 10px);
   font-size: 13px;
 }
 
@@ -166,11 +166,11 @@
 }
 
 .table thead {
-  background: #f1f5f9;
+  background: var(--color-surface-muted, #f1f5f9);
   text-transform: uppercase;
   font-size: 12px;
   letter-spacing: 0.08em;
-  color: #64748b;
+  color: var(--color-text-muted, #64748b);
 }
 
 .table th,
@@ -185,12 +185,12 @@
 }
 
 .table tbody tr {
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-border-subtle, #e2e8f0);
   transition: background-color 0.2s ease;
 }
 
 .table tbody tr:is(:hover, :focus-within) {
-  background: #f8fafc;
+  background: var(--color-app-background, #f8fafc);
 }
 
 .table input,
@@ -218,24 +218,24 @@
 }
 
 .badge--ok {
-  background: #dcfce7;
-  color: #15803d;
+  background: var(--color-success-soft, #dcfce7);
+  color: var(--color-success-700, #15803d);
 }
 
 .badge--low {
-  background: #fef3c7;
-  color: #c2410c;
+  background: var(--color-warning-alt, #fef3c7);
+  color: var(--color-warning-accent, #c2410c);
 }
 
 .badge--out {
-  background: #fee2e2;
-  color: #b91c1c;
+  background: var(--color-danger-subtle, #fee2e2);
+  color: var(--color-danger-500, #b91c1c);
 }
 
 .empty-state {
   padding: 48px 24px;
   text-align: center;
-  color: #64748b;
+  color: var(--color-text-muted, #64748b);
   display: grid;
   gap: 12px;
 }
@@ -244,18 +244,18 @@
   margin: 0;
   font-size: 18px;
   font-weight: 600;
-  color: #1e293b;
+  color: var(--color-text-strong, #1e293b);
 }
 
 .feedback {
   font-size: 14px;
-  color: #047857;
+  color: var(--color-success-500, #047857);
 }
 
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.55);
+  background: rgba(var(--color-overlay-rgb, 15, 23, 42), 0.55);
   display: grid;
   place-items: center;
   padding: 20px;
@@ -263,14 +263,14 @@
 }
 
 .modal {
-  background: #ffffff;
-  border-radius: 20px;
+  background: var(--color-surface-base, #ffffff);
+  border-radius: var(--radius-2xl, 20px);
   width: min(480px, 100%);
   padding: 24px;
   display: grid;
   gap: 16px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 30px 80px -40px rgba(15, 23, 42, 0.5);
+  border: 1px solid var(--color-border-subtle, #e2e8f0);
+  box-shadow: var(--shadow-card-strong, 0 30px 80px -40px rgba(15, 23, 42, 0.5));
 }
 
 .modal__title {
@@ -281,12 +281,12 @@
 
 .modal__message {
   margin: 0;
-  color: #4b5563;
+  color: var(--color-text-secondary, #4b5563);
   font-size: 14px;
 }
 
 .modal__error {
-  color: #b91c1c;
+  color: var(--color-danger-500, #b91c1c);
   font-weight: 600;
 }
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { createHashRouter, RouterProvider } from 'react-router-dom'
+import './styles/theme.css'
 import App from './App'
 import SheetAccessGuard from './SheetAccessGuard'
 import Shell from './layout/Shell'

--- a/web/src/pages/AuthScreen.tsx
+++ b/web/src/pages/AuthScreen.tsx
@@ -4,6 +4,7 @@ import { AuthForm, inputGroupStyle, inputStyle, labelStyle, noteStyle } from '..
 import { useToast } from '../components/ToastProvider'
 import { afterSignupBootstrap } from '../controllers/accessController'
 import { supabase } from '../supabaseClient'
+import { colors, overlays, radii, shadows } from '../styles/themeTokens'
 
 type AuthMode = 'sign-in' | 'sign-up'
 
@@ -261,7 +262,7 @@ const screenStyle: CSSProperties = {
   alignItems: 'center',
   justifyContent: 'center',
   padding: '2rem',
-  background: 'radial-gradient(circle at top, rgba(37, 99, 235, 0.08), transparent 55%), #f8fafc',
+  background: `radial-gradient(circle at top, ${overlays.brandTint}, transparent 55%), ${colors.background}`,
 }
 
 const panelStyle: CSSProperties = {
@@ -275,7 +276,7 @@ const panelStyle: CSSProperties = {
 
 const brandStyle: CSSProperties = {
   textAlign: 'center',
-  color: '#0f172a',
+  color: colors.textPrimary,
 }
 
 const logoStyle: CSSProperties = {
@@ -287,14 +288,14 @@ const logoStyle: CSSProperties = {
 const taglineStyle: CSSProperties = {
   margin: '0.5rem 0 0',
   fontSize: '1rem',
-  color: '#475569',
+  color: colors.textSecondary,
 }
 
 const modeToggleStyle: CSSProperties = {
   display: 'grid',
   gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-  backgroundColor: 'rgba(148, 163, 184, 0.14)',
-  borderRadius: '999px',
+  backgroundColor: overlays.brandOutline,
+  borderRadius: radii.pill,
   padding: '0.25rem',
   gap: '0.25rem',
 }
@@ -302,27 +303,27 @@ const modeToggleStyle: CSSProperties = {
 const modeButtonStyle: CSSProperties = {
   appearance: 'none',
   border: 'none',
-  borderRadius: '999px',
+  borderRadius: radii.pill,
   padding: '0.6rem 1.25rem',
   fontSize: '0.95rem',
   fontWeight: 600,
   backgroundColor: 'transparent',
-  color: '#475569',
+  color: colors.textSecondary,
   cursor: 'pointer',
   transition: 'background-color 150ms ease, color 150ms ease, box-shadow 150ms ease',
 }
 
 const modeButtonActiveStyle: CSSProperties = {
-  backgroundColor: '#fff',
-  color: '#1d4ed8',
-  boxShadow: '0 10px 25px rgba(30, 64, 175, 0.18)',
+  backgroundColor: colors.surface,
+  color: colors.info,
+  boxShadow: shadows.infoLift,
 }
 
 const footerActionButtonStyle: CSSProperties = {
   appearance: 'none',
   background: 'none',
   border: 'none',
-  color: '#2563eb',
+  color: colors.infoStrong,
   fontWeight: 600,
   cursor: 'pointer',
   padding: 0,

--- a/web/src/pages/Sell.css
+++ b/web/src/pages/Sell.css
@@ -3,8 +3,8 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 4px;
-  background: #eef2ff;
-  border-radius: 16px;
+  background: var(--color-brand-50, #eef2ff);
+  border-radius: var(--radius-xl, 16px);
   padding: 12px 16px;
   min-width: 160px;
 }
@@ -13,14 +13,14 @@
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #6366f1;
+  color: var(--color-brand-400, #6366f1);
   font-weight: 600;
 }
 
 .sell-page__total-value {
   font-size: 20px;
   font-weight: 700;
-  color: #312e81;
+  color: var(--color-brand-700, #312e81);
 }
 
 .sell-page__grid {
@@ -53,9 +53,9 @@
   justify-content: space-between;
   align-items: center;
   gap: 16px;
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
-  border-radius: 14px;
+  border: 1px solid var(--color-border-subtle, #e2e8f0);
+  background: var(--color-app-background, #f8fafc);
+  border-radius: var(--radius-lg, 14px);
   padding: 14px 16px;
   text-align: left;
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
@@ -63,26 +63,26 @@
 
 .sell-page__product:hover,
 .sell-page__product:focus-visible {
-  border-color: rgba(99, 102, 241, 0.4);
-  box-shadow: 0 18px 40px -26px rgba(99, 102, 241, 0.6);
+  border-color: rgba(var(--color-brand-accent-rgb, 99, 102, 241), 0.4);
+  box-shadow: var(--shadow-brand-lift, 0 18px 40px -26px rgba(99, 102, 241, 0.6));
   transform: translateY(-1px);
 }
 
 .sell-page__product-name {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text-primary, #0f172a);
 }
 
 .sell-page__product-meta {
   display: block;
   font-size: 13px;
-  color: #64748b;
+  color: var(--color-text-muted, #64748b);
   margin-top: 4px;
 }
 
 .sell-page__product-action {
   font-weight: 600;
-  color: #4338ca;
+  color: var(--color-brand-500, #4338ca);
 }
 
 .sell-page__summary {
@@ -95,7 +95,7 @@
 
 .sell-page__summary strong {
   font-size: 20px;
-  color: #111827;
+  color: var(--color-neutral-900, #111827);
 }
 
 .sell-page__numeric {
@@ -124,20 +124,20 @@
 .sell-page__input,
 .sell-page__select {
   padding: 10px 12px;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border: 1px solid var(--color-border-subtle, #e2e8f0);
+  border-radius: var(--radius-md, 12px);
   font-size: 15px;
 }
 
 .sell-page__input:focus,
 .sell-page__select:focus {
   outline: none;
-  border-color: rgba(99, 102, 241, 0.6);
-  box-shadow: 0 0 0 2px rgba(129, 140, 248, 0.35);
+  border-color: rgba(var(--color-brand-accent-rgb, 99, 102, 241), 0.6);
+  box-shadow: 0 0 0 2px rgba(var(--color-brand-soft-rgb, 129, 140, 248), 0.35);
 }
 
 .sell-page__customers-link {
-  color: #4338ca;
+  color: var(--color-brand-500, #4338ca);
   font-weight: 600;
 }
 
@@ -147,14 +147,14 @@
   gap: 12px;
   margin-top: 20px;
   padding-top: 16px;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--color-border-subtle, #e2e8f0);
 }
 
 .sell-page__payment-breakdown {
   display: block;
   margin-top: 4px;
   font-size: 13px;
-  color: #64748b;
+  color: var(--color-text-muted, #64748b);
 }
 
 @media (min-width: 720px) {
@@ -169,16 +169,16 @@
   font-size: 12px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #64748b;
+  color: var(--color-text-muted, #64748b);
   margin-bottom: 4px;
 }
 
 .sell-page__change {
-  color: #047857;
+  color: var(--color-success-500, #047857);
 }
 
 .sell-page__change.is-short {
-  color: #b91c1c;
+  color: var(--color-danger-500, #b91c1c);
 }
 
 .sell-page__message {
@@ -190,19 +190,19 @@
 }
 
 .sell-page__message--error {
-  color: #b91c1c;
+  color: var(--color-danger-500, #b91c1c);
 }
 
 .sell-page__message--success {
-  color: #047857;
+  color: var(--color-success-500, #047857);
 }
 
 .sell-page__loyalty {
   margin-top: 12px;
   padding: 12px 14px;
-  border: 1px dashed rgba(67, 56, 202, 0.35);
-  border-radius: 12px;
-  background: rgba(224, 231, 255, 0.4);
+  border: 1px dashed rgba(var(--color-brand-rgb, 67, 56, 202), 0.35);
+  border-radius: var(--radius-md, 12px);
+  background: rgba(var(--color-brand-50-rgb, 224, 231, 255), 0.4);
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -210,12 +210,12 @@
 
 .sell-page__loyalty-title {
   font-size: 14px;
-  color: #312e81;
+  color: var(--color-brand-700, #312e81);
 }
 
 .sell-page__loyalty-text {
   font-size: 13px;
-  color: #4338ca;
+  color: var(--color-brand-500, #4338ca);
   margin: 0;
 }
 
@@ -228,9 +228,9 @@
 .sell-page__engagement {
   margin-top: 16px;
   padding: 16px;
-  border: 1px solid #bbf7d0;
-  border-radius: 16px;
-  background: #f0fdf4;
+  border: 1px solid var(--color-success-border, #bbf7d0);
+  border-radius: var(--radius-xl, 16px);
+  background: var(--color-success-bg, #f0fdf4);
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -239,14 +239,14 @@
 .sell-page__engagement-title {
   font-size: 16px;
   font-weight: 600;
-  color: #065f46;
+  color: var(--color-success-600, #065f46);
   margin: 0;
 }
 
 .sell-page__engagement-text {
   margin: 0;
   font-size: 14px;
-  color: #047857;
+  color: var(--color-success-500, #047857);
 }
 
 .sell-page__engagement-actions {
@@ -257,14 +257,14 @@
 
 .sell-page__engagement-details {
   font-size: 13px;
-  color: #14532d;
+  color: var(--color-success-deep, #14532d);
 }
 
 .sell-page__engagement-preview {
   margin: 8px 0 0;
   padding: 12px;
-  background: #dcfce7;
-  border-radius: 12px;
+  background: var(--color-success-soft, #dcfce7);
+  border-radius: var(--radius-md, 12px);
   font-family: 'Courier New', Courier, monospace;
   white-space: pre-wrap;
 }
@@ -278,8 +278,8 @@
   position: fixed;
   inset: 0;
   padding: 24px;
-  background: #ffffff;
-  color: #111827;
+  background: var(--color-surface-base, #ffffff);
+  color: var(--color-neutral-900, #111827);
   font-family: 'Courier New', Courier, monospace;
   z-index: -1;
 }
@@ -316,7 +316,7 @@
 .receipt-print__table td {
   padding: 6px 0;
   text-align: left;
-  border-bottom: 1px dashed #d4d4d4;
+  border-bottom: 1px dashed var(--color-border-neutral, #d4d4d4);
 }
 
 .receipt-print__table th:last-child,
@@ -339,7 +339,7 @@
   flex-basis: 100%;
   text-align: right;
   font-size: 13px;
-  color: #475569;
+  color: var(--color-text-secondary, #475569);
   margin-top: 4px;
 }
 

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -1,0 +1,123 @@
+:root {
+  /* Typography */
+  --font-family-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+  /* Base colors */
+  --color-app-background: #f8fafc;
+  --color-surface-base: #ffffff;
+  --color-surface-soft: #eef2ff;
+  --color-surface-muted: #f1f5f9;
+  --color-surface-translucent: rgba(255, 255, 255, 0.92);
+  --color-elevated-surface: #1f2937;
+
+  --color-border-subtle: #e2e8f0;
+  --color-border-muted: #cbd5f5;
+  --color-border-strong: #bbf7d0;
+  --color-border-input-rgb: 148, 163, 184;
+
+  --color-text-primary: #0f172a;
+  --color-text-strong: #1e293b;
+  --color-text-secondary: #475569;
+  --color-text-muted: #64748b;
+  --color-text-subtle: #94a3b8;
+  --color-text-inverse: #ffffff;
+
+  /* Brand palette */
+  --color-brand-50: #eef2ff;
+  --color-brand-100: #e0e7ff;
+  --color-brand-400: #6366f1;
+  --color-brand-500: #4338ca;
+  --color-brand-600: #4f46e5;
+  --color-brand-700: #312e81;
+  --color-brand-800: #5b21b6;
+  --color-brand-accent: #6366f1;
+  --color-brand-vivid: #7c3aed;
+  --color-brand-50-rgb: 224, 231, 255;
+  --color-brand-soft-rgb: 129, 140, 248;
+  --color-brand-rgb: 67, 56, 202;
+  --color-brand-strong-rgb: 79, 70, 229;
+  --color-brand-accent-rgb: 99, 102, 241;
+  --color-brand-vivid-rgb: 124, 58, 237;
+
+  /* Informational palette */
+  --color-info-500: #1d4ed8;
+  --color-info-600: #2563eb;
+  --color-info-accent: #3b82f6;
+  --color-info-soft: #eff6ff;
+  --color-info-rgb: 37, 99, 235;
+  --color-info-accent-rgb: 59, 130, 246;
+
+  /* Success palette */
+  --color-success-400: #34d399;
+  --color-success-500: #047857;
+  --color-success-600: #065f46;
+  --color-success-700: #15803d;
+  --color-success-deep: #14532d;
+  --color-success-soft: #dcfce7;
+  --color-success-bg: #f0fdf4;
+  --color-success-border: #bbf7d0;
+  --color-success-rgb: 5, 150, 105;
+
+  /* Warning palette */
+  --color-warning-500: #f59e0b;
+  --color-warning-600: #d97706;
+  --color-warning-contrast: #92400e;
+  --color-warning-soft: #fff7ed;
+  --color-warning-alt: #fef3c7;
+  --color-warning-accent: #c2410c;
+  --color-warning-rgb: 245, 158, 11;
+
+  /* Danger palette */
+  --color-danger-400: #f87171;
+  --color-danger-500: #b91c1c;
+  --color-danger-600: #991b1b;
+  --color-danger-strong: #7f1d1d;
+  --color-danger-intense: #dc2626;
+  --color-danger-soft: #fef2f2;
+  --color-danger-border: #fecaca;
+  --color-danger-subtle: #fee2e2;
+  --color-danger-rgb: 239, 68, 68;
+  --color-danger-light-rgb: 248, 113, 113;
+  --color-danger-strong-rgb: 185, 28, 28;
+  --color-danger-intense-rgb: 220, 38, 38;
+
+  --color-neutral-900: #111827;
+  --color-border-neutral: #d4d4d4;
+  --color-overlay-rgb: 15, 23, 42;
+
+  /* Gradients */
+  --gradient-brand: linear-gradient(135deg, var(--color-brand-500), var(--color-brand-600));
+  --gradient-info: linear-gradient(135deg, var(--color-info-600), var(--color-info-500));
+  --gradient-success: linear-gradient(135deg, #059669, #047857);
+  --gradient-auth: linear-gradient(135deg, var(--color-info-600), var(--color-brand-vivid, #7c3aed));
+
+  /* Shadows */
+  --shadow-brand-halo: 0 6px 18px rgba(var(--color-brand-rgb), 0.1);
+  --shadow-brand-halo-strong: 0 6px 18px rgba(var(--color-brand-rgb), 0.18);
+  --shadow-brand-focus: 0 6px 18px rgba(var(--color-brand-rgb), 0.25);
+  --shadow-brand-strong: 0 18px 40px -24px rgba(var(--color-brand-rgb), 0.6);
+  --shadow-brand-stronger: 0 20px 44px -22px rgba(var(--color-brand-rgb), 0.8);
+  --shadow-brand-lift: 0 18px 40px -26px rgba(var(--color-brand-accent-rgb), 0.6);
+  --shadow-info-lift: 0 10px 25px rgba(30, 64, 175, 0.18);
+  --shadow-card: 0 24px 60px -40px rgba(var(--color-overlay-rgb), 0.45);
+  --shadow-card-strong: 0 30px 80px -40px rgba(var(--color-overlay-rgb), 0.5);
+  --shadow-elevated: 0 18px 45px rgba(var(--color-overlay-rgb), 0.12);
+  --shadow-overlay: 0 10px 30px rgba(0, 0, 0, 0.2);
+  --shadow-cta: 0 14px 30px rgba(var(--color-info-rgb), 0.35);
+  --shadow-info-strong: 0 18px 40px -24px rgba(var(--color-info-rgb), 0.6);
+  --shadow-info-stronger: 0 20px 44px -22px rgba(var(--color-info-rgb), 0.8);
+  --shadow-success: 0 18px 40px -24px rgba(var(--color-success-rgb), 0.55);
+
+  /* Radii */
+  --radius-xs: 8px;
+  --radius-sm: 10px;
+  --radius-md: 12px;
+  --radius-lg: 14px;
+  --radius-xl: 16px;
+  --radius-2xl: 20px;
+  --radius-pill: 999px;
+
+  /* Focus */
+  --focus-ring-primary: 0 0 0 3px rgba(var(--color-brand-rgb), 0.12);
+  --focus-outline-info: rgba(var(--color-info-rgb), 0.6);
+}

--- a/web/src/styles/themeTokens.ts
+++ b/web/src/styles/themeTokens.ts
@@ -1,0 +1,56 @@
+export const colors = {
+  background: 'var(--color-app-background, #f8fafc)',
+  surface: 'var(--color-surface-base, #ffffff)',
+  surfaceSoft: 'var(--color-surface-soft, #eef2ff)',
+  surfaceElevated: 'var(--color-elevated-surface, #1f2937)',
+  textPrimary: 'var(--color-text-primary, #0f172a)',
+  textSecondary: 'var(--color-text-secondary, #475569)',
+  textMuted: 'var(--color-text-muted, #64748b)',
+  textInverse: 'var(--color-text-inverse, #ffffff)',
+  brand: 'var(--color-brand-500, #4338ca)',
+  brandAccent: 'var(--color-brand-400, #6366f1)',
+  brandDeep: 'var(--color-brand-700, #312e81)',
+  info: 'var(--color-info-500, #1d4ed8)',
+  infoStrong: 'var(--color-info-600, #2563eb)',
+  success: 'var(--color-success-500, #047857)',
+  successStrong: 'var(--color-success-600, #065f46)',
+  danger: 'var(--color-danger-500, #b91c1c)',
+  dangerSurface: 'var(--color-danger-soft, #fef2f2)',
+  neutralStrong: 'var(--color-neutral-900, #111827)',
+}
+
+export const borders = {
+  subtle: 'var(--color-border-subtle, #e2e8f0)',
+  muted: 'var(--color-border-muted, #cbd5f5)',
+}
+
+export const radii = {
+  md: 'var(--radius-md, 12px)',
+  lg: 'var(--radius-lg, 14px)',
+  xl: 'var(--radius-xl, 16px)',
+  xxl: 'var(--radius-2xl, 20px)',
+  pill: 'var(--radius-pill, 999px)',
+}
+
+export const gradients = {
+  brand: 'var(--gradient-brand, linear-gradient(135deg, #4338ca, #4f46e5))',
+  info: 'var(--gradient-info, linear-gradient(135deg, #2563eb, #1d4ed8))',
+  auth: 'var(--gradient-auth, linear-gradient(135deg, #2563eb, #7c3aed))',
+}
+
+export const shadows = {
+  card: 'var(--shadow-card, 0 24px 60px -40px rgba(15, 23, 42, 0.45))',
+  elevated: 'var(--shadow-elevated, 0 18px 45px rgba(15, 23, 42, 0.12))',
+  cta: 'var(--shadow-cta, 0 14px 30px rgba(37, 99, 235, 0.35))',
+  brandLift: 'var(--shadow-brand-lift, 0 18px 40px -26px rgba(99, 102, 241, 0.6))',
+  infoLift: 'var(--shadow-info-lift, 0 10px 25px rgba(30, 64, 175, 0.18))',
+  overlay: 'var(--shadow-overlay, 0 10px 30px rgba(0, 0, 0, 0.2))',
+}
+
+export const overlays = {
+  brandTint: 'rgba(var(--color-brand-accent-rgb, 99, 102, 241), 0.08)',
+  brandSoft: 'rgba(var(--color-brand-soft-rgb, 129, 140, 248), 0.35)',
+  brandOutline: 'rgba(var(--color-border-input-rgb, 148, 163, 184), 0.14)',
+  brandHalo: 'rgba(var(--color-brand-rgb, 67, 56, 202), 0.35)',
+  dangerOutline: 'rgba(var(--color-danger-light-rgb, 248, 113, 113), 0.4)',
+}


### PR DESCRIPTION
## Summary
- add a global theme stylesheet and TypeScript tokens to define shared colors, radii, and shadows
- refactor Shell, Workspace, Sell, and supporting components to consume the new CSS variables instead of hardcoded values
- align authentication and feedback components with the centralized palette for consistent styling

## Testing
- npm run lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ad1473148321a2f84f386e90fa56