### PR TITLE
Refactor Ads connection to shared Google OAuth flow

### DIFF
--- a/web/api/google-ads/oauth-start.ts
+++ b/web/api/google-ads/oauth-start.ts
@@ -1,10 +1,11 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import {
-  buildOAuthStartUrl,
-  persistOAuthState,
-  requireStoreId,
-} from '../_google-ads.js'
 import { requireApiUser, requireStoreMembership } from '../_api-auth.js'
+import { buildGoogleOAuthStartUrl } from '../_google-oauth.js'
+
+function requireStoreId(raw: unknown): string {
+  if (typeof raw !== 'string' || !raw.trim()) throw new Error('invalid-store-id')
+  return raw.trim()
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
@@ -21,15 +22,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       typeof req.body?.managerId === 'string' ? req.body.managerId.trim() : ''
     const accountEmail =
       typeof req.body?.accountEmail === 'string' ? req.body.accountEmail.trim() : ''
-    const { url, rawState } = buildOAuthStartUrl({ storeId, uid: user.uid })
-
-    await persistOAuthState({
+    const { url } = await buildGoogleOAuthStartUrl({
       uid: user.uid,
       storeId,
-      rawState,
-      customerId,
-      managerId,
-      email: accountEmail || user.email,
+      integrations: ['ads'],
+      adsCustomerId: customerId,
+      adsManagerId: managerId,
+      accountEmail: accountEmail || user.email,
     })
 
     return res.status(200).json({ url })

--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -228,6 +228,18 @@ export default function AdsCampaigns() {
     return 'Campaign draft is ready for launch.'
   }, [settings.campaign.status])
 
+  const connectLabel = useMemo(() => {
+    if (settings.connection.connected) return 'Connected'
+    const hasIdentity =
+      settings.connection.accountEmail.trim().length > 0 &&
+      settings.connection.customerId.trim().length > 0
+    return hasIdentity ? 'Grant Google Ads access' : 'Connect Google'
+  }, [
+    settings.connection.accountEmail,
+    settings.connection.connected,
+    settings.connection.customerId,
+  ])
+
   async function saveChanges(changes: Partial<AdsAutomationSettings>) {
     if (!storeId) return
     setSaving(true)
@@ -252,6 +264,8 @@ export default function AdsCampaigns() {
   }
 
   async function handleConnectClick() {
+    if (settings.connection.connected) return
+
     if (!settings.connection.accountEmail.trim()) {
       setNotice('Add the Google account email first.')
       return
@@ -416,10 +430,10 @@ export default function AdsCampaigns() {
             <button
               type="button"
               className="button button--primary"
-              disabled={saving}
+              disabled={saving || settings.connection.connected}
               onClick={handleConnectClick}
             >
-              {settings.connection.connected ? 'Update connection' : 'Connect Google Ads'}
+              {connectLabel}
             </button>
             <p>
               Connected: <strong>{settings.connection.connected ? 'Yes' : 'No'}</strong> · Last updated:{' '}


### PR DESCRIPTION
### Motivation
- Replace legacy Ads-only OAuth start logic with the new shared Google OAuth system to unify flows and reuse the shared callback handling.
- Preserve existing auth and store membership checks while carrying Ads-specific context (customer/manager/account) into the shared OAuth state.
- Update the Ads UI to present the required Connect/Grant/Connected states and avoid redundant reconnect actions when already connected.

### Description
- Replaced the Ads-specific OAuth starter import and state persistence with a call to the shared `buildGoogleOAuthStartUrl` from `web/api/_google-oauth.ts` and pass `integrations: ['ads']` along with `adsCustomerId`, `adsManagerId`, and `accountEmail` (file: `web/api/google-ads/oauth-start.ts`).
- Kept API auth and membership enforcement using `requireApiUser` and `requireStoreMembership`, and implemented a local `requireStoreId` helper to validate `storeId` (file: `web/api/google-ads/oauth-start.ts`).
- Updated the Ads page connect CTA and handler to compute and render the three UI states `Connect Google`, `Grant Google Ads access`, and `Connected`, prevent starting the flow when already connected, and continue to start the shared OAuth path (file: `web/src/pages/AdsCampaigns.tsx`).
- This change reuses the shared callback route (`/api/google/oauth-callback`) and preserves `storeId` and user context inside the shared OAuth state; Merchant and Business flows are unchanged.

### Testing
- Ran lint with `npm -C web run lint`, which failed in this environment due to a missing ESLint runtime dependency (`@eslint/js`), so no further automated checks were executed.
- Basic project build/format checks were not run here due to the lint dependency failure; no unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d963009b588321a7b8ac7d0b97d811)