### PR TITLE
Add Google sign-in option on auth login

### DIFF
--- a/web/src/pages/AuthPage.test.tsx
+++ b/web/src/pages/AuthPage.test.tsx
@@ -8,6 +8,8 @@ import AuthPage from './AuthPage'
 const mockAuth = { signOut: vi.fn(async () => {}) }
 const mockSignInWithEmailAndPassword = vi.fn()
 const mockCreateUserWithEmailAndPassword = vi.fn()
+const mockSignInWithPopup = vi.fn()
+const mockGoogleAuthProviderSetCustomParameters = vi.fn()
 const mockPersistSession = vi.fn(async () => {})
 const mockResolveStoreAccess = vi.fn(async () => ({
   storeId: 'store-1',
@@ -29,6 +31,12 @@ vi.mock('../firebase', () => ({
 vi.mock('firebase/auth', () => ({
   createUserWithEmailAndPassword: (...args: unknown[]) => mockCreateUserWithEmailAndPassword(...args),
   signInWithEmailAndPassword: (...args: unknown[]) => mockSignInWithEmailAndPassword(...args),
+  signInWithPopup: (...args: unknown[]) => mockSignInWithPopup(...args),
+  GoogleAuthProvider: class {
+    setCustomParameters(...args: unknown[]) {
+      mockGoogleAuthProviderSetCustomParameters(...args)
+    }
+  },
 }))
 
 vi.mock('firebase/firestore', () => ({
@@ -64,6 +72,8 @@ describe('AuthPage', () => {
   beforeEach(() => {
     mockSignInWithEmailAndPassword.mockReset()
     mockCreateUserWithEmailAndPassword.mockReset()
+    mockSignInWithPopup.mockReset()
+    mockGoogleAuthProviderSetCustomParameters.mockReset()
     mockPersistSession.mockClear()
     mockResolveStoreAccess.mockClear()
     mockInitializeStore.mockClear()
@@ -101,5 +111,24 @@ describe('AuthPage', () => {
 
     const successToast = mockPublish.mock.calls.find(([options]) => options.tone === 'success')?.[0]
     expect(successToast?.message).toBe('Welcome back! Redirecting…')
+  })
+
+  it('supports Google sign in from login page', async () => {
+    const user = userEvent.setup()
+    mockSignInWithPopup.mockResolvedValueOnce({ user: { uid: 'google-user-1' } })
+
+    render(
+      <MemoryRouter>
+        <AuthPage />
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Continue with Google/i }))
+
+    await waitFor(() => expect(mockSignInWithPopup).toHaveBeenCalledTimes(1))
+    expect(mockGoogleAuthProviderSetCustomParameters).toHaveBeenCalledWith({
+      prompt: 'select_account',
+    })
+    await waitFor(() => expect(mockPersistSession).toHaveBeenCalledTimes(2))
   })
 })

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -2,7 +2,9 @@ import React, { useEffect, useMemo, useState } from 'react'
 import type { User } from 'firebase/auth'
 import {
   createUserWithEmailAndPassword,
+  GoogleAuthProvider,
   signInWithEmailAndPassword,
+  signInWithPopup,
   sendEmailVerification,
 } from 'firebase/auth'
 import {
@@ -347,6 +349,27 @@ export default function AuthPage() {
   const isSubmitDisabled =
     isLoading || (mode === 'login' ? !isLoginFormValid : !isSignupFormValid)
 
+  const completeLogin = async (nextUser: User) => {
+    await persistSession(nextUser)
+    try {
+      const resolution = await resolveStoreAccess()
+      await persistSession(nextUser, {
+        storeId: resolution.storeId,
+        workspaceSlug: resolution.workspaceSlug,
+        role: resolution.role,
+      })
+      const reminder = formatTrialReminder(resolution.billing)
+      if (reminder) {
+        publish({ tone: 'info', message: reminder })
+      }
+    } catch (error) {
+      console.warn('[auth] Failed to resolve workspace access', error)
+      setStatus({ tone: 'error', message: getAuthErrorMessage(error, 'login') })
+      return false
+    }
+    return true
+  }
+
   useEffect(() => {
     document.title = mode === 'login' ? 'Sedifex — Log in' : 'Sedifex — Sign up'
   }, [mode])
@@ -560,21 +583,8 @@ export default function AuthPage() {
           sanitizedEmail,
           sanitizedPassword,
         )
-        await persistSession(nextUser)
-        try {
-          const resolution = await resolveStoreAccess()
-          await persistSession(nextUser, {
-            storeId: resolution.storeId,
-            workspaceSlug: resolution.workspaceSlug,
-            role: resolution.role,
-          })
-          const reminder = formatTrialReminder(resolution.billing)
-          if (reminder) {
-            publish({ tone: 'info', message: reminder })
-          }
-        } catch (error) {
-          console.warn('[auth] Failed to resolve workspace access', error)
-          setStatus({ tone: 'error', message: getAuthErrorMessage(error, 'login') })
+        const didCompleteLogin = await completeLogin(nextUser)
+        if (!didCompleteLogin) {
           return
         }
       } else {
@@ -705,6 +715,23 @@ export default function AuthPage() {
       setAddress('')
     } catch (err: unknown) {
       setStatus({ tone: 'error', message: getAuthErrorMessage(err, mode) })
+    }
+  }
+
+  async function handleGoogleSignIn() {
+    if (mode !== 'login' || isLoading) return
+
+    setStatus({ tone: 'loading', message: 'Connecting to Google…' })
+    try {
+      const provider = new GoogleAuthProvider()
+      provider.setCustomParameters({ prompt: 'select_account' })
+      const { user: nextUser } = await signInWithPopup(auth, provider)
+      const didCompleteLogin = await completeLogin(nextUser)
+      if (!didCompleteLogin) return
+
+      setStatus({ tone: 'success', message: 'Welcome back! Redirecting…' })
+    } catch (error) {
+      setStatus({ tone: 'error', message: getAuthErrorMessage(error, 'login') })
     }
   }
 
@@ -1010,6 +1037,17 @@ export default function AuthPage() {
                   ? 'Log in'
                   : 'Start free trial'}
             </button>
+
+            {mode === 'login' && (
+              <button
+                className="secondary-button"
+                type="button"
+                onClick={handleGoogleSignIn}
+                disabled={isLoading}
+              >
+                Continue with Google
+              </button>
+            )}
           </form>
 
           {status.tone !== 'idle' && status.message && (


### PR DESCRIPTION
### Motivation

- Provide an alternative OAuth login option on the landing auth page so users can sign in with Google instead of email/password.

### Description

- Added `GoogleAuthProvider` and `signInWithPopup` integration in `web/src/pages/AuthPage.tsx` and wired a `Continue with Google` button in the login view. 
- Introduced a shared `completeLogin` helper to centralize session persistence and workspace resolution for both email/password and Google logins. 
- Implemented `handleGoogleSignIn` to perform the popup OAuth flow and reuse `completeLogin` for post-auth processing. 
- Updated tests in `web/src/pages/AuthPage.test.tsx` to mock `signInWithPopup` and `GoogleAuthProvider` and added a test that verifies the Google sign-in flow triggers the popup and persists the session.

### Testing

- Updated unit tests: added an automated test case ensuring Google sign-in triggers `signInWithPopup` and calls `persistSession` in `web/src/pages/AuthPage.test.tsx`. 
- Attempted to run the test suite with `npm test -- --run src/pages/AuthPage.test.tsx` from the `web/` directory, but the run failed because `vitest` is not available in the execution environment (`sh: 1: vitest: not found`).
- An earlier attempt to run `npm test -- --run web/src/pages/AuthPage.test.tsx` from the repo root failed due to missing root `package.json`.
- All test changes are committed but could not be executed in this environment due to the missing test runner dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f52b94f48321b0122179f95febeb)