### PR TITLE
Expand signup input styling

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -594,8 +594,11 @@ label {
   font-size: 14px;
 }
 
-input[type="email"],
-input[type="password"] {
+.form input[type="email"],
+.form input[type="password"],
+.form input[type="text"],
+.form input[type="tel"] {
+  width: 100%;
   padding: 15px 18px;
   border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.45);
@@ -606,19 +609,21 @@ input[type="password"] {
   backdrop-filter: blur(8px);
 }
 
-input::placeholder {
+.form input::placeholder {
   color: rgba(148, 163, 184, 0.6);
 }
 
-input[type="email"]:focus-visible,
-input[type="password"]:focus-visible {
+.form input[type="email"]:focus-visible,
+.form input[type="password"]:focus-visible,
+.form input[type="text"]:focus-visible,
+.form input[type="tel"]:focus-visible {
   outline: none;
   border-color: var(--color-border-strong);
   box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.25);
   transform: translateY(-1px);
 }
 
-input[disabled] {
+.form input[disabled] {
   background-color: rgba(15, 23, 42, 0.35);
   color: rgba(148, 163, 184, 0.6);
 }


### PR DESCRIPTION
## Summary
- extend the shared form field styling to cover text and telephone inputs used during signup
- ensure the additional signup inputs fill the available width and reuse the same placeholder, focus, and disabled states as other fields

## Testing
- npm run build *(fails: existing TypeScript errors in test files such as src/App.signup.test.tsx)*
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: Vite compilation error from duplicate Sparkline declaration in src/pages/Dashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e657e8f08321acfe1d582db5669c