### PR TITLE
Fix roster fallback error handling

### DIFF
--- a/web/src/hooks/useMemberships.ts
+++ b/web/src/hooks/useMemberships.ts
@@ -81,9 +81,9 @@ async function loadMembershipsForUser(uid: string): Promise<Membership[]> {
       return rosterRows
     }
 
-    return primaryRows ?? rosterRows
+    return primaryRows && primaryRows.length > 0 ? primaryRows : rosterRows
   } catch (error) {
-    if (primaryRows) {
+    if (primaryRows && primaryRows.length > 0) {
       return primaryRows
     }
     throw primaryError ?? error


### PR DESCRIPTION
## Summary
- ensure the roster fallback only returns primary memberships when results exist
- surface roster fetch failures when both databases lack membership rows

## Testing
- not run (environment limitations)

------
https://chatgpt.com/codex/tasks/task_e_68e622bc22348321b79ef1b52ed7a27b