### PR TITLE
Add Google Connect hub with sub-tabs

### DIFF
--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -19,7 +19,8 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/finance', label: 'Invoice', parentTo: '/sell', roles: ['owner'] },
   { to: '/account', label: 'Account', roles: ['owner'] },
   { to: '/public-page', label: 'Public page', roles: ['owner'] },
-  { to: '/ads', label: 'Google Ads', roles: ['owner'] },
-  { to: '/google-shopping', label: 'Google Shopping', roles: ['owner'] },
-  { to: '/google-business', label: 'Google Business', roles: ['owner'] },
+  { to: '/google-connect', label: 'Google Connect', roles: ['owner'] },
+  { to: '/ads', label: 'Google Ads', parentTo: '/google-connect', roles: ['owner'] },
+  { to: '/google-shopping', label: 'Google Shopping', parentTo: '/google-connect', roles: ['owner'] },
+  { to: '/google-business', label: 'Google Business', parentTo: '/google-connect', roles: ['owner'] },
 ]

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -31,6 +31,7 @@ import PublicPageSettings from './pages/PublicPageSettings'
 import AdsCampaigns from './pages/AdsCampaigns'
 import GoogleShopping from './pages/GoogleShopping'
 import GoogleBusinessProfile from './pages/GoogleBusinessProfile'
+import GoogleConnect from './pages/GoogleConnect'
 
 // ✅ NEW: public receipt page used by QR/share
 import ReceiptView from './pages/ReceiptView'
@@ -89,6 +90,7 @@ const router = createBrowserRouter([
           { path: 'account', element: <AccountOverview /> },
           { path: 'account/overview', element: <AccountOverview /> },
           { path: 'public-page', element: <PublicPageSettings /> },
+          { path: 'google-connect', element: <GoogleConnect /> },
           { path: 'ads', element: <AdsCampaigns /> },
           { path: 'google-shopping', element: <GoogleShopping /> },
           { path: 'google-business', element: <GoogleBusinessProfile /> },

--- a/web/src/pages/GoogleConnect.css
+++ b/web/src/pages/GoogleConnect.css
@@ -1,0 +1,46 @@
+.google-connect-page {
+  display: grid;
+  gap: 16px;
+}
+
+.google-connect-page__header h1 {
+  margin: 0;
+}
+
+.google-connect-page__header p {
+  margin: 6px 0 0;
+  color: #4b5563;
+}
+
+.google-connect-page__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.google-connect-page__tab {
+  text-decoration: none;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  padding: 8px 14px;
+  color: #111827;
+  background: #fff;
+  font-weight: 600;
+}
+
+.google-connect-page__tab.is-active {
+  background: #111827;
+  color: #fff;
+  border-color: #111827;
+}
+
+.google-connect-page__panel {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 14px 16px;
+  background: #f9fafb;
+}
+
+.google-connect-page__panel p {
+  margin: 0;
+}

--- a/web/src/pages/GoogleConnect.tsx
+++ b/web/src/pages/GoogleConnect.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Link, useLocation } from 'react-router-dom'
+
+import './GoogleConnect.css'
+
+const TABS = [
+  { to: '/ads', label: 'Google Ads' },
+  { to: '/google-shopping', label: 'Google Shopping' },
+  { to: '/google-business', label: 'Google Business Profile' },
+]
+
+export default function GoogleConnect() {
+  const location = useLocation()
+
+  return (
+    <main className="google-connect-page">
+      <header className="google-connect-page__header">
+        <h1>Google Connect</h1>
+        <p>Use one workspace to jump into Ads, Shopping, and Business Profile setup.</p>
+      </header>
+
+      <nav className="google-connect-page__tabs" aria-label="Google tools">
+        {TABS.map(tab => {
+          const active = location.pathname === tab.to
+          return (
+            <Link key={tab.to} to={tab.to} className={`google-connect-page__tab ${active ? 'is-active' : ''}`}>
+              {tab.label}
+            </Link>
+          )
+        })}
+      </nav>
+
+      <section className="google-connect-page__panel">
+        <p>Select a Google tool above to continue setup.</p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a single, clear entry point for all Google integrations so users can access Ads, Shopping, and Business Profile from one place.

### Description
- Added a new page `web/src/pages/GoogleConnect.tsx` that presents a header, an info panel, and pill-style sub-tabs linking to `/ads`, `/google-shopping`, and `/google-business`.
- Added styling for the new page in `web/src/pages/GoogleConnect.css` to render the tab buttons and info panel.
- Registered the route `/google-connect` in `web/src/main.tsx` so the page is reachable from authenticated routes.
- Updated `web/src/config/navigation.ts` to surface a single top-level `Google Connect` navigation item and nest the three Google pages under it with `parentTo: '/google-connect'`.

### Testing
- Ran `npm --prefix web run build` to validate the web bundle, which failed in this environment due to missing TypeScript type definitions for `vite/client` and `vitest/globals` (failure unrelated to the UI changes themselves).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d916574024832197c24c2c473d2e89)