### PR TITLE
Shell: Add navigation page search and resume-last-page banner with persistence

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -150,6 +150,37 @@ body.shell--menu-open {
   flex-grow: 1;
 }
 
+.shell__nav-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: 4px;
+}
+
+.shell__nav-search-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #475569;
+}
+
+.shell__nav-search-input {
+  width: min(220px, 40vw);
+  min-width: 160px;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
+.shell__nav-empty {
+  margin: 0;
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  color: #475569;
+  background: #f8fafc;
+  border: 1px dashed #cbd5e1;
+}
+
 .shell__nav-item-group {
   display: inline-flex;
   align-items: center;
@@ -245,6 +276,25 @@ body.shell--menu-open {
   gap: 12px;
   flex-wrap: wrap;
   justify-content: flex-end;
+}
+
+.shell__resume-banner {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #eef2ff;
+  border: 1px solid rgba(67, 56, 202, 0.18);
+  color: #312e81;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.shell__resume-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .shell__account {
@@ -479,6 +529,18 @@ body.shell--menu-open {
     gap: 12px;
   }
 
+  .shell__nav-search {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    margin-right: 0;
+  }
+
+  .shell__nav-search-input {
+    width: 100%;
+    min-width: 0;
+  }
+
   .shell__nav-item-group {
     flex-direction: column;
     align-items: stretch;
@@ -521,6 +583,13 @@ body.shell--menu-open {
     justify-content: flex-start;
     align-items: stretch;
     gap: 10px;
+  }
+
+  .shell__resume-banner {
+    width: 100%;
+    border-radius: 12px;
+    justify-content: space-between;
+    align-items: center;
   }
 
   .shell__account {

--- a/web/src/layout/Shell.test.tsx
+++ b/web/src/layout/Shell.test.tsx
@@ -45,9 +45,9 @@ vi.mock('firebase/auth', () => ({
   signOut: vi.fn(),
 }))
 
-function renderShell() {
+function renderShell(initialEntries: string[] = ['/']) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <ToastProvider>
         <Shell>
           <div>Content</div>
@@ -68,7 +68,7 @@ describe('Shell', () => {
     mockUseWorkspaceIdentity.mockReset()
     mockUseMemberships.mockReset()
 
-    mockUseAuthUser.mockReturnValue({ email: 'owner@example.com' })
+    mockUseAuthUser.mockReturnValue({ uid: 'user-123', email: 'owner@example.com' })
     mockUseActiveStore.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
     mockUseWorkspaceIdentity.mockReturnValue({ name: 'Demo Store', loading: false })
     mockUseMemberships.mockReturnValue({ memberships: [], loading: false, error: null })
@@ -160,5 +160,33 @@ describe('Shell', () => {
     ).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Account' })).toBeInTheDocument()
     expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+  })
+
+  it('filters navigation links using page search', async () => {
+    renderShell(['/dashboard'])
+    const user = userEvent.setup()
+
+    await user.type(screen.getByRole('searchbox', { name: /search pages/i }), 'cust')
+
+    expect(screen.getByRole('link', { name: 'Customers' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Dashboard' })).not.toBeInTheDocument()
+  })
+
+  it('offers return-to-last-page action when a previous path exists', async () => {
+    localStorage.setItem('sedifex-last-path-user-123', '/customers')
+    renderShell(['/dashboard'])
+
+    expect(screen.getByText('Return to where you left off?')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Return' })).toBeInTheDocument()
+  })
+
+  it('allows dismissing the return-to-last-page prompt', async () => {
+    localStorage.setItem('sedifex-last-path-user-123', '/customers')
+    renderShell(['/dashboard'])
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }))
+
+    expect(screen.queryByText('Return to where you left off?')).not.toBeInTheDocument()
   })
 })

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
 import { signOut } from 'firebase/auth'
 import { auth } from '../firebase'
@@ -40,6 +40,7 @@ type BillingNotice = {
 
 const CONTRACT_END_WARNING_DAYS = 14
 const DISMISS_KEY_PREFIX = 'sedifex-billing-dismissed-'
+const LAST_PATH_KEY_PREFIX = 'sedifex-last-path-'
 
 function formatRequestCount(count: number) {
   if (count <= 0) return 'queued request'
@@ -91,6 +92,10 @@ export default function Shell({ children }: { children: React.ReactNode }) {
   const { name: workspaceName, loading: workspaceLoading } = useWorkspaceIdentity()
 
   const [dismissedOn, setDismissedOn] = useState<string | null>(null)
+  const [navSearchQuery, setNavSearchQuery] = useState('')
+  const [resumePath, setResumePath] = useState<string | null>(null)
+  const [dismissedResumePath, setDismissedResumePath] = useState<string | null>(null)
+  const shouldSkipInitialPathPersist = useRef(true)
 
   const trialEndsAt = billing?.trialEndsAt?.toDate?.() ?? null
   const hasTrialEnded = Boolean(
@@ -134,6 +139,11 @@ export default function Shell({ children }: { children: React.ReactNode }) {
         })),
     [navItems],
   )
+  const filteredNavItems = useMemo(() => {
+    const normalizedQuery = navSearchQuery.trim().toLowerCase()
+    if (!normalizedQuery) return navItems
+    return navItems.filter(item => item.label.toLowerCase().includes(normalizedQuery))
+  }, [navItems, navSearchQuery])
 
   const billingNotice = useMemo<BillingNotice | null>(() => {
     if (!billing) return null
@@ -202,6 +212,54 @@ export default function Shell({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     setIsMenuOpen(false)
   }, [location.pathname])
+
+  useEffect(() => {
+    shouldSkipInitialPathPersist.current = true
+  }, [user?.uid])
+
+  useEffect(() => {
+    if (!user?.uid) return
+    if (shouldSkipInitialPathPersist.current) {
+      shouldSkipInitialPathPersist.current = false
+      return
+    }
+
+    const currentPath = `${location.pathname}${location.search}${location.hash}`
+    if (!currentPath.startsWith('/')) return
+
+    try {
+      localStorage.setItem(`${LAST_PATH_KEY_PREFIX}${user.uid}`, currentPath)
+    } catch (error) {
+      console.warn('[shell] Unable to persist last visited path', error)
+    }
+  }, [location.hash, location.pathname, location.search, user?.uid])
+
+  useEffect(() => {
+    if (!user?.uid) {
+      setResumePath(null)
+      return
+    }
+
+    const key = `${LAST_PATH_KEY_PREFIX}${user.uid}`
+    const storedPath = localStorage.getItem(key)
+    if (!storedPath || !storedPath.startsWith('/')) {
+      setResumePath(null)
+      return
+    }
+
+    const currentPath = `${location.pathname}${location.search}${location.hash}`
+    if (storedPath === currentPath) {
+      setResumePath(null)
+      return
+    }
+
+    if (dismissedResumePath === storedPath) {
+      setResumePath(null)
+      return
+    }
+
+    setResumePath(storedPath)
+  }, [dismissedResumePath, location.hash, location.pathname, location.search, user?.uid])
 
   useEffect(() => {
     document.body.classList.toggle('shell--menu-open', isMenuOpen)
@@ -347,7 +405,18 @@ export default function Shell({ children }: { children: React.ReactNode }) {
                 aria-label="Primary"
                 id="primary-nav"
               >
-                {navItems.map(item => (
+                <label className="shell__nav-search">
+                  <span className="shell__nav-search-label">Search pages</span>
+                  <input
+                    type="search"
+                    placeholder="Find a page…"
+                    value={navSearchQuery}
+                    onChange={event => setNavSearchQuery(event.target.value)}
+                    className="shell__nav-search-input"
+                  />
+                </label>
+
+                {filteredNavItems.map(item => (
                   <NavLink
                     key={item.to}
                     to={item.to}
@@ -357,10 +426,46 @@ export default function Shell({ children }: { children: React.ReactNode }) {
                     {item.label}
                   </NavLink>
                 ))}
+
+                {filteredNavItems.length === 0 && (
+                  <p className="shell__nav-empty" role="status">
+                    No pages match “{navSearchQuery.trim()}”.
+                  </p>
+                )}
               </nav>
             </div>
 
             <div className="shell__controls">
+              {resumePath && (
+                <div className="shell__resume-banner" role="status" aria-live="polite">
+                  <span>Return to where you left off?</span>
+                  <div className="shell__resume-actions">
+                    <button
+                      type="button"
+                      className="button button--primary button--small"
+                      onClick={() => {
+                        const targetPath = resumePath
+                        setResumePath(null)
+                        setDismissedResumePath(targetPath)
+                        navigate(targetPath)
+                      }}
+                    >
+                      Return
+                    </button>
+                    <button
+                      type="button"
+                      className="button button--ghost button--small"
+                      onClick={() => {
+                        setDismissedResumePath(resumePath)
+                        setResumePath(null)
+                      }}
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              )}
+
               <div
                 className="shell__store-switcher"
                 role="status"


### PR DESCRIPTION
### Motivation

- Provide a quick way to find pages in the primary navigation and help users return to the last page they visited after signing back in.

### Description

- Add a search input to the primary nav that filters `NAV_ITEMS` by label and show an empty state when no pages match, including new CSS classes (`.shell__nav-search`, `.shell__nav-search-input`, `.shell__nav-empty`).
- Persist the last visited path per user to `localStorage` under the `sedifex-last-path-<uid>` key and skip persisting on the initial load to avoid capturing the landing navigation.
- Surface a dismissible resume banner (`.shell__resume-banner`) in the toolbar offering a `Return` action to navigate to the stored path or `Dismiss` to hide it permanently for that stored path.
- Add related state and effects in `Shell.tsx`: `navSearchQuery`, `resumePath`, `dismissedResumePath`, `shouldSkipInitialPathPersist`, filtering `navItems` into `filteredNavItems`, and safe `localStorage` handling with warnings on error.
- Update responsive styles to accommodate the search input and resume banner and add several new utility CSS rules for the UI elements.
- Update tests and test helper signature: `renderShell` now accepts `initialEntries` and mocked auth user includes a `uid`.
- Add three tests in `Shell.test.tsx` to verify search filtering, presence of the return-to-last-page banner when a stored path exists, and dismissal behavior.

### Testing

- Ran unit tests for the shell module in `web/src/layout/Shell.test.tsx`, which include the new tests for search and resume banner, and they passed.
- All updated `Shell` unit tests were executed as part of the test suite and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81df6b4bc8321bad067c196ac42cc)