### PR TITLE
Auto-generate integration API key when saving Google Merchant connection

### DIFF
--- a/functions/src/googleShopping.ts
+++ b/functions/src/googleShopping.ts
@@ -111,6 +111,55 @@ function hashValue(value: string): string {
   return createHash('sha256').update(value).digest('hex')
 }
 
+function generateIntegrationSecret(): string {
+  return randomBytes(24).toString('base64url')
+}
+
+function shortMask(value: string): string {
+  if (value.length <= 8) return '••••••••'
+  return `${value.slice(0, 4)}••••${value.slice(-4)}`
+}
+
+async function ensureIntegrationApiKey(params: {
+  storeId: string
+  uid: string
+  existingIntegrationApiKey: string
+}): Promise<string> {
+  if (params.existingIntegrationApiKey) return params.existingIntegrationApiKey
+
+  const token = `sedx_${generateIntegrationSecret()}`
+  const keyHash = hashValue(token)
+  const keyPreview = shortMask(token)
+  const timestamp = FieldValue.serverTimestamp()
+
+  await db.collection('integrationApiKeys').doc().set({
+    storeId: params.storeId,
+    name: 'Google Shopping auto-generated key',
+    status: 'active',
+    keyHash,
+    keyPreview,
+    createdBy: params.uid,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    revokedAt: null,
+    lastUsedAt: null,
+    source: 'google-shopping-connect',
+  })
+
+  await db.collection('integrationAuditLogs').add({
+    storeId: params.storeId,
+    action: 'api_key.created',
+    actorUid: params.uid,
+    metadata: {
+      name: 'Google Shopping auto-generated key',
+      source: 'google-shopping-connect',
+    },
+    createdAt: timestamp,
+  })
+
+  return token
+}
+
 function parseTokenExpiry(tokenPayload: Record<string, unknown>): Timestamp | null {
   const expiresInRaw = tokenPayload.expires_in
   const expiresIn = typeof expiresInRaw === 'number' ? expiresInRaw : Number(expiresInRaw || 0)
@@ -382,6 +431,11 @@ async function saveGoogleMerchantConnection(params: {
   const tokenExpiry = parseTokenExpiry(params.tokenPayload)
 
   const existingIntegrationApiKey = normalizeString(catalogSync.integrationApiKey)
+  const ensuredIntegrationApiKey = await ensureIntegrationApiKey({
+    storeId: params.storeId,
+    uid: params.uid,
+    existingIntegrationApiKey,
+  })
   const existingIntegrationBaseUrl = normalizeString(catalogSync.integrationBaseUrl)
   const existingAutoSyncEnabled = catalogSync.autoSyncEnabled === false ? false : true
 
@@ -392,7 +446,7 @@ async function saveGoogleMerchantConnection(params: {
     tokenUpdatedAt: FieldValue.serverTimestamp(),
     autoSyncEnabled: existingAutoSyncEnabled,
     integrationBaseUrl: existingIntegrationBaseUrl || DEFAULT_INTEGRATION_BASE_URL,
-    integrationApiKey: existingIntegrationApiKey,
+    integrationApiKey: ensuredIntegrationApiKey,
     ...(tokenExpiry ? { tokenExpiry } : {}),
   }
 


### PR DESCRIPTION
### Motivation
- Ensure a usable integration API key exists when a store connects Google Merchant so catalog sync can operate without manual key setup.
- Record creation of auto-generated keys in the audit log to maintain traceability for keys created during the Google Shopping connect flow.

### Description
- Add `generateIntegrationSecret` to produce a URL-safe random token and `shortMask` to create a masked preview for storage.
- Add `ensureIntegrationApiKey` which returns an existing key or creates a new `integrationApiKeys` document with `keyHash`, `keyPreview`, metadata and `source`, and writes an `integrationAuditLogs` entry, then returns the plaintext token.
- Use `hashValue` to store a hashed key and `FieldValue.serverTimestamp()` for created/updated timestamps in the created documents.
- Update `saveGoogleMerchantConnection` to call `ensureIntegrationApiKey` and populate `catalogSync.integrationApiKey` with the ensured token instead of relying on a possibly-missing existing value.

### Testing
- Ran existing unit test suite with `npm test` which includes Google Shopping-related tests, and they passed.
- Ran linting with `npm run lint` and there were no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d947ad39508321af7bc61bc53d20d9)