### PR TITLE
Gate Google Business uploader behind shared Google OAuth states

### DIFF
--- a/web/src/api/googleIntegrations.ts
+++ b/web/src/api/googleIntegrations.ts
@@ -2,6 +2,11 @@ import { auth } from '../firebase'
 
 export type GoogleIntegrationKey = 'business' | 'ads' | 'merchant'
 export type GoogleIntegrationStatus = 'Connected' | 'Needs permission' | 'Developer token required'
+export type GoogleIntegrationOverview = {
+  statuses: Record<GoogleIntegrationKey, GoogleIntegrationStatus>
+  grantedScopes: string[]
+  hasGoogleConnection: boolean
+}
 
 async function authHeaders() {
   const token = await auth.currentUser?.getIdToken()
@@ -45,5 +50,40 @@ export async function fetchGoogleIntegrationStatus(storeId: string): Promise<Rec
           ? 'Developer token required'
           : 'Needs permission',
     merchant: payload.merchant === 'Connected' ? 'Connected' : 'Needs permission',
+  }
+}
+
+export async function fetchGoogleIntegrationOverview(storeId: string): Promise<GoogleIntegrationOverview> {
+  const headers = await authHeaders()
+  const response = await fetch('/api/google/status', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ storeId }),
+  })
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>
+  if (!response.ok) {
+    throw new Error(typeof payload.error === 'string' ? payload.error : 'Unable to load Google integration status.')
+  }
+
+  const statuses: Record<GoogleIntegrationKey, GoogleIntegrationStatus> = {
+    business: payload.business === 'Connected' ? 'Connected' : 'Needs permission',
+    ads:
+      payload.ads === 'Connected'
+        ? 'Connected'
+        : payload.ads === 'Developer token required'
+          ? 'Developer token required'
+          : 'Needs permission',
+    merchant: payload.merchant === 'Connected' ? 'Connected' : 'Needs permission',
+  }
+  const grantedScopes = Array.isArray(payload.grantedScopes)
+    ? payload.grantedScopes.filter((scope): scope is string => typeof scope === 'string')
+    : []
+  const hasGoogleConnection =
+    grantedScopes.length > 0 || statuses.ads === 'Developer token required' || statuses.business === 'Connected' || statuses.merchant === 'Connected'
+
+  return {
+    statuses,
+    grantedScopes,
+    hasGoogleConnection,
   }
 }

