### PR TITLE
Add configurable Supabase functions client

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ This repo is a drop-in starter for **Sedifex** (inventory & POS). It ships as a 
    VITE_FB_APP_ID=REPLACE_ME
    VITE_FB_FUNCTIONS_REGION=us-central1
    VITE_DATA_API_URL=http://localhost:8787 # proxy for the Postgres-backed API
+   VITE_SUPABASE_URL=https://YOUR-project.supabase.co
+   VITE_SUPABASE_ANON_KEY=REPLACE_ME
+   # Optional: point to a different Functions deployment (defaults to ${VITE_SUPABASE_URL}/functions/v1)
+   VITE_SUPABASE_FUNCTIONS_URL=https://custom-edge.example.com/functions/v1
    ```
 4. Provision a Postgres database (Neon, Supabase, or Cloud SQL). Copy the connection strings into `functions/.env`:
    ```env

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,16 @@
+# Firebase configuration
+VITE_FB_API_KEY=
+VITE_FB_AUTH_DOMAIN=
+VITE_FB_PROJECT_ID=
+VITE_FB_STORAGE_BUCKET=
+VITE_FB_APP_ID=
+VITE_FB_FUNCTIONS_REGION=us-central1
+
+# Backend services
+VITE_DATA_API_URL=http://localhost:8787
+
+# Supabase configuration
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+# Optional: override the Supabase Edge Functions URL (defaults to ${VITE_SUPABASE_URL}/functions/v1)
+VITE_SUPABASE_FUNCTIONS_URL=

