### PR TITLE
Add reusable Google integration status hook and migrate Business page

### DIFF
--- a/web/src/api/googleIntegrations.ts
+++ b/web/src/api/googleIntegrations.ts
@@ -14,7 +14,13 @@ async function authHeaders() {
   return { authorization: `Bearer ${token}`, 'content-type': 'application/json' }
 }
 
-export async function startGoogleOAuth(params: { storeId: string; integrations: GoogleIntegrationKey[] }) {
+export async function startGoogleOAuth(params: {
+  storeId: string
+  integrations: GoogleIntegrationKey[]
+  customerId?: string
+  managerId?: string
+  accountEmail?: string
+}) {
   const headers = await authHeaders()
   const response = await fetch('/api/google/oauth-start', {
     method: 'POST',

--- a/web/src/hooks/useGoogleIntegrationStatus.ts
+++ b/web/src/hooks/useGoogleIntegrationStatus.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import {
+  fetchGoogleIntegrationOverview,
+  startGoogleOAuth,
+  type GoogleIntegrationKey,
+  type GoogleIntegrationStatus,
+} from '../api/googleIntegrations'
+
+const REQUIRED_SCOPE_BY_INTEGRATION: Record<GoogleIntegrationKey, string> = {
+  ads: 'https://www.googleapis.com/auth/adwords',
+  business: 'https://www.googleapis.com/auth/business.manage',
+  merchant: 'https://www.googleapis.com/auth/content',
+}
+
+function getStateTitle(hasGoogleConnection: boolean, hasRequiredScope: boolean) {
+  if (!hasGoogleConnection) return '1) Connect Google'
+  if (!hasRequiredScope) return '2) Grant required access'
+  return '3) Connected'
+}
+
+function getButtonLabel(params: {
+  integration: GoogleIntegrationKey
+  hasGoogleConnection: boolean
+  hasRequiredScope: boolean
+  status: GoogleIntegrationStatus
+}) {
+  if (params.hasRequiredScope && params.status === 'Connected') return 'Connected'
+  if (!params.hasGoogleConnection) return 'Connect Google'
+
+  if (params.integration === 'ads') return 'Grant Google Ads access'
+  if (params.integration === 'business') return 'Grant Google Business access'
+  return 'Grant Google Merchant access'
+}
+
+type UseGoogleIntegrationStatusInput = {
+  integration: GoogleIntegrationKey
+  storeId: string | null
+}
+
+type StartGoogleOAuthInput = {
+  customerId?: string
+  managerId?: string
+  accountEmail?: string
+}
+
+export function useGoogleIntegrationStatus(input: UseGoogleIntegrationStatusInput) {
+  const { integration, storeId } = input
+  const requiredScope = REQUIRED_SCOPE_BY_INTEGRATION[integration]
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [isStartingOAuth, setIsStartingOAuth] = useState(false)
+  const [status, setStatus] = useState<GoogleIntegrationStatus>('Needs permission')
+  const [hasGoogleConnection, setHasGoogleConnection] = useState(false)
+  const [grantedScopes, setGrantedScopes] = useState<string[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!storeId) {
+      setStatus('Needs permission')
+      setHasGoogleConnection(false)
+      setGrantedScopes([])
+      return
+    }
+
+    let mounted = true
+    setIsLoading(true)
+    setError(null)
+
+    fetchGoogleIntegrationOverview(storeId)
+      .then((overview) => {
+        if (!mounted) return
+        setStatus(overview.statuses[integration])
+        setHasGoogleConnection(overview.hasGoogleConnection)
+        setGrantedScopes(overview.grantedScopes)
+      })
+      .catch((nextError) => {
+        if (!mounted) return
+        setError(nextError instanceof Error ? nextError.message : 'Unable to load Google integration status.')
+      })
+      .finally(() => {
+        if (mounted) setIsLoading(false)
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [integration, storeId])
+
+  const hasRequiredScope = useMemo(
+    () => grantedScopes.includes(requiredScope) || status === 'Connected',
+    [grantedScopes, requiredScope, status],
+  )
+
+  const isConnected = status === 'Connected'
+
+  const buttonLabel = useMemo(
+    () => getButtonLabel({ integration, hasGoogleConnection, hasRequiredScope, status }),
+    [hasGoogleConnection, hasRequiredScope, integration, status],
+  )
+
+  const stateTitle = useMemo(
+    () => getStateTitle(hasGoogleConnection, hasRequiredScope),
+    [hasGoogleConnection, hasRequiredScope],
+  )
+
+  const startOAuth = useCallback(
+    async (oauthInput: StartGoogleOAuthInput = {}) => {
+      if (!storeId || isStartingOAuth) return
+      setIsStartingOAuth(true)
+      setError(null)
+      try {
+        const url = await startGoogleOAuth({
+          storeId,
+          integrations: [integration],
+          customerId: oauthInput.customerId,
+          managerId: oauthInput.managerId,
+          accountEmail: oauthInput.accountEmail,
+        })
+        window.location.assign(url)
+      } catch (nextError) {
+        setError(nextError instanceof Error ? nextError.message : 'Unable to start Google OAuth.')
+        setIsStartingOAuth(false)
+      }
+    },
+    [integration, isStartingOAuth, storeId],
+  )
+
+  return {
+    isLoading,
+    isStartingOAuth,
+    isConnected,
+    hasRequiredScope,
+    hasGoogleConnection,
+    status,
+    stateTitle,
+    buttonLabel,
+    requiredScope,
+    error,
+    startOAuth,
+  }
+}

--- a/web/src/pages/GoogleBusinessProfile.tsx
+++ b/web/src/pages/GoogleBusinessProfile.tsx
@@ -1,17 +1,27 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-import { fetchGoogleIntegrationOverview, startGoogleOAuth, type GoogleIntegrationStatus } from '../api/googleIntegrations'
 import GoogleBusinessMediaUploader from '../components/GoogleBusinessMediaUploader'
 import { useActiveStore } from '../hooks/useActiveStore'
+import { useGoogleIntegrationStatus } from '../hooks/useGoogleIntegrationStatus'
 import './GoogleShopping.css'
 
 export default function GoogleBusinessProfile() {
   const { storeId } = useActiveStore()
-  const [status, setStatus] = useState<GoogleIntegrationStatus>('Needs permission')
-  const [hasGoogleConnection, setHasGoogleConnection] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [connecting, setConnecting] = useState(false)
   const [message, setMessage] = useState('')
+
+  const {
+    isLoading,
+    isStartingOAuth,
+    isConnected,
+    hasGoogleConnection,
+    buttonLabel,
+    stateTitle,
+    error,
+    startOAuth,
+  } = useGoogleIntegrationStatus({
+    integration: 'business',
+    storeId,
+  })
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -33,53 +43,9 @@ export default function GoogleBusinessProfile() {
   }, [])
 
   useEffect(() => {
-    if (!storeId) {
-      setStatus('Needs permission')
-      setHasGoogleConnection(false)
-      return
-    }
-
-    let mounted = true
-    setLoading(true)
-    fetchGoogleIntegrationOverview(storeId)
-      .then((overview) => {
-        if (!mounted) return
-        setStatus(overview.statuses.business)
-        setHasGoogleConnection(overview.hasGoogleConnection)
-      })
-      .catch((error) => {
-        if (!mounted) return
-        setMessage(error instanceof Error ? error.message : 'Unable to load Google integration status.')
-      })
-      .finally(() => {
-        if (mounted) setLoading(false)
-      })
-
-    return () => {
-      mounted = false
-    }
-  }, [storeId])
-
-  const isConnected = status === 'Connected'
-  const stateTitle = useMemo(() => {
-    if (!hasGoogleConnection) return '1) Connect Google'
-    if (!isConnected) return '2) Grant Google Business access'
-    return '3) Connected'
-  }, [hasGoogleConnection, isConnected])
-  const buttonLabel = !hasGoogleConnection ? 'Connect Google' : 'Grant Google Business access'
-
-  async function handleConnect() {
-    if (!storeId || connecting) return
-    setConnecting(true)
-    setMessage('')
-    try {
-      const url = await startGoogleOAuth({ storeId, integrations: ['business'] })
-      window.location.assign(url)
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Unable to start Google OAuth.')
-      setConnecting(false)
-    }
-  }
+    if (!error) return
+    setMessage(error)
+  }, [error])
 
   return (
     <main className="google-shopping-page">
@@ -106,10 +72,10 @@ export default function GoogleBusinessProfile() {
                   ? 'Your Google account is connected. Grant Google Business Profile access to continue.'
                   : 'Google Business Profile access is connected for this store.'}
             </p>
-            {loading ? <p className="google-shopping-panel__hint">Checking Google connection…</p> : null}
-            {!isConnected && !loading ? (
-              <button type="button" onClick={handleConnect} disabled={connecting}>
-                {connecting ? 'Connecting…' : buttonLabel}
+            {isLoading ? <p className="google-shopping-panel__hint">Checking Google connection…</p> : null}
+            {!isConnected && !isLoading ? (
+              <button type="button" onClick={() => void startOAuth()} disabled={isStartingOAuth}>
+                {isStartingOAuth ? 'Connecting…' : buttonLabel}
               </button>
             ) : null}
             {message ? <p className="google-shopping-panel__hint">{message}</p> : null}


### PR DESCRIPTION
### Motivation
- Consolidate Google integration status and OAuth start logic so Ads, Business, and Merchant pages can share behavior and avoid duplicated connect/grant/connected logic.
- Leverage the shared server-side Google OAuth flow and required-scope mapping to keep UI state consistent across pages.

### Description
- Add a new hook `useGoogleIntegrationStatus` (`web/src/hooks/useGoogleIntegrationStatus.ts`) that supports `integration: 'ads'|'business'|'merchant'` and `storeId` and returns `isLoading`, `isStartingOAuth`, `isConnected`, `hasRequiredScope`, `hasGoogleConnection`, `buttonLabel`, `stateTitle`, `requiredScope`, `error`, and `startOAuth`.
- Implement required-scope mapping for each integration (`ads`, `business`, `merchant`) and derive UI-ready states (`Connect Google`, `Grant required access`, `Connected`).
- Extend the client helper `startGoogleOAuth` (`web/src/api/googleIntegrations.ts`) to accept optional Ads metadata (`customerId`, `managerId`, `accountEmail`) so `startOAuth` can start Ads flows without changing server behavior.
- Refactor `GoogleBusinessProfile` (`web/src/pages/GoogleBusinessProfile.tsx`) to consume `useGoogleIntegrationStatus` and remove duplicated status/connect logic; the page now uses `startOAuth()` for the CTA.
- Kept Ads page behavior unchanged and did not refactor Merchant page in this pass because Merchant flow includes additional selection logic that should be migrated separately.

### Testing
- Ran lint: `npm -C web run lint -- src/hooks/useGoogleIntegrationStatus.ts src/pages/GoogleBusinessProfile.tsx src/api/googleIntegrations.ts`, which failed in this environment due to missing developer dependency `@eslint/js` (environment issue, not code error).
- Ran build: `npm -C web run build`, which failed here because type packages (`vite/client`, `vitest/globals`) are not available in the runner (environment issue).
- No unit tests were modified; local automated checks could not be completed in this CI-limited environment, but the changes are self-contained and preserve the existing Ads API endpoints and OAuth flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d966ef1e688321ab8f3ef13b1e7ba6)