### PR TITLE
Fix crash on Ads Campaigns connect form submit

### DIFF
--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -277,6 +277,11 @@ export default function AdsCampaigns() {
     }
   }
 
+  function handleConnectSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    void handleConnectClick()
+  }
+
   async function handleBillingConfirmClick() {
     if (!settings.billing.legalName.trim()) {
       setNotice('Enter the business legal name used for billing.')


### PR DESCRIPTION
### Motivation
- The Google Ads connection form referenced `handleConnectSubmit` but the handler was missing, causing a runtime error (`handleConnectSubmit is not defined`) when the form was submitted.

### Description
- Add `handleConnectSubmit(event: React.FormEvent<HTMLFormElement>)` to `web/src/pages/AdsCampaigns.tsx` which calls `event.preventDefault()` and delegates to the existing `handleConnectClick` flow to handle form submission.

### Testing
- Ran `cd web && npm run lint` which failed in this environment due to a missing dev dependency (`@eslint/js`).
- Ran `cd web && npm run build` which failed in this environment due to missing type definitions (`vite/client` and `vitest/globals`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e31c9b7c83219320c4502437b931)