### PR TITLE
Fix sell page membership lookup fallback

### DIFF
--- a/web/src/hooks/useMemberships.test.tsx
+++ b/web/src/hooks/useMemberships.test.tsx
@@ -9,7 +9,8 @@ vi.mock('./useAuthUser', () => ({
 }))
 
 vi.mock('../firebase', () => ({
-  rosterDb: {},
+  db: { name: 'primary-db' },
+  rosterDb: { name: 'roster-db' },
 }))
 
 const collectionMock = vi.fn(() => ({ type: 'collection' }))
@@ -66,7 +67,7 @@ describe('useMemberships', () => {
       }),
     }
 
-    getDocsMock.mockResolvedValue({ docs: [membershipDoc] })
+    getDocsMock.mockResolvedValueOnce({ docs: [membershipDoc] })
 
     const { result } = renderHook(() => useMemberships())
 
@@ -106,7 +107,7 @@ describe('useMemberships', () => {
       }),
     }
 
-    getDocsMock.mockResolvedValue({ docs: [membershipDoc] })
+    getDocsMock.mockResolvedValueOnce({ docs: [membershipDoc] })
 
     const { result } = renderHook(() => useMemberships())
 
@@ -124,6 +125,52 @@ describe('useMemberships', () => {
         phone: null,
         invitedBy: null,
         firstSignupEmail: null,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ])
+  })
+
+  it('falls back to the roster database when the primary store returns no rows', async () => {
+    mockUseAuthUser.mockReturnValue({ uid: 'user-789' })
+
+    const emptySnapshot = { docs: [] as Array<never> }
+    const rosterMembership = {
+      id: 'member-roster',
+      data: () => ({
+        uid: 'user-789',
+        role: 'owner',
+        storeId: 'store-roster',
+        email: 'owner@example.com',
+        phone: '+1112223333',
+        invitedBy: 'owner',
+        firstSignupEmail: 'owner@example.com',
+        createdAt: null,
+        updatedAt: null,
+      }),
+    }
+
+    getDocsMock
+      .mockResolvedValueOnce(emptySnapshot)
+      .mockResolvedValueOnce({ docs: [rosterMembership] })
+
+    const { result } = renderHook(() => useMemberships())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(getDocsMock).toHaveBeenCalledTimes(2)
+    expect(result.current.memberships).toEqual([
+      {
+        id: 'member-roster',
+        uid: 'user-789',
+        role: 'owner',
+        storeId: 'store-roster',
+        email: 'owner@example.com',
+        phone: '+1112223333',
+        invitedBy: 'owner',
+        firstSignupEmail: 'owner@example.com',
         createdAt: null,
         updatedAt: null,
       },


### PR DESCRIPTION
## Summary
- load team memberships from the primary Firestore database before falling back to the roster copy
- expand the membership hook tests to cover the new fallback behavior

## Testing
- npm test -- hooks/useMemberships.test.tsx *(fails: vitest not found before dependencies are installed)*
- npm install *(fails: 403 Forbidden for @types/node from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e61be231f48321a939048a6365885b