### PR TITLE
Fix Firestore database selection for primary data

### DIFF
--- a/web/src/firebase.ts
+++ b/web/src/firebase.ts
@@ -34,10 +34,11 @@ export const auth = getAuth(app)
 
 const firestoreSettings = { ignoreUndefinedProperties: true }
 
-// ---- Key change: use the named database "roster" as the primary app DB ----
+// Primary app data lives in the default Firestore database.
+export const db = initializeFirestore(app, firestoreSettings)
+
+// The roster database stores team-member metadata used by access checks.
 export const rosterDb = initializeFirestore(app, firestoreSettings, 'roster')
-export const db = rosterDb
-// ---------------------------------------------------------------------------
 
 enableIndexedDbPersistence(db).catch(() => {
   /* multi-tab fallback handled */


### PR DESCRIPTION
## Summary
- initialize the default Firestore database for primary app data while keeping the roster database for team member metadata

## Testing
- npx vitest run src/pages/AuthScreen.test.tsx *(fails: sessionController mock lacks ensureStoreDocument export in test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e3db6707d883219b75968aed07e0bd