### PR TITLE
Improve signup status feedback

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -325,6 +325,16 @@ export default function App() {
   }, [])
 
   useEffect(() => {
+    if (!isAuthReady || user) {
+      return
+    }
+
+    if (status.tone === 'loading') {
+      setStatus({ tone: 'idle', message: '' })
+    }
+  }, [isAuthReady, status.tone, user])
+
+  useEffect(() => {
     if (!user) return
     refreshSessionHeartbeat(user).catch(error => {
       console.warn('[session] Unable to refresh session', error)
@@ -527,11 +537,15 @@ export default function App() {
           console.warn('[auth] Unable to refresh ID token after signup', error)
         }
         setOnboardingStatus(nextUser.uid, 'pending')
+
       }
 
       setStatus({
         tone: 'success',
-        message: mode === 'login' ? 'Welcome back! Redirecting…' : 'All set! Your account is ready.',
+        message:
+          mode === 'login'
+            ? 'Welcome back! Redirecting…'
+            : 'All set! Redirecting you to your workspace…',
       })
       setPassword('')
       setConfirmPassword('')


### PR DESCRIPTION
## Summary
- reset the authentication status message when the user signs out mid-request to avoid lingering loading copy
- clarify the post-signup success message so users see that they are being redirected to their workspace

## Testing
- `npm run test` *(fails: suite expects additional environment configuration in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a13c912c832198a4f364037b6e2f