### PR TITLE
Read account roster from workspace database

### DIFF
--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -11,7 +11,7 @@ import {
   type DocumentSnapshot,
   type QueryDocumentSnapshot,
 } from 'firebase/firestore'
-import { db, rosterDb } from '../firebase'
+import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useMemberships, type Membership } from '../hooks/useMemberships'
 import { manageStaffAccount } from '../controllers/storeController'
@@ -217,7 +217,7 @@ export default function AccountOverview() {
     setRosterLoading(true)
     setRosterError(null)
 
-    const membersRef = collection(rosterDb, 'teamMembers')
+    const membersRef = collection(db, 'teamMembers')
     const rosterQuery = query(membersRef, where('storeId', '==', storeId))
     getDocs(rosterQuery)
       .then(snapshot => {

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -47,7 +47,6 @@ vi.mock('firebase/firestore', () => ({
 
 vi.mock('../../firebase', () => ({
   db: {},
-  rosterDb: {},
 }))
 
 const originalConsoleError = console.error


### PR DESCRIPTION
## Summary
- update the AccountOverview page to query team members from the workspace Firestore database
- adjust the AccountOverview unit tests to match the new data source

## Testing
- npm test -- AccountOverview

------
https://chatgpt.com/codex/tasks/task_e_68e373cbae0c8321975c725afa7809a3