### PR TITLE
Enable Firestore long polling auto-detection

### DIFF
--- a/web/src/firebase.ts
+++ b/web/src/firebase.ts
@@ -74,7 +74,10 @@ export const storage = getStorage(app)
 export const functions = getFunctions(app)
 
 // --- Firestore (default + secondary "roster") ---
-const FIRESTORE_SETTINGS = { ignoreUndefinedProperties: true }
+const FIRESTORE_SETTINGS = {
+  ignoreUndefinedProperties: true,
+  experimentalAutoDetectLongPolling: true,
+}
 
 export const rosterApp = initializeApp(rosterFirebaseConfig, 'roster')
 


### PR DESCRIPTION
## Summary
- enable Firestore long-polling auto detection so Firestore listeners stay in sync without manual page refreshes

## Testing
- npm test -- --runInBand *(fails: vitest: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6137bf46c83218818bb456686a469