### PR TITLE
Persist workspace metadata in session documents

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -239,7 +239,17 @@ describe('App signup cleanup', () => {
       await user.click(screen.getByRole('button', { name: /Create account/i }))
     })
 
-    await waitFor(() => expect(mocks.persistSession).toHaveBeenCalled())
+    await waitFor(() => expect(mocks.persistSession).toHaveBeenCalledTimes(2))
+    const firstPersistCall = mocks.persistSession.mock.calls[0]
+    expect(firstPersistCall?.[0]).toBe(createdUser)
+    expect(firstPersistCall?.[1]).toBeUndefined()
+
+    const secondPersistCall = mocks.persistSession.mock.calls[1]
+    expect(secondPersistCall?.[0]).toBe(createdUser)
+    expect(secondPersistCall?.[1]).toEqual({
+      storeId: 'workspace-store-id',
+      role: 'staff',
+    })
     await waitFor(() =>
       expect(mocks.resolveStoreAccess).toHaveBeenCalledWith('workspace-store-id'),
     )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -450,6 +450,10 @@ export default function App() {
         await persistSession(nextUser)
         try {
           const resolution = await resolveStoreAccess()
+          await persistSession(nextUser, {
+            storeId: resolution.storeId,
+            role: resolution.role,
+          })
           await persistStoreSeedData(resolution)
         } catch (error) {
           console.warn('[auth] Failed to resolve workspace access', error)
@@ -473,6 +477,11 @@ export default function App() {
           await cleanupFailedSignup(nextUser)
           return
         }
+
+        await persistSession(nextUser, {
+          storeId: resolution.storeId,
+          role: resolution.role,
+        })
 
         await persistTeamMemberMetadata(nextUser, sanitizedEmail, sanitizedPhone, resolution)
 

--- a/web/src/controllers/sessionController.ts
+++ b/web/src/controllers/sessionController.ts
@@ -21,7 +21,12 @@ export async function configureAuthPersistence(auth: Auth) {
   }
 }
 
-export async function persistSession(user: User) {
+type WorkspaceMetadata = {
+  storeId?: string
+  role?: 'owner' | 'staff'
+}
+
+export async function persistSession(user: User, workspace?: WorkspaceMetadata) {
   const sessionId = ensureSessionId()
   try {
     await setDoc(
@@ -32,7 +37,9 @@ export async function persistSession(user: User) {
         displayName: user.displayName ?? null,
         lastLoginAt: serverTimestamp(),
         lastActiveAt: serverTimestamp(),
-        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+        storeId: workspace?.storeId ?? null,
+        role: workspace?.role ?? null
       },
       { merge: true }
     )


### PR DESCRIPTION
## Summary
- allow session persistence to record optional workspace metadata such as store and role
- update login and signup flows to refresh sessions with workspace context and adjust tests accordingly

## Testing
- npm test -- App.signup

------
https://chatgpt.com/codex/tasks/task_e_68e25788dff08321adf8ec6470715eb7