### PR TITLE
Integrate goal planner into dashboard

### DIFF
--- a/web/src/components/GoalPlanner.tsx
+++ b/web/src/components/GoalPlanner.tsx
@@ -25,7 +25,7 @@ function useGoalFormState(initial: FormState = { title: '', notes: '' }) {
   return { formState, updateField, reset }
 }
 
-export default function GoalPlannerPage() {
+export default function GoalPlanner() {
   const {
     plan,
     isLoading,

--- a/web/src/components/__tests__/GoalPlanner.test.tsx
+++ b/web/src/components/__tests__/GoalPlanner.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter } from 'react-router-dom'
 import { vi } from 'vitest'
 
-import GoalPlannerPage from '../KpiMetrics'
+import GoalPlanner from '../GoalPlanner'
 import Shell from '../../layout/Shell'
 
 const mockUseAuthUser = vi.fn(() => ({ uid: 'user-1', email: 'manager@example.com' }))
@@ -64,10 +64,10 @@ vi.mock('firebase/firestore', () => ({
 
 const renderPlanner = () => {
   render(
-    <MemoryRouter initialEntries={['/goals']}>
-      <Routes>
-        <Route path="/goals" element={<Shell><GoalPlannerPage /></Shell>} />
-      </Routes>
+    <MemoryRouter initialEntries={['/']}>
+      <Shell>
+        <GoalPlanner />
+      </Shell>
     </MemoryRouter>,
   )
 }
@@ -91,7 +91,7 @@ function formatIsoWeek(date: Date) {
   return `${utcDate.getUTCFullYear()}-W${String(week).padStart(2, '0')}`
 }
 
-describe('Goal planner page', () => {
+describe('Goal planner component', () => {
   const uuidSpy = vi.spyOn(globalThis.crypto, 'randomUUID')
   let dayKey = ''
   let weekKey = ''

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -11,7 +11,6 @@ type NavItem = { to: string; label: string; end?: boolean }
 
 const NAV_ITEMS: NavItem[] = [
   { to: '/', label: 'Dashboard', end: true },
-  { to: '/goals', label: 'Goals' },
   { to: '/products', label: 'Products' },
   { to: '/sell', label: 'Sell' },
   { to: '/receive', label: 'Receive' },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,7 +10,6 @@ import Receive from './pages/Receive'
 import CloseDay from './pages/CloseDay'
 import Customers from './pages/Customers'
 import Onboarding from './pages/Onboarding'
-import GoalPlannerPage from './pages/KpiMetrics'
 import AccountOverview from './pages/AccountOverview'
 import { ToastProvider } from './components/ToastProvider'
 
@@ -20,7 +19,6 @@ const router = createHashRouter([
     element: <App />,
     children: [
       { index: true, element: <Shell><Dashboard /></Shell> },
-      { path: 'goals',     element: <Shell><GoalPlannerPage /></Shell> },
       { path: 'products',  element: <Shell><Products /></Shell> },
       { path: 'sell',      element: <Shell><Sell /></Shell> },
       { path: 'receive',   element: <Shell><Receive /></Shell> },

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import Sparkline from '../components/Sparkline'
+import GoalPlanner from '../components/GoalPlanner'
 import { useStoreMetrics } from '../hooks/useStoreMetrics'
 
 const QUICK_LINKS: Array<{
@@ -583,6 +584,10 @@ export default function Dashboard() {
           </dl>
         </article>
       </section>
+
+      <div style={{ marginBottom: 32 }}>
+        <GoalPlanner />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- move the goal planner into a shared component and render it from the dashboard
- remove the standalone goals route and navigation entry to consolidate navigation
- relocate the goal planner tests to the new component location

## Testing
- npm test *(fails: suite requires Firebase env variables and existing tests outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d9f661d0832181176e844aea5a57