### PR TITLE
feat: show workspace details during onboarding

### DIFF
--- a/web/src/pages/AuthScreen.test.tsx
+++ b/web/src/pages/AuthScreen.test.tsx
@@ -11,6 +11,8 @@ const mockAuth = vi.hoisted(() => ({} as unknown as Record<string, unknown>))
 const mockCreateUserWithEmailAndPassword = vi.fn()
 const mockSignInWithEmailAndPassword = vi.fn()
 const mockPersistSession = vi.fn(async (..._args: unknown[]) => {})
+const mockEnsureStoreDocument = vi.fn(async (..._args: unknown[]) => {})
+const mockEnsureTeamMemberDocument = vi.fn(async (..._args: unknown[]) => {})
 const mockSetOnboardingStatus = vi.fn()
 const mockPublish = vi.fn<(options: MockToastOptions) => void>()
 const mockNavigate = vi.fn()
@@ -29,6 +31,8 @@ vi.mock('../firebase', () => ({
 
 vi.mock('../controllers/sessionController', () => ({
   persistSession: (...args: unknown[]) => mockPersistSession(...args),
+  ensureStoreDocument: (...args: unknown[]) => mockEnsureStoreDocument(...args),
+  ensureTeamMemberDocument: (...args: unknown[]) => mockEnsureTeamMemberDocument(...args),
 }))
 
 vi.mock('../utils/onboarding', () => ({
@@ -57,6 +61,8 @@ describe('AuthScreen', () => {
     mockCreateUserWithEmailAndPassword.mockReset()
     mockSignInWithEmailAndPassword.mockReset()
     mockPersistSession.mockClear()
+    mockEnsureStoreDocument.mockClear()
+    mockEnsureTeamMemberDocument.mockClear()
     mockSetOnboardingStatus.mockReset()
     mockPublish.mockReset()
     mockNavigate.mockReset()
@@ -91,9 +97,11 @@ describe('AuthScreen', () => {
       )
     })
 
+    expect(mockEnsureStoreDocument).toHaveBeenCalledWith(mockUser)
     expect(mockPersistSession).toHaveBeenCalledWith(mockUser)
     expect(mockPublish).toHaveBeenCalledWith({ message: 'Welcome back!', tone: 'success' })
     expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+    expect(mockEnsureTeamMemberDocument).not.toHaveBeenCalled()
   })
 
   it('creates an account and triggers onboarding helpers', async () => {
@@ -125,7 +133,15 @@ describe('AuthScreen', () => {
       )
     })
 
-    expect(mockPersistSession).toHaveBeenCalledWith(mockUser)
+    expect(mockEnsureStoreDocument).toHaveBeenCalledWith(mockUser)
+    expect(mockEnsureTeamMemberDocument).toHaveBeenCalledWith(mockUser, {
+      storeId: 'new-user',
+      role: 'owner',
+    })
+    expect(mockPersistSession).toHaveBeenCalledWith(mockUser, {
+      storeId: 'new-user',
+      role: 'owner',
+    })
     expect(mockSetOnboardingStatus).toHaveBeenCalledWith('new-user', 'pending')
     expect(mockAfterSignupBootstrap).toHaveBeenCalled()
 

--- a/web/src/pages/AuthScreen.tsx
+++ b/web/src/pages/AuthScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from '../components/auth/AuthForm'
 import { useToast } from '../components/ToastProvider'
 import { afterSignupBootstrap } from '../controllers/accessController'
-import { ensureStoreDocument, persistSession } from '../controllers/sessionController'
+import { ensureStoreDocument, ensureTeamMemberDocument, persistSession } from '../controllers/sessionController'
 import { auth } from '../firebase'
 import { setOnboardingStatus } from '../utils/onboarding'
 import './AuthScreen.css'
@@ -119,7 +119,8 @@ export default function AuthScreen() {
 
         const { user } = await createUserWithEmailAndPassword(auth, trimmedEmail, password)
         await ensureStoreDocument(user)
-        await persistSession(user)
+        await ensureTeamMemberDocument(user, { storeId: user.uid, role: 'owner' })
+        await persistSession(user, { storeId: user.uid, role: 'owner' })
         setOnboardingStatus(user.uid, 'pending')
 
         try {

--- a/web/src/pages/Onboarding.css
+++ b/web/src/pages/Onboarding.css
@@ -67,6 +67,89 @@
   align-self: flex-start;
 }
 
+.onboarding-card__details {
+  display: grid;
+  gap: 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: #f8fafc;
+}
+
+.onboarding-card__details-header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.onboarding-card__details-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  color: #0f172a;
+}
+
+.onboarding-card__details-subtitle {
+  margin: 0;
+  color: #475569;
+  font-size: 0.875rem;
+}
+
+.onboarding-card__details-status {
+  margin: 0;
+  color: #475569;
+  font-size: 0.875rem;
+}
+
+.onboarding-card__details-status--error {
+  color: #b91c1c;
+}
+
+.onboarding-card__details-columns {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.onboarding-card__details-section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.onboarding-card__details-section-title {
+  margin: 0;
+  color: #475569;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.onboarding-card__details-grid {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.onboarding-card__details-row {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.onboarding-card__details-term {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.onboarding-card__details-value {
+  margin: 0;
+  color: #0f172a;
+  font-weight: 600;
+  word-break: break-word;
+}
+
 @media (min-width: 768px) {
   .onboarding-page {
     gap: 2rem;
@@ -74,5 +157,9 @@
 
   .onboarding-card__title {
     font-size: 1.5rem;
+  }
+
+  .onboarding-card__details-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/web/src/pages/Onboarding.tsx
+++ b/web/src/pages/Onboarding.tsx
@@ -1,16 +1,161 @@
 import React, { useEffect, useState } from 'react'
+import { doc, getDoc, Timestamp } from 'firebase/firestore'
 import { useNavigate } from 'react-router-dom'
 import { useAuthUser } from '../hooks/useAuthUser'
+import { db, rosterDb } from '../firebase'
 import { getOnboardingStatus, setOnboardingStatus, type OnboardingStatus } from '../utils/onboarding'
 import './Onboarding.css'
+
+type TeamMemberDocument = {
+  uid?: string | null
+  storeId?: string | null
+  role?: string | null
+  email?: string | null
+  phone?: string | null
+  createdAt?: Timestamp | null
+  updatedAt?: Timestamp | null
+}
+
+type TeamMemberDetails = TeamMemberDocument & { id: string }
+
+type StoreDocument = {
+  ownerId?: string | null
+  status?: string | null
+  contractStatus?: string | null
+  createdAt?: Timestamp | null
+  updatedAt?: Timestamp | null
+}
+
+type StoreDetails = StoreDocument & { id: string }
+
+function formatTimestamp(value: unknown): string | null {
+  if (!value) {
+    return null
+  }
+
+  if (value instanceof Timestamp) {
+    return value.toDate().toLocaleString()
+  }
+
+  if (value instanceof Date) {
+    return value.toLocaleString()
+  }
+
+  if (typeof value === 'object' && value !== null && 'toDate' in value) {
+    try {
+      const date = (value as { toDate: () => Date }).toDate()
+      return date.toLocaleString()
+    } catch (error) {
+      console.warn('[onboarding] Unable to format timestamp value', error)
+    }
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  return null
+}
+
+function formatLabel(value: string | null | undefined): string {
+  if (!value) {
+    return '—'
+  }
+  const normalized = value.trim()
+  if (!normalized) {
+    return '—'
+  }
+  return normalized.replace(/\b\w/g, letter => letter.toUpperCase())
+}
+
+function formatRole(value: string | null | undefined): string {
+  const label = formatLabel(value ?? 'Owner')
+  return label
+}
 
 export default function Onboarding() {
   const user = useAuthUser()
   const navigate = useNavigate()
   const [status, setStatus] = useState<OnboardingStatus | null>(() => getOnboardingStatus(user?.uid ?? null))
+  const [teamMemberDetails, setTeamMemberDetails] = useState<TeamMemberDetails | null>(null)
+  const [storeDetails, setStoreDetails] = useState<StoreDetails | null>(null)
+  const [detailsError, setDetailsError] = useState<string | null>(null)
+  const [isLoadingDetails, setIsLoadingDetails] = useState(false)
+
+  const ownerUid = teamMemberDetails?.uid ?? user?.uid ?? '—'
+  const ownerEmail = teamMemberDetails?.email ?? user?.email ?? '—'
+  const ownerRole = formatRole(teamMemberDetails?.role)
+  const createdAtLabel = formatTimestamp(teamMemberDetails?.createdAt ?? null)
+  const storeIdLabel = teamMemberDetails?.storeId ?? storeDetails?.id ?? user?.uid ?? '—'
+  const storeStatusLabel = formatLabel(storeDetails?.status)
+  const contractStatusLabel = formatLabel(storeDetails?.contractStatus)
+  const updatedAtLabel = formatTimestamp(storeDetails?.updatedAt ?? null)
 
   useEffect(() => {
     setStatus(getOnboardingStatus(user?.uid ?? null))
+  }, [user?.uid])
+
+  useEffect(() => {
+    if (!user?.uid) {
+      setTeamMemberDetails(null)
+      setStoreDetails(null)
+      setDetailsError(null)
+      setIsLoadingDetails(false)
+      return
+    }
+
+    let isActive = true
+    setIsLoadingDetails(true)
+    setDetailsError(null)
+
+    const fetchDetails = async () => {
+      try {
+        const [memberSnapshot, storeSnapshot] = await Promise.all([
+          getDoc(doc(rosterDb, 'teamMembers', user.uid)),
+          getDoc(doc(db, 'stores', user.uid)),
+        ])
+
+        if (!isActive) {
+          return
+        }
+
+        if (memberSnapshot.exists()) {
+          setTeamMemberDetails({
+            id: memberSnapshot.id,
+            ...(memberSnapshot.data() as TeamMemberDocument),
+          })
+        } else {
+          setTeamMemberDetails(null)
+        }
+
+        if (storeSnapshot.exists()) {
+          setStoreDetails({
+            id: storeSnapshot.id,
+            ...(storeSnapshot.data() as StoreDocument),
+          })
+        } else {
+          setStoreDetails(null)
+        }
+      } catch (error) {
+        if (!isActive) {
+          return
+        }
+        console.warn('[onboarding] Failed to load workspace details', error)
+        setTeamMemberDetails(null)
+        setStoreDetails(null)
+        setDetailsError('We couldn’t load your workspace details. Refresh to try again.')
+      } finally {
+        if (isActive) {
+          setIsLoadingDetails(false)
+        }
+      }
+    }
+
+    void fetchDetails()
+
+    return () => {
+      isActive = false
+    }
   }, [user?.uid])
 
   const hasCompleted = status === 'completed'
@@ -60,6 +205,70 @@ export default function Onboarding() {
           <li>Turn on multi-factor authentication for extra protection.</li>
           <li>Plan which teammates need day-to-day access to Sedifex.</li>
         </ul>
+        <div className="onboarding-card__details" aria-live="polite">
+          <div className="onboarding-card__details-header">
+            <h3 className="onboarding-card__details-title" id="onboarding-owner-details">
+              Review your workspace details
+            </h3>
+            <p className="onboarding-card__details-subtitle">
+              Confirm that your owner profile and store information look correct before inviting your team.
+            </p>
+          </div>
+          {isLoadingDetails ? (
+            <p className="onboarding-card__details-status">Loading your workspace data…</p>
+          ) : detailsError ? (
+            <p className="onboarding-card__details-status onboarding-card__details-status--error">{detailsError}</p>
+          ) : (
+            <div className="onboarding-card__details-columns" aria-describedby="onboarding-owner-details">
+              <div className="onboarding-card__details-section">
+                <p className="onboarding-card__details-section-title">Account</p>
+                <dl className="onboarding-card__details-grid">
+                  <div className="onboarding-card__details-row">
+                    <dt className="onboarding-card__details-term">Owner UID</dt>
+                    <dd className="onboarding-card__details-value">{ownerUid}</dd>
+                  </div>
+                  <div className="onboarding-card__details-row">
+                    <dt className="onboarding-card__details-term">Email</dt>
+                    <dd className="onboarding-card__details-value">{ownerEmail}</dd>
+                  </div>
+                  <div className="onboarding-card__details-row">
+                    <dt className="onboarding-card__details-term">Role</dt>
+                    <dd className="onboarding-card__details-value">{ownerRole}</dd>
+                  </div>
+                  {createdAtLabel ? (
+                    <div className="onboarding-card__details-row">
+                      <dt className="onboarding-card__details-term">Created</dt>
+                      <dd className="onboarding-card__details-value">{createdAtLabel}</dd>
+                    </div>
+                  ) : null}
+                </dl>
+              </div>
+              <div className="onboarding-card__details-section">
+                <p className="onboarding-card__details-section-title">Store</p>
+                <dl className="onboarding-card__details-grid">
+                  <div className="onboarding-card__details-row">
+                    <dt className="onboarding-card__details-term">Store ID</dt>
+                    <dd className="onboarding-card__details-value">{storeIdLabel}</dd>
+                  </div>
+                  <div className="onboarding-card__details-row">
+                    <dt className="onboarding-card__details-term">Status</dt>
+                    <dd className="onboarding-card__details-value">{storeStatusLabel}</dd>
+                  </div>
+                  <div className="onboarding-card__details-row">
+                    <dt className="onboarding-card__details-term">Contract</dt>
+                    <dd className="onboarding-card__details-value">{contractStatusLabel}</dd>
+                  </div>
+                  {updatedAtLabel ? (
+                    <div className="onboarding-card__details-row">
+                      <dt className="onboarding-card__details-term">Last updated</dt>
+                      <dd className="onboarding-card__details-value">{updatedAtLabel}</dd>
+                    </div>
+                  ) : null}
+                </dl>
+              </div>
+            </div>
+          )}
+        </div>
       </section>
 
       <section className="card onboarding-card" aria-labelledby="onboarding-step-2">


### PR DESCRIPTION
## Summary
- persist owner metadata in the roster `teamMembers` collection during signup
- show the signed-in owner and store identifiers on the onboarding review card
- update onboarding and auth tests to exercise the new workflow

## Testing
- npm test -- src/pages/AuthScreen.test.tsx src/pages/Onboarding.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e522936944832186027b8c2f82c400