### PR TITLE
Refactor Google Business uploader auth/scope error handling

### DIFF
--- a/web/src/api/googleBusinessProfile.ts
+++ b/web/src/api/googleBusinessProfile.ts
@@ -17,6 +17,26 @@ export type GoogleBusinessUploadResult = {
   }
 }
 
+export type GoogleBusinessErrorKind =
+  | 'not_connected'
+  | 'missing_scope'
+  | 'not_authenticated'
+  | 'unknown'
+
+export class GoogleBusinessApiError extends Error {
+  code: string
+  status: number
+  kind: GoogleBusinessErrorKind
+
+  constructor(params: { message: string; code: string; status: number; kind: GoogleBusinessErrorKind }) {
+    super(params.message)
+    this.name = 'GoogleBusinessApiError'
+    this.code = params.code
+    this.status = params.status
+    this.kind = params.kind
+  }
+}
+
 async function getAuthHeader() {
   const token = await auth.currentUser?.getIdToken()
   if (!token) throw new Error('Sign in again to continue.')
@@ -24,14 +44,76 @@ async function getAuthHeader() {
   return { authorization: `Bearer ${token}` }
 }
 
+function inferErrorKind(code: string, status: number): GoogleBusinessErrorKind {
+  if (code === 'google-business-not-connected' || code === 'google-business-missing-tokens') {
+    return 'not_connected'
+  }
+
+  if (
+    code.includes('scope') ||
+    code.includes('insufficient') ||
+    code.includes('permission') ||
+    code.includes('forbidden') ||
+    code.includes('business.manage')
+  ) {
+    return 'missing_scope'
+  }
+
+  if (code === 'not-authenticated' || status === 401) {
+    return 'not_authenticated'
+  }
+
+  return 'unknown'
+}
+
+function defaultErrorMessage(kind: GoogleBusinessErrorKind): string {
+  if (kind === 'not_connected') {
+    return 'Google Business Profile is not connected for this store.'
+  }
+  if (kind === 'missing_scope') {
+    return 'Google Business Profile access is missing the required business.manage permission.'
+  }
+  if (kind === 'not_authenticated') {
+    return 'Your session has expired. Sign in again to continue.'
+  }
+
+  return 'Request failed.'
+}
+
 async function parseApiResponse<T>(response: Response): Promise<T> {
   const body = (await response.json().catch(() => ({}))) as Record<string, unknown>
   if (!response.ok) {
-    const message = typeof body.error === 'string' ? body.error : 'Request failed.'
-    throw new Error(message)
+    const rawError = typeof body.error === 'string' ? body.error : ''
+    const normalizedCode = rawError.trim().toLowerCase()
+    const kind = inferErrorKind(normalizedCode, response.status)
+
+    throw new GoogleBusinessApiError({
+      message: rawError || defaultErrorMessage(kind),
+      code: normalizedCode || 'request-failed',
+      status: response.status,
+      kind,
+    })
   }
 
   return body as T
+}
+
+export function parseGoogleBusinessApiError(error: unknown) {
+  if (error instanceof GoogleBusinessApiError) {
+    return {
+      kind: error.kind,
+      code: error.code,
+      status: error.status,
+      message: error.message,
+    }
+  }
+
+  return {
+    kind: 'unknown' as const,
+    code: '',
+    status: 0,
+    message: error instanceof Error ? error.message : 'Request failed.',
+  }
 }
 
 export async function listGoogleBusinessLocations(params: { storeId: string }): Promise<GoogleBusinessLocationOption[]> {

--- a/web/src/components/GoogleBusinessMediaUploader.tsx
+++ b/web/src/components/GoogleBusinessMediaUploader.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 
 import {
   listGoogleBusinessLocations,
+  parseGoogleBusinessApiError,
   uploadGoogleBusinessLocationMedia,
   type GoogleBusinessLocationOption,
 } from '../api/googleBusinessProfile'
@@ -11,6 +12,7 @@ type Props = {
 }
 
 type UploadState = 'idle' | 'loading' | 'success' | 'error'
+type LocationState = 'idle' | 'loading' | 'ready' | 'empty' | 'not_connected' | 'missing_scope' | 'error'
 
 const CATEGORIES = [
   'COVER',
@@ -28,6 +30,23 @@ const CATEGORIES = [
   'ADDITIONAL',
 ] as const
 
+function getLocationMessage(state: LocationState, fallbackMessage: string): string {
+  if (state === 'not_connected') {
+    return 'Google Business Profile is not connected for this store. Connect Google first, then try again.'
+  }
+  if (state === 'missing_scope') {
+    return 'Google Business Profile access is missing permission. Reconnect Google and grant Business Profile access.'
+  }
+  if (state === 'empty') {
+    return 'No Google Business locations were found for the connected account.'
+  }
+  if (state === 'error') {
+    return fallbackMessage || 'Unable to load Google Business locations right now.'
+  }
+
+  return ''
+}
+
 export default function GoogleBusinessMediaUploader({ storeId }: Props) {
   const [locations, setLocations] = useState<GoogleBusinessLocationOption[]>([])
   const [selectedLocationKey, setSelectedLocationKey] = useState('')
@@ -35,28 +54,50 @@ export default function GoogleBusinessMediaUploader({ storeId }: Props) {
   const [file, setFile] = useState<File | null>(null)
   const [previewUrl, setPreviewUrl] = useState('')
   const [uploadState, setUploadState] = useState<UploadState>('idle')
-  const [message, setMessage] = useState('')
-  const [loadingLocations, setLoadingLocations] = useState(false)
+  const [uploadMessage, setUploadMessage] = useState('')
+  const [locationState, setLocationState] = useState<LocationState>('idle')
+  const [locationMessage, setLocationMessage] = useState('')
   const [uploadedResult, setUploadedResult] = useState<{ thumbnailUrl: string; googleUrl: string; uploadedAt: string } | null>(null)
 
   useEffect(() => {
     if (!storeId) return
     let mounted = true
-    setLoadingLocations(true)
+
+    setLocationState('loading')
+    setLocationMessage('')
 
     listGoogleBusinessLocations({ storeId })
       .then((options) => {
         if (!mounted) return
+
         setLocations(options)
         setSelectedLocationKey(options[0] ? `${options[0].accountId}:${options[0].locationId}` : '')
+
+        if (!options.length) {
+          setLocationState('empty')
+          return
+        }
+
+        setLocationState('ready')
       })
       .catch((error) => {
         if (!mounted) return
-        setMessage(error instanceof Error ? error.message : 'Unable to load Google Business locations.')
-        setUploadState('error')
-      })
-      .finally(() => {
-        if (mounted) setLoadingLocations(false)
+
+        const parsed = parseGoogleBusinessApiError(error)
+        if (parsed.kind === 'not_connected') {
+          setLocationState('not_connected')
+          setLocationMessage(getLocationMessage('not_connected', parsed.message))
+          return
+        }
+
+        if (parsed.kind === 'missing_scope') {
+          setLocationState('missing_scope')
+          setLocationMessage(getLocationMessage('missing_scope', parsed.message))
+          return
+        }
+
+        setLocationState('error')
+        setLocationMessage(parsed.message || getLocationMessage('error', ''))
       })
 
     return () => {
@@ -80,21 +121,23 @@ export default function GoogleBusinessMediaUploader({ storeId }: Props) {
     return locations.find((option) => option.accountId === accountId && option.locationId === locationId) || null
   }, [locations, selectedLocationKey])
 
+  const uploadBlocked = locationState !== 'ready'
+
   async function handleUpload() {
     if (!selectedLocation) {
       setUploadState('error')
-      setMessage('Please choose a location.')
+      setUploadMessage('Please choose a location.')
       return
     }
 
     if (!file) {
       setUploadState('error')
-      setMessage('Please choose an image file.')
+      setUploadMessage('Please choose an image file.')
       return
     }
 
     setUploadState('loading')
-    setMessage('')
+    setUploadMessage('')
 
     try {
       const payload = await uploadGoogleBusinessLocationMedia({
@@ -111,10 +154,22 @@ export default function GoogleBusinessMediaUploader({ storeId }: Props) {
         uploadedAt: new Date().toISOString(),
       })
       setUploadState('success')
-      setMessage('Image uploaded to Google Business Profile successfully.')
+      setUploadMessage('Image uploaded to Google Business Profile successfully.')
     } catch (error) {
+      const parsed = parseGoogleBusinessApiError(error)
       setUploadState('error')
-      setMessage(error instanceof Error ? error.message : 'Upload failed.')
+
+      if (parsed.kind === 'not_connected') {
+        setUploadMessage('Google Business Profile is no longer connected. Reconnect Google and try again.')
+        return
+      }
+
+      if (parsed.kind === 'missing_scope') {
+        setUploadMessage('Google Business Profile permission is missing. Reconnect Google and grant Business Profile access.')
+        return
+      }
+
+      setUploadMessage(parsed.message || 'Upload failed.')
     }
   }
 
@@ -128,7 +183,7 @@ export default function GoogleBusinessMediaUploader({ storeId }: Props) {
         <select
           value={selectedLocationKey}
           onChange={(event) => setSelectedLocationKey(event.target.value)}
-          disabled={loadingLocations || uploadState === 'loading'}
+          disabled={locationState === 'loading' || uploadState === 'loading' || uploadBlocked}
         >
           {!locations.length && <option value="">No locations available</option>}
           {locations.map((option) => {
@@ -144,7 +199,11 @@ export default function GoogleBusinessMediaUploader({ storeId }: Props) {
 
       <label>
         <span>Category</span>
-        <select value={category} onChange={(event) => setCategory(event.target.value as (typeof CATEGORIES)[number])}>
+        <select
+          value={category}
+          onChange={(event) => setCategory(event.target.value as (typeof CATEGORIES)[number])}
+          disabled={uploadBlocked}
+        >
           {CATEGORIES.map((categoryOption) => (
             <option key={categoryOption} value={categoryOption}>
               {categoryOption}
@@ -159,7 +218,7 @@ export default function GoogleBusinessMediaUploader({ storeId }: Props) {
           type="file"
           accept="image/jpeg,image/png"
           onChange={(event) => setFile(event.target.files?.[0] || null)}
-          disabled={uploadState === 'loading'}
+          disabled={uploadState === 'loading' || uploadBlocked}
         />
       </label>
 
@@ -169,13 +228,19 @@ export default function GoogleBusinessMediaUploader({ storeId }: Props) {
         <button
           type="button"
           onClick={handleUpload}
-          disabled={uploadState === 'loading' || !file || !selectedLocation || loadingLocations}
+          disabled={uploadState === 'loading' || !file || !selectedLocation || uploadBlocked}
         >
           {uploadState === 'loading' ? 'Uploading…' : 'Upload image'}
         </button>
       </div>
 
-      {message && <p className="google-shopping-panel__hint">{message}</p>}
+      {locationState !== 'ready' && locationState !== 'loading' && (
+        <p className="google-shopping-panel__hint">{getLocationMessage(locationState, locationMessage)}</p>
+      )}
+
+      {locationState === 'loading' && <p className="google-shopping-panel__hint">Loading Google Business locations…</p>}
+
+      {uploadMessage && <p className="google-shopping-panel__hint">{uploadMessage}</p>}
 
       {uploadState === 'success' && uploadedResult && (
         <article className="google-shopping-page__status" aria-live="polite">


### PR DESCRIPTION
### Motivation
- The uploader previously surfaced all failures from `listGoogleBusinessLocations` as a generic uploader error, mixing authentication/scope problems with real upload issues. 
- The goal is to clearly distinguish connection and permission failures (`not connected`, missing `business.manage` scope) from empty-location and genuine upload errors while keeping the existing UI and flow intact. 
- The component must remain resilient even if a parent page later gates access before rendering the uploader.

### Description
- Added structured API error modeling in `web/src/api/googleBusinessProfile.ts` via `GoogleBusinessApiError`, `GoogleBusinessErrorKind`, `inferErrorKind`, and `defaultErrorMessage`, and changed `parseApiResponse` to throw the typed error. 
- Exported `parseGoogleBusinessApiError` so callers can normalize errors into kinds: `not_connected`, `missing_scope`, `not_authenticated`, and `unknown`. 
- Kept the existing `listGoogleBusinessLocations` and `uploadGoogleBusinessLocationMedia` signatures but made their failures parseable into the new kinds. 
- Refactored `web/src/components/GoogleBusinessMediaUploader.tsx` to track `locationState` separately from upload state, show clearer messages via `getLocationMessage`, block uploads unless locations are `ready`, and handle `not_connected`/`missing_scope` explicitly for both location loading and upload flows.

### Testing
- Ran lint with `npm --prefix web run lint`, which failed in this environment due to a missing local dev dependency (`@eslint/js`).
- Ran build with `npm --prefix web run build`, which failed in this environment due to missing type dependencies (`vite/client` and `vitest/globals`).
- No automated unit tests were added or executed in this change set; the modifications are limited to frontend error parsing and UI state handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9691c87c88321a4a6187cd02ab46c)