### PR TITLE
Align store defaults with workspace status

### DIFF
--- a/functions/src/onAuthCreate.ts
+++ b/functions/src/onAuthCreate.ts
@@ -25,7 +25,8 @@ export const onAuthCreate = functions.auth.user().onCreate(async user => {
     .set(
       {
         ownerId: uid,
-        status: 'active',
+        status: 'Active',
+        contractStatus: 'Active',
         inventorySummary: {
           trackedSkus: 0,
           lowStockSkus: 0,


### PR DESCRIPTION
## Summary
- update the auth-triggered store document seed to use the workspace "Active" status values
- add the missing contractStatus field so the generated store record matches app expectations

## Testing
- npm test -- --runTestsByPath ./test/initializeStore.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2e03b8b4c8321ad97c85e423276a7