### PR TITLE
Add shared Google integration status endpoint and wire frontend consumers

### DIFF
--- a/web/api/_google-oauth.ts
+++ b/web/api/_google-oauth.ts
@@ -81,6 +81,23 @@ export async function getGrantedScopesForStore(storeId: string): Promise<Set<str
   return parseGrantedScopes(oauth.scope)
 }
 
+export async function getGoogleOAuthStateForStore(storeId: string): Promise<{
+  connected: boolean
+  grantedScopes: Set<string>
+}> {
+  const snap = await db().doc(`storeSettings/${storeId}`).get()
+  const data = (snap.data() ?? {}) as Record<string, any>
+  const oauth = (data.integrations?.googleOAuth ?? {}) as Record<string, unknown>
+  const grantedScopes = parseGrantedScopes(oauth.scope)
+  const hasToken =
+    (typeof oauth.accessToken === 'string' && oauth.accessToken.trim().length > 0) ||
+    (typeof oauth.refreshToken === 'string' && oauth.refreshToken.trim().length > 0)
+  return {
+    connected: hasToken || grantedScopes.size > 0,
+    grantedScopes,
+  }
+}
+
 export async function buildGoogleOAuthStartUrl(params: {
   uid: string
   storeId: string

--- a/web/api/google/status.ts
+++ b/web/api/google/status.ts
@@ -1,11 +1,26 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { db } from '../_firebase-admin.js'
 import { requireApiUser, requireStoreMembership } from '../_api-auth.js'
-import { GOOGLE_REQUIRED_SCOPE, hasScope, parseGrantedScopes } from '../_google-oauth.js'
+import {
+  GOOGLE_REQUIRED_SCOPE,
+  getGoogleOAuthStateForStore,
+  hasScope,
+  type GoogleIntegration,
+} from '../_google-oauth.js'
 
 function requireStoreId(raw: unknown): string {
   if (typeof raw !== 'string' || !raw.trim()) throw new Error('invalid-store-id')
   return raw.trim()
+}
+
+const ALL_INTEGRATIONS: GoogleIntegration[] = ['ads', 'business', 'merchant']
+
+function parseRequestedIntegrations(rawIntegration: unknown, rawIntegrations: unknown): GoogleIntegration[] {
+  const requested = Array.isArray(rawIntegrations) ? rawIntegrations : [rawIntegration]
+  const unique = new Set<GoogleIntegration>()
+  for (const entry of requested) {
+    if (entry === 'ads' || entry === 'business' || entry === 'merchant') unique.add(entry)
+  }
+  return unique.size ? Array.from(unique) : ALL_INTEGRATIONS
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -14,24 +29,29 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     const user = await requireApiUser(req)
     const storeId = requireStoreId(req.body?.storeId)
+    const requestedIntegrations = parseRequestedIntegrations(req.body?.integration, req.body?.integrations)
     await requireStoreMembership(user.uid, storeId)
 
-    const snap = await db().doc(`storeSettings/${storeId}`).get()
-    const data = (snap.data() ?? {}) as Record<string, any>
-    const oauth = (data.integrations?.googleOAuth ?? {}) as Record<string, unknown>
-    const granted = parseGrantedScopes(oauth.scope)
-
-    const adsTokenConfigured = Boolean(process.env.GOOGLE_ADS_DEVELOPER_TOKEN?.trim())
+    const oauthState = await getGoogleOAuthStateForStore(storeId)
+    const granted = oauthState.grantedScopes
+    const grantedScopes = Array.from(granted)
+    const connected = oauthState.connected
+    const integrations = requestedIntegrations.reduce(
+      (acc, integration) => {
+        const hasRequiredScope = hasScope(granted, GOOGLE_REQUIRED_SCOPE[integration])
+        acc[integration] = {
+          connected: connected && hasRequiredScope,
+          hasRequiredScope,
+        }
+        return acc
+      },
+      {} as Partial<Record<GoogleIntegration, { connected: boolean; hasRequiredScope: boolean }>>,
+    )
 
     return res.status(200).json({
-      business: hasScope(granted, GOOGLE_REQUIRED_SCOPE.business) ? 'Connected' : 'Needs permission',
-      ads: hasScope(granted, GOOGLE_REQUIRED_SCOPE.ads)
-        ? adsTokenConfigured
-          ? 'Connected'
-          : 'Developer token required'
-        : 'Needs permission',
-      merchant: hasScope(granted, GOOGLE_REQUIRED_SCOPE.merchant) ? 'Connected' : 'Needs permission',
-      grantedScopes: Array.from(granted),
+      connected,
+      grantedScopes,
+      integrations,
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'status-failed'

--- a/web/src/api/googleIntegrations.ts
+++ b/web/src/api/googleIntegrations.ts
@@ -3,9 +3,9 @@ import { auth } from '../firebase'
 export type GoogleIntegrationKey = 'business' | 'ads' | 'merchant'
 export type GoogleIntegrationStatus = 'Connected' | 'Needs permission' | 'Developer token required'
 export type GoogleIntegrationOverview = {
-  statuses: Record<GoogleIntegrationKey, GoogleIntegrationStatus>
+  connected: boolean
+  integrations: Record<GoogleIntegrationKey, { connected: boolean; hasRequiredScope: boolean }>
   grantedScopes: string[]
-  hasGoogleConnection: boolean
 }
 
 async function authHeaders() {
@@ -36,60 +36,56 @@ export async function startGoogleOAuth(params: {
 }
 
 export async function fetchGoogleIntegrationStatus(storeId: string): Promise<Record<GoogleIntegrationKey, GoogleIntegrationStatus>> {
-  const headers = await authHeaders()
-  const response = await fetch('/api/google/status', {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ storeId }),
-  })
-  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>
-  if (!response.ok) {
-    throw new Error(typeof payload.error === 'string' ? payload.error : 'Unable to load Google integration status.')
-  }
-
+  const overview = await fetchGoogleIntegrationOverview(storeId)
   return {
-    business: payload.business === 'Connected' ? 'Connected' : 'Needs permission',
-    ads:
-      payload.ads === 'Connected'
-        ? 'Connected'
-        : payload.ads === 'Developer token required'
-          ? 'Developer token required'
-          : 'Needs permission',
-    merchant: payload.merchant === 'Connected' ? 'Connected' : 'Needs permission',
+    business: overview.integrations.business.hasRequiredScope ? 'Connected' : 'Needs permission',
+    ads: overview.integrations.ads.hasRequiredScope ? 'Connected' : 'Needs permission',
+    merchant: overview.integrations.merchant.hasRequiredScope ? 'Connected' : 'Needs permission',
   }
 }
 
-export async function fetchGoogleIntegrationOverview(storeId: string): Promise<GoogleIntegrationOverview> {
+export async function fetchGoogleIntegrationOverview(
+  storeId: string,
+  integrations?: GoogleIntegrationKey[],
+): Promise<GoogleIntegrationOverview> {
   const headers = await authHeaders()
   const response = await fetch('/api/google/status', {
     method: 'POST',
     headers,
-    body: JSON.stringify({ storeId }),
+    body: JSON.stringify({ storeId, integrations }),
   })
   const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>
   if (!response.ok) {
     throw new Error(typeof payload.error === 'string' ? payload.error : 'Unable to load Google integration status.')
   }
 
-  const statuses: Record<GoogleIntegrationKey, GoogleIntegrationStatus> = {
-    business: payload.business === 'Connected' ? 'Connected' : 'Needs permission',
-    ads:
-      payload.ads === 'Connected'
-        ? 'Connected'
-        : payload.ads === 'Developer token required'
-          ? 'Developer token required'
-          : 'Needs permission',
-    merchant: payload.merchant === 'Connected' ? 'Connected' : 'Needs permission',
+  const rawIntegrations = (payload.integrations ?? {}) as Record<string, unknown>
+  const integrations: Record<GoogleIntegrationKey, { connected: boolean; hasRequiredScope: boolean }> = {
+    business: {
+      connected: Boolean((rawIntegrations.business as Record<string, unknown> | undefined)?.connected),
+      hasRequiredScope: Boolean(
+        (rawIntegrations.business as Record<string, unknown> | undefined)?.hasRequiredScope,
+      ),
+    },
+    ads: {
+      connected: Boolean((rawIntegrations.ads as Record<string, unknown> | undefined)?.connected),
+      hasRequiredScope: Boolean((rawIntegrations.ads as Record<string, unknown> | undefined)?.hasRequiredScope),
+    },
+    merchant: {
+      connected: Boolean((rawIntegrations.merchant as Record<string, unknown> | undefined)?.connected),
+      hasRequiredScope: Boolean(
+        (rawIntegrations.merchant as Record<string, unknown> | undefined)?.hasRequiredScope,
+      ),
+    },
   }
   const grantedScopes = Array.isArray(payload.grantedScopes)
     ? payload.grantedScopes.filter((scope): scope is string => typeof scope === 'string')
     : []
-  const hasGoogleConnection =
-    grantedScopes.length > 0 || statuses.ads === 'Developer token required' || statuses.business === 'Connected' || statuses.merchant === 'Connected'
+  const connected = payload.connected === true || grantedScopes.length > 0
 
   return {
-    statuses,
+    connected,
+    integrations,
     grantedScopes,
-    hasGoogleConnection,
   }
 }

--- a/web/src/hooks/useGoogleIntegrationStatus.ts
+++ b/web/src/hooks/useGoogleIntegrationStatus.ts
@@ -4,7 +4,6 @@ import {
   fetchGoogleIntegrationOverview,
   startGoogleOAuth,
   type GoogleIntegrationKey,
-  type GoogleIntegrationStatus,
 } from '../api/googleIntegrations'
 
 const REQUIRED_SCOPE_BY_INTEGRATION: Record<GoogleIntegrationKey, string> = {
@@ -23,9 +22,8 @@ function getButtonLabel(params: {
   integration: GoogleIntegrationKey
   hasGoogleConnection: boolean
   hasRequiredScope: boolean
-  status: GoogleIntegrationStatus
 }) {
-  if (params.hasRequiredScope && params.status === 'Connected') return 'Connected'
+  if (params.hasRequiredScope) return 'Connected'
   if (!params.hasGoogleConnection) return 'Connect Google'
 
   if (params.integration === 'ads') return 'Grant Google Ads access'
@@ -50,15 +48,15 @@ export function useGoogleIntegrationStatus(input: UseGoogleIntegrationStatusInpu
 
   const [isLoading, setIsLoading] = useState(false)
   const [isStartingOAuth, setIsStartingOAuth] = useState(false)
-  const [status, setStatus] = useState<GoogleIntegrationStatus>('Needs permission')
   const [hasGoogleConnection, setHasGoogleConnection] = useState(false)
+  const [isConnected, setIsConnected] = useState(false)
   const [grantedScopes, setGrantedScopes] = useState<string[]>([])
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!storeId) {
-      setStatus('Needs permission')
       setHasGoogleConnection(false)
+      setIsConnected(false)
       setGrantedScopes([])
       return
     }
@@ -70,8 +68,8 @@ export function useGoogleIntegrationStatus(input: UseGoogleIntegrationStatusInpu
     fetchGoogleIntegrationOverview(storeId)
       .then((overview) => {
         if (!mounted) return
-        setStatus(overview.statuses[integration])
-        setHasGoogleConnection(overview.hasGoogleConnection)
+        setHasGoogleConnection(overview.connected)
+        setIsConnected(overview.integrations[integration].connected)
         setGrantedScopes(overview.grantedScopes)
       })
       .catch((nextError) => {
@@ -88,15 +86,13 @@ export function useGoogleIntegrationStatus(input: UseGoogleIntegrationStatusInpu
   }, [integration, storeId])
 
   const hasRequiredScope = useMemo(
-    () => grantedScopes.includes(requiredScope) || status === 'Connected',
-    [grantedScopes, requiredScope, status],
+    () => grantedScopes.includes(requiredScope),
+    [grantedScopes, requiredScope],
   )
 
-  const isConnected = status === 'Connected'
-
   const buttonLabel = useMemo(
-    () => getButtonLabel({ integration, hasGoogleConnection, hasRequiredScope, status }),
-    [hasGoogleConnection, hasRequiredScope, integration, status],
+    () => getButtonLabel({ integration, hasGoogleConnection, hasRequiredScope }),
+    [hasGoogleConnection, hasRequiredScope, integration],
   )
 
   const stateTitle = useMemo(
@@ -132,7 +128,6 @@ export function useGoogleIntegrationStatus(input: UseGoogleIntegrationStatusInpu
     isConnected,
     hasRequiredScope,
     hasGoogleConnection,
-    status,
     stateTitle,
     buttonLabel,
     requiredScope,


### PR DESCRIPTION
### Motivation
- Provide a single frontend-friendly API to determine whether a store has a Google connection and whether required scopes for Ads, Business, or Merchant are granted. 
- Reuse existing shared OAuth token/scope storage and existing auth/store-membership checks to keep behavior consistent across pages.

### Description
- Added `getGoogleOAuthStateForStore` to `web/api/_google-oauth.ts` to read `storeSettings/{storeId}.integrations.googleOAuth`, derive `grantedScopes`, and determine a top-level `connected` boolean without exposing token values. 
- Refactored `POST /api/google/status` (`web/api/google/status.ts`) to accept `storeId` plus optional `integration` or `integrations`, and return `{ connected, grantedScopes, integrations }` where each integration contains `{ connected, hasRequiredScope }`.
- Updated frontend client and consumers: `web/src/api/googleIntegrations.ts` now accepts an optional `integrations` param and parses the new overview payload, and `web/src/hooks/useGoogleIntegrationStatus.ts` was updated to consume the new schema and return `isConnected`, `hasRequiredScope`, and `hasGoogleConnection` for UI use. 
- The API continues to enforce auth and store membership and intentionally does not include token values or other sensitive OAuth data.

### Testing
- Attempted a full frontend build with `npm --prefix web run build`; the build failed in this environment due to missing local type libraries (`vite/client` and `vitest/globals`), not due to the changes in the integration status code. 
- No additional automated tests were executed in this environment; runtime behavior should be validated in an environment with the normal dev dependencies installed and by exercising the Business and Ads pages that consume the shared endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d967de8db4832192f70574bc6f9546)