### PR TITLE
Discover Google Ads customer ID during OAuth and relax frontend requirement

### DIFF
--- a/web/api/_google-ads.ts
+++ b/web/api/_google-ads.ts
@@ -140,7 +140,7 @@ export async function persistOAuthState(params: {
   uid: string
   storeId: string
   rawState: string
-  customerId: string
+  customerId?: string
   managerId?: string
   email?: string
 }) {
@@ -148,7 +148,7 @@ export async function persistOAuthState(params: {
   await db().collection('googleAdsOAuthStates').doc(hashedState).set({
     uid: params.uid,
     storeId: params.storeId,
-    customerId: params.customerId,
+    customerId: params.customerId || '',
     managerId: params.managerId || '',
     email: params.email || '',
     createdAt: FieldValue.serverTimestamp(),
@@ -184,9 +184,34 @@ export async function consumeOAuthState(rawState: string): Promise<{
   const customerId = typeof data.customerId === 'string' ? data.customerId : ''
   const managerId = typeof data.managerId === 'string' ? data.managerId : ''
   const email = typeof data.email === 'string' ? data.email : ''
-  if (!uid || !storeId || !customerId) throw new Error('invalid-state')
+  if (!uid || !storeId) throw new Error('invalid-state')
 
   return { uid, storeId, customerId, managerId, email }
+}
+
+export async function discoverGoogleAdsCustomerId(params: {
+  accessToken: string
+  managerId?: string
+}): Promise<string> {
+  const url = `${GOOGLE_ADS_API_BASE}/${GOOGLE_ADS_API_VERSION}/customers:listAccessibleCustomers`
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: googleAdsHeaders({
+      accessToken: params.accessToken,
+      managerId: params.managerId || '',
+    }),
+  })
+
+  if (!response.ok) return ''
+
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>
+  const names = Array.isArray(payload.resourceNames) ? payload.resourceNames : []
+  const first = typeof names[0] === 'string' ? names[0] : ''
+  if (!first) return ''
+
+  const parts = first.split('/')
+  const candidate = parts[parts.length - 1] || ''
+  return candidate.trim()
 }
 
 export async function exchangeCodeForTokens(code: string) {

--- a/web/api/google-ads/oauth-callback.ts
+++ b/web/api/google-ads/oauth-callback.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import {
   consumeOAuthState,
+  discoverGoogleAdsCustomerId,
   exchangeCodeForTokens,
   storeGoogleTokens,
   getOAuthClientConfig,
@@ -41,12 +42,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const statePayload = await consumeOAuthState(state)
     const tokenPayload = await exchangeCodeForTokens(code)
+    const accessToken =
+      typeof tokenPayload.access_token === 'string' ? tokenPayload.access_token : ''
+    const customerId =
+      statePayload.customerId ||
+      (accessToken
+        ? await discoverGoogleAdsCustomerId({
+            accessToken,
+            managerId: statePayload.managerId,
+          })
+        : '')
 
     await storeGoogleTokens({
       storeId: statePayload.storeId,
       uid: statePayload.uid,
       email: statePayload.email,
-      customerId: statePayload.customerId,
+      customerId,
       managerId: statePayload.managerId,
       tokenPayload,
     })

--- a/web/api/google-ads/oauth-start.ts
+++ b/web/api/google-ads/oauth-start.ts
@@ -2,7 +2,6 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import {
   buildOAuthStartUrl,
   persistOAuthState,
-  requireCustomerId,
   requireStoreId,
 } from '../_google-ads.js'
 import { requireApiUser, requireStoreMembership } from '../_api-auth.js'
@@ -16,7 +15,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const user = await requireApiUser(req)
     const storeId = requireStoreId(req.body?.storeId)
     await requireStoreMembership(user.uid, storeId)
-    const customerId = requireCustomerId(req.body?.customerId)
+    const customerId =
+      typeof req.body?.customerId === 'string' ? req.body.customerId.trim() : ''
     const managerId =
       typeof req.body?.managerId === 'string' ? req.body.managerId.trim() : ''
     const accountEmail =

--- a/web/src/api/googleAdsAutomation.ts
+++ b/web/src/api/googleAdsAutomation.ts
@@ -33,7 +33,7 @@ async function parseApiResult<T>(response: Response): Promise<T> {
 
 export async function beginGoogleAdsOAuth(input: {
   storeId: string
-  customerId: string
+  customerId?: string
   managerId?: string
   accountEmail?: string
 }) {

--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -247,10 +247,9 @@ export default function AdsCampaigns() {
     }
   }
 
-  async function handleConnectSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    if (!settings.connection.accountEmail.trim() || !settings.connection.customerId.trim()) {
-      setNotice('Add the Google Ads account email and customer ID first.')
+  async function handleConnectClick() {
+    if (!settings.connection.accountEmail.trim()) {
+      setNotice('Add the Google account email first.')
       return
     }
 
@@ -262,7 +261,6 @@ export default function AdsCampaigns() {
       const { url } = await beginGoogleAdsOAuth({
         storeId,
         accountEmail: settings.connection.accountEmail,
-        customerId: settings.connection.customerId,
         managerId: settings.connection.managerId,
       })
       window.location.assign(url)
@@ -274,8 +272,7 @@ export default function AdsCampaigns() {
     }
   }
 
-  async function handleBillingConfirm(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault()
+  async function handleBillingConfirmClick() {
     if (!settings.billing.legalName.trim()) {
       setNotice('Enter the business legal name used for billing.')
       return
@@ -350,7 +347,7 @@ export default function AdsCampaigns() {
           </p>
         </div>
 
-        <form onSubmit={handleConnectSubmit} className="ads-campaigns__form-grid">
+        <div className="ads-campaigns__form-grid">
           <label>
             <span>Google account email</span>
             <input
@@ -366,26 +363,6 @@ export default function AdsCampaigns() {
                 }))
               }
               placeholder="owner@business.com"
-              required
-            />
-          </label>
-
-          <label>
-            <span>Google Ads customer ID</span>
-            <input
-              type="text"
-              value={settings.connection.customerId}
-              onChange={event =>
-                setSettings(previous => ({
-                  ...previous,
-                  connection: {
-                    ...previous.connection,
-                    customerId: event.target.value,
-                  },
-                }))
-              }
-              placeholder="123-456-7890"
-              required
             />
           </label>
 
@@ -408,7 +385,12 @@ export default function AdsCampaigns() {
           </label>
 
           <div className="ads-campaigns__actions">
-            <button type="submit" className="button button--primary" disabled={saving}>
+            <button
+              type="button"
+              className="button button--primary"
+              disabled={saving}
+              onClick={handleConnectClick}
+            >
               {settings.connection.connected ? 'Update connection' : 'Connect Google Ads'}
             </button>
             <p>
@@ -416,7 +398,7 @@ export default function AdsCampaigns() {
               {toIso(settings.connection.connectedAt)}
             </p>
           </div>
-        </form>
+        </div>
       </section>
 
       <section className="ads-campaigns__section" aria-labelledby="billing-ownership">
@@ -425,7 +407,7 @@ export default function AdsCampaigns() {
           <p>Capture consent before Sedifex starts spending ad budget.</p>
         </div>
 
-        <form onSubmit={handleBillingConfirm} className="ads-campaigns__form-grid">
+        <div className="ads-campaigns__form-grid">
           <label>
             <span>Business legal name</span>
             <input
@@ -440,11 +422,15 @@ export default function AdsCampaigns() {
                 }))
               }
               placeholder="Sedifex Biz Ltd"
-              required
             />
           </label>
           <div className="ads-campaigns__actions">
-            <button type="submit" className="button button--primary" disabled={saving}>
+            <button
+              type="button"
+              className="button button--primary"
+              disabled={saving}
+              onClick={handleBillingConfirmClick}
+            >
               Confirm billing ownership
             </button>
             <p>
@@ -452,7 +438,7 @@ export default function AdsCampaigns() {
               {toIso(settings.billing.confirmedAt)}
             </p>
           </div>
-        </form>
+        </div>
       </section>
 
       <section className="ads-campaigns__section" aria-labelledby="campaign-brief">


### PR DESCRIPTION
### Motivation

- Allow connecting Google Ads even when the user does not supply a customer ID up-front by discovering the ID via the API after OAuth. 
- Make the OAuth flow more forgiving by treating `customerId` as optional in state persistence and consumption. 
- Simplify the UI and UX by removing the mandatory customer ID input and only requiring the Google account email.

### Description

- Added `discoverGoogleAdsCustomerId` which calls `customers:listAccessibleCustomers` using the OAuth `access_token` and optional `managerId` to infer a customer ID. 
- Made `customerId` optional in `persistOAuthState` and store an empty string as a default, and relaxed `consumeOAuthState` so it does not require `customerId`. 
- Updated the OAuth callback to use the discovered customer ID when the state-provided `customerId` is empty by invoking `discoverGoogleAdsCustomerId`. 
- Frontend changes: made `beginGoogleAdsOAuth` accept an optional `customerId`, removed the customer ID input from `AdsCampaigns` and updated form handlers to use button click handlers with simplified validation that only requires the account email.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fe126cbc8321bd484fe497ac2de7)