### PR TITLE
Replace support modal with mailto help link

### DIFF
--- a/web/src/components/SupportTicketLauncher.tsx
+++ b/web/src/components/SupportTicketLauncher.tsx
@@ -1,128 +1,28 @@
-import React, { useMemo, useState } from 'react'
-import { addDoc, collection, serverTimestamp } from 'firebase/firestore'
+import { useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
-import { db } from '../firebase'
-import { useAuthUser } from '../hooks/useAuthUser'
-import { useActiveStore } from '../hooks/useActiveStore'
-import { useToast } from './ToastProvider'
 import './SupportTicketLauncher.css'
 
 export default function SupportTicketLauncher() {
-  const user = useAuthUser()
   const location = useLocation()
-  const { storeId } = useActiveStore()
-  const { publish } = useToast()
 
-  const [isOpen, setIsOpen] = useState(false)
-  const [message, setMessage] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitError, setSubmitError] = useState<string | null>(null)
-
-  const screen = useMemo(() => {
+  const supportHref = useMemo(() => {
     const path = location.pathname || '/'
     const hash = location.hash || ''
-    return `${path}${hash}`
+    const screen = `${path}${hash}`
+    const subject = encodeURIComponent('Sedifex help request')
+    const body = encodeURIComponent(`Hi Sedifex team,\n\nI need help with: \n\nScreen: ${screen}`)
+
+    return `mailto:info@sedifex.com?subject=${subject}&body=${body}`
   }, [location.hash, location.pathname])
-
-  const canSubmit = Boolean(message.trim()) && !!user && !isSubmitting
-
-  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    if (!user) return
-
-    setSubmitError(null)
-    setIsSubmitting(true)
-
-    try {
-      await addDoc(collection(db, 'supportTickets'), {
-        uid: user.uid,
-        storeId: storeId ?? null,
-        screen,
-        message: message.trim(),
-        createdAt: serverTimestamp(),
-        status: 'open',
-      })
-
-      setMessage('')
-      setIsOpen(false)
-      publish({ message: 'Thanks! Your request was sent to support.', tone: 'success' })
-    } catch (error) {
-      console.error('[support] Unable to submit ticket', error)
-      setSubmitError('We could not send your request. Please try again.')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
 
   return (
     <div className="support-launcher">
-      <button
-        type="button"
+      <a
         className="button button--outline button--small support-launcher__toggle"
-        onClick={() => setIsOpen(true)}
+        href={supportHref}
       >
         Need help?
-      </button>
-
-      {isOpen ? (
-        <div className="support-launcher__backdrop" role="presentation">
-          <div
-            className="support-launcher__dialog"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="support-title"
-          >
-            <header className="support-launcher__header">
-              <div>
-                <p className="support-launcher__eyebrow">Support</p>
-                <h2 id="support-title">Tell us what you need help with</h2>
-                <p className="support-launcher__context">We’ll route this to the Sedifex team.</p>
-              </div>
-              <button
-                type="button"
-                className="button button--ghost button--small"
-                onClick={() => setIsOpen(false)}
-              >
-                Close
-              </button>
-            </header>
-
-            <form className="support-launcher__form" onSubmit={handleSubmit}>
-              <label className="field">
-                <span className="field__label">Message</span>
-                <textarea
-                  required
-                  rows={5}
-                  value={message}
-                  onChange={event => setMessage(event.target.value)}
-                  placeholder="Describe what you were doing and what you need help with."
-                />
-                <span className="support-launcher__hint">Screen: {screen}</span>
-              </label>
-
-              {submitError ? <p className="support-launcher__error">{submitError}</p> : null}
-
-              <div className="support-launcher__actions">
-                <button
-                  type="button"
-                  className="button button--ghost button--small"
-                  onClick={() => setIsOpen(false)}
-                  disabled={isSubmitting}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  className="button button--primary button--small"
-                  disabled={!canSubmit}
-                >
-                  {isSubmitting ? 'Sending…' : 'Send to support'}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      ) : null}
+      </a>
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Simplify the in-app support flow by opening the user's email client so support messages go to `info@sedifex.com` with context, avoiding the Firebase ticketing flow.

### Description
- Replaced the modal-based support ticket launcher with an anchor `mailto:` link in `web/src/components/SupportTicketLauncher.tsx` that is styled like the previous button.
- Prefills the email `subject` and `body` (including the current screen `pathname` and `hash`) using `useLocation` and `useMemo`.
- Removed Firebase ticket submission logic and related imports/hooks (`firebase`, `useAuthUser`, `useActiveStore`, `useToast`) and the modal state/UX.

### Testing
- Ran `npm --prefix web run lint` which failed in this environment due to a missing package (`@eslint/js`).
- Ran `npm --prefix web run test -- SupportTicketLauncher` which failed because the `vitest` binary is not available in this environment (dependencies not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b10e98a48321a14fbeb3c9706a2b)