### PR TITLE
Scope shell link color reset to unstyled anchors

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -111,7 +111,7 @@
   padding: 32px clamp(20px, 4vw, 64px) 48px;
 }
 
-.shell a {
+.shell :where(a:not([class])) {
   color: inherit;
 }
 


### PR DESCRIPTION
## Summary
- limit the shell-level link color reset to anchors without additional classes to avoid overriding button styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e280ff96e08321a444071614da880f