### PR TITLE
Unify Google connection status UI and OAuth callback cleanup

### DIFF
--- a/web/src/api/googleIntegrations.ts
+++ b/web/src/api/googleIntegrations.ts
@@ -46,13 +46,13 @@ export async function fetchGoogleIntegrationStatus(storeId: string): Promise<Rec
 
 export async function fetchGoogleIntegrationOverview(
   storeId: string,
-  integrations?: GoogleIntegrationKey[],
+  requestedIntegrations?: GoogleIntegrationKey[],
 ): Promise<GoogleIntegrationOverview> {
   const headers = await authHeaders()
   const response = await fetch('/api/google/status', {
     method: 'POST',
     headers,
-    body: JSON.stringify({ storeId, integrations }),
+    body: JSON.stringify({ storeId, integrations: requestedIntegrations }),
   })
   const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>
   if (!response.ok) {
@@ -60,7 +60,7 @@ export async function fetchGoogleIntegrationOverview(
   }
 
   const rawIntegrations = (payload.integrations ?? {}) as Record<string, unknown>
-  const integrations: Record<GoogleIntegrationKey, { connected: boolean; hasRequiredScope: boolean }> = {
+  const integrationStates: Record<GoogleIntegrationKey, { connected: boolean; hasRequiredScope: boolean }> = {
     business: {
       connected: Boolean((rawIntegrations.business as Record<string, unknown> | undefined)?.connected),
       hasRequiredScope: Boolean(
@@ -85,7 +85,7 @@ export async function fetchGoogleIntegrationOverview(
 
   return {
     connected,
-    integrations,
+    integrations: integrationStates,
     grantedScopes,
   }
 }

--- a/web/src/components/GoogleConnectionStatusCard.tsx
+++ b/web/src/components/GoogleConnectionStatusCard.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from 'react'
+
+import {
+  fetchGoogleIntegrationStatus,
+  startGoogleOAuth,
+  type GoogleIntegrationKey,
+  type GoogleIntegrationStatus,
+} from '../api/googleIntegrations'
+import { isReconnectRequiredError } from '../utils/googleOAuthCallback'
+
+type Props = {
+  storeId: string
+  currentIntegration?: GoogleIntegrationKey
+  message?: string | null
+}
+
+const ROWS: Array<{ key: GoogleIntegrationKey; label: string }> = [
+  { key: 'ads', label: 'Ads status' },
+  { key: 'business', label: 'Business status' },
+  { key: 'merchant', label: 'Merchant status' },
+]
+
+export default function GoogleConnectionStatusCard({ storeId, currentIntegration, message }: Props) {
+  const [statuses, setStatuses] = useState<Record<GoogleIntegrationKey, GoogleIntegrationStatus>>({
+    business: 'Needs permission',
+    ads: 'Needs permission',
+    merchant: 'Needs permission',
+  })
+  const [loading, setLoading] = useState(true)
+  const [connecting, setConnecting] = useState<GoogleIntegrationKey | ''>('')
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let mounted = true
+    setLoading(true)
+    fetchGoogleIntegrationStatus(storeId)
+      .then(next => {
+        if (mounted) setStatuses(next)
+      })
+      .catch(nextError => {
+        if (mounted) setError(nextError instanceof Error ? nextError.message : 'Unable to load Google status.')
+      })
+      .finally(() => {
+        if (mounted) setLoading(false)
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [storeId])
+
+  async function connect(integration: GoogleIntegrationKey) {
+    setConnecting(integration)
+    setError('')
+    try {
+      const url = await startGoogleOAuth({ storeId, integrations: [integration] })
+      window.location.assign(url)
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Unable to start Google connection.')
+      setConnecting('')
+    }
+  }
+
+  const reconnectMessage = message && isReconnectRequiredError(message) ? 'Reconnect Google' : null
+
+  return (
+    <section className="google-shopping-panel" aria-label="Google connection status">
+      <h2>Google connection status</h2>
+      {loading ? <p className="google-shopping-panel__hint">Loading statuses…</p> : null}
+      <ul className="account-overview__integration-key-list">
+        {ROWS.map(row => {
+          const actionable = currentIntegration === row.key
+          const status = statuses[row.key]
+          const needsReconnect = actionable && reconnectMessage
+
+          return (
+            <li key={row.key} className="account-overview__integration-key-item">
+              <div>
+                <strong>{row.label}</strong>
+                <p className="account-overview__hint">{status}</p>
+              </div>
+              {actionable ? (
+                <button
+                  type="button"
+                  className="button button--secondary"
+                  disabled={connecting === row.key}
+                  onClick={() => connect(row.key)}
+                >
+                  {connecting === row.key
+                    ? 'Connecting…'
+                    : needsReconnect || (status === 'Connected' ? 'Upgrade/refresh permission' : 'Connect')}
+                </button>
+              ) : null}
+            </li>
+          )
+        })}
+      </ul>
+      {message ? <p className="google-shopping-panel__hint">{message}</p> : null}
+      {!message && error ? <p className="google-shopping-panel__hint">{error}</p> : null}
+    </section>
+  )
+}

--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -7,8 +7,10 @@ import {
   pauseOrResumeCampaign,
   saveCampaignBrief,
 } from '../api/googleAdsAutomation'
+import GoogleConnectionStatusCard from '../components/GoogleConnectionStatusCard'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
+import { clearGoogleOAuthQueryState, isReconnectRequiredError, parseGoogleOAuthQueryState } from '../utils/googleOAuthCallback'
 import './AdsCampaigns.css'
 
 type CampaignGoal = 'leads' | 'sales' | 'traffic' | 'calls' | 'awareness'
@@ -174,21 +176,18 @@ export default function AdsCampaigns() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    const params = new URLSearchParams(window.location.search)
-    const oauthState = params.get('googleOAuth')
-    const oauthMessage = params.get('message')
-    if (!oauthState) return
+    const queryState = parseGoogleOAuthQueryState(window.location.search)
+    if (!queryState.status) return
 
-    if (oauthState === 'success') {
-      setNotice(oauthMessage || 'Google Ads connected.')
+    if (queryState.status === 'success') {
+      setNotice(queryState.message || 'Google Ads connected.')
+    } else if (isReconnectRequiredError(queryState.message)) {
+      setNotice('Reconnect Google')
     } else {
-      setNotice(oauthMessage || 'Google OAuth failed.')
+      setNotice(queryState.message || 'Google OAuth failed.')
     }
 
-    params.delete('googleOAuth')
-    params.delete('message')
-    const nextQuery = params.toString()
-    const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ''}`
+    const nextUrl = clearGoogleOAuthQueryState(window.location.href)
     window.history.replaceState({}, '', nextUrl)
   }, [])
 
@@ -362,6 +361,7 @@ export default function AdsCampaigns() {
 
       {loading ? <p className="ads-campaigns__status">Loading Google Ads workspace…</p> : null}
       {notice ? <p className="ads-campaigns__status">{notice}</p> : null}
+      {storeId ? <GoogleConnectionStatusCard storeId={storeId} currentIntegration="ads" message={notice} /> : null}
 
       <section className="ads-campaigns__section" aria-labelledby="google-connect">
         <div>

--- a/web/src/pages/GoogleBusinessProfile.tsx
+++ b/web/src/pages/GoogleBusinessProfile.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react'
 
 import GoogleBusinessMediaUploader from '../components/GoogleBusinessMediaUploader'
+import GoogleConnectionStatusCard from '../components/GoogleConnectionStatusCard'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useGoogleIntegrationStatus } from '../hooks/useGoogleIntegrationStatus'
+import { clearGoogleOAuthQueryState, parseGoogleOAuthQueryState } from '../utils/googleOAuthCallback'
 import './GoogleShopping.css'
 
 export default function GoogleBusinessProfile() {
@@ -25,20 +27,16 @@ export default function GoogleBusinessProfile() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    const params = new URLSearchParams(window.location.search)
-    const oauthState = params.get('googleOAuth')
-    if (!oauthState) return
+    const queryState = parseGoogleOAuthQueryState(window.location.search)
+    if (!queryState.status) return
 
-    if (oauthState === 'success') {
-      setMessage(params.get('message') || 'Google connected successfully.')
+    if (queryState.status === 'success') {
+      setMessage(queryState.message || 'Google connected successfully.')
     } else {
-      setMessage(params.get('message') || 'Google OAuth failed.')
+      setMessage(queryState.message || 'Google OAuth failed.')
     }
 
-    params.delete('googleOAuth')
-    params.delete('message')
-    const nextQuery = params.toString()
-    const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ''}`
+    const nextUrl = clearGoogleOAuthQueryState(window.location.href)
     window.history.replaceState({}, '', nextUrl)
   }, [])
 
@@ -63,6 +61,8 @@ export default function GoogleBusinessProfile() {
         </section>
       ) : (
         <>
+          <GoogleConnectionStatusCard storeId={storeId} currentIntegration="business" message={message} />
+
           <section className="google-shopping-panel">
             <h2>{stateTitle}</h2>
             <p>
@@ -78,7 +78,6 @@ export default function GoogleBusinessProfile() {
                 {isStartingOAuth ? 'Connecting…' : buttonLabel}
               </button>
             ) : null}
-            {message ? <p className="google-shopping-panel__hint">{message}</p> : null}
           </section>
 
           {isConnected ? <GoogleBusinessMediaUploader storeId={storeId} /> : null}

--- a/web/src/pages/GoogleShopping.tsx
+++ b/web/src/pages/GoogleShopping.tsx
@@ -10,19 +10,12 @@ import {
 } from '../api/googleShopping'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
+import GoogleConnectionStatusCard from '../components/GoogleConnectionStatusCard'
 import { useGoogleIntegrationStatus } from '../hooks/useGoogleIntegrationStatus'
+import { clearGoogleOAuthQueryState, parseGoogleOAuthQueryState } from '../utils/googleOAuthCallback'
 import './GoogleShopping.css'
 
 type WizardStep = 'connect' | 'map' | 'fix' | 'status'
-
-type OAuthQueryState = {
-  oauthStatus: 'success' | 'failed' | ''
-  oauthMessage: string
-  integrations: string[]
-  oauthMerchantId: string
-  pendingSelectionId: string
-  refreshTokenMissing: boolean
-}
 
 type GoogleShoppingConnection = {
   connected: boolean
@@ -34,43 +27,6 @@ const STEP_LABELS: Record<WizardStep, string> = {
   map: '2. Map fields',
   fix: '3. Fix errors',
   status: '4. View sync status',
-}
-
-function parseOAuthQueryState(): OAuthQueryState {
-  const params = new URLSearchParams(window.location.search)
-  const sharedOAuth = params.get('googleOAuth')
-  const legacyMerchantOAuth = params.get('googleMerchantOAuth')
-  const integrations = (params.get('integrations') || '')
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-
-  return {
-    oauthStatus:
-      sharedOAuth === 'success' || legacyMerchantOAuth === 'success'
-        ? 'success'
-        : sharedOAuth === 'failed' || legacyMerchantOAuth === 'failed'
-          ? 'failed'
-          : '',
-    oauthMessage: params.get('message') || '',
-    integrations,
-    oauthMerchantId: params.get('merchantId') || '',
-    pendingSelectionId: params.get('pendingSelectionId') || '',
-    refreshTokenMissing: params.get('refreshTokenMissing') === '1',
-  }
-}
-
-function clearOAuthQueryState() {
-  const url = new URL(window.location.href)
-  url.searchParams.delete('googleOAuth')
-  url.searchParams.delete('integrations')
-  url.searchParams.delete('googleMerchantOAuth')
-  url.searchParams.delete('message')
-  url.searchParams.delete('merchantId')
-  url.searchParams.delete('pendingSelectionId')
-  url.searchParams.delete('refreshTokenMissing')
-  url.searchParams.delete('storeId')
-  window.history.replaceState({}, '', url.toString())
 }
 
 export default function GoogleShopping() {
@@ -112,30 +68,31 @@ export default function GoogleShopping() {
   )
 
   useEffect(() => {
-    const queryState = parseOAuthQueryState()
+    const queryState = parseGoogleOAuthQueryState(window.location.search)
     const includesMerchant = queryState.integrations.length === 0 || queryState.integrations.includes('merchant')
 
-    if (queryState.oauthStatus === 'failed' && includesMerchant) {
-      setStatus(queryState.oauthMessage || 'We could not connect your Google Merchant account. Please try again.')
+    if (queryState.status === 'failed' && includesMerchant) {
+      setStatus(queryState.message || 'We could not connect your Google Merchant account. Please try again.')
     }
 
-    if (queryState.oauthStatus === 'success' && includesMerchant) {
+    if (queryState.status === 'success' && includesMerchant) {
       if (queryState.pendingSelectionId) {
         setPendingSelectionId(queryState.pendingSelectionId)
         setStatus('We found multiple Merchant accounts. Please choose the one you want to connect.')
-      } else if (queryState.oauthMerchantId) {
+      } else if (queryState.merchantId) {
         const message = queryState.refreshTokenMissing
-          ? `Connected to Merchant ID ${queryState.oauthMerchantId}. Note: Google did not return a refresh token, so reconnect may be required later.`
-          : `Connected to Merchant ID ${queryState.oauthMerchantId}.`
+          ? `Connected to Merchant ID ${queryState.merchantId}. Note: Google did not return a refresh token, so reconnect may be required later.`
+          : `Connected to Merchant ID ${queryState.merchantId}.`
         setStatus(message)
       } else {
-        setStatus(queryState.oauthMessage || 'Google Merchant connected successfully.')
+        setStatus(queryState.message || 'Google Merchant connected successfully.')
       }
       setStep('connect')
     }
 
-    if (queryState.oauthStatus) {
-      clearOAuthQueryState()
+    if (queryState.status) {
+      const nextUrl = clearGoogleOAuthQueryState(window.location.href)
+      window.history.replaceState({}, '', nextUrl)
     }
   }, [])
 
@@ -285,65 +242,68 @@ export default function GoogleShopping() {
       </nav>
 
       {step === 'connect' && (
-        <section className="google-shopping-panel">
-          <h2>{stateTitle}</h2>
-          <p>
-            {!hasGoogleConnection
-              ? 'Connect your Google account to continue.'
-              : !hasRequiredScope
-                ? 'Your Google account is connected. Grant Google Merchant access to continue.'
-                : connection.connected
-                  ? 'Google Merchant is connected for this store.'
-                  : 'Google Merchant access is ready. Connect and choose your Merchant account.'}
-          </p>
+        <>
+          {storeId ? <GoogleConnectionStatusCard storeId={storeId} currentIntegration="merchant" message={status} /> : null}
+          <section className="google-shopping-panel">
+            <h2>{stateTitle}</h2>
+            <p>
+              {!hasGoogleConnection
+                ? 'Connect your Google account to continue.'
+                : !hasRequiredScope
+                  ? 'Your Google account is connected. Grant Google Merchant access to continue.'
+                  : connection.connected
+                    ? 'Google Merchant is connected for this store.'
+                    : 'Google Merchant access is ready. Connect and choose your Merchant account.'}
+            </p>
 
-          {oauthStatusLoading ? <p className="google-shopping-panel__hint">Checking Google connection…</p> : null}
+            {oauthStatusLoading ? <p className="google-shopping-panel__hint">Checking Google connection…</p> : null}
 
-          {!isConnected || !connection.connected ? (
-            <button type="button" disabled={isStartingOAuth || saving} onClick={connectGoogleMerchant}>
-              {isStartingOAuth ? 'Connecting…' : buttonLabel}
-            </button>
-          ) : null}
-
-          {connection.connected && (
-            <p className="google-shopping-panel__connected">Connected Merchant ID: <strong>{connection.merchantId}</strong></p>
-          )}
-
-          {pendingAccounts.length > 1 && (
-            <div className="google-shopping-panel__picker">
-              <h3>Choose your Merchant account</h3>
-              <label>
-                Merchant account
-                <select
-                  value={selectedMerchantId}
-                  onChange={(event) => setSelectedMerchantId(event.target.value)}
-                >
-                  {pendingAccounts.map((account) => (
-                    <option key={account.id} value={account.id}>
-                      {account.displayName} ({account.id})
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <button type="button" disabled={saving} onClick={confirmMerchantSelection}>
-                {saving ? 'Saving…' : 'Use this Merchant account'}
+            {!isConnected || !connection.connected ? (
+              <button type="button" disabled={isStartingOAuth || saving} onClick={connectGoogleMerchant}>
+                {isStartingOAuth ? 'Connecting…' : buttonLabel}
               </button>
-            </div>
-          )}
+            ) : null}
 
-          <label>
-            Sedifex Integration API key
-            <input value={integrationApiKey} readOnly />
-          </label>
-          <label>
-            Integration feed base URL
-            <input value={integrationBaseUrl} readOnly />
-          </label>
-          <label className="google-shopping-panel__checkbox">
-            <input type="checkbox" checked={autoSyncEnabled} readOnly />
-            Scheduled incremental sync is enabled
-          </label>
-        </section>
+            {connection.connected && (
+              <p className="google-shopping-panel__connected">Connected Merchant ID: <strong>{connection.merchantId}</strong></p>
+            )}
+
+            {pendingAccounts.length > 1 && (
+              <div className="google-shopping-panel__picker">
+                <h3>Choose your Merchant account</h3>
+                <label>
+                  Merchant account
+                  <select
+                    value={selectedMerchantId}
+                    onChange={(event) => setSelectedMerchantId(event.target.value)}
+                  >
+                    {pendingAccounts.map((account) => (
+                      <option key={account.id} value={account.id}>
+                        {account.displayName} ({account.id})
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <button type="button" disabled={saving} onClick={confirmMerchantSelection}>
+                  {saving ? 'Saving…' : 'Use this Merchant account'}
+                </button>
+              </div>
+            )}
+
+            <label>
+              Sedifex Integration API key
+              <input value={integrationApiKey} readOnly />
+            </label>
+            <label>
+              Integration feed base URL
+              <input value={integrationBaseUrl} readOnly />
+            </label>
+            <label className="google-shopping-panel__checkbox">
+              <input type="checkbox" checked={autoSyncEnabled} readOnly />
+              Scheduled incremental sync is enabled
+            </label>
+          </section>
+        </>
       )}
 
       {step === 'map' && (

--- a/web/src/utils/googleOAuthCallback.ts
+++ b/web/src/utils/googleOAuthCallback.ts
@@ -1,0 +1,66 @@
+export type GoogleOAuthQueryState = {
+  status: 'success' | 'failed' | ''
+  message: string
+  integrations: string[]
+  merchantId: string
+  pendingSelectionId: string
+  refreshTokenMissing: boolean
+}
+
+const CALLBACK_PARAMS = [
+  'googleOAuth',
+  'googleMerchantOAuth',
+  'integrations',
+  'message',
+  'merchantId',
+  'pendingSelectionId',
+  'refreshTokenMissing',
+  'storeId',
+] as const
+
+export function parseGoogleOAuthQueryState(search: string): GoogleOAuthQueryState {
+  const params = new URLSearchParams(search)
+  const integrations = (params.get('integrations') || '')
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean)
+
+  const sharedOAuth = params.get('googleOAuth')
+  const legacyMerchantOAuth = params.get('googleMerchantOAuth')
+  const status: GoogleOAuthQueryState['status'] =
+    sharedOAuth === 'success' || legacyMerchantOAuth === 'success'
+      ? 'success'
+      : sharedOAuth === 'failed' || legacyMerchantOAuth === 'failed'
+        ? 'failed'
+        : ''
+
+  return {
+    status,
+    message: params.get('message') || '',
+    integrations,
+    merchantId: params.get('merchantId') || '',
+    pendingSelectionId: params.get('pendingSelectionId') || '',
+    refreshTokenMissing: params.get('refreshTokenMissing') === '1',
+  }
+}
+
+export function clearGoogleOAuthQueryState(currentUrl: string) {
+  const url = new URL(currentUrl)
+  CALLBACK_PARAMS.forEach(param => {
+    url.searchParams.delete(param)
+  })
+
+  return url.toString()
+}
+
+export function isReconnectRequiredError(message: string) {
+  const normalized = message.toLowerCase()
+  return (
+    normalized.includes('refresh token') ||
+    normalized.includes('invalid_grant') ||
+    normalized.includes('revoked') ||
+    normalized.includes('reauth') ||
+    normalized.includes('re-auth') ||
+    normalized.includes('consent')
+  )
+}


### PR DESCRIPTION
### Motivation
- Consolidate fragmented Google integration UI and legacy OAuth callback handling to present a single, reusable connection panel and avoid stale query state after redirects.
- Surface explicit reconnect flows when refresh tokens are missing/revoked so pages show `Reconnect Google` instead of generic errors.

### Description
- Added a shared status card component `web/src/components/GoogleConnectionStatusCard.tsx` to show Ads/Business/Merchant health and provide per-integration connect/reconnect CTAs.
- Centralized callback parsing/cleanup and reconnect-detection in `web/src/utils/googleOAuthCallback.ts` with `parseGoogleOAuthQueryState`, `clearGoogleOAuthQueryState`, and `isReconnectRequiredError`.
- Fixed a naming/shadowing issue in `web/src/api/googleIntegrations.ts` by renaming the request parameter to `requestedIntegrations` and the local parsed map to `integrationStates` so TypeScript no longer conflicts with `integrations` usage.
- Updated pages to use the shared UI and utilities: `web/src/pages/GoogleShopping.tsx`, `web/src/pages/GoogleBusinessProfile.tsx`, and `web/src/pages/AdsCampaigns.tsx` now consume the shared card and clear legacy callback params after consumption.

### Testing
- Ran `cd web && npm run lint` which failed in this environment due to a missing ESLint peer dependency (`@eslint/js`).
- Ran `cd web && npm run build` which failed in this environment due to missing type packages for `vite/client` and `vitest/globals` (environment limitations), so no successful full build was produced.
- No additional automated tests were run in this environment due to missing dev dependencies and type packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96c65850c83218e7f3e604bacbbec)