### PR TITLE
Canonicalize OAuth callback domain to https://www.sedifex.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ Minimum backend vars:
 
 - `GOOGLE_ADS_CLIENT_ID`
 - `GOOGLE_ADS_CLIENT_SECRET`
-- `GOOGLE_ADS_REDIRECT_URI`
-- `APP_BASE_URL`
+- `GOOGLE_ADS_REDIRECT_URI` (set to `https://www.sedifex.com/api/google-ads/oauth-callback`)
+- `APP_BASE_URL` (set to `https://www.sedifex.com`)
 - `GOOGLE_ADS_SYNC_SECRET` (used by the optional manual sync endpoint)
 
 These are required by OAuth/token exchange and callback redirect logic.
@@ -167,11 +167,11 @@ Firebase Functions uses its runtime service account by default, so no extra Admi
 In your OAuth client:
 
 - Add authorized redirect URI exactly matching:
-  - `https://<your-firebase-hosting-domain>/api/google-ads/oauth-callback`
+  - `https://www.sedifex.com/api/google-ads/oauth-callback`
 - Ensure Google Ads scope is allowed:
   - `https://www.googleapis.com/auth/adwords`
 
-The backend builds the OAuth URL with that redirect URI and exchanges auth code for tokens.
+The backend builds the OAuth URL with that redirect URI and exchanges auth code for tokens. The URI in Google Cloud Console must be an exact string match with `GOOGLE_ADS_REDIRECT_URI`.
 
 ### 3) Deploy Firebase Hosting + Cloud Functions
 
@@ -218,6 +218,12 @@ Metrics sync runs every 30 minutes through:
 Optional manual sync endpoint:
 
 - `POST /api/google-ads/metrics-sync` with `x-google-ads-sync-secret: <GOOGLE_ADS_SYNC_SECRET>` (or `?secret=...`)
+
+### 7) Quick sanity notes
+
+- Use a single canonical Sedifex domain for OAuth callback-related variables to avoid redirect mismatches. Recommended canonical base: `https://www.sedifex.com`.
+- If you still have duplicate `PAYSTACK_STANDARD_PLAN_CODE` entries in runtime config, remove duplicates and keep one source of truth.
+- After updating env variables, redeploy and retry Google connect.
 
 ## Firebase setup notes
 - Enable **Authentication → Phone** and **Email/Password** (optional).

--- a/functions/src/googleAds.ts
+++ b/functions/src/googleAds.ts
@@ -53,6 +53,18 @@ const GOOGLE_SCOPES = [
 const GOOGLE_ADS_API_BASE = 'https://googleads.googleapis.com'
 const GOOGLE_ADS_API_VERSION = process.env.GOOGLE_ADS_API_VERSION?.trim() || 'v18'
 
+function canonicalizeSedifexUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.hostname === 'sedifex.com') parsed.hostname = 'www.sedifex.com'
+    return parsed.toString()
+  } catch {
+    return trimmed
+  }
+}
+
 function hashSecret(value: string): string {
   return createHash('sha256').update(value).digest('hex')
 }
