### PR TITLE
Support GOOGLE_ADS_REDIRECT_URI in shared Google OAuth config

### DIFF
--- a/web/api/_google-oauth.ts
+++ b/web/api/_google-oauth.ts
@@ -37,6 +37,7 @@ function getOAuthConfig() {
   const appBase = canonicalizeSedifexUrl(process.env.APP_BASE_URL?.trim() || '')
   const redirectUri =
     canonicalizeSedifexUrl(process.env.GOOGLE_REDIRECT_URI?.trim() || '') ||
+    canonicalizeSedifexUrl(process.env.GOOGLE_ADS_REDIRECT_URI?.trim() || '') ||
     (appBase ? new URL(SHARED_CALLBACK_PATH, appBase).toString() : '')
 
   if (!clientId || !clientSecret || !redirectUri) {


### PR DESCRIPTION
### Motivation
- Fix a runtime config mismatch where `GOOGLE_ADS_REDIRECT_URI` provided by deployments was ignored by the shared OAuth flow, causing `google-oauth-config-missing` errors.
- Preserve existing dual-name support for client credentials while ensuring the redirect URI is resolved in the requested order to avoid breaking existing deployments.

### Description
- Updated `getOAuthConfig()` in `web/api/_google-oauth.ts` to compute `redirectUri` from `GOOGLE_REDIRECT_URI` or `GOOGLE_ADS_REDIRECT_URI` or `new URL(SHARED_CALLBACK_PATH, appBase).toString()` in that order, while keeping `clientId` and `clientSecret` resolution as `GOOGLE_CLIENT_*` or `GOOGLE_ADS_CLIENT_*`.
- Left `SHARED_CALLBACK_PATH` as `'/api/google/oauth-callback'` because this module implements the unified/shared Google OAuth flow used by `business`/`ads`/`merchant` integrations.
- Only one file was modified: `web/api/_google-oauth.ts` (small insertion to include `GOOGLE_ADS_REDIRECT_URI` in the fallback chain).

### Testing
- Attempted an automated frontend build with `npm --prefix web run -s build`, which failed in this environment due to missing type definitions (`vite/client`, `vitest/globals`) unrelated to the logic change.
- Verified via automated searches that Ads-specific modules already use `GOOGLE_ADS_REDIRECT_URI` and that the only change required for the shared flow was the update to `web/api/_google-oauth.ts`.
- No unit tests were present/executed for this logic in the current environment; the code change is a local config-resolution fix and compiles in TypeScript contexts with proper dev dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d927ce10e08321ac2b80db5055bd1a)