### PR TITLE
Refactor Google Shopping Merchant connect to shared Google OAuth UX

### DIFF
--- a/web/src/api/googleShopping.ts
+++ b/web/src/api/googleShopping.ts
@@ -47,21 +47,6 @@ async function authedPost<T>(functionName: string, payload: unknown): Promise<T>
   return body as T
 }
 
-export async function startGoogleMerchantOAuth(params: { storeId: string }): Promise<string> {
-  const token = await getToken()
-  const response = await fetch('/api/google/oauth-start', {
-    method: 'POST',
-    headers: {
-      authorization: `Bearer ${token}`,
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({ ...params, integrations: ['merchant'] }),
-  })
-  const payload = (await response.json().catch(() => ({}))) as { url?: string; error?: string }
-  if (!response.ok) throw new Error(payload.error || 'Unable to start Google Merchant connection right now.')
-  if (!payload.url) throw new Error('Unable to start Google Merchant connection right now.')
-  return payload.url
-}
 
 export async function getGoogleMerchantPendingAccounts(params: {
   pendingSelectionId: string

--- a/web/src/pages/GoogleShopping.tsx
+++ b/web/src/pages/GoogleShopping.tsx
@@ -4,13 +4,13 @@ import { doc, onSnapshot } from 'firebase/firestore'
 import {
   getGoogleMerchantPendingAccounts,
   selectGoogleMerchantAccount,
-  startGoogleMerchantOAuth,
   triggerGoogleShoppingSync,
   type GoogleMerchantAccount,
   type GoogleShoppingSyncSummary,
 } from '../api/googleShopping'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
+import { useGoogleIntegrationStatus } from '../hooks/useGoogleIntegrationStatus'
 import './GoogleShopping.css'
 
 type WizardStep = 'connect' | 'map' | 'fix' | 'status'
@@ -18,6 +18,7 @@ type WizardStep = 'connect' | 'map' | 'fix' | 'status'
 type OAuthQueryState = {
   oauthStatus: 'success' | 'failed' | ''
   oauthMessage: string
+  integrations: string[]
   oauthMerchantId: string
   pendingSelectionId: string
   refreshTokenMissing: boolean
@@ -37,14 +38,22 @@ const STEP_LABELS: Record<WizardStep, string> = {
 
 function parseOAuthQueryState(): OAuthQueryState {
   const params = new URLSearchParams(window.location.search)
+  const sharedOAuth = params.get('googleOAuth')
+  const legacyMerchantOAuth = params.get('googleMerchantOAuth')
+  const integrations = (params.get('integrations') || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
   return {
     oauthStatus:
-      params.get('googleMerchantOAuth') === 'success'
+      sharedOAuth === 'success' || legacyMerchantOAuth === 'success'
         ? 'success'
-        : params.get('googleMerchantOAuth') === 'failed'
+        : sharedOAuth === 'failed' || legacyMerchantOAuth === 'failed'
           ? 'failed'
           : '',
     oauthMessage: params.get('message') || '',
+    integrations,
     oauthMerchantId: params.get('merchantId') || '',
     pendingSelectionId: params.get('pendingSelectionId') || '',
     refreshTokenMissing: params.get('refreshTokenMissing') === '1',
@@ -53,6 +62,8 @@ function parseOAuthQueryState(): OAuthQueryState {
 
 function clearOAuthQueryState() {
   const url = new URL(window.location.href)
+  url.searchParams.delete('googleOAuth')
+  url.searchParams.delete('integrations')
   url.searchParams.delete('googleMerchantOAuth')
   url.searchParams.delete('message')
   url.searchParams.delete('merchantId')
@@ -73,11 +84,21 @@ export default function GoogleShopping() {
   const [status, setStatus] = useState<string | null>(null)
   const [summary, setSummary] = useState<GoogleShoppingSyncSummary | null>(null)
   const [saving, setSaving] = useState(false)
-  const [oauthConnecting, setOauthConnecting] = useState(false)
   const [pendingSelectionId, setPendingSelectionId] = useState('')
   const [pendingAccounts, setPendingAccounts] = useState<GoogleMerchantAccount[]>([])
   const [selectedMerchantId, setSelectedMerchantId] = useState('')
   const [connection, setConnection] = useState<GoogleShoppingConnection>({ connected: false, merchantId: '' })
+  const {
+    isLoading: oauthStatusLoading,
+    isStartingOAuth,
+    hasGoogleConnection,
+    hasRequiredScope,
+    isConnected,
+    buttonLabel,
+    stateTitle,
+    error: oauthError,
+    startOAuth,
+  } = useGoogleIntegrationStatus({ integration: 'merchant', storeId })
 
   const checklist = useMemo(
     () => [
@@ -92,11 +113,13 @@ export default function GoogleShopping() {
 
   useEffect(() => {
     const queryState = parseOAuthQueryState()
-    if (queryState.oauthStatus === 'failed') {
+    const includesMerchant = queryState.integrations.length === 0 || queryState.integrations.includes('merchant')
+
+    if (queryState.oauthStatus === 'failed' && includesMerchant) {
       setStatus(queryState.oauthMessage || 'We could not connect your Google Merchant account. Please try again.')
     }
 
-    if (queryState.oauthStatus === 'success') {
+    if (queryState.oauthStatus === 'success' && includesMerchant) {
       if (queryState.pendingSelectionId) {
         setPendingSelectionId(queryState.pendingSelectionId)
         setStatus('We found multiple Merchant accounts. Please choose the one you want to connect.')
@@ -172,23 +195,19 @@ export default function GoogleShopping() {
     }
   }, [pendingSelectionId])
 
+  useEffect(() => {
+    if (!oauthError) return
+    setStatus(oauthError)
+  }, [oauthError])
+
   async function connectGoogleMerchant() {
     if (!storeId) {
       setStatus('Please select a store before connecting Google Merchant.')
       return
     }
 
-    setOauthConnecting(true)
     setStatus(null)
-
-    try {
-      const url = await startGoogleMerchantOAuth({ storeId })
-      window.location.assign(url)
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unable to start Google Merchant connection.'
-      setStatus(message)
-      setOauthConnecting(false)
-    }
+    await startOAuth()
   }
 
   async function confirmMerchantSelection() {
@@ -267,15 +286,24 @@ export default function GoogleShopping() {
 
       {step === 'connect' && (
         <section className="google-shopping-panel">
-          <h2>Connect account</h2>
+          <h2>{stateTitle}</h2>
           <p>
-            Click below to sign in with Google. Sedifex will discover your Merchant accounts and
-            connect automatically when possible.
+            {!hasGoogleConnection
+              ? 'Connect your Google account to continue.'
+              : !hasRequiredScope
+                ? 'Your Google account is connected. Grant Google Merchant access to continue.'
+                : connection.connected
+                  ? 'Google Merchant is connected for this store.'
+                  : 'Google Merchant access is ready. Connect and choose your Merchant account.'}
           </p>
 
-          <button type="button" disabled={oauthConnecting || saving} onClick={connectGoogleMerchant}>
-            {oauthConnecting ? 'Connecting…' : connection.connected ? 'Reconnect Google Merchant' : 'Connect Google Merchant'}
-          </button>
+          {oauthStatusLoading ? <p className="google-shopping-panel__hint">Checking Google connection…</p> : null}
+
+          {!isConnected || !connection.connected ? (
+            <button type="button" disabled={isStartingOAuth || saving} onClick={connectGoogleMerchant}>
+              {isStartingOAuth ? 'Connecting…' : buttonLabel}
+            </button>
+          ) : null}
 
           {connection.connected && (
             <p className="google-shopping-panel__connected">Connected Merchant ID: <strong>{connection.merchantId}</strong></p>


### PR DESCRIPTION
### Motivation
- Align Google Merchant connection UX with the shared Google OAuth flow already used for Ads and Business so the page uses the same 3-state experience (Connect Google → Grant Google Merchant access → Connected). 
- Reuse the centralized integration status and OAuth start logic to ensure consistent scope checks and preserve store/auth checks. 
- Keep the existing Merchant account selection backend flow (pending accounts / selection) while removing the now-redundant frontend start helper.

### Description
- Switched `GoogleShopping` to use the shared hook `useGoogleIntegrationStatus({ integration: 'merchant', storeId })` so labels, button text and state come from the central logic and the required scope is `https://www.googleapis.com/auth/content`.
- Reworked OAuth query parsing to accept the shared callback params (`googleOAuth` and `integrations`) while still honoring legacy `googleMerchantOAuth` query values and clearing both sets from the URL after processing.
- Updated the primary connect CTA to call the shared `startOAuth` (via the hook) instead of the page-specific `startGoogleMerchantOAuth`, and surfaced the shared loading/error/button labels (`stateTitle`, `buttonLabel`, `isStartingOAuth`, `isLoading`, `error`).
- Removed the now-unused frontend helper `startGoogleMerchantOAuth` from `web/src/api/googleShopping.ts` and preserved the existing pending-account selection functions (`getGoogleMerchantPendingAccounts`, `selectGoogleMerchantAccount`) and their UI flow.

### Testing
- Ran `cd web && npm run lint`, which failed in this environment due to a missing ESLint dependency (`@eslint/js`) required by the local ESLint config.
- Ran `cd web && npm run build`, which failed in this environment due to missing TypeScript type definitions for `vite/client` and `vitest/globals`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96a7fd1cc8321b4a484b2806afb93)