### PR TITLE
Guard signup bootstrap against missing session

### DIFF
--- a/web/src/pages/AuthScreen.test.tsx
+++ b/web/src/pages/AuthScreen.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import AuthScreen from './AuthScreen'
+
+type MockToastOptions = { message: string; tone?: 'success' | 'error' | 'info'; duration?: number }
+
+const mockSignUp = vi.fn()
+const mockSignInWithPassword = vi.fn()
+const mockPublish = vi.fn<(options: MockToastOptions) => void>()
+const mockNavigate = vi.fn()
+const mockAfterSignupBootstrap = vi.fn()
+
+vi.mock('../supabaseClient', () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: (...args: unknown[]) => mockSignInWithPassword(...args),
+      signUp: (...args: unknown[]) => mockSignUp(...args),
+    },
+  },
+}))
+
+vi.mock('../components/ToastProvider', () => ({
+  useToast: () => ({ publish: mockPublish }),
+}))
+
+vi.mock('../controllers/accessController', () => ({
+  afterSignupBootstrap: (...args: unknown[]) => mockAfterSignupBootstrap(...args),
+}))
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: '/', state: null }),
+  }
+})
+
+describe('AuthScreen sign up flow', () => {
+  beforeEach(() => {
+    mockSignUp.mockReset()
+    mockSignInWithPassword.mockReset()
+    mockPublish.mockReset()
+    mockNavigate.mockReset()
+    mockAfterSignupBootstrap.mockReset()
+  })
+
+  it('skips bootstrap and error toast when session is missing after sign up', async () => {
+    mockSignUp.mockResolvedValue({
+      data: {
+        user: { id: 'user-1' },
+        session: null,
+      },
+      error: null,
+    })
+
+    render(<AuthScreen />)
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: /create one/i }))
+    await user.type(screen.getByLabelText(/email/i), 'new.user@example.com')
+    await user.type(screen.getByLabelText(/password/i), 'password123')
+
+    const submitButton = screen
+      .getAllByRole('button', { name: /create account/i })
+      .find(button => button.getAttribute('type') === 'submit')
+
+    if (!submitButton) {
+      throw new Error('Could not find submit button')
+    }
+
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockSignUp).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mockAfterSignupBootstrap).not.toHaveBeenCalled()
+    const errorToastCall = mockPublish.mock.calls.find(
+      ([options]) => options.tone === 'error' && options.message.includes('snag syncing workspace data'),
+    )
+    expect(errorToastCall).toBeUndefined()
+
+    const successToastCall = mockPublish.mock.calls.find(([options]) => options.tone === 'success')
+    expect(successToastCall?.[0].message).toContain(
+      'Check your inbox to confirm your email and finish setting up your account.',
+    )
+  })
+})

--- a/web/src/pages/AuthScreen.tsx
+++ b/web/src/pages/AuthScreen.tsx
@@ -139,7 +139,7 @@ export default function AuthScreen() {
           return
         }
 
-        if (data.user?.id) {
+        if (data.session && data.user?.id) {
           try {
             await afterSignupBootstrap()
           } catch (bootstrapError) {


### PR DESCRIPTION
## Summary
- ensure the signup bootstrap helper only runs when Supabase returns a session
- scope the workspace sync error toast to real bootstrap failures
- add a Vitest/RTL spec covering sign-up flows without a session

## Testing
- npm test -- AuthScreen *(fails: vitest binary unavailable before installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d402e57083218451d22ead36191c