### PR TITLE
Refactor Shell layout and responsive navigation (sidebar + header controls)

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -29,7 +29,10 @@ body.shell--menu-open {
   display: flex;
   align-items: center;
   gap: 16px;
-  flex-wrap: wrap;
+}
+
+.shell__header-controls {
+  margin-left: auto;
 }
 
 .shell__toolbar {
@@ -39,6 +42,7 @@ body.shell--menu-open {
   gap: 14px;
   width: 100%;
   z-index: 40;
+  display: none;
 }
 
 .shell__backdrop {
@@ -143,18 +147,17 @@ body.shell--menu-open {
 
 .shell__nav {
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: center;
-  flex-grow: 1;
+  gap: 10px;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
 }
 
 .shell__nav-search {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin-right: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
 }
 
 .shell__nav-search-label {
@@ -164,8 +167,8 @@ body.shell--menu-open {
 }
 
 .shell__nav-search-input {
-  width: min(220px, 40vw);
-  min-width: 160px;
+  width: 100%;
+  min-width: 0;
   border-radius: 999px;
   padding: 8px 12px;
   font-size: 13px;
@@ -195,10 +198,20 @@ body.shell--menu-open {
 
 .shell__nav-group {
   display: flex;
-  align-items: center;
+  align-items: stretch;
+  flex-direction: column;
   gap: 12px;
-  flex-wrap: wrap;
-  justify-content: space-between;
+}
+
+.shell__sidebar {
+  position: sticky;
+  top: 92px;
+  align-self: start;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  box-shadow: 0 12px 28px -24px rgba(15, 23, 42, 0.45);
 }
 
 .shell__workspace-pill {
@@ -226,12 +239,12 @@ body.shell--menu-open {
 }
 
 .shell__nav-link {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 6px;
   padding: 8px 14px;
-  border-radius: 999px;
+  border-radius: 12px;
   text-decoration: none;
   font-size: 14px;
   font-weight: 500;
@@ -270,7 +283,6 @@ body.shell--menu-open {
 }
 
 .shell__controls {
-  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -315,6 +327,21 @@ body.shell--menu-open {
 .shell__main {
   width: 100%;
   padding: 32px 0 48px;
+}
+
+.shell__layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 270px) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.shell__content {
+  min-width: 0;
+}
+
+.shell__content-inner {
+  min-width: 0;
 }
 
 .shell :where(a:not([class])) {
@@ -477,6 +504,11 @@ body.shell--menu-open {
 
   .shell__header-inner {
     align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .shell__header-controls {
+    display: none;
   }
 
   .shell__brand {
@@ -523,17 +555,11 @@ body.shell--menu-open {
   }
 
   .shell__nav {
-    flex-direction: column;
-    align-items: stretch;
-    width: 100%;
     gap: 12px;
   }
 
   .shell__nav-search {
     width: 100%;
-    flex-direction: column;
-    align-items: stretch;
-    margin-right: 0;
   }
 
   .shell__nav-search-input {
@@ -558,6 +584,10 @@ body.shell--menu-open {
   .shell__nav-group {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .shell__sidebar {
+    display: none;
   }
 
   .shell__workspace-pill {
@@ -609,6 +639,10 @@ body.shell--menu-open {
   }
 
   .shell__main {
-    padding: 24px 16px 36px;
+    padding: 24px 0 36px;
+  }
+
+  .shell__layout {
+    display: block;
   }
 }

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -344,6 +344,113 @@ export default function Shell({ children }: { children: React.ReactNode }) {
   const workspaceStatus = billing?.planKey ?? 'Workspace ready'
   const workspaceLabel = workspaceName || workspaceStatus
 
+  const navSection = (
+    <div className="shell__nav-group">
+      <div
+        className="shell__workspace-pill"
+        role="status"
+        aria-live="polite"
+      >
+        <span className="shell__workspace-label">Workspace</span>
+        <span className="shell__workspace-name">
+          {workspaceLoading && !workspaceLabel
+            ? 'Loading…'
+            : workspaceLabel}
+        </span>
+      </div>
+
+      <nav
+        className="shell__nav"
+        aria-label="Primary"
+        id="primary-nav"
+      >
+        <label className="shell__nav-search">
+          <span className="shell__nav-search-label">Search pages</span>
+          <input
+            type="search"
+            placeholder="Find a page…"
+            value={navSearchQuery}
+            onChange={event => setNavSearchQuery(event.target.value)}
+            className="shell__nav-search-input"
+          />
+        </label>
+
+        {filteredNavItems.map(item => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            end={item.end}
+            className={({ isActive }) => navLinkClass(isActive, Boolean(item.parentTo))}
+          >
+            {item.label}
+          </NavLink>
+        ))}
+
+        {filteredNavItems.length === 0 && (
+          <p className="shell__nav-empty" role="status">
+            No pages match “{navSearchQuery.trim()}”.
+          </p>
+        )}
+      </nav>
+    </div>
+  )
+
+  const controlsSection = (
+    <div className="shell__controls">
+      <div
+        className="shell__store-switcher"
+        role="status"
+        aria-live="polite"
+      >
+        <span className="shell__store-label">Workspace</span>
+        <span
+          className="shell__store-select"
+          data-readonly
+        >
+          {workspaceStatus}
+        </span>
+      </div>
+
+      {banner && (
+        <div
+          className="shell__status-badge"
+          data-variant={banner.variant}
+          role="status"
+          aria-live="polite"
+          title={banner.message}
+        >
+          <span
+            className={`shell__status-dot${
+              banner.pulse ? ' is-pulsing' : ''
+            }`}
+            aria-hidden="true"
+          />
+          <span className="shell__status-label">
+            {BADGE_LABELS[banner.variant]}
+          </span>
+          <span className="shell__sr-only">
+            {banner.message}
+          </span>
+        </div>
+      )}
+
+      <SupportTicketLauncher />
+
+      <div className="shell__account">
+        <span className="shell__account-email">
+          {userEmail}
+        </span>
+        <button
+          type="button"
+          className="button button--primary button--small"
+          onClick={() => signOut(auth)}
+        >
+          Sign out
+        </button>
+      </div>
+    </div>
+  )
+
   return (
     <div className="shell">
       {isMenuOpen && (
@@ -360,6 +467,10 @@ export default function Shell({ children }: { children: React.ReactNode }) {
             <div className="shell__brand">
               <div className="shell__logo">Sedifex</div>
               <span className="shell__tagline">Sell faster. Count smarter.</span>
+            </div>
+
+            <div className="shell__header-controls">
+              {controlsSection}
             </div>
 
             <button
@@ -386,138 +497,8 @@ export default function Shell({ children }: { children: React.ReactNode }) {
               isMenuOpen ? ' is-open' : ''
             }`}
           >
-            <div className="shell__nav-group">
-              <div
-                className="shell__workspace-pill"
-                role="status"
-                aria-live="polite"
-              >
-                <span className="shell__workspace-label">Workspace</span>
-                <span className="shell__workspace-name">
-                  {workspaceLoading && !workspaceLabel
-                    ? 'Loading…'
-                    : workspaceLabel}
-                </span>
-              </div>
-
-              <nav
-                className="shell__nav"
-                aria-label="Primary"
-                id="primary-nav"
-              >
-                <label className="shell__nav-search">
-                  <span className="shell__nav-search-label">Search pages</span>
-                  <input
-                    type="search"
-                    placeholder="Find a page…"
-                    value={navSearchQuery}
-                    onChange={event => setNavSearchQuery(event.target.value)}
-                    className="shell__nav-search-input"
-                  />
-                </label>
-
-                {filteredNavItems.map(item => (
-                  <NavLink
-                    key={item.to}
-                    to={item.to}
-                    end={item.end}
-                    className={({ isActive }) => navLinkClass(isActive, Boolean(item.parentTo))}
-                  >
-                    {item.label}
-                  </NavLink>
-                ))}
-
-                {filteredNavItems.length === 0 && (
-                  <p className="shell__nav-empty" role="status">
-                    No pages match “{navSearchQuery.trim()}”.
-                  </p>
-                )}
-              </nav>
-            </div>
-
-            <div className="shell__controls">
-              {resumePath && (
-                <div className="shell__resume-banner" role="status" aria-live="polite">
-                  <span>Return to where you left off?</span>
-                  <div className="shell__resume-actions">
-                    <button
-                      type="button"
-                      className="button button--primary button--small"
-                      onClick={() => {
-                        const targetPath = resumePath
-                        setResumePath(null)
-                        setDismissedResumePath(targetPath)
-                        navigate(targetPath)
-                      }}
-                    >
-                      Return
-                    </button>
-                    <button
-                      type="button"
-                      className="button button--ghost button--small"
-                      onClick={() => {
-                        setDismissedResumePath(resumePath)
-                        setResumePath(null)
-                      }}
-                    >
-                      Dismiss
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              <div
-                className="shell__store-switcher"
-                role="status"
-                aria-live="polite"
-              >
-                <span className="shell__store-label">Workspace</span>
-                <span
-                  className="shell__store-select"
-                  data-readonly
-                >
-                  {workspaceStatus}
-                </span>
-              </div>
-
-              {banner && (
-                <div
-                  className="shell__status-badge"
-                  data-variant={banner.variant}
-                  role="status"
-                  aria-live="polite"
-                  title={banner.message}
-                >
-                  <span
-                    className={`shell__status-dot${
-                      banner.pulse ? ' is-pulsing' : ''
-                    }`}
-                    aria-hidden="true"
-                  />
-                  <span className="shell__status-label">
-                    {BADGE_LABELS[banner.variant]}
-                  </span>
-                  <span className="shell__sr-only">
-                    {banner.message}
-                  </span>
-                </div>
-              )}
-
-              <SupportTicketLauncher />
-
-              <div className="shell__account">
-                <span className="shell__account-email">
-                  {userEmail}
-                </span>
-                <button
-                  type="button"
-                  className="button button--primary button--small"
-                  onClick={() => signOut(auth)}
-                >
-                  Sign out
-                </button>
-              </div>
-            </div>
+            {navSection}
+            {controlsSection}
           </div>
         </div>
 
@@ -568,7 +549,43 @@ export default function Shell({ children }: { children: React.ReactNode }) {
       </header>
 
       <main className="shell__main">
-        <div className="shell__container">{children}</div>
+        <div className="shell__container shell__layout">
+          <aside className="shell__sidebar">
+            {navSection}
+          </aside>
+          <section className="shell__content">
+            {resumePath && (
+              <div className="shell__resume-banner" role="status" aria-live="polite">
+                <span>Return to where you left off?</span>
+                <div className="shell__resume-actions">
+                  <button
+                    type="button"
+                    className="button button--primary button--small"
+                    onClick={() => {
+                      const targetPath = resumePath
+                      setResumePath(null)
+                      setDismissedResumePath(targetPath)
+                      navigate(targetPath)
+                    }}
+                  >
+                    Return
+                  </button>
+                  <button
+                    type="button"
+                    className="button button--ghost button--small"
+                    onClick={() => {
+                      setDismissedResumePath(resumePath)
+                      setResumePath(null)
+                    }}
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              </div>
+            )}
+            <div className="shell__content-inner">{children}</div>
+          </section>
+        </div>
       </main>
     </div>
   )


### PR DESCRIPTION
### Motivation
- Move the primary navigation out of the header toolbar into a reusable sidebar on wide viewports and keep a compact toolbar for smaller screens to improve layout clarity and accessibility.
- Reduce duplication by extracting the navigation and controls markup into `navSection` and `controlsSection` variables and reuse them between header toolbar and main layout.
- Adjust styling and spacing to support a two-column layout with a sticky sidebar and constrained content area for better desktop UX.

### Description
- Added `navSection` and `controlsSection` JSX fragments in `Shell.tsx` and replaced the duplicated toolbar content by reusing those fragments inside the header toolbar and the main sidebar. 
- Moved the resume banner into the main content flow and wrapped children in a new `.shell__content-inner` element to preserve layout constraints.
- Introduced a desktop grid layout with `.shell__layout`, `.shell__sidebar`, `.shell__content`, and `.shell__content-inner` CSS rules in `Shell.css` and made the sidebar sticky with visual chrome (padding, border, background, shadow).
- Reworked several navigation and header styles in `Shell.css` to support columnar nav (`.shell__nav`, `.shell__nav-search`, `.shell__nav-group`, `.shell__nav-link`), header controls placement (`.shell__header-controls`), and responsive behavior (hide/show `.shell__toolbar` and `.shell__sidebar` at breakpoints).

### Testing
- Ran the project build with `yarn build` and the TypeScript typecheck, and both completed successfully.
- Executed the test suite with `yarn test` and all automated tests passed.
- Ran linting with `yarn lint` with no new lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ea9c22208321ba70abb8451c4743)