### PR TITLE
Harden Google Ads campaign creation with verified mutate flow

### DIFF
--- a/web/api/_google-ads.ts
+++ b/web/api/_google-ads.ts
@@ -226,6 +226,34 @@ export async function discoverGoogleAdsCustomerId(params: {
   return candidate.trim()
 }
 
+export async function listAccessibleGoogleAdsCustomers(params: {
+  accessToken: string
+  managerId?: string
+}): Promise<string[]> {
+  const url = `${GOOGLE_ADS_API_BASE}/${GOOGLE_ADS_API_VERSION}/customers:listAccessibleCustomers`
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: googleAdsHeaders({
+      accessToken: params.accessToken,
+      managerId: params.managerId || '',
+    }),
+  })
+
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>
+  if (!response.ok) {
+    throw new Error(
+      `google-ads-accessible-customers-failed:${typeof payload.message === 'string' ? payload.message : response.status}`,
+    )
+  }
+
+  const names = Array.isArray(payload.resourceNames) ? payload.resourceNames : []
+  const customerIds = names
+    .map(entry => (typeof entry === 'string' ? entry.split('/').pop()?.trim() || '' : ''))
+    .filter(Boolean)
+
+  return Array.from(new Set(customerIds))
+}
+
 export async function exchangeCodeForTokens(code: string) {
   const { clientId, clientSecret, redirectUri } = getOAuthClientConfig()
 
@@ -381,7 +409,9 @@ export async function getGoogleAdsAuthContext(storeId: string): Promise<{
   customerId: string
   managerId: string
   accessToken: string
+  accessibleCustomerIds: string[]
 }> {
+  console.info(JSON.stringify({ event: 'google_ads.auth.start', storeId }))
   const settingsRef = db().doc(`storeSettings/${storeId}`)
   const snap = await settingsRef.get()
   const data = (snap.data() ?? {}) as Record<string, any>
@@ -406,12 +436,13 @@ export async function getGoogleAdsAuthContext(storeId: string): Promise<{
     refreshToken = sharedGoogle.refreshToken
   }
 
-  if (!customerId || !accessToken) {
+  if (!accessToken) {
     throw new Error('google-ads-not-connected')
   }
 
   const expired = toMillis(googleAds.expiresAt) <= Date.now() + 15_000
   if (expired) {
+    console.info(JSON.stringify({ event: 'google_ads.auth.token_refresh.start', storeId }))
     if (!refreshToken) throw new Error('google-ads-refresh-token-missing')
 
     const refreshed = await refreshGoogleAccessToken(refreshToken)
@@ -446,9 +477,46 @@ export async function getGoogleAdsAuthContext(storeId: string): Promise<{
       },
       { merge: true },
     )
+    console.info(JSON.stringify({ event: 'google_ads.auth.token_refresh.success', storeId }))
   }
 
-  return { customerId, managerId, accessToken }
+  const accessibleCustomerIds = await listAccessibleGoogleAdsCustomers({ accessToken, managerId })
+  let resolvedCustomerId = customerId ? normalizeCustomerId(customerId) : ''
+  if (!resolvedCustomerId && accessibleCustomerIds[0]) {
+    resolvedCustomerId = normalizeCustomerId(accessibleCustomerIds[0])
+    await settingsRef.set(
+      {
+        integrations: {
+          googleAds: {
+            customerId: resolvedCustomerId,
+            updatedAt: FieldValue.serverTimestamp(),
+          },
+        },
+        googleAdsAutomation: {
+          connection: {
+            customerId: resolvedCustomerId,
+            tokenValidatedAt: FieldValue.serverTimestamp(),
+          },
+        },
+      },
+      { merge: true },
+    )
+  }
+
+  if (!resolvedCustomerId) {
+    throw new Error('google-ads-customer-id-missing')
+  }
+
+  console.info(
+    JSON.stringify({
+      event: 'google_ads.auth.success',
+      storeId,
+      customerId: resolvedCustomerId,
+      loginCustomerId: managerId || null,
+      accessibleCustomerCount: accessibleCustomerIds.length,
+    }),
+  )
+  return { customerId: resolvedCustomerId, managerId, accessToken, accessibleCustomerIds }
 }
 
 function normalizeCustomerId(customerId: string): string {
@@ -480,6 +548,14 @@ export async function googleAdsMutate(params: {
 }): Promise<Record<string, unknown>> {
   const customerId = normalizeCustomerId(params.customerId)
   const url = `${GOOGLE_ADS_API_BASE}/${GOOGLE_ADS_API_VERSION}/customers/${customerId}/googleAds:mutate`
+  console.info(
+    JSON.stringify({
+      event: 'google_ads.mutate.start',
+      customerId,
+      loginCustomerId: params.managerId ? normalizeCustomerId(params.managerId) : null,
+      operations: params.operations.length,
+    }),
+  )
 
   const response = await fetch(url, {
     method: 'POST',
@@ -489,11 +565,31 @@ export async function googleAdsMutate(params: {
 
   const payload = (await response.json()) as Record<string, unknown>
   if (!response.ok) {
+    const details = Array.isArray((payload as Record<string, unknown>).details)
+      ? JSON.stringify((payload as Record<string, unknown>).details)
+      : ''
+    console.error(
+      JSON.stringify({
+        event: 'google_ads.mutate.error',
+        customerId,
+        loginCustomerId: params.managerId ? normalizeCustomerId(params.managerId) : null,
+        status: response.status,
+        message: payload.message || null,
+        details: (payload as Record<string, unknown>).details || null,
+      }),
+    )
     throw new Error(
-      `google-ads-mutate-failed:${typeof payload.message === 'string' ? payload.message : response.status}`,
+      `google-ads-mutate-failed:${typeof payload.message === 'string' ? payload.message : response.status}${details ? `:${details}` : ''}`,
     )
   }
 
+  console.info(
+    JSON.stringify({
+      event: 'google_ads.mutate.success',
+      customerId,
+      loginCustomerId: params.managerId ? normalizeCustomerId(params.managerId) : null,
+    }),
+  )
   return payload
 }
 
@@ -507,11 +603,29 @@ export async function createGoogleAdsCampaign(params: {
   accessToken: string
   brief: CampaignBrief
   campaignName: string
-}): Promise<{ campaignId: string; adGroupName: string }> {
+}): Promise<{
+  budgetResourceName: string
+  budgetId: string
+  campaignResourceName: string
+  campaignId: string
+  adGroupResourceName: string
+  adGroupId: string
+  adResourceName: string
+  keywordResourceName: string | null
+  adGroupName: string
+}> {
   const normalizedCustomerId = normalizeCustomerId(params.customerId)
   const micros = Math.max(1_000_000, Math.round(params.brief.dailyBudget * 1_000_000))
   const campaignName = params.campaignName.slice(0, 120)
   const adGroupName = `${params.brief.goal.toUpperCase()} Primary`.slice(0, 120)
+  const keywordText = params.brief.headline
+    .replace(/[^\w\s-]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .slice(0, 8)
+    .join(' ')
+    .slice(0, 80)
+  const hasKeyword = keywordText.length > 0
 
   const payload = await googleAdsMutate({
     customerId: params.customerId,
@@ -564,6 +678,22 @@ export async function createGoogleAdsCampaign(params: {
           },
         },
       },
+      ...(hasKeyword
+        ? [
+            {
+              adGroupCriterionOperation: {
+                create: {
+                  adGroup: `customers/${normalizedCustomerId}/adGroups/-3`,
+                  status: 'ENABLED',
+                  keyword: {
+                    text: keywordText,
+                    matchType: 'PHRASE',
+                  },
+                },
+              },
+            },
+          ]
+        : []),
     ],
   })
 
@@ -571,15 +701,44 @@ export async function createGoogleAdsCampaign(params: {
     ? payload.mutateOperationResponses
     : []
 
+  const budgetResourceName = parseResourceName(
+    (mutateResponses[0] as Record<string, any> | undefined)?.campaignBudgetResult?.resourceName,
+  )
   const campaignResourceName = parseResourceName(
     (mutateResponses[1] as Record<string, any> | undefined)?.campaignResult?.resourceName,
   )
+  const adGroupResourceName = parseResourceName(
+    (mutateResponses[2] as Record<string, any> | undefined)?.adGroupResult?.resourceName,
+  )
+  const adResourceName = parseResourceName(
+    (mutateResponses[3] as Record<string, any> | undefined)?.adGroupAdResult?.resourceName,
+  )
+  const keywordResourceName = hasKeyword
+    ? parseResourceName(
+        (mutateResponses[4] as Record<string, any> | undefined)?.adGroupCriterionResult?.resourceName,
+      ) || null
+    : null
 
-  const match = campaignResourceName.match(/\/campaigns\/(\d+)/)
-  const campaignId = match?.[1] || campaignResourceName || `SFX-${Date.now().toString().slice(-6)}`
+  if (!budgetResourceName || !campaignResourceName || !adGroupResourceName || !adResourceName) {
+    throw new Error('google-ads-mutate-incomplete:missing-resource-name')
+  }
+
+  const campaignId = campaignResourceName.match(/\/campaigns\/(\d+)/)?.[1] || ''
+  const budgetId = budgetResourceName.match(/\/campaignBudgets\/(\d+)/)?.[1] || ''
+  const adGroupId = adGroupResourceName.match(/\/adGroups\/(\d+)/)?.[1] || ''
+  if (!campaignId || !budgetId || !adGroupId) {
+    throw new Error('google-ads-mutate-incomplete:missing-entity-id')
+  }
 
   return {
+    budgetResourceName,
+    budgetId,
+    campaignResourceName,
     campaignId,
+    adGroupResourceName,
+    adGroupId,
+    adResourceName,
+    keywordResourceName,
     adGroupName,
   }
 }

--- a/web/api/google-ads/campaign.ts
+++ b/web/api/google-ads/campaign.ts
@@ -13,6 +13,20 @@ import { requireApiUser, requireStoreMembership } from '../_api-auth.js'
 
 type CampaignAction = 'create' | 'pause' | 'resume' | 'edit'
 
+type CampaignCreateResponse = {
+  ok: boolean
+  status: string
+  campaignCreatedInGoogleAds: boolean
+  customerId: string
+  loginCustomerId: string
+  campaignId: string
+  campaignResourceName: string
+  budgetId?: string
+  adGroupId?: string
+  adGroupResourceName?: string
+  warnings: string[]
+}
+
 function parseAction(raw: unknown): CampaignAction {
   if (raw === 'pause' || raw === 'resume' || raw === 'edit') return raw
   return 'create'
@@ -43,6 +57,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const existingMetrics = (googleAdsAutomation.metrics ?? {}) as Record<string, any>
 
     const auth = await getGoogleAdsAuthContext(storeId)
+    const normalizedConfiguredCustomer = connection.customerId ? String(connection.customerId).replace(/\D/g, '') : ''
+    console.info(
+      JSON.stringify({
+        event: 'google_ads_campaign.auth_context',
+        storeId,
+        action,
+        configuredCustomerId: normalizedConfiguredCustomer || null,
+        resolvedCustomerId: auth.customerId,
+        loginCustomerId: auth.managerId || null,
+        accessibleCustomerIds: auth.accessibleCustomerIds,
+      }),
+    )
 
     if (action === 'pause' || action === 'resume') {
       if (!existingCampaign.campaignId) {
@@ -91,8 +117,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const isCreate = action === 'create'
     let campaignId = typeof existingCampaign.campaignId === 'string' ? existingCampaign.campaignId : ''
     let adGroupName = typeof existingCampaign.adGroupName === 'string' ? existingCampaign.adGroupName : ''
+    let createResponse: CampaignCreateResponse | null = null
 
     if (isCreate) {
+      const warnings: string[] = []
+      if (normalizedConfiguredCustomer && normalizedConfiguredCustomer !== auth.customerId) {
+        warnings.push(
+          `Selected customer ID ${normalizedConfiguredCustomer} differs from authenticated customer ID ${auth.customerId}.`,
+        )
+      }
+      if (!auth.accessibleCustomerIds.includes(auth.customerId)) {
+        warnings.push(`Authenticated customer ID ${auth.customerId} is not in accessible customer list.`)
+      }
+
       const created = await createGoogleAdsCampaign({
         customerId: auth.customerId,
         managerId: auth.managerId,
@@ -102,6 +139,36 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       })
       campaignId = created.campaignId
       adGroupName = created.adGroupName
+      createResponse = {
+        ok: true,
+        status: 'live',
+        campaignCreatedInGoogleAds: true,
+        customerId: auth.customerId,
+        loginCustomerId: auth.managerId || '',
+        campaignId: created.campaignId,
+        campaignResourceName: created.campaignResourceName,
+        budgetId: created.budgetId,
+        adGroupId: created.adGroupId,
+        adGroupResourceName: created.adGroupResourceName,
+        warnings,
+      }
+      console.info(
+        JSON.stringify({
+          event: 'google_ads_campaign.create_result',
+          storeId,
+          customerId: auth.customerId,
+          loginCustomerId: auth.managerId || null,
+          budgetResourceName: created.budgetResourceName,
+          budgetId: created.budgetId,
+          campaignResourceName: created.campaignResourceName,
+          campaignId: created.campaignId,
+          adGroupResourceName: created.adGroupResourceName,
+          adGroupId: created.adGroupId,
+          adResourceName: created.adResourceName,
+          keywordResourceName: created.keywordResourceName,
+          warnings,
+        }),
+      )
     }
 
     if (action === 'edit' && campaignId) {
@@ -124,6 +191,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             status: isCreate ? 'live' : existingCampaign.status || 'draft',
             campaignId,
             adGroupName,
+            customerId: isCreate ? auth.customerId : existingCampaign.customerId || auth.customerId,
+            loginCustomerId: isCreate ? auth.managerId || '' : existingCampaign.loginCustomerId || auth.managerId || '',
+            campaignResourceName:
+              isCreate && createResponse ? createResponse.campaignResourceName : existingCampaign.campaignResourceName || '',
+            adGroupId: isCreate && createResponse ? createResponse.adGroupId || '' : existingCampaign.adGroupId || '',
+            adGroupResourceName:
+              isCreate && createResponse ? createResponse.adGroupResourceName || '' : existingCampaign.adGroupResourceName || '',
+            budgetId: isCreate && createResponse ? createResponse.budgetId || '' : existingCampaign.budgetId || '',
             updatedAt: FieldValue.serverTimestamp(),
           },
           metrics: {
@@ -137,9 +212,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       { merge: true },
     )
 
+    if (isCreate && createResponse) {
+      return res.status(200).json(createResponse)
+    }
+
     return res.status(200).json({ ok: true, status: isCreate ? 'live' : 'edited', campaignId })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'campaign-update-failed'
+    console.error(
+      JSON.stringify({
+        event: 'google_ads_campaign.create_error',
+        error: message,
+        storeId: typeof req.body?.storeId === 'string' ? req.body.storeId : null,
+        action: typeof req.body?.action === 'string' ? req.body.action : 'create',
+      }),
+    )
     if (message === 'missing-auth' || message === 'invalid-auth') {
       return res.status(401).json({ error: 'Unauthorized' })
     }

--- a/web/src/api/googleAdsAutomation.ts
+++ b/web/src/api/googleAdsAutomation.ts
@@ -74,7 +74,18 @@ export async function createOrUpdateCampaign(input: { storeId: string; brief: Ca
     }),
   })
 
-  return parseApiResult<{ ok: boolean; status: string }>(response)
+  return parseApiResult<{
+    ok: boolean
+    status: string
+    campaignCreatedInGoogleAds?: boolean
+    customerId?: string
+    loginCustomerId?: string
+    campaignId?: string
+    campaignResourceName?: string
+    adGroupId?: string
+    adGroupResourceName?: string
+    warnings?: string[]
+  }>(response)
 }
 
 export async function pauseOrResumeCampaign(input: { storeId: string; resume: boolean }) {

--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -321,14 +321,26 @@ export default function AdsCampaigns() {
     setSaving(true)
     setNotice(null)
     try {
-      await createOrUpdateCampaign({
+      const result = await createOrUpdateCampaign({
         storeId,
         brief: settings.brief,
       })
-      setNotice('Campaign is live.')
+      if (!result.campaignCreatedInGoogleAds) {
+        setNotice('Campaign was not confirmed in Google Ads. Check logs and retry.')
+        return
+      }
+
+      const warningText = Array.isArray(result.warnings) && result.warnings.length > 0 ? ` Warnings: ${result.warnings.join(' ')}` : ''
+      setNotice(
+        `Campaign created in Google Ads (customer ${result.customerId || 'unknown'}, campaign ${result.campaignId || 'unknown'}).${warningText}`,
+      )
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to create campaign.'
-      setNotice(message)
+      if (message.includes('google-ads-mutate-failed:')) {
+        setNotice(`Google Ads API rejected campaign creation: ${message.replace('google-ads-mutate-failed:', '')}`)
+      } else {
+        setNotice(message)
+      }
     } finally {
       setSaving(false)
     }


### PR DESCRIPTION
### Motivation
- Ensure the “Create Campaign” flow performs a real, end-to-end Google Ads API push and does not report success based on local saves or fabricated IDs. 
- Make account resolution and token validation explicit so pushes target the expected customer and failures are observable and debuggable.

### Description
- Add `listAccessibleGoogleAdsCustomers` and use it in `getGoogleAdsAuthContext` to validate/resolve the correct `customerId`, persist a resolved customer when absent, and return `accessibleCustomerIds` for diagnostics. 
- Add structured logging around auth and mutate stages (`google_ads.auth.*`, `google_ads.mutate.*`, `google_ads_campaign.*`) and include manager/login customer context in requests. 
- Harden `googleAdsMutate` to surface detailed API error messages and log mutation `details`, and emit success/error logs. 
- Expand `createGoogleAdsCampaign` mutate to create budget, campaign, ad group, ad, and optional keyword criterion, require returned resource names/IDs (throw if incomplete), and return budget/campaign/ad resource names and numeric IDs. 
- Update `/api/google-ads/campaign` to: validate resolved vs configured customer IDs, record warnings, require real mutate results before reporting success, persist returned Google Ads resource IDs into Firestore under `googleAdsAutomation.campaign`, and return a structured confirmation payload (`campaignCreatedInGoogleAds`, `customerId`, `loginCustomerId`, `campaignResourceName`/ID, adGroup info, `warnings`). 
- Surface real errors and richer success context in the frontend by updating `createOrUpdateCampaign` typings and `AdsCampaigns.tsx` messaging to show confirmation (customer + campaign ID), warnings, or explicit Google Ads API rejection details.

### Testing
- Ran lint: `npm run -s lint` — failed in this environment due to missing local ESLint peer package (`@eslint/js`).
- Ran build: `npm run -s build` — failed in this environment due to missing type definitions from dependencies that were not installed.
- Attempted dependency install: `npm install` — blocked by npm registry 403 in this environment, so automated install/build could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d973e320b8832196808843cbf5f787)