### PR TITLE
Enable workspace selection and expand seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,22 +53,18 @@ This repo is a drop-in starter for **Sedifex** (inventory & POS). It ships as a 
 
 **Seeding / maintenance steps**
 1. Ensure you have the Firebase CLI installed and are logged in: `npx firebase login`.
-2. Create a JSON seed file with workspace documents, for example:
-   ```json
-   {
-     "workspaces": {
-       "demo-store": {
-         "company": "Demo Store",
-         "contractStart": { ".sv": "timestamp" },
-         "contractEnd": "2024-12-31",
-         "paymentStatus": "paid",
-         "amountPaid": 129900
-       }
-     }
-   }
+2. Seed Firestore using [`seed/workspaces.seed.json`](seed/workspaces.seed.json), which now provisions the `workspaces`, `stores`, and `teamMembers` collections used across the UI:
+   ```bash
+   npx firebase firestore:delete workspaces stores teamMembers --project <project-id> --force
+   npx firebase firestore:import seed/workspaces.seed.json --project <project-id>
    ```
-3. Import the seed data into Firestore: `npx firebase firestore:delete workspaces --project <project-id> --force && npx firebase firestore:import seed.json --project <project-id>`.
-4. For ongoing updates, edit the documents directly in the Firebase console or via your preferred admin tooling.
+3. For ongoing updates, edit the documents directly in the Firebase console or via your preferred admin tooling.
+
+### Connect the UI to your Firestore workspace data
+1. Update `web/.env.local` with the Firebase config for the project you seeded (the same values you use in hosting/CI environments).
+2. In the Firebase console, create authentication users whose `uid` values match the `teamMembers` you seeded (for example, a user with `uid` of `demo-owner` and email `owner@demo-store.test`). Assign a password so you can sign in locally.
+3. Start the PWA locally with `npm run dev` inside `web/` and sign in with the seeded account.
+4. Use the workspace selector in the header to switch between any memberships tied to that user. The Account page will load the matching `stores/<storeId>` profile and roster data once a workspace is selected.
 
 ## Branding
 - Name: **Sedifex**

--- a/seed/workspaces.seed.json
+++ b/seed/workspaces.seed.json
@@ -1,0 +1,142 @@
+{
+  "collections": {
+    "workspaces": {
+      "demo-store": {
+        "company": "Demo Store",
+        "storeId": "store-demo",
+        "status": "active",
+        "contractStart": { "__datatype__": "timestamp", "value": "2024-01-01T00:00:00.000Z" },
+        "contractEnd": { "__datatype__": "timestamp", "value": "2025-12-31T23:59:59.000Z" },
+        "paymentStatus": "paid",
+        "amountPaid": 129900,
+        "billingCycle": "annual",
+        "plan": "Growth",
+        "contactEmail": "owner@demo-store.test",
+        "notes": "Default workspace used for staging and QA reviewers."
+      },
+      "sedifex-labs": {
+        "company": "Sedifex Labs",
+        "storeId": "store-labs",
+        "status": "active",
+        "contractStart": { "__datatype__": "timestamp", "value": "2024-03-15T00:00:00.000Z" },
+        "contractEnd": { "__datatype__": "timestamp", "value": "2026-03-14T23:59:59.000Z" },
+        "paymentStatus": "trial",
+        "amountPaid": 0,
+        "billingCycle": "monthly",
+        "plan": "Starter",
+        "contactEmail": "ops@sedifex.com",
+        "notes": "Internal workspace for product experimentation and demos."
+      },
+      "nairobi-collective": {
+        "company": "Nairobi Collective",
+        "storeId": "store-nairobi",
+        "status": "active",
+        "contractStart": { "__datatype__": "timestamp", "value": "2024-06-01T00:00:00.000Z" },
+        "contractEnd": { "__datatype__": "timestamp", "value": "2025-05-31T23:59:59.000Z" },
+        "paymentStatus": "past-due",
+        "amountPaid": 59900,
+        "billingCycle": "monthly",
+        "plan": "Standard",
+        "contactEmail": "finance@nairobi-collective.com",
+        "notes": "Flagged for follow-up by customer success due to outstanding balance."
+      }
+    },
+    "stores": {
+      "store-demo": {
+        "name": "Demo Store",
+        "displayName": "Demo Storefront",
+        "email": "hello@demo-store.test",
+        "phone": "+1-555-0100",
+        "status": "active",
+        "timezone": "America/New_York",
+        "currency": "USD",
+        "billingPlan": "Growth",
+        "paymentProvider": "stripe",
+        "addressLine1": "123 Market Street",
+        "addressLine2": "Suite 500",
+        "city": "New York",
+        "region": "NY",
+        "postalCode": "10001",
+        "country": "US",
+        "createdAt": { "__datatype__": "timestamp", "value": "2023-11-18T15:00:00.000Z" },
+        "updatedAt": { "__datatype__": "timestamp", "value": "2024-07-04T12:30:00.000Z" }
+      },
+      "store-labs": {
+        "name": "Sedifex Labs",
+        "displayName": "Sedifex Labs",
+        "email": "labs@sedifex.com",
+        "phone": "+1-555-0125",
+        "status": "active",
+        "timezone": "America/Chicago",
+        "currency": "USD",
+        "billingPlan": "Starter",
+        "paymentProvider": "stripe",
+        "addressLine1": "88 Innovation Way",
+        "addressLine2": "",
+        "city": "Austin",
+        "region": "TX",
+        "postalCode": "73301",
+        "country": "US",
+        "createdAt": { "__datatype__": "timestamp", "value": "2024-03-15T10:00:00.000Z" },
+        "updatedAt": { "__datatype__": "timestamp", "value": "2024-06-12T18:45:00.000Z" }
+      },
+      "store-nairobi": {
+        "name": "Nairobi Collective",
+        "displayName": "Nairobi Collective",
+        "email": "support@nairobi-collective.com",
+        "phone": "+254-20-555-0100",
+        "status": "delinquent",
+        "timezone": "Africa/Nairobi",
+        "currency": "KES",
+        "billingPlan": "Standard",
+        "paymentProvider": "flutterwave",
+        "addressLine1": "45 Kijiji Lane",
+        "addressLine2": "",
+        "city": "Nairobi",
+        "region": "Nairobi",
+        "postalCode": "00100",
+        "country": "KE",
+        "createdAt": { "__datatype__": "timestamp", "value": "2024-05-01T08:00:00.000Z" },
+        "updatedAt": { "__datatype__": "timestamp", "value": "2024-06-28T09:15:00.000Z" }
+      }
+    },
+    "teamMembers": {
+      "demo-owner": {
+        "uid": "demo-owner",
+        "storeId": "store-demo",
+        "role": "owner",
+        "email": "owner@demo-store.test",
+        "phone": "+1-555-0100",
+        "status": "active",
+        "contractStatus": "active",
+        "firstSignupEmail": "owner@demo-store.test",
+        "createdAt": { "__datatype__": "timestamp", "value": "2023-11-18T15:30:00.000Z" },
+        "updatedAt": { "__datatype__": "timestamp", "value": "2024-07-04T12:30:00.000Z" }
+      },
+      "demo-ops": {
+        "uid": "demo-owner",
+        "storeId": "store-labs",
+        "role": "staff",
+        "email": "ops@sedifex.com",
+        "phone": "+1-555-0126",
+        "status": "active",
+        "contractStatus": "active",
+        "invitedBy": "demo-owner",
+        "createdAt": { "__datatype__": "timestamp", "value": "2024-03-16T14:00:00.000Z" },
+        "updatedAt": { "__datatype__": "timestamp", "value": "2024-06-12T18:45:00.000Z" }
+      },
+      "nairobi-cashier": {
+        "uid": "nairobi-cashier",
+        "storeId": "store-nairobi",
+        "role": "staff",
+        "email": "cashier@nairobi-collective.com",
+        "phone": "+254-20-555-0110",
+        "status": "active",
+        "contractStatus": "past-due",
+        "invitedBy": "demo-owner",
+        "createdAt": { "__datatype__": "timestamp", "value": "2024-05-01T08:30:00.000Z" },
+        "updatedAt": { "__datatype__": "timestamp", "value": "2024-06-28T09:15:00.000Z" }
+      }
+    }
+  }
+}

--- a/web/src/components/__tests__/GoalPlanner.test.tsx
+++ b/web/src/components/__tests__/GoalPlanner.test.tsx
@@ -11,7 +11,30 @@ vi.mock('../../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
 }))
 
-const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+function createActiveStoreState() {
+  return {
+    storeId: 'store-1',
+    isLoading: false,
+    error: null,
+    memberships: [
+      {
+        id: 'membership-1',
+        uid: 'user-1',
+        role: 'owner' as const,
+        storeId: 'store-1',
+        email: null,
+        phone: null,
+        invitedBy: null,
+        firstSignupEmail: null,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ],
+    setActiveStoreId: vi.fn(),
+  }
+}
+
+const mockUseActiveStore = vi.fn(() => createActiveStoreState())
 vi.mock('../../hooks/useActiveStore', () => ({
   useActiveStore: () => mockUseActiveStore(),
 }))
@@ -102,7 +125,7 @@ describe('Goal planner component', () => {
     uuidSpy.mockReturnValue('goal-new-id')
 
     mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'manager@example.com' })
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStore.mockReturnValue(createActiveStoreState())
     mockPublish.mockReset()
 
     docMock.mockClear()

--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -1,25 +1,117 @@
-import { useMemo } from 'react'
-import { useMemberships } from './useMemberships'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAuthUser } from './useAuthUser'
+import { useMemberships, type Membership } from './useMemberships'
+import {
+  clearActiveStoreIdForUser,
+  clearLegacyActiveStoreId,
+  persistActiveStoreIdForUser,
+  readActiveStoreId,
+} from '../utils/activeStoreStorage'
 
 interface ActiveStoreState {
   storeId: string | null
   isLoading: boolean
   error: string | null
+  memberships: Membership[]
+  setActiveStoreId: (storeId: string | null) => void
 }
 
 const STORE_ERROR_MESSAGE = 'We could not load your workspace access. Some features may be limited.'
 
+function uniqueStoreIds(memberships: Membership[]): string[] {
+  const seen = new Set<string>()
+
+  return memberships.reduce<string[]>((acc, membership) => {
+    const { storeId } = membership
+    if (!storeId || seen.has(storeId)) {
+      return acc
+    }
+
+    seen.add(storeId)
+    acc.push(storeId)
+    return acc
+  }, [])
+}
+
 export function useActiveStore(): ActiveStoreState {
-  const { memberships, loading, error } = useMemberships()
-  const activeStoreId = memberships.find(m => m.storeId)?.storeId ?? null
+  const user = useAuthUser()
+  const [persistedStoreId, setPersistedStoreId] = useState<string | null>(() => readActiveStoreId(user?.uid ?? null))
+  const { memberships, loading, error } = useMemberships(persistedStoreId)
+
+  useEffect(() => {
+    clearLegacyActiveStoreId()
+  }, [])
+
+  useEffect(() => {
+    if (!user?.uid) {
+      setPersistedStoreId(null)
+      return
+    }
+
+    setPersistedStoreId(readActiveStoreId(user.uid))
+  }, [user?.uid])
+
+  const availableStoreIds = useMemo(() => uniqueStoreIds(memberships), [memberships])
+
+  const resolvedStoreId = useMemo(() => {
+    if (availableStoreIds.length === 0) {
+      return null
+    }
+
+    if (persistedStoreId && availableStoreIds.includes(persistedStoreId)) {
+      return persistedStoreId
+    }
+
+    return availableStoreIds[0] ?? null
+  }, [availableStoreIds, persistedStoreId])
+
+  useEffect(() => {
+    if (!user?.uid) {
+      return
+    }
+
+    if (resolvedStoreId && persistedStoreId !== resolvedStoreId) {
+      persistActiveStoreIdForUser(user.uid, resolvedStoreId)
+      setPersistedStoreId(resolvedStoreId)
+    }
+
+    if (!resolvedStoreId && persistedStoreId) {
+      clearActiveStoreIdForUser(user.uid)
+      setPersistedStoreId(null)
+    }
+  }, [resolvedStoreId, persistedStoreId, user?.uid])
+
+  const handleSetActiveStoreId = useCallback(
+    (nextStoreId: string | null) => {
+      const validNextStoreId = nextStoreId && availableStoreIds.includes(nextStoreId) ? nextStoreId : null
+
+      if (!user?.uid) {
+        setPersistedStoreId(validNextStoreId)
+        return
+      }
+
+      if (validNextStoreId) {
+        setPersistedStoreId(validNextStoreId)
+        persistActiveStoreIdForUser(user.uid, validNextStoreId)
+        return
+      }
+
+      setPersistedStoreId(null)
+      clearActiveStoreIdForUser(user.uid)
+    },
+    [availableStoreIds, user?.uid],
+  )
+
   const hasError = error != null
 
   return useMemo(
     () => ({
-      storeId: activeStoreId,
+      storeId: resolvedStoreId,
       isLoading: loading,
       error: hasError ? STORE_ERROR_MESSAGE : null,
+      memberships,
+      setActiveStoreId: handleSetActiveStoreId,
     }),
-    [activeStoreId, hasError, loading],
+    [resolvedStoreId, loading, hasError, memberships, handleSetActiveStoreId],
   )
 }

--- a/web/src/hooks/useMemberships.ts
+++ b/web/src/hooks/useMemberships.ts
@@ -51,7 +51,7 @@ function mapMembershipSnapshot(snapshot: QueryDocumentSnapshot<DocumentData>): M
   }
 }
 
-export function useMemberships() {
+export function useMemberships(_activeStoreId?: string | null) {
   const user = useAuthUser()
   const [loading, setLoading] = useState(true)
   const [memberships, setMemberships] = useState<Membership[]>([])

--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -91,6 +91,40 @@
   justify-content: flex-end;
 }
 
+.shell__store-switcher {
+  display: grid;
+  gap: 6px;
+  min-width: 200px;
+}
+
+.shell__store-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.shell__store-select {
+  min-height: 40px;
+}
+
+.shell__store-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: #eef2ff;
+  color: #4338ca;
+  font-weight: 600;
+}
+
+.shell__store-hint {
+  font-size: 12px;
+  color: #b91c1c;
+}
+
 .shell__account {
   display: flex;
   align-items: center;

--- a/web/src/layout/Shell.test.tsx
+++ b/web/src/layout/Shell.test.tsx
@@ -6,6 +6,7 @@ import Shell from './Shell'
 
 const mockUseAuthUser = vi.fn()
 const mockUseConnectivityStatus = vi.fn()
+const mockUseActiveStore = vi.fn()
 
 vi.mock('../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
@@ -13,6 +14,10 @@ vi.mock('../hooks/useAuthUser', () => ({
 
 vi.mock('../hooks/useConnectivityStatus', () => ({
   useConnectivityStatus: () => mockUseConnectivityStatus(),
+}))
+
+vi.mock('../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
 }))
 
 vi.mock('../firebase', () => ({
@@ -37,6 +42,7 @@ describe('Shell', () => {
   beforeEach(() => {
     mockUseAuthUser.mockReset()
     mockUseConnectivityStatus.mockReset()
+    mockUseActiveStore.mockReset()
 
     mockUseAuthUser.mockReturnValue({ email: 'owner@example.com' })
     mockUseConnectivityStatus.mockReturnValue({
@@ -47,12 +53,34 @@ describe('Shell', () => {
       heartbeatError: null,
       queue: { status: 'idle', pending: 0, lastError: null, updatedAt: null },
     })
+    mockUseActiveStore.mockReturnValue({
+      storeId: 'store-1',
+      isLoading: false,
+      error: null,
+      memberships: [
+        {
+          id: 'membership-1',
+          uid: 'user-1',
+          role: 'owner',
+          storeId: 'store-1',
+          email: 'owner@example.com',
+          phone: null,
+          invitedBy: null,
+          firstSignupEmail: null,
+          createdAt: null,
+          updatedAt: null,
+        },
+      ],
+      setActiveStoreId: vi.fn(),
+    })
   })
 
-  it('renders the workspace status', () => {
+  it('renders the workspace selector', () => {
     renderShell()
 
-    expect(screen.getByText('Workspace ready')).toBeInTheDocument()
+    const select = screen.getByLabelText('Workspace')
+    expect(select).toBeInTheDocument()
+    expect(select).toHaveValue('store-1')
 
   })
 })

--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -12,7 +12,30 @@ vi.mock('../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
 }))
 
-const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+function createActiveStoreState() {
+  return {
+    storeId: 'store-1',
+    isLoading: false,
+    error: null,
+    memberships: [
+      {
+        id: 'membership-1',
+        uid: 'cashier-123',
+        role: 'owner' as const,
+        storeId: 'store-1',
+        email: 'cashier@example.com',
+        phone: null,
+        invitedBy: null,
+        firstSignupEmail: null,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ],
+    setActiveStoreId: vi.fn(),
+  }
+}
+
+const mockUseActiveStore = vi.fn(() => createActiveStoreState())
 vi.mock('../hooks/useActiveStore', () => ({
   useActiveStore: () => mockUseActiveStore(),
 }))
@@ -151,7 +174,7 @@ describe('Sell page', () => {
       uid: 'cashier-123',
       email: 'cashier@example.com',
     })
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStore.mockReturnValue(createActiveStoreState())
 
 
     mockCommitSale.mockResolvedValue({

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -80,7 +80,26 @@ describe('AccountOverview', () => {
     queryMock.mockClear()
     whereMock.mockClear()
 
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
+    mockUseActiveStore.mockReturnValue({
+      storeId: 'store-123',
+      isLoading: false,
+      error: null,
+      memberships: [
+        {
+          id: 'membership-1',
+          uid: 'owner-1',
+          role: 'owner' as const,
+          storeId: 'store-123',
+          email: 'owner@example.com',
+          phone: null,
+          invitedBy: null,
+          firstSignupEmail: null,
+          createdAt: null,
+          updatedAt: null,
+        },
+      ],
+      setActiveStoreId: vi.fn(),
+    })
     getDocMock.mockResolvedValue({
       exists: () => true,
       data: () => ({

--- a/web/src/pages/__tests__/Products.test.tsx
+++ b/web/src/pages/__tests__/Products.test.tsx
@@ -20,7 +20,30 @@ vi.mock('../../firebase', () => ({
   db: {},
 }))
 
-const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+function createActiveStoreState() {
+  return {
+    storeId: 'store-1',
+    isLoading: false,
+    error: null,
+    memberships: [
+      {
+        id: 'membership-1',
+        uid: 'user-1',
+        role: 'owner' as const,
+        storeId: 'store-1',
+        email: 'owner@example.com',
+        phone: null,
+        invitedBy: null,
+        firstSignupEmail: null,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ],
+    setActiveStoreId: vi.fn(),
+  }
+}
+
+const mockUseActiveStore = vi.fn(() => createActiveStoreState())
 vi.mock('../../hooks/useActiveStore', () => ({
   useActiveStore: () => mockUseActiveStore(),
 }))
@@ -87,7 +110,7 @@ describe('Products page', () => {
     docMock.mockClear()
     whereMock.mockClear()
     mockUseActiveStore.mockReset()
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStore.mockReturnValue(createActiveStoreState())
 
 
 

--- a/web/src/pages/__tests__/Sell.test.tsx
+++ b/web/src/pages/__tests__/Sell.test.tsx
@@ -40,7 +40,30 @@ vi.mock('../../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
 }))
 
-const mockUseActiveStore = vi.fn(() => ({ storeId: 'store-1', isLoading: false, error: null }))
+function createActiveStoreState() {
+  return {
+    storeId: 'store-1',
+    isLoading: false,
+    error: null,
+    memberships: [
+      {
+        id: 'membership-1',
+        uid: 'user-1',
+        role: 'owner' as const,
+        storeId: 'store-1',
+        email: 'cashier@example.com',
+        phone: null,
+        invitedBy: null,
+        firstSignupEmail: null,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ],
+    setActiveStoreId: vi.fn(),
+  }
+}
+
+const mockUseActiveStore = vi.fn(() => createActiveStoreState())
 vi.mock('../../hooks/useActiveStore', () => ({
   useActiveStore: () => mockUseActiveStore(),
 }))
@@ -118,7 +141,7 @@ describe('Sell page barcode scanner', () => {
     mockUseAuthUser.mockReset()
     mockUseAuthUser.mockReturnValue({ uid: 'user-1', email: 'cashier@example.com' })
     mockUseActiveStore.mockReset()
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-1', isLoading: false, error: null })
+    mockUseActiveStore.mockReturnValue(createActiveStoreState())
 
     mockLoadCachedProducts.mockResolvedValue([])
     mockLoadCachedCustomers.mockResolvedValue([])


### PR DESCRIPTION
## Summary
- add stores and team member collections to the Firestore seed and document how to connect the UI
- enhance the active store hook and header shell to support selecting a workspace
- update affected unit tests to the new active store shape

## Testing
- npm run test -- src/hooks/useActiveStore.test.tsx
- npm run test -- src/layout/Shell.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e2dceaa2c08321a9aa4a95c5f5b9c3