@@ -104,7 +116,7 @@ function decryptToken(payload: GoogleAdsSecretsCipher | undefined): string {
 function getOAuthClientConfig() {
   const clientId = process.env.GOOGLE_ADS_CLIENT_ID?.trim() || ''
   const clientSecret = process.env.GOOGLE_ADS_CLIENT_SECRET?.trim() || ''
-  const redirectUri = process.env.GOOGLE_ADS_REDIRECT_URI?.trim() || ''
+  const redirectUri = canonicalizeSedifexUrl(process.env.GOOGLE_ADS_REDIRECT_URI?.trim() || '')
 
   if (!clientId || !clientSecret || !redirectUri) {
     throw new Error(
@@ -707,7 +719,7 @@ async function fetchGoogleAdsCampaignMetrics(params: {
 }
 
 function callbackDoneUrl(params: { ok: boolean; message: string; storeId?: string }) {
-  const appOrigin = process.env.APP_BASE_URL?.trim() || ''
+  const appOrigin = canonicalizeSedifexUrl(process.env.APP_BASE_URL?.trim() || '')
   if (!appOrigin) return null
 
   const url = new URL('/ads', appOrigin)

--- a/functions/src/googleShopping.ts
+++ b/functions/src/googleShopping.ts
@@ -64,6 +64,18 @@ const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 const GOOGLE_MERCHANT_SCOPES = ['https://www.googleapis.com/auth/content', 'openid', 'email', 'profile']
 const DEFAULT_INTEGRATION_BASE_URL = 'https://us-central1-sedifex-web.cloudfunctions.net'
 
+function canonicalizeSedifexUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.hostname === 'sedifex.com') parsed.hostname = 'www.sedifex.com'
+    return parsed.toString()
+  } catch {
+    return trimmed
+  }
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== 'object') return {}
   return value as Record<string, unknown>
@@ -86,7 +98,7 @@ function setCors(res: functions.Response<any>) {
 function getOAuthClientConfig() {
   const clientId = process.env.GOOGLE_MERCHANT_CLIENT_ID?.trim() || ''
   const clientSecret = process.env.GOOGLE_MERCHANT_CLIENT_SECRET?.trim() || ''
-  const redirectUri = process.env.GOOGLE_MERCHANT_REDIRECT_URI?.trim() || ''
+  const redirectUri = canonicalizeSedifexUrl(process.env.GOOGLE_MERCHANT_REDIRECT_URI?.trim() || '')
 
   if (!clientId || !clientSecret || !redirectUri) {
     throw new Error('google-merchant-oauth-config-missing')
@@ -177,7 +189,7 @@ function oauthCallbackDoneUrl(params: {
   pendingSelectionId?: string
   refreshTokenMissing?: boolean
 }) {
-  const appOrigin = process.env.APP_BASE_URL?.trim() || ''
+  const appOrigin = canonicalizeSedifexUrl(process.env.APP_BASE_URL?.trim() || '')
   if (!appOrigin) return null
 
   const callbackUrl = new URL('/google-shopping', appOrigin)

--- a/web/api/_google-ads.ts
+++ b/web/api/_google-ads.ts
@@ -14,6 +14,18 @@ const GOOGLE_SCOPES = [
 const GOOGLE_ADS_API_BASE = 'https://googleads.googleapis.com'
 const GOOGLE_ADS_API_VERSION = process.env.GOOGLE_ADS_API_VERSION?.trim() || 'v18'
 
+function canonicalizeSedifexUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.hostname === 'sedifex.com') parsed.hostname = 'www.sedifex.com'
+    return parsed.toString()
+  } catch {
+    return trimmed
+  }
+}
+
 export type CampaignGoal = 'leads' | 'sales' | 'traffic' | 'calls' | 'awareness'
 export type CampaignStatus = 'draft' | 'live' | 'paused'
 
@@ -100,7 +112,7 @@ function decryptToken(payload: GoogleAdsSecretsCipher | undefined): string {
 export function getOAuthClientConfig() {
   const clientId = process.env.GOOGLE_ADS_CLIENT_ID?.trim() || ''
   const clientSecret = process.env.GOOGLE_ADS_CLIENT_SECRET?.trim() || ''
-  const redirectUri = process.env.GOOGLE_ADS_REDIRECT_URI?.trim() || ''
+  const redirectUri = canonicalizeSedifexUrl(process.env.GOOGLE_ADS_REDIRECT_URI?.trim() || '')
 
   if (!clientId || !clientSecret || !redirectUri) {
     throw new Error(

--- a/web/api/_google-oauth.ts
+++ b/web/api/_google-oauth.ts
@@ -8,6 +8,18 @@ const GOOGLE_OAUTH_BASE = 'https://accounts.google.com/o/oauth2/v2/auth'
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 const SHARED_CALLBACK_PATH = '/api/google/oauth-callback'
 
+function canonicalizeSedifexUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.hostname === 'sedifex.com') parsed.hostname = 'www.sedifex.com'
+    return parsed.toString()
+  } catch {
+    return trimmed
+  }
+}
+
 const INTEGRATION_SCOPES: Record<GoogleIntegration, string> = {
   business: 'https://www.googleapis.com/auth/business.manage',
   ads: 'https://www.googleapis.com/auth/adwords',
@@ -22,8 +34,10 @@ function getOAuthConfig() {
   const clientId = process.env.GOOGLE_CLIENT_ID?.trim() || process.env.GOOGLE_ADS_CLIENT_ID?.trim() || ''
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim() || process.env.GOOGLE_ADS_CLIENT_SECRET?.trim() || ''
 
-  const appBase = process.env.APP_BASE_URL?.trim() || ''
-  const redirectUri = process.env.GOOGLE_REDIRECT_URI?.trim() || (appBase ? new URL(SHARED_CALLBACK_PATH, appBase).toString() : '')
+  const appBase = canonicalizeSedifexUrl(process.env.APP_BASE_URL?.trim() || '')
+  const redirectUri =
+    canonicalizeSedifexUrl(process.env.GOOGLE_REDIRECT_URI?.trim() || '') ||
+    (appBase ? new URL(SHARED_CALLBACK_PATH, appBase).toString() : '')
 
   if (!clientId || !clientSecret || !redirectUri) {
     throw new Error('google-oauth-config-missing')

--- a/web/api/google-ads/oauth-callback.ts
+++ b/web/api/google-ads/oauth-callback.ts
@@ -7,8 +7,20 @@ import {
   getOAuthClientConfig,
 } from '../_google-ads.js'
 
+function canonicalizeSedifexUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.hostname === 'sedifex.com') parsed.hostname = 'www.sedifex.com'
+    return parsed.toString()
+  } catch {
+    return trimmed
+  }
+}
+
 function callbackDoneUrl(params: { ok: boolean; message: string; storeId?: string }) {
-  const appOrigin = process.env.APP_BASE_URL?.trim() || ''
+  const appOrigin = canonicalizeSedifexUrl(process.env.APP_BASE_URL?.trim() || '')
   if (!appOrigin) return null
 
   const url = new URL('/ads', appOrigin)

--- a/web/api/google/oauth-callback.ts
+++ b/web/api/google/oauth-callback.ts
@@ -1,8 +1,20 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { consumeGoogleOAuthState, exchangeGoogleCode, storeUnifiedGoogleTokens } from '../_google-oauth.js'
 
+function canonicalizeSedifexUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.hostname === 'sedifex.com') parsed.hostname = 'www.sedifex.com'
+    return parsed.toString()
+  } catch {
+    return trimmed
+  }
+}
+
 function callbackDoneUrl(params: { ok: boolean; message: string; storeId?: string; integrations?: string[] }) {
-  const appOrigin = process.env.APP_BASE_URL?.trim() || ''
+  const appOrigin = canonicalizeSedifexUrl(process.env.APP_BASE_URL?.trim() || '')
   if (!appOrigin) return null
 
   const url = new URL('/account?tab=integrations', appOrigin)


### PR DESCRIPTION
### Motivation

- Prevent mismatched OAuth redirect URIs caused by mixing `sedifex.com` and `www.sedifex.com` so Google OAuth callbacks are deterministic.
- Make backend-built redirect URIs and `APP_BASE_URL` consistent with the canonical production origin `https://www.sedifex.com` to avoid Google Cloud Console exact-match failures.
- Surface a quick deploy checklist reminder to remove duplicate `PAYSTACK_STANDARD_PLAN_CODE` entries and redeploy after env changes.

### Description

- Added a `canonicalizeSedifexUrl` helper and applied it where OAuth callback/base URLs are derived in Vercel handlers and Firebase Functions (files updated include `web/api/_google-ads.ts`, `web/api/_google-oauth.ts`, `web/api/google-ads/oauth-callback.ts`, `web/api/google/oauth-callback.ts`, `functions/src/googleAds.ts`, and `functions/src/googleShopping.ts`).
- Switched `GOOGLE_ADS_REDIRECT_URI`, `GOOGLE_REDIRECT_URI`, `GOOGLE_MERCHANT_REDIRECT_URI`, and `APP_BASE_URL` usages to the canonicalized form so `sedifex.com` hostnames are normalized to `www.sedifex.com` before use.
- Updated the Google Ads deployment checklist in `README.md` to explicitly recommend `APP_BASE_URL=https://www.sedifex.com` and `GOOGLE_ADS_REDIRECT_URI=https://www.sedifex.com/api/google-ads/oauth-callback`, and added quick sanity notes about duplicate `PAYSTACK_STANDARD_PLAN_CODE` and redeploy guidance.

### Testing

- Ran lint with `npm --prefix web run -s lint`, which failed in this environment due to a missing dev dependency (`@eslint/js`).
- Ran build with `npm --prefix web run -s build`, which failed in this environment due to missing type definitions (`vite/client` and `vitest/globals`).
- No other automated tests were executed in this environment; code changes are limited to URL normalization and README updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91378231883218157ade5b8a6a3d1)