### PR TITLE
Enable copyable invite link on account page

### DIFF
--- a/web/src/pages/AccountOverview.css
+++ b/web/src/pages/AccountOverview.css
@@ -1,0 +1,56 @@
+.account-overview__invite {
+  margin-bottom: 24px;
+  padding: 20px;
+  border-radius: 18px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  display: grid;
+  gap: 12px;
+}
+
+.account-overview__invite h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.account-overview__invite-description {
+  margin: 0;
+  color: #475569;
+  font-size: 14px;
+}
+
+.account-overview__invite-link {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.account-overview__invite-input {
+  flex: 1 1 260px;
+  min-width: 220px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  color: #1e293b;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.account-overview__invite-input:focus {
+  outline: 2px solid rgba(67, 56, 202, 0.3);
+  outline-offset: 2px;
+}
+
+.account-overview__invite-feedback {
+  margin: 0;
+  font-size: 13px;
+  color: #047857;
+}
+
+.account-overview__invite-feedback--error {
+  color: #b91c1c;
+}


### PR DESCRIPTION
## Summary
- add a shareable invite panel on the account roster so owners can copy or email the workspace link
- style the invite panel and cover copy-to-clipboard handling in the AccountOverview tests

## Testing
- npm test -- AccountOverview *(blocked: vitest binary unavailable and npm install failed with a 403 from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e61450fdcc8321844ead798d4293c9