### PR TITLE
Fix Ads billing form submit handler

### DIFF
--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -435,7 +435,14 @@ export default function AdsCampaigns() {
           <p>Capture consent before Sedifex starts spending ad budget.</p>
         </div>
 
-        <form onSubmit={handleBillingConfirm} className="ads-campaigns__form-grid" noValidate>
+        <form
+          onSubmit={event => {
+            event.preventDefault()
+            void handleBillingConfirmClick()
+          }}
+          className="ads-campaigns__form-grid"
+          noValidate
+        >
           <label>
             <span>Business legal name</span>
             <input


### PR DESCRIPTION
### Motivation
- Fix a runtime error on the `/ads` page caused by the billing ownership form referencing an undefined `handleBillingConfirm` handler so users can submit the billing confirmation (including pressing Enter).

### Description
- Replace the form `onSubmit` to `preventDefault()` and call the existing `handleBillingConfirmClick()` handler in `web/src/pages/AdsCampaigns.tsx` so the form submission uses the same confirmation logic as the button.

### Testing
- Ran `npm -C web run lint` which failed in this environment due to a missing ESLint dependency (`@eslint/js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9107ae6708321b31abb61ae131306)