### PR TITLE
Save roster email doc during signup

### DIFF
--- a/web/src/App.signup.test.tsx
+++ b/web/src/App.signup.test.tsx
@@ -286,6 +286,7 @@ describe('App signup cleanup', () => {
     const seededCustomerDocKey = 'customers/seeded-customer'
 
     const ownerDocRef = firestore.docRefByPath.get(ownerDocKey)
+    const ownerEmailDocKey = `teamMembers/${createdUser.email!.toLowerCase()}`
     const ownerStoreDocRef = firestore.docRefByPath.get(ownerStoreDocKey)
     const customerDocRef = firestore.docRefByPath.get(customerDocKey)
     const seededTeamMemberDocRef = firestore.docRefByPath.get(seededTeamMemberDocKey)
@@ -293,7 +294,10 @@ describe('App signup cleanup', () => {
     const seededProductDocRef = firestore.docRefByPath.get(seededProductDocKey)
     const seededCustomerDocRef = firestore.docRefByPath.get(seededCustomerDocKey)
 
+    const ownerEmailDocRef = firestore.docRefByPath.get(ownerEmailDocKey)
+
     expect(ownerDocRef).toBeDefined()
+    expect(ownerEmailDocRef).toBeDefined()
     expect(ownerStoreDocRef).toBeDefined()
     expect(customerDocRef).toBeDefined()
     expect(seededTeamMemberDocRef).toBeDefined()
@@ -322,6 +326,27 @@ describe('App signup cleanup', () => {
         }),
       )
       expect(ownerOptions).toEqual({ merge: true })
+    })
+
+    const ownerEmailCalls = setDocCalls.filter(([ref]) => ref === ownerEmailDocRef)
+    expect(ownerEmailCalls).toHaveLength(1)
+    ownerEmailCalls.forEach(([, ownerEmailPayload, ownerEmailOptions]) => {
+      expect(ownerEmailPayload).toEqual(
+        expect.objectContaining({
+          storeId: 'workspace-store-id',
+          name: 'Morgan Owner',
+          companyName: 'Morgan Retail Co',
+          phone: '5551234567',
+          email: 'owner@example.com',
+          role: 'staff',
+          country: 'United States',
+          town: 'Seattle',
+          signupRole: 'team-member',
+          createdAt: expect.objectContaining({ __type: 'serverTimestamp' }),
+          updatedAt: expect.objectContaining({ __type: 'serverTimestamp' }),
+        }),
+      )
+      expect(ownerEmailOptions).toEqual({ merge: true })
     })
 
     const ownerStoreCall = setDocCalls.find(([ref]) => ref === ownerStoreDocRef)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -110,10 +110,19 @@ async function persistTeamMemberMetadata(
       updatedAt: serverTimestamp(),
     }
 
-    await Promise.all([
+    const writes: Array<Promise<unknown>> = [
       setDoc(doc(rosterDb, 'teamMembers', user.uid), basePayload, { merge: true }),
       setDoc(doc(db, 'teamMembers', user.uid), basePayload, { merge: true }),
-    ])
+    ]
+
+    const normalizedEmail = email.trim().toLowerCase()
+    if (normalizedEmail) {
+      writes.push(
+        setDoc(doc(rosterDb, 'teamMembers', normalizedEmail), basePayload, { merge: true }),
+      )
+    }
+
+    await Promise.all(writes)
   } catch (error) {
     console.warn('[signup] Failed to persist team member metadata', error)
   }


### PR DESCRIPTION
## Summary
- persist signup metadata to a roster document keyed by the member email in addition to UID
- extend the signup flow test to assert the roster email document is written

## Testing
- npm test *(fails: suite depends on Firebase environment variables and missing mock modules in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68e43884c8d88321b3f2d039ef6a1060