### PR TITLE
Add location and role fields to signup flow

### DIFF
--- a/functions/test/initializeStore.test.js
+++ b/functions/test/initializeStore.test.js
@@ -73,6 +73,9 @@ async function runInitializeStoreCreatesWorkspaceTest() {
         firstSignupEmail: 'Fresh.Owner@Example.com',
         ownerName: ' Fresh Owner ',
         businessName: ' Fresh Retail ',
+        country: '  United States ',
+        town: '  Portland ',
+        signupRole: 'team-member',
       },
     },
     context,
@@ -89,6 +92,8 @@ async function runInitializeStoreCreatesWorkspaceTest() {
   assert.strictEqual(storeDoc.ownerName, 'Fresh Owner')
   assert.strictEqual(storeDoc.displayName, 'Fresh Retail')
   assert.strictEqual(storeDoc.businessName, 'Fresh Retail')
+  assert.strictEqual(storeDoc.country, 'United States')
+  assert.strictEqual(storeDoc.town, 'Portland')
   assert.ok(storeDoc.updatedAt, 'Expected updatedAt to be set')
   assert.ok(storeDoc.createdAt, 'Expected createdAt to be set on new store')
 
@@ -98,6 +103,9 @@ async function runInitializeStoreCreatesWorkspaceTest() {
   assert.strictEqual(rosterMemberDoc.companyName, 'Fresh Retail')
   assert.strictEqual(rosterMemberDoc.phone, '+1 (555) 000-0000')
   assert.strictEqual(rosterMemberDoc.firstSignupEmail, 'fresh.owner@example.com')
+  assert.strictEqual(rosterMemberDoc.country, 'United States')
+  assert.strictEqual(rosterMemberDoc.town, 'Portland')
+  assert.strictEqual(rosterMemberDoc.signupRole, 'team-member')
 
   const resolveResult = await resolveStoreAccess.run({}, context)
   assert.strictEqual(resolveResult.ok, true, 'Expected resolveStoreAccess to succeed')

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -545,6 +545,49 @@ body {
   gap: 10px;
 }
 
+.form__field--choices {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.form__field--choices legend {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.form__choice-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.form__choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.72);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: border 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.form__choice[data-selected='true'] {
+  border-color: rgba(94, 234, 212, 0.7);
+  background: rgba(45, 212, 191, 0.12);
+  box-shadow: 0 0 0 1px rgba(94, 234, 212, 0.18);
+  color: var(--color-text-primary);
+}
+
+.form__choice input[type='radio'] {
+  accent-color: var(--color-positive);
+}
+
 .form__hint {
   color: var(--color-text-muted);
   font-size: 14px;

--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -172,6 +172,8 @@ describe('App signup cleanup', () => {
       await user.type(screen.getByLabelText(/Full name/i), 'Morgan Owner')
       await user.type(screen.getByLabelText(/Business name/i), 'Morgan Retail Co')
       await user.type(screen.getByLabelText(/Phone/i), '5551234567')
+      await user.type(screen.getByLabelText(/Country/i), 'Canada')
+      await user.type(screen.getByLabelText(/Town or city/i), 'Toronto')
       await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
       await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
 
@@ -240,6 +242,9 @@ describe('App signup cleanup', () => {
       await user.type(screen.getByLabelText(/Full name/i), 'Morgan Owner')
       await user.type(screen.getByLabelText(/Business name/i), 'Morgan Retail Co')
       await user.type(screen.getByLabelText(/Phone/i), ' (555) 123-4567 ')
+      await user.type(screen.getByLabelText(/Country/i), 'United States')
+      await user.type(screen.getByLabelText(/Town or city/i), 'Seattle')
+      await user.click(screen.getByLabelText(/team member/i))
       await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
       await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
 
@@ -263,6 +268,9 @@ describe('App signup cleanup', () => {
         firstSignupEmail: 'owner@example.com',
         ownerName: 'Morgan Owner',
         businessName: 'Morgan Retail Co',
+        country: 'United States',
+        town: 'Seattle',
+        signupRole: 'team-member',
       }),
     )
     await waitFor(() =>
@@ -306,6 +314,9 @@ describe('App signup cleanup', () => {
           phone: '5551234567',
           email: 'owner@example.com',
           role: 'staff',
+          country: 'United States',
+          town: 'Seattle',
+          signupRole: 'team-member',
           createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
           updatedAt: expect.objectContaining({ __type: 'serverTimestamp' }),
         }),
@@ -343,6 +354,8 @@ describe('App signup cleanup', () => {
         phone: '5551234567',
         businessName: 'Morgan Retail Co',
         ownerName: 'Morgan Owner',
+        country: 'United States',
+        town: 'Seattle',
         status: 'active',
         role: 'client',
         createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
@@ -409,6 +422,8 @@ describe('App signup cleanup', () => {
       await user.type(screen.getByLabelText(/Full name/i), 'Morgan Owner')
       await user.type(screen.getByLabelText(/Business name/i), 'Morgan Retail Co')
       await user.type(screen.getByLabelText(/Phone/i), '5551234567')
+      await user.type(screen.getByLabelText(/Country/i), 'Kenya')
+      await user.type(screen.getByLabelText(/Town or city/i), 'Nairobi')
       await user.type(screen.getByLabelText(/^Password$/i), 'Password1!')
       await user.type(screen.getByLabelText(/Confirm password/i), 'Password1!')
 
@@ -421,6 +436,9 @@ describe('App signup cleanup', () => {
         firstSignupEmail: 'owner@example.com',
         ownerName: 'Morgan Owner',
         businessName: 'Morgan Retail Co',
+        country: 'Kenya',
+        town: 'Nairobi',
+        signupRole: 'owner',
       }),
     )
     await waitFor(() => expect(mocks.resolveStoreAccess).toHaveBeenCalledWith('store-001'))

--- a/web/src/controllers/accessController.ts
+++ b/web/src/controllers/accessController.ts
@@ -8,11 +8,26 @@ type RawSeededDocument = {
   data?: unknown
 }
 
+export type SignupRoleOption = 'owner' | 'team-member'
+
 export type InitializeStoreContactPayload = {
   phone?: string | null
   firstSignupEmail?: string | null
   ownerName?: string | null
   businessName?: string | null
+  country?: string | null
+  town?: string | null
+  signupRole?: SignupRoleOption | null
+}
+
+function normalizeSignupRoleInput(value: SignupRoleOption | null | undefined): SignupRoleOption | null {
+  if (value === 'team-member') {
+    return 'team-member'
+  }
+  if (value === 'owner') {
+    return 'owner'
+  }
+  return null
 }
 
 type InitializeStorePayload = {
@@ -162,6 +177,18 @@ export async function initializeStore(contact?: InitializeStoreContactPayload) {
     }
     if (contact.businessName !== undefined) {
       payloadContact.businessName = contact.businessName ?? null
+      hasContactField = true
+    }
+    if (contact.country !== undefined) {
+      payloadContact.country = contact.country ?? null
+      hasContactField = true
+    }
+    if (contact.town !== undefined) {
+      payloadContact.town = contact.town ?? null
+      hasContactField = true
+    }
+    if (contact.signupRole !== undefined) {
+      payloadContact.signupRole = normalizeSignupRoleInput(contact.signupRole)
       hasContactField = true
     }
 


### PR DESCRIPTION
## Summary
- collect country, town, and signup role during onboarding and surface new inputs in the auth form
- propagate the extra contact data through the client, callable controller, and Cloud Function implementation
- persist the new metadata on team members, stores, and customers and extend unit tests to cover the new behaviour

## Testing
- npm test -- App.signup.test.tsx
- npm test -- initializeStore.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e374a1b8948321a9057d8165261a1b