### PR TITLE
Refresh membership claims after login

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import {
   configureAuthPersistence,
   ensureStoreDocument,
   persistSession,
+  refreshMembershipClaims,
   refreshSessionHeartbeat,
 } from './controllers/sessionController'
 import {
@@ -474,6 +475,7 @@ export default function App() {
         )
         await ensureStoreDocument(nextUser)
         await persistSession(nextUser)
+        await refreshMembershipClaims()
         try {
           const resolution = await resolveStoreAccess()
           await persistSession(nextUser, {
@@ -493,6 +495,7 @@ export default function App() {
           sanitizedPassword,
         )
         await persistSession(nextUser)
+        await refreshMembershipClaims()
 
         let initializedStoreId: string | undefined
         try {

--- a/web/src/controllers/sessionController.ts
+++ b/web/src/controllers/sessionController.ts
@@ -8,7 +8,7 @@ import {
   setPersistence,
 } from 'firebase/auth'
 import { doc, serverTimestamp, setDoc, updateDoc } from 'firebase/firestore'
-import { db, rosterDb } from '../firebase'
+import { auth, db, rosterDb } from '../firebase'
 
 const SESSION_COOKIE = 'sedifex_session'
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 90 // 90 days
@@ -29,6 +29,18 @@ export async function configureAuthPersistence(auth: Auth) {
   } catch (error) {
     console.warn('[auth] Falling back to in-memory persistence', error)
     await setPersistence(auth, inMemoryPersistence)
+  }
+}
+
+export async function refreshMembershipClaims() {
+  const currentUser = auth.currentUser
+  if (!currentUser) return
+
+  try {
+    await currentUser.getIdToken(true)
+    await currentUser.reload()
+  } catch (error) {
+    console.warn('[auth] Failed to refresh membership claims', error)
   }
 }
 

--- a/web/src/hooks/useMemberships.ts
+++ b/web/src/hooks/useMemberships.ts
@@ -81,9 +81,9 @@ async function loadMembershipsForUser(uid: string): Promise<Membership[]> {
       return rosterRows
     }
 
-    return primaryRows ?? rosterRows
+    return primaryRows && primaryRows.length > 0 ? primaryRows : rosterRows
   } catch (error) {
-    if (primaryRows) {
+    if (primaryRows && primaryRows.length > 0) {
       return primaryRows
     }
     throw primaryError ?? error

--- a/web/src/pages/AuthScreen.tsx
+++ b/web/src/pages/AuthScreen.tsx
@@ -10,7 +10,12 @@ import {
 } from '../components/auth/AuthForm'
 import { useToast } from '../components/ToastProvider'
 import { afterSignupBootstrap } from '../controllers/accessController'
-import { ensureStoreDocument, ensureTeamMemberDocument, persistSession } from '../controllers/sessionController'
+import {
+  ensureStoreDocument,
+  ensureTeamMemberDocument,
+  persistSession,
+  refreshMembershipClaims,
+} from '../controllers/sessionController'
 import { auth } from '../firebase'
 import { setOnboardingStatus } from '../utils/onboarding'
 import './AuthScreen.css'
@@ -111,6 +116,7 @@ export default function AuthScreen() {
           const { user } = await signInWithEmailAndPassword(auth, trimmedEmail, password)
           await ensureStoreDocument(user)
           await persistSession(user)
+          await refreshMembershipClaims()
 
           publish({ message: 'Welcome back!', tone: 'success' })
           navigate(redirectTo, { replace: true })
@@ -121,6 +127,7 @@ export default function AuthScreen() {
         await ensureStoreDocument(user)
         await ensureTeamMemberDocument(user, { storeId: user.uid, role: 'owner' })
         await persistSession(user, { storeId: user.uid, role: 'owner' })
+        await refreshMembershipClaims()
         setOnboardingStatus(user.uid, 'pending')
 
         try {


### PR DESCRIPTION
## Summary
- refresh Firebase custom claims after successful sign-in flows
- add helper to force-refresh membership claims from the current user session

## Testing
- not run (environment limitations)


------
https://chatgpt.com/codex/tasks/task_e_68e622bc22348321b79ef1b52ed7a27b