### PR TITLE
Ensure signup persists team members in both Firestore databases

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -295,22 +295,23 @@ describe('App signup cleanup', () => {
 
     const setDocCalls = firestore.setDocMock.mock.calls
 
-    const ownerCall = setDocCalls.find(([ref]) => ref === ownerDocRef)
-    expect(ownerCall).toBeDefined()
-    const [, ownerPayload, ownerOptions] = ownerCall!
-    expect(ownerPayload).toEqual(
-      expect.objectContaining({
-        storeId: 'workspace-store-id',
-        name: 'Morgan Owner',
-        companyName: 'Morgan Retail Co',
-        phone: '5551234567',
-        email: 'owner@example.com',
-        role: 'staff',
-        createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
-        updatedAt: expect.objectContaining({ __type: 'serverTimestamp' }),
-      }),
-    )
-    expect(ownerOptions).toEqual({ merge: true })
+    const ownerCalls = setDocCalls.filter(([ref]) => ref === ownerDocRef)
+    expect(ownerCalls).toHaveLength(2)
+    ownerCalls.forEach(([, ownerPayload, ownerOptions]) => {
+      expect(ownerPayload).toEqual(
+        expect.objectContaining({
+          storeId: 'workspace-store-id',
+          name: 'Morgan Owner',
+          companyName: 'Morgan Retail Co',
+          phone: '5551234567',
+          email: 'owner@example.com',
+          role: 'staff',
+          createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
+          updatedAt: expect.objectContaining({ __type: 'serverTimestamp' }),
+        }),
+      )
+      expect(ownerOptions).toEqual({ merge: true })
+    })
 
     const ownerStoreCall = setDocCalls.find(([ref]) => ref === ownerStoreDocRef)
     expect(ownerStoreCall).toBeDefined()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -82,23 +82,24 @@ async function persistTeamMemberMetadata(
   try {
     const ownerName = resolveOwnerName(user, metadata?.ownerName ?? null)
     const businessName = metadata?.businessName?.trim()
-    await setDoc(
-      doc(rosterDb, 'teamMembers', user.uid),
-      {
-        uid: user.uid,
-        role: resolution.role,
-        storeId: resolution.storeId,
-        name: ownerName,
-        phone,
-        email,
-        firstSignupEmail: email,
-        invitedBy: user.uid,
-        companyName: businessName ?? null,
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp(),
-      },
-      { merge: true },
-    )
+    const basePayload = {
+      uid: user.uid,
+      role: resolution.role,
+      storeId: resolution.storeId,
+      name: ownerName,
+      phone,
+      email,
+      firstSignupEmail: email,
+      invitedBy: user.uid,
+      companyName: businessName ?? null,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    }
+
+    await Promise.all([
+      setDoc(doc(rosterDb, 'teamMembers', user.uid), basePayload, { merge: true }),
+      setDoc(doc(db, 'teamMembers', user.uid), basePayload, { merge: true }),
+    ])
   } catch (error) {
     console.warn('[signup] Failed to persist team member metadata', error)
   }


### PR DESCRIPTION
## Summary
- persist new team members to both the roster and default Firestore databases during signup
- update the signup flow test to assert that both team member documents are written

## Testing
- npm test *(fails: existing suite requires Firebase env vars and additional mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68e367e67934832194353449216a58a4