### PR TITLE
Switch SheetAccessGuard to Firebase auth

### DIFF
--- a/web/src/hooks/useActiveStore.test.tsx
+++ b/web/src/hooks/useActiveStore.test.tsx
@@ -35,7 +35,7 @@ describe('useActiveStore', () => {
     mockUseMemberships.mockReset()
     mockUseAuthUser.mockReset()
     window.localStorage.clear()
-    mockUseAuthUser.mockReturnValue({ id: 'user-1' })
+    mockUseAuthUser.mockReturnValue({ uid: 'user-1' })
   })
 
   it('prefers the persisted store id when it matches the membership store', async () => {
@@ -110,7 +110,7 @@ describe('useActiveStore', () => {
   })
 
   it('resets the active store when switching to a different user', async () => {
-    let currentUser: { id: string } = { id: 'user-1' }
+    let currentUser: { uid: string } = { uid: 'user-1' }
     mockUseAuthUser.mockImplementation(() => currentUser)
 
     mockUseMemberships.mockImplementation(storeId => {
@@ -118,7 +118,7 @@ describe('useActiveStore', () => {
         return { memberships: [], loading: true, error: null }
       }
 
-      if (currentUser.id === 'user-1') {
+      if (currentUser.uid === 'user-1') {
         return {
           memberships: [createMembership('user-1-store')],
           loading: false,
@@ -143,7 +143,7 @@ describe('useActiveStore', () => {
       expect(result.current.storeId).toBe('user-1-store')
     })
 
-    currentUser = { id: 'user-2' }
+    currentUser = { uid: 'user-2' }
     const user2Key = getActiveStoreStorageKey('user-2')
     window.localStorage.setItem(user2Key, 'user-2-store')
     rerender()


### PR DESCRIPTION
## Summary
- replace the Supabase dependency in `SheetAccessGuard` with the Firebase auth client and types
- key membership lookups and persistence helpers by `user.uid` instead of `user.id`
- align the active store hook test doubles with the Firebase user shape

## Testing
- npm test -- src/hooks/useActiveStore.test.tsx src/hooks/useMemberships.test.tsx *(fails: useActiveStore tests expect loading state to resolve in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e253edb1ac83219073eb19266468a0