--- a/web/src/pages/GoogleBusinessProfile.tsx
+++ b/web/src/pages/GoogleBusinessProfile.tsx
@@ -1,11 +1,85 @@
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
+import { fetchGoogleIntegrationOverview, startGoogleOAuth, type GoogleIntegrationStatus } from '../api/googleIntegrations'
 import GoogleBusinessMediaUploader from '../components/GoogleBusinessMediaUploader'
 import { useActiveStore } from '../hooks/useActiveStore'
 import './GoogleShopping.css'
 
 export default function GoogleBusinessProfile() {
   const { storeId } = useActiveStore()
+  const [status, setStatus] = useState<GoogleIntegrationStatus>('Needs permission')
+  const [hasGoogleConnection, setHasGoogleConnection] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [connecting, setConnecting] = useState(false)
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    const oauthState = params.get('googleOAuth')
+    if (!oauthState) return
+
+    if (oauthState === 'success') {
+      setMessage(params.get('message') || 'Google connected successfully.')
+    } else {
+      setMessage(params.get('message') || 'Google OAuth failed.')
+    }
+
+    params.delete('googleOAuth')
+    params.delete('message')
+    const nextQuery = params.toString()
+    const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ''}`
+    window.history.replaceState({}, '', nextUrl)
+  }, [])
+
+  useEffect(() => {
+    if (!storeId) {
+      setStatus('Needs permission')
+      setHasGoogleConnection(false)
+      return
+    }
+
+    let mounted = true
+    setLoading(true)
+    fetchGoogleIntegrationOverview(storeId)
+      .then((overview) => {
+        if (!mounted) return
+        setStatus(overview.statuses.business)
+        setHasGoogleConnection(overview.hasGoogleConnection)
+      })
+      .catch((error) => {
+        if (!mounted) return
+        setMessage(error instanceof Error ? error.message : 'Unable to load Google integration status.')
+      })
+      .finally(() => {
+        if (mounted) setLoading(false)
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [storeId])
+
+  const isConnected = status === 'Connected'
+  const stateTitle = useMemo(() => {
+    if (!hasGoogleConnection) return '1) Connect Google'
+    if (!isConnected) return '2) Grant Google Business access'
+    return '3) Connected'
+  }, [hasGoogleConnection, isConnected])
+  const buttonLabel = !hasGoogleConnection ? 'Connect Google' : 'Grant Google Business access'
+
+  async function handleConnect() {
+    if (!storeId || connecting) return
+    setConnecting(true)
+    setMessage('')
+    try {
+      const url = await startGoogleOAuth({ storeId, integrations: ['business'] })
+      window.location.assign(url)
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Unable to start Google OAuth.')
+      setConnecting(false)
+    }
+  }
 
   return (
     <main className="google-shopping-page">
@@ -22,7 +96,27 @@ export default function GoogleBusinessProfile() {
           <p>Please choose a store first.</p>
         </section>
       ) : (
-        <GoogleBusinessMediaUploader storeId={storeId} />
+        <>
+          <section className="google-shopping-panel">
+            <h2>{stateTitle}</h2>
+            <p>
+              {!hasGoogleConnection
+                ? 'Connect your Google account to continue.'
+                : !isConnected
+                  ? 'Your Google account is connected. Grant Google Business Profile access to continue.'
+                  : 'Google Business Profile access is connected for this store.'}
+            </p>
+            {loading ? <p className="google-shopping-panel__hint">Checking Google connection…</p> : null}
+            {!isConnected && !loading ? (
+              <button type="button" onClick={handleConnect} disabled={connecting}>
+                {connecting ? 'Connecting…' : buttonLabel}
+              </button>
+            ) : null}
+            {message ? <p className="google-shopping-panel__hint">{message}</p> : null}
+          </section>
+
+          {isConnected ? <GoogleBusinessMediaUploader storeId={storeId} /> : null}
+        </>
       )}
     </main>
   )


### PR DESCRIPTION
### Motivation
- The Google Business page rendered the uploader immediately, causing failures when the store lacked a shared Google connection or the `business.manage` scope. 
- The goal is to match the Ads page UX by using the shared Google OAuth flow so users see a 3‑state sequence before uploader access.

### Description
- Added `fetchGoogleIntegrationOverview` and `GoogleIntegrationOverview` in `web/src/api/googleIntegrations.ts` to expose parsed statuses, granted scopes, and a `hasGoogleConnection` flag from `/api/google/status`.
- Updated `web/src/pages/GoogleBusinessProfile.tsx` to implement the three UI states (`1) Connect Google`, `2) Grant Google Business access`, `3) Connected`) and parse OAuth callback query params, using the shared `startGoogleOAuth` call with `integrations: ['business']`.
- The uploader (`GoogleBusinessMediaUploader`) is unchanged and is only rendered when the store has an active Google connection and the required Business scope is present, preventing premature `listGoogleBusinessLocations` calls.
- Preserved existing layout and styling (`google-shopping-*` classes) and reused existing auth/store context patterns (`useActiveStore`).

### Testing
- Ran lint (`npm --prefix web run lint`) which failed due to missing local dev dependency `@eslint/js` so ESLint could not complete.
- Ran build (`npm --prefix web run build`) which failed due to missing type definitions (`vite/client`, `vitest/globals`) so a full TypeScript/Vite build could not complete.
- Basic runtime behavior was exercised locally by loading the updated page flow (manual validation), and the changes were committed (`web/src/api/googleIntegrations.ts`, `web/src/pages/GoogleBusinessProfile.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96618661c8321a29df0f5097477e6)