### PR TITLE
Stop auto signing in after signup

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -383,8 +383,14 @@ describe('App signup cleanup', () => {
     const seededCustomerCall = setDocCalls.find(([ref]) => ref === seededCustomerDocRef)
     expect(seededCustomerCall?.[1]).toEqual(expect.objectContaining({ name: 'Seeded Customer' }))
 
+    await waitFor(() => expect(mocks.auth.signOut).toHaveBeenCalled())
+    expect(mocks.auth.currentUser).toBeNull()
+
     expect(mocks.publish).toHaveBeenCalledWith(
-      expect.objectContaining({ tone: 'success', message: expect.stringMatching(/All set/i) }),
+      expect.objectContaining({
+        tone: 'success',
+        message: 'Account created! You can now sign in.',
+      }),
     )
   })
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -537,7 +537,12 @@ export default function App() {
           console.warn('[auth] Unable to refresh ID token after signup', error)
         }
         setOnboardingStatus(nextUser.uid, 'pending')
-
+        try {
+          await auth.signOut()
+        } catch (error) {
+          console.warn('[signup] Unable to sign out after successful signup', error)
+        }
+        setMode('login')
       }
 
       setStatus({
@@ -545,7 +550,7 @@ export default function App() {
         message:
           mode === 'login'
             ? 'Welcome back! Redirecting…'
-            : 'All set! Redirecting you to your workspace…',
+            : 'Account created! You can now sign in.',
       })
       setPassword('')
       setConfirmPassword('')


### PR DESCRIPTION
## Summary
- sign out newly created accounts after running the workspace bootstrap so they can log in manually
- change the signup success toast to instruct users to sign in and return the form to login mode
- update the signup flow test to cover the new logout behavior

## Testing
- npx vitest run src/App.signup.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68e3f2bb9c6c832190a764c422fddd92