### PR TITLE
Collect additional signup profile details

### DIFF
--- a/functions/test/initializeStore.test.js
+++ b/functions/test/initializeStore.test.js
@@ -66,7 +66,17 @@ async function runInitializeStoreCreatesWorkspaceTest() {
     },
   }
 
-  const initResult = await initializeStore.run({}, context)
+  const initResult = await initializeStore.run(
+    {
+      contact: {
+        phone: ' +1 (555) 000-0000 ',
+        firstSignupEmail: 'Fresh.Owner@Example.com',
+        ownerName: ' Fresh Owner ',
+        businessName: ' Fresh Retail ',
+      },
+    },
+    context,
+  )
   assert.strictEqual(initResult.ok, true, 'Expected initializeStore to succeed')
   assert.ok(initResult.storeId, 'Expected initializeStore to return a storeId')
 
@@ -75,8 +85,19 @@ async function runInitializeStoreCreatesWorkspaceTest() {
   assert.strictEqual(storeDoc.ownerId, 'new-owner-uid')
   assert.strictEqual(storeDoc.status, 'Active')
   assert.strictEqual(storeDoc.contractStatus, 'Active')
+  assert.strictEqual(storeDoc.ownerEmail, 'fresh.owner@example.com')
+  assert.strictEqual(storeDoc.ownerName, 'Fresh Owner')
+  assert.strictEqual(storeDoc.displayName, 'Fresh Retail')
+  assert.strictEqual(storeDoc.businessName, 'Fresh Retail')
   assert.ok(storeDoc.updatedAt, 'Expected updatedAt to be set')
   assert.ok(storeDoc.createdAt, 'Expected createdAt to be set on new store')
+
+  const rosterMemberDoc = currentRosterDb.getDoc('teamMembers/new-owner-uid')
+  assert.ok(rosterMemberDoc, 'Expected roster member document to be created')
+  assert.strictEqual(rosterMemberDoc.name, 'Fresh Owner')
+  assert.strictEqual(rosterMemberDoc.companyName, 'Fresh Retail')
+  assert.strictEqual(rosterMemberDoc.phone, '+1 (555) 000-0000')
+  assert.strictEqual(rosterMemberDoc.firstSignupEmail, 'fresh.owner@example.com')
 
   const resolveResult = await resolveStoreAccess.run({}, context)
   assert.strictEqual(resolveResult.ok, true, 'Expected resolveStoreAccess to succeed')

--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -168,6 +168,8 @@ describe('App signup cleanup', () => {
     await act(async () => {
       await user.click(screen.getByRole('tab', { name: /Sign up/i }))
       await user.type(screen.getByLabelText(/Email/i), 'owner@example.com')
+      await user.type(screen.getByLabelText(/Full name/i), 'Morgan Owner')
+      await user.type(screen.getByLabelText(/Business name/i), 'Morgan Retail Co')
       await user.type(screen.getByLabelText(/Phone/i), '5551234567')
       await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
       await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
@@ -234,6 +236,8 @@ describe('App signup cleanup', () => {
     await act(async () => {
       await user.click(screen.getByRole('tab', { name: /Sign up/i }))
       await user.type(screen.getByLabelText(/Email/i), 'owner@example.com')
+      await user.type(screen.getByLabelText(/Full name/i), 'Morgan Owner')
+      await user.type(screen.getByLabelText(/Business name/i), 'Morgan Retail Co')
       await user.type(screen.getByLabelText(/Phone/i), ' (555) 123-4567 ')
       await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
       await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
@@ -256,6 +260,8 @@ describe('App signup cleanup', () => {
       expect(mocks.initializeStore).toHaveBeenCalledWith({
         phone: '5551234567',
         firstSignupEmail: 'owner@example.com',
+        ownerName: 'Morgan Owner',
+        businessName: 'Morgan Retail Co',
       }),
     )
     await waitFor(() =>
@@ -294,7 +300,8 @@ describe('App signup cleanup', () => {
     expect(ownerPayload).toEqual(
       expect.objectContaining({
         storeId: 'workspace-store-id',
-        name: 'Owner account',
+        name: 'Morgan Owner',
+        companyName: 'Morgan Retail Co',
         phone: '5551234567',
         email: 'owner@example.com',
         role: 'staff',
@@ -328,10 +335,12 @@ describe('App signup cleanup', () => {
     expect(customerPayload).toEqual(
       expect.objectContaining({
         storeId: 'workspace-store-id',
-        name: 'owner@example.com',
-        displayName: 'owner@example.com',
+        name: 'Morgan Retail Co',
+        displayName: 'Morgan Owner',
         email: 'owner@example.com',
         phone: '5551234567',
+        businessName: 'Morgan Retail Co',
+        ownerName: 'Morgan Owner',
         status: 'active',
         role: 'client',
         createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
@@ -395,6 +404,8 @@ describe('App signup cleanup', () => {
     await act(async () => {
       await user.click(screen.getByRole('tab', { name: /Sign up/i }))
       await user.type(screen.getByLabelText(/Email/i), 'owner@example.com')
+      await user.type(screen.getByLabelText(/Full name/i), 'Morgan Owner')
+      await user.type(screen.getByLabelText(/Business name/i), 'Morgan Retail Co')
       await user.type(screen.getByLabelText(/Phone/i), '5551234567')
       await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
       await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
@@ -406,6 +417,8 @@ describe('App signup cleanup', () => {
       expect(mocks.initializeStore).toHaveBeenCalledWith({
         phone: '5551234567',
         firstSignupEmail: 'owner@example.com',
+        ownerName: 'Morgan Owner',
+        businessName: 'Morgan Retail Co',
       }),
     )
     await waitFor(() => expect(mocks.resolveStoreAccess).toHaveBeenCalledWith('store-001'))

--- a/web/src/controllers/accessController.ts
+++ b/web/src/controllers/accessController.ts
@@ -11,6 +11,8 @@ type RawSeededDocument = {
 export type InitializeStoreContactPayload = {
   phone?: string | null
   firstSignupEmail?: string | null
+  ownerName?: string | null
+  businessName?: string | null
 }
 
 type InitializeStorePayload = {
@@ -142,12 +144,29 @@ export function extractCallableErrorMessage(error: FirebaseError): string | null
 export async function initializeStore(contact?: InitializeStoreContactPayload) {
   let payload: InitializeStorePayload | undefined
 
-  if (contact && (contact.phone !== undefined || contact.firstSignupEmail !== undefined)) {
-    payload = {
-      contact: {
-        phone: contact.phone ?? null,
-        firstSignupEmail: contact.firstSignupEmail ?? null,
-      },
+  if (contact) {
+    const payloadContact: InitializeStoreContactPayload = {}
+    let hasContactField = false
+
+    if (contact.phone !== undefined) {
+      payloadContact.phone = contact.phone ?? null
+      hasContactField = true
+    }
+    if (contact.firstSignupEmail !== undefined) {
+      payloadContact.firstSignupEmail = contact.firstSignupEmail ?? null
+      hasContactField = true
+    }
+    if (contact.ownerName !== undefined) {
+      payloadContact.ownerName = contact.ownerName ?? null
+      hasContactField = true
+    }
+    if (contact.businessName !== undefined) {
+      payloadContact.businessName = contact.businessName ?? null
+      hasContactField = true
+    }
+
+    if (hasContactField) {
+      payload = { contact: payloadContact }
     }
   }
 


### PR DESCRIPTION
## Summary
- capture a full name and business name during signup and validate the additional fields
- propagate the new contact details through initializeStore, metadata persistence, and customer records
- extend initializeStore backend handling and tests to normalize and store the new contact fields

## Testing
- npx vitest run src/App.signup.test.tsx
- npm test (functions)


------
https://chatgpt.com/codex/tasks/task_e_68e2d038c52883219998f2e5b4cbdbb7