### PR TITLE
Improve Google Connect page with actionable integration cards

### DIFF
--- a/web/src/pages/GoogleConnect.css
+++ b/web/src/pages/GoogleConnect.css
@@ -1,6 +1,6 @@
 .google-connect-page {
   display: grid;
-  gap: 16px;
+  gap: 18px;
 }
 
 .google-connect-page__header h1 {
@@ -8,27 +8,86 @@
 }
 
 .google-connect-page__header p {
+  max-width: 74ch;
   margin: 6px 0 0;
   color: #4b5563;
 }
 
-.google-connect-page__tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+.google-connect-page__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 12px;
 }
 
-.google-connect-page__tab {
+.google-connect-card {
+  display: grid;
+  gap: 10px;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  background: #fff;
+  padding: 14px;
+}
+
+.google-connect-card.is-active {
+  border-color: #111827;
+  box-shadow: 0 0 0 1px #111827;
+}
+
+.google-connect-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.google-connect-card h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.google-connect-card__status {
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  padding: 3px 9px;
+  font-size: 0.75rem;
+  color: #374151;
+  background: #f9fafb;
+}
+
+.google-connect-card.is-active .google-connect-card__status {
+  border-color: #111827;
+  color: #111827;
+  background: #f3f4f6;
+}
+
+.google-connect-card p {
+  margin: 0;
+  color: #374151;
+}
+
+.google-connect-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: #4b5563;
+}
+
+.google-connect-card li + li {
+  margin-top: 4px;
+}
+
+.google-connect-card__cta {
+  width: fit-content;
   text-decoration: none;
   border: 1px solid #d1d5db;
   border-radius: 999px;
-  padding: 8px 14px;
+  padding: 8px 12px;
   color: #111827;
   background: #fff;
   font-weight: 600;
 }
 
-.google-connect-page__tab.is-active {
+.google-connect-card.is-active .google-connect-card__cta,
+.google-connect-card__cta:hover {
   background: #111827;
   color: #fff;
   border-color: #111827;
@@ -41,6 +100,16 @@
   background: #f9fafb;
 }
 
-.google-connect-page__panel p {
+.google-connect-page__panel h3 {
   margin: 0;
+  font-size: 1rem;
+}
+
+.google-connect-page__panel ol {
+  margin: 10px 0 0;
+  padding-left: 18px;
+}
+
+.google-connect-page__panel li + li {
+  margin-top: 6px;
 }

--- a/web/src/pages/GoogleConnect.tsx
+++ b/web/src/pages/GoogleConnect.tsx
@@ -3,10 +3,32 @@ import { Link, useLocation } from 'react-router-dom'
 
 import './GoogleConnect.css'
 
-const TABS = [
-  { to: '/ads', label: 'Google Ads' },
-  { to: '/google-shopping', label: 'Google Shopping' },
-  { to: '/google-business', label: 'Google Business Profile' },
+type GoogleToolTab = {
+  to: string
+  label: string
+  summary: string
+  checklist: string[]
+}
+
+const TABS: GoogleToolTab[] = [
+  {
+    to: '/ads',
+    label: 'Google Ads',
+    summary: 'Create campaigns with AI-ready briefs and budget controls from one screen.',
+    checklist: ['Connect account', 'Add billing details', 'Launch your first campaign'],
+  },
+  {
+    to: '/google-shopping',
+    label: 'Google Shopping',
+    summary: 'Sync products to Merchant Center and resolve feed issues before they block sales.',
+    checklist: ['Connect Merchant account', 'Map product fields', 'Run sync and fix warnings'],
+  },
+  {
+    to: '/google-business',
+    label: 'Google Business Profile',
+    summary: 'Manage listing visibility, branches, and profile consistency for local discovery.',
+    checklist: ['Authorize Business Profile', 'Choose account location', 'Review profile health'],
+  },
 ]
 
 export default function GoogleConnect() {
@@ -16,22 +38,45 @@ export default function GoogleConnect() {
     <main className="google-connect-page">
       <header className="google-connect-page__header">
         <h1>Google Connect</h1>
-        <p>Use one workspace to jump into Ads, Shopping, and Business Profile setup.</p>
+        <p>
+          Manage Google Ads, Shopping, and Business Profile from one workspace. Start with the integration that
+          impacts revenue fastest, then complete the rest.
+        </p>
       </header>
 
-      <nav className="google-connect-page__tabs" aria-label="Google tools">
+      <section className="google-connect-page__cards" aria-label="Google integrations">
         {TABS.map(tab => {
           const active = location.pathname === tab.to
+
           return (
-            <Link key={tab.to} to={tab.to} className={`google-connect-page__tab ${active ? 'is-active' : ''}`}>
-              {tab.label}
-            </Link>
+            <article key={tab.to} className={`google-connect-card ${active ? 'is-active' : ''}`}>
+              <div className="google-connect-card__top">
+                <h2>{tab.label}</h2>
+                <span className="google-connect-card__status">{active ? 'Current' : 'Available'}</span>
+              </div>
+              <p>{tab.summary}</p>
+
+              <ul>
+                {tab.checklist.map(item => (
+                  <li key={`${tab.to}-${item}`}>{item}</li>
+                ))}
+              </ul>
+
+              <Link to={tab.to} className="google-connect-card__cta" aria-current={active ? 'page' : undefined}>
+                {active ? 'Continue setup' : `Open ${tab.label}`}
+              </Link>
+            </article>
           )
         })}
-      </nav>
+      </section>
 
-      <section className="google-connect-page__panel">
-        <p>Select a Google tool above to continue setup.</p>
+      <section className="google-connect-page__panel" aria-label="Suggested sequence">
+        <h3>Recommended setup order</h3>
+        <ol>
+          <li>Connect Google Ads first to start generating traffic quickly.</li>
+          <li>Connect Google Shopping to capture high-intent product searches.</li>
+          <li>Finish Google Business Profile for local trust and map visibility.</li>
+        </ol>
       </section>
     </main>
   )


### PR DESCRIPTION
### Motivation
- Make the Google Connect area more actionable and informative so users understand what each integration does and what steps to take before navigating away. 
- Surface recommended setup order and current/available state so owners can prioritize high-impact integrations quickly.

### Description
- Replace the simple tab strip with responsive card-style overviews for Ads, Shopping, and Business Profile in `web/src/pages/GoogleConnect.tsx`. 
- Add per-tool `summary` and `checklist` fields and render a CTA per card with active-state text and `aria-current` behavior. 
- Introduce new CSS for a responsive card grid, status pills, active styling and spacing in `web/src/pages/GoogleConnect.css`. 
- Add a small “Recommended setup order” panel and refine header copy to encourage starting with the highest-impact integration.

### Testing
- Ran `npm --prefix web run build`, which failed due to missing local type definitions (`vite/client` and `vitest/globals`).
- Ran `npm --prefix web ci`, which failed with a `403 Forbidden` when attempting to fetch `@azure/msal-browser` from the npm registry due to environment/registry policy.
- No unit or integration tests were executed successfully in this environment because dependency installation and the build are blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d919c8637483218eaca89c2efcb4d3)