### PR TITLE
Fix Google Ads connection state, include customerId in OAuth start, and fix form JSX

### DIFF
--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -108,14 +108,18 @@ function parseSettings(raw: Record<string, unknown> | undefined): AdsAutomationS
 
   const goal = typeof briefRaw.goal === 'string' ? briefRaw.goal : DEFAULT_SETTINGS.brief.goal
   const status = typeof campaignRaw.status === 'string' ? campaignRaw.status : DEFAULT_SETTINGS.campaign.status
+  const accountEmail =
+    typeof connectionRaw.accountEmail === 'string' ? connectionRaw.accountEmail : ''
+  const customerId = typeof connectionRaw.customerId === 'string' ? connectionRaw.customerId : ''
+  const managerId = typeof connectionRaw.managerId === 'string' ? connectionRaw.managerId : ''
+  const hasConnectionDetails = accountEmail.trim().length > 0 && customerId.trim().length > 0
 
   return {
     connection: {
-      connected: connectionRaw.connected === true,
-      accountEmail:
-        typeof connectionRaw.accountEmail === 'string' ? connectionRaw.accountEmail : '',
-      customerId: typeof connectionRaw.customerId === 'string' ? connectionRaw.customerId : '',
-      managerId: typeof connectionRaw.managerId === 'string' ? connectionRaw.managerId : '',
+      connected: connectionRaw.connected === true && hasConnectionDetails,
+      accountEmail,
+      customerId,
+      managerId,
       connectedAt: connectionRaw.connectedAt,
     },
     billing: {
@@ -260,6 +264,7 @@ export default function AdsCampaigns() {
     try {
       const { url } = await beginGoogleAdsOAuth({
         storeId,
+        customerId: settings.connection.customerId,
         accountEmail: settings.connection.accountEmail,
         managerId: settings.connection.managerId,
       })
@@ -416,7 +421,7 @@ export default function AdsCampaigns() {
               {toIso(settings.connection.connectedAt)}
             </p>
           </div>
-        </div>
+        </form>
       </section>
 
       <section className="ads-campaigns__section" aria-labelledby="billing-ownership">
@@ -456,7 +461,7 @@ export default function AdsCampaigns() {
               {toIso(settings.billing.confirmedAt)}
             </p>
           </div>
-        </div>
+        </form>
       </section>
 
       <section className="ads-campaigns__section" aria-labelledby="campaign-brief">


### PR DESCRIPTION
### Motivation
- Prevent the Ads UI from showing a misleading "Connected: Yes" when required connection details are missing. 
- Ensure the OAuth start flow carries the selected Google Ads `customerId` so the backend receives the account identifier when the page triggers OAuth.
- Repair broken JSX structure introduced during edits so the page compiles.

### Description
- Update `parseSettings` in `web/src/pages/AdsCampaigns.tsx` to compute `accountEmail`, `customerId`, and `managerId` and treat `connection.connected` as true only when the persisted `connected` flag is present **and** required details exist (`hasConnectionDetails`).
- Include `customerId: settings.connection.customerId` in the payload passed to `beginGoogleAdsOAuth` from `handleConnectClick` so the OAuth start request includes the selected customer ID.
- Fix mismatched JSX tags in the Ads Campaigns page by correcting the form closing tags in the connection and billing sections of `web/src/pages/AdsCampaigns.tsx`.

### Testing
- Ran `npm --prefix web run build`; the initial run failed due to JSX tag mismatches which were fixed, then a subsequent build fails in this environment due to missing type definitions for `vite/client` and `vitest/globals`, so a full successful build could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c92a9474832191b889c75a313ae9)