### PR TITLE
Switch AuthScreen to Firebase email auth

### DIFF
--- a/web/src/pages/AuthScreen.test.tsx
+++ b/web/src/pages/AuthScreen.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
@@ -6,19 +6,33 @@ import AuthScreen from './AuthScreen'
 
 type MockToastOptions = { message: string; tone?: 'success' | 'error' | 'info'; duration?: number }
 
-const mockSignUp = vi.fn()
-const mockSignInWithPassword = vi.fn()
+const mockAuth = vi.hoisted(() => ({} as unknown as Record<string, unknown>))
+
+const mockCreateUserWithEmailAndPassword = vi.fn()
+const mockSignInWithEmailAndPassword = vi.fn()
+const mockPersistSession = vi.fn(async (..._args: unknown[]) => {})
+const mockSetOnboardingStatus = vi.fn()
 const mockPublish = vi.fn<(options: MockToastOptions) => void>()
 const mockNavigate = vi.fn()
 const mockAfterSignupBootstrap = vi.fn()
 
-vi.mock('../supabaseClient', () => ({
-  supabase: {
-    auth: {
-      signInWithPassword: (...args: unknown[]) => mockSignInWithPassword(...args),
-      signUp: (...args: unknown[]) => mockSignUp(...args),
-    },
-  },
+vi.mock('firebase/auth', () => ({
+  createUserWithEmailAndPassword: (...args: unknown[]) =>
+    mockCreateUserWithEmailAndPassword(...args),
+  signInWithEmailAndPassword: (...args: unknown[]) =>
+    mockSignInWithEmailAndPassword(...args),
+}))
+
+vi.mock('../firebase', () => ({
+  auth: mockAuth,
+}))
+
+vi.mock('../controllers/sessionController', () => ({
+  persistSession: (...args: unknown[]) => mockPersistSession(...args),
+}))
+
+vi.mock('../utils/onboarding', () => ({
+  setOnboardingStatus: (...args: unknown[]) => mockSetOnboardingStatus(...args),
 }))
 
 vi.mock('../components/ToastProvider', () => ({
@@ -38,23 +52,53 @@ vi.mock('react-router-dom', async importOriginal => {
   }
 })
 
-describe('AuthScreen sign up flow', () => {
+describe('AuthScreen', () => {
   beforeEach(() => {
-    mockSignUp.mockReset()
-    mockSignInWithPassword.mockReset()
+    mockCreateUserWithEmailAndPassword.mockReset()
+    mockSignInWithEmailAndPassword.mockReset()
+    mockPersistSession.mockClear()
+    mockSetOnboardingStatus.mockReset()
     mockPublish.mockReset()
     mockNavigate.mockReset()
     mockAfterSignupBootstrap.mockReset()
   })
 
-  it('skips bootstrap and error toast when session is missing after sign up', async () => {
-    mockSignUp.mockResolvedValue({
-      data: {
-        user: { id: 'user-1' },
-        session: null,
-      },
-      error: null,
+  it('signs in with Firebase auth and persists the session', async () => {
+    const mockUser = { uid: 'user-123' }
+    mockSignInWithEmailAndPassword.mockResolvedValue({ user: mockUser })
+
+    render(<AuthScreen />)
+    const user = userEvent.setup()
+
+    await user.type(screen.getByLabelText(/email/i), '  user@example.com  ')
+    await user.type(screen.getByLabelText(/password/i), 'password123')
+
+    const submitButton = screen
+      .getAllByRole('button', { name: /sign in/i })
+      .find(button => button.getAttribute('type') === 'submit')
+
+    if (!submitButton) {
+      throw new Error('Could not find submit button')
+    }
+
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockSignInWithEmailAndPassword).toHaveBeenCalledWith(
+        mockAuth,
+        'user@example.com',
+        'password123',
+      )
     })
+
+    expect(mockPersistSession).toHaveBeenCalledWith(mockUser)
+    expect(mockPublish).toHaveBeenCalledWith({ message: 'Welcome back!', tone: 'success' })
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+  })
+
+  it('creates an account and triggers onboarding helpers', async () => {
+    const mockUser = { uid: 'new-user' }
+    mockCreateUserWithEmailAndPassword.mockResolvedValue({ user: mockUser })
 
     render(<AuthScreen />)
     const user = userEvent.setup()
@@ -74,18 +118,50 @@ describe('AuthScreen sign up flow', () => {
     await user.click(submitButton)
 
     await waitFor(() => {
-      expect(mockSignUp).toHaveBeenCalledTimes(1)
+      expect(mockCreateUserWithEmailAndPassword).toHaveBeenCalledWith(
+        mockAuth,
+        'new.user@example.com',
+        'password123',
+      )
     })
 
-    expect(mockAfterSignupBootstrap).not.toHaveBeenCalled()
-    const errorToastCall = mockPublish.mock.calls.find(
-      ([options]) => options.tone === 'error' && options.message.includes('snag syncing workspace data'),
-    )
-    expect(errorToastCall).toBeUndefined()
+    expect(mockPersistSession).toHaveBeenCalledWith(mockUser)
+    expect(mockSetOnboardingStatus).toHaveBeenCalledWith('new-user', 'pending')
+    expect(mockAfterSignupBootstrap).toHaveBeenCalled()
 
     const successToastCall = mockPublish.mock.calls.find(([options]) => options.tone === 'success')
-    expect(successToastCall?.[0].message).toContain(
-      'Check your inbox to confirm your email and finish setting up your account.',
-    )
+    expect(successToastCall?.[0].message).toBe('Account created! Setting things up now…')
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+  })
+
+  it('surfaces bootstrap errors after signup', async () => {
+    const mockUser = { uid: 'new-user' }
+    mockCreateUserWithEmailAndPassword.mockResolvedValue({ user: mockUser })
+    mockAfterSignupBootstrap.mockRejectedValueOnce(new Error('sync failed'))
+
+    render(<AuthScreen />)
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: /create one/i }))
+    await user.type(screen.getByLabelText(/email/i), 'new.user@example.com')
+    await user.type(screen.getByLabelText(/password/i), 'password123')
+
+    const submitButton = screen
+      .getAllByRole('button', { name: /create account/i })
+      .find(button => button.getAttribute('type') === 'submit')
+
+    if (!submitButton) {
+      throw new Error('Could not find submit button')
+    }
+
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockAfterSignupBootstrap).toHaveBeenCalled()
+    })
+
+    const errorToastCall = mockPublish.mock.calls.find(([options]) => options.tone === 'error')
+    expect(errorToastCall?.[0].message).toContain('We created your account but hit a snag syncing workspace data')
   })
 })
+


### PR DESCRIPTION
## Summary
- switch the authentication flow on `AuthScreen` to use Firebase email/password APIs and persist onboarding/session state
- update the auth screen tests to mock Firebase auth helpers and assert the refreshed success and error handling

## Testing
- npx vitest run src/pages/AuthScreen.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e2510285a48321a2385c58cc1936dd