--- a/web/src/__tests__/supabaseFunctionsClient.test.ts
+++ b/web/src/__tests__/supabaseFunctionsClient.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getSessionMock = vi.fn(async () => ({ data: { session: null }, error: null }))
+
+vi.mock('../config/supabaseEnv', () => ({
+  supabaseEnv: {
+    url: 'https://demo.supabase.co',
+    anonKey: 'anon-key',
+    functionsUrl: 'https://demo.supabase.co/functions/v1',
+  },
+}))
+
+vi.mock('../supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getSession: getSessionMock,
+    },
+  },
+}))
+
+describe('supabaseFunctionsClient', () => {
+  const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>()
+  let invokeSupabaseFunction: (typeof import('../supabaseFunctionsClient'))['invokeSupabaseFunction']
+  let getSupabaseFunctionUrl: (typeof import('../supabaseFunctionsClient'))['getSupabaseFunctionUrl']
+
+  beforeEach(async () => {
+    vi.resetModules()
+    getSessionMock.mockClear()
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    ;({ invokeSupabaseFunction, getSupabaseFunctionUrl } = await import('../supabaseFunctionsClient'))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('builds function URLs using the configured base path', () => {
+    expect(getSupabaseFunctionUrl('syncInventory')).toBe(
+      'https://demo.supabase.co/functions/v1/syncInventory',
+    )
+  })
+
+  it('includes the session access token when available', async () => {
+    getSessionMock.mockResolvedValueOnce({
+      data: { session: { access_token: 'session-token' } },
+      error: null,
+    })
+
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const result = await invokeSupabaseFunction('manageStaff', {
+      payload: { value: 42 },
+    })
+
+    expect(result.error).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(url).toBe('https://demo.supabase.co/functions/v1/manageStaff')
+    const headers = new Headers(init?.headers)
+    expect(headers.get('authorization')).toBe('Bearer session-token')
+    expect(headers.get('apikey')).toBe('anon-key')
+    expect(headers.get('content-type')).toBe('application/json')
+    expect(init?.body).toBe(JSON.stringify({ value: 42 }))
+  })
+
+  it('falls back to the anon key when no session is available', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(null, {
+        status: 204,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const result = await invokeSupabaseFunction('afterSignup', {})
+
+    expect(result.error).toBeNull()
+    const [, init] = fetchMock.mock.calls[0] ?? []
+    const headers = new Headers(init?.headers)
+    expect(headers.get('authorization')).toBe('Bearer anon-key')
+  })
+})

--- a/web/src/config/supabaseEnv.ts
+++ b/web/src/config/supabaseEnv.ts
@@ -1,6 +1,8 @@
 const requiredEnvKeys = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY'] as const
+const optionalEnvKeys = ['VITE_SUPABASE_FUNCTIONS_URL'] as const
 
 export type SupabaseEnvKey = (typeof requiredEnvKeys)[number]
+type OptionalSupabaseEnvKey = (typeof optionalEnvKeys)[number]
 
 export type SupabaseEnvConfig = {
   url: string
@@ -24,13 +26,25 @@ function normalizeUrl(value: string): string {
   return value.replace(/\/?$/, '')
 }
 
+function getOptionalEnv(key: OptionalSupabaseEnvKey): string | null {
+  const value = import.meta.env[key]
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
 export const supabaseEnv: SupabaseEnvConfig = (() => {
   const baseUrl = normalizeUrl(getRequiredEnv('VITE_SUPABASE_URL'))
   const anonKey = getRequiredEnv('VITE_SUPABASE_ANON_KEY')
+  const overrideFunctionsUrl = getOptionalEnv('VITE_SUPABASE_FUNCTIONS_URL')
+  const functionsBase = overrideFunctionsUrl ?? `${baseUrl}/functions/v1`
 
   return {
     url: baseUrl,
     anonKey,
-    functionsUrl: `${baseUrl}/functions/v1`,
+    functionsUrl: normalizeUrl(functionsBase),
   }
 })()

--- a/web/src/controllers/accessController.ts
+++ b/web/src/controllers/accessController.ts
@@ -6,6 +6,7 @@ import { SUPABASE_FUNCTIONS, type SupabaseEndpointDefinition } from '@shared/fir
 import { auth, db } from '../firebase'
 
 import { supabase } from '../supabaseClient'
+import { invokeSupabaseFunction } from '../supabaseFunctionsClient'
 
 export type ResolveStoreAccessSuccess = {
   ok: true
@@ -42,8 +43,9 @@ async function invokeSupabaseEdgeFunction<Payload>(
   definition: SupabaseEndpointDefinition,
   payload: Payload | undefined,
 ): Promise<void> {
-  const body = payload === undefined ? undefined : payload
-  const { data, error } = await supabase.functions.invoke<unknown>(definition.name, { body })
+  const { data, error } = await invokeSupabaseFunction<Payload, unknown>(definition.name, {
+    payload,
+  })
 
   if (error) {
     throw error

--- a/web/src/controllers/storeController.ts
+++ b/web/src/controllers/storeController.ts
@@ -1,7 +1,7 @@
 // web/src/controllers/storeController.ts
 import { SUPABASE_FUNCTIONS, type SupabaseEndpointDefinition } from '@shared/firebaseCallables'
 
-import { supabase } from '../supabaseClient'
+import { invokeSupabaseFunction } from '../supabaseFunctionsClient'
 
 type ManageStaffAccountPayload = {
   storeId: string
@@ -46,7 +46,9 @@ async function invokeSupabaseEdgeFunction<Payload, Result>(
   definition: SupabaseEndpointDefinition,
   payload: Payload,
 ): Promise<Result> {
-  const { data, error } = await supabase.functions.invoke<Result>(definition.name, { body: payload })
+  const { data, error } = await invokeSupabaseFunction<Payload, Result>(definition.name, {
+    payload,
+  })
 
   if (error) {
     throw error

--- a/web/src/supabaseFunctionsClient.ts
+++ b/web/src/supabaseFunctionsClient.ts
@@ -1,0 +1,116 @@
+import { supabaseEnv } from './config/supabaseEnv'
+import { supabase } from './supabaseClient'
+
+export type SupabaseFunctionInvokeOptions<Payload> = {
+  payload?: Payload
+  signal?: AbortSignal
+  headers?: Record<string, string>
+}
+
+export type SupabaseFunctionInvokeResult<Result> = {
+  data: Result | null
+  error: Error | null
+  status: number
+}
+
+function ensureFunctionsBaseUrl(): string {
+  const { functionsUrl } = supabaseEnv
+  if (!functionsUrl) {
+    throw new Error('[supabase-functions] Missing Supabase functions URL configuration')
+  }
+  return functionsUrl
+}
+
+export function getSupabaseFunctionUrl(functionName: string): string {
+  const baseUrl = ensureFunctionsBaseUrl()
+  const normalized = functionName.replace(/^\/+/, '').trim()
+  if (!normalized) {
+    throw new Error('[supabase-functions] Function name is required')
+  }
+  return `${baseUrl}/${normalized}`
+}
+
+async function resolveAuthToken(): Promise<string> {
+  try {
+    const { data, error } = await supabase.auth.getSession()
+    if (error) {
+      console.warn('[supabase-functions] Failed to read auth session for functions request', error)
+    } else if (data?.session?.access_token) {
+      return data.session.access_token
+    }
+  } catch (error) {
+    console.warn('[supabase-functions] Unexpected error while reading session', error)
+  }
+
+  return supabaseEnv.anonKey
+}
+
+function parseResponseBody<Result>(response: Response, rawBody: string): Result | null {
+  if (!rawBody) {
+    return null
+  }
+
+  const contentType = response.headers.get('content-type') ?? ''
+  const shouldParseAsJson = contentType.includes('application/json')
+
+  if (shouldParseAsJson) {
+    try {
+      return JSON.parse(rawBody) as Result
+    } catch (error) {
+      console.warn('[supabase-functions] Failed to parse JSON response', error)
+      return null
+    }
+  }
+
+  try {
+    return JSON.parse(rawBody) as Result
+  } catch {
+    return rawBody as unknown as Result
+  }
+}
+
+export async function invokeSupabaseFunction<Payload, Result>(
+  functionName: string,
+  options: SupabaseFunctionInvokeOptions<Payload> = {},
+): Promise<SupabaseFunctionInvokeResult<Result>> {
+  const url = getSupabaseFunctionUrl(functionName)
+  const headers = new Headers(options.headers)
+
+  headers.set('apikey', supabaseEnv.anonKey)
+  const authToken = await resolveAuthToken()
+  headers.set('authorization', `Bearer ${authToken}`)
+
+  let body: string | undefined
+  if (options.payload !== undefined) {
+    headers.set('content-type', 'application/json')
+    body = JSON.stringify(options.payload)
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body,
+      signal: options.signal,
+    })
+
+    const rawBody = response.status === 204 ? '' : await response.text()
+    const data = parseResponseBody<Result>(response, rawBody)
+
+    if (!response.ok) {
+      const message =
+        (data && typeof data === 'object' && 'error' in (data as Record<string, unknown>)
+          ? String((data as Record<string, unknown>).error)
+          : null) ?? `Supabase function ${functionName} responded with status ${response.status}`
+
+      return { data, error: new Error(message), status: response.status }
+    }
+
+    return { data, error: null, status: response.status }
+  } catch (error) {
+    const normalizedError =
+      error instanceof Error ? error : new Error(typeof error === 'string' ? error : 'Unknown error')
+
+    return { data: null, error: normalizedError, status: 0 }
+  }
+}

--- a/web/src/utils/__tests__/offlineQueue.test.ts
+++ b/web/src/utils/__tests__/offlineQueue.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const getSessionMock = vi.fn(async () => ({ data: { session: null }, error: null }))
+
 vi.mock('../../config/supabaseEnv', () => ({
   supabaseEnv: {
     url: 'https://demo.supabase.co',
@@ -8,12 +10,10 @@ vi.mock('../../config/supabaseEnv', () => ({
   },
 }))
 
-
 vi.mock('../../supabaseClient', () => ({
   supabase: {
     auth: {
-      getSession: vi.fn(async () => ({ data: { session: null }, error: null })),
-
+      getSession: getSessionMock,
     },
   },
 }))

--- a/web/src/utils/offlineQueue.ts
+++ b/web/src/utils/offlineQueue.ts
@@ -1,9 +1,6 @@
 
-import { supabaseEnv } from '../config/supabaseEnv'
-
 import { supabase } from '../supabaseClient'
-
-const FUNCTIONS_BASE_URL = supabaseEnv.functionsUrl
+import { getSupabaseFunctionUrl } from '../supabaseFunctionsClient'
 
 const SYNC_TAG = 'sync-pending-requests'
 
@@ -27,14 +24,7 @@ function getController(registration: ServiceWorkerRegistration) {
 }
 
 export function getCallableEndpoint(functionName: string) {
-  if (!FUNCTIONS_BASE_URL) {
-    throw new Error('Missing Supabase function configuration')
-  }
-  const normalized = functionName.replace(/^\/+/, '').trim()
-  if (!normalized) {
-    throw new Error('Function name is required')
-  }
-  return `${FUNCTIONS_BASE_URL}/${normalized}`
+  return getSupabaseFunctionUrl(functionName)
 }
 
 export async function queueCallableRequest(


### PR DESCRIPTION
## Summary
- allow overriding the Supabase Functions origin via `VITE_SUPABASE_FUNCTIONS_URL`
- introduce a shared Supabase functions client and refactor controllers/offline queue to use it
- document the new env var, provide an `.env` template, and add unit coverage for the helper

## Testing
- npm run test *(fails: vitest not found before installing dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e106ffb8a48321ad0d724b27ccf006