### PR TITLE
Fix Google Ads action buttons to always trigger handlers

### DIFF
--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -350,7 +350,7 @@ export default function AdsCampaigns() {
           </p>
         </div>
 
-        <form onSubmit={handleConnectSubmit} className="ads-campaigns__form-grid">
+        <form onSubmit={handleConnectSubmit} className="ads-campaigns__form-grid" noValidate>
           <label>
             <span>Google account email</span>
             <input
@@ -366,7 +366,6 @@ export default function AdsCampaigns() {
                 }))
               }
               placeholder="owner@business.com"
-              required
             />
           </label>
 
@@ -385,7 +384,6 @@ export default function AdsCampaigns() {
                 }))
               }
               placeholder="123-456-7890"
-              required
             />
           </label>
 
@@ -425,7 +423,7 @@ export default function AdsCampaigns() {
           <p>Capture consent before Sedifex starts spending ad budget.</p>
         </div>
 
-        <form onSubmit={handleBillingConfirm} className="ads-campaigns__form-grid">
+        <form onSubmit={handleBillingConfirm} className="ads-campaigns__form-grid" noValidate>
           <label>
             <span>Business legal name</span>
             <input
@@ -440,7 +438,6 @@ export default function AdsCampaigns() {
                 }))
               }
               placeholder="Sedifex Biz Ltd"
-              required
             />
           </label>
           <div className="ads-campaigns__actions">


### PR DESCRIPTION
### Motivation
- Browsers' native form validation could block submission and make the `Connect Google Ads` and `Confirm billing ownership` buttons appear unresponsive, preventing the app's in-form validation and notice flows from running.

### Description
- Add `noValidate` to both forms and remove native `required` attributes from the `accountEmail`, `customerId`, and `legalName` inputs so the React submit handlers always run (change in `web/src/pages/AdsCampaigns.tsx`).

### Testing
- Ran `npm --prefix web run lint` which failed in this environment because the dev dependency `@eslint/js` is not installed, so automated linting did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fe126cbc8321bd484fe497ac2de7)