### PR TITLE
Import existing Google Ads campaign: backend support and UI

### DIFF
--- a/web/api/_google-ads.ts
+++ b/web/api/_google-ads.ts
@@ -743,6 +743,87 @@ export async function createGoogleAdsCampaign(params: {
   }
 }
 
+export async function fetchGoogleAdsCampaignById(params: {
+  customerId: string
+  managerId: string
+  accessToken: string
+  campaignId: string
+}): Promise<{
+  campaignId: string
+  campaignName: string
+  adGroupName: string
+  status: CampaignStatus
+}> {
+  const customerId = normalizeCustomerId(params.customerId)
+  const campaignId = params.campaignId.replace(/\D/g, '')
+  if (!campaignId) {
+    throw new Error('campaign-id-required')
+  }
+
+  const url = `${GOOGLE_ADS_API_BASE}/${GOOGLE_ADS_API_VERSION}/customers/${customerId}/googleAds:searchStream`
+  const query = `
+    SELECT
+      campaign.id,
+      campaign.name,
+      campaign.status,
+      ad_group.name
+    FROM ad_group
+    WHERE campaign.id = ${campaignId}
+    LIMIT 50
+  `.replace(/\s+/g, ' ')
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: googleAdsHeaders({ accessToken: params.accessToken, managerId: params.managerId }),
+    body: JSON.stringify({ query }),
+  })
+
+  const payload = (await response.json()) as Array<Record<string, any>> | Record<string, unknown>
+  if (!response.ok) {
+    const message = Array.isArray(payload)
+      ? JSON.stringify(payload[0] || {})
+      : typeof (payload as Record<string, unknown>).message === 'string'
+        ? ((payload as Record<string, unknown>).message as string)
+        : response.status.toString()
+    throw new Error(`google-ads-campaign-lookup-failed:${message}`)
+  }
+
+  const batches = Array.isArray(payload) ? payload : []
+  const results: Array<Record<string, any>> = []
+  for (const batch of batches) {
+    if (!Array.isArray(batch.results)) continue
+    for (const result of batch.results) {
+      if (result && typeof result === 'object') results.push(result as Record<string, any>)
+    }
+  }
+
+  if (results.length === 0) {
+    throw new Error('campaign-not-found')
+  }
+
+  const campaign = (results[0].campaign ?? {}) as Record<string, unknown>
+  const adGroup = (results.find(row => row.adGroup || row.ad_group) ?? {}).adGroup ?? (results[0].ad_group ?? {})
+  const id = String(campaign.id ?? campaignId).replace(/\D/g, '')
+  const campaignName = typeof campaign.name === 'string' ? campaign.name : ''
+  const rawStatus = String(campaign.status ?? '').toUpperCase()
+  const status: CampaignStatus = rawStatus === 'PAUSED' ? 'paused' : 'live'
+  const adGroupName =
+    typeof adGroup === 'object' && adGroup && typeof (adGroup as Record<string, unknown>).name === 'string'
+      ? ((adGroup as Record<string, unknown>).name as string)
+      : ''
+
+  if (!id || !campaignName) {
+    throw new Error('campaign-not-found')
+  }
+
+  return {
+    campaignId: id,
+    campaignName,
+    adGroupName,
+    status,
+  }
+}
+
 function buildCampaignResource(customerId: string, campaignId: string): string {
   const normalizedCustomer = normalizeCustomerId(customerId)
   return campaignId.startsWith('customers/')

--- a/web/api/google-ads/campaign.ts
+++ b/web/api/google-ads/campaign.ts
@@ -3,6 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore'
 import { db } from '../_firebase-admin.js'
 import {
   createGoogleAdsCampaign,
+  fetchGoogleAdsCampaignById,
   fetchGoogleAdsCampaignMetrics,
   getGoogleAdsAuthContext,
   parseCampaignBrief,
@@ -11,7 +12,7 @@ import {
 } from '../_google-ads.js'
 import { requireApiUser, requireStoreMembership } from '../_api-auth.js'
 
-type CampaignAction = 'create' | 'pause' | 'resume' | 'edit'
+type CampaignAction = 'create' | 'pause' | 'resume' | 'edit' | 'import'
 
 type CampaignCreateResponse = {
   ok: boolean
@@ -28,7 +29,7 @@ type CampaignCreateResponse = {
 }
 
 function parseAction(raw: unknown): CampaignAction {
-  if (raw === 'pause' || raw === 'resume' || raw === 'edit') return raw
+  if (raw === 'pause' || raw === 'resume' || raw === 'edit' || raw === 'import') return raw
   return 'create'
 }
 
@@ -100,6 +101,53 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const brief = parseCampaignBrief(req.body?.brief)
+    if (action === 'import') {
+      const requestedCampaignId = typeof req.body?.campaignId === 'string' ? req.body.campaignId : ''
+      const imported = await fetchGoogleAdsCampaignById({
+        customerId: auth.customerId,
+        managerId: auth.managerId,
+        accessToken: auth.accessToken,
+        campaignId: requestedCampaignId,
+      })
+      const metrics = await fetchGoogleAdsCampaignMetrics({
+        customerId: auth.customerId,
+        managerId: auth.managerId,
+        accessToken: auth.accessToken,
+        campaignId: imported.campaignId,
+      })
+
+      await settingsRef.set(
+        {
+          googleAdsAutomation: {
+            campaign: {
+              ...existingCampaign,
+              status: imported.status,
+              campaignId: imported.campaignId,
+              campaignName: imported.campaignName,
+              adGroupName: imported.adGroupName || existingCampaign.adGroupName || '',
+              customerId: auth.customerId,
+              loginCustomerId: auth.managerId || '',
+              updatedAt: FieldValue.serverTimestamp(),
+            },
+            metrics: {
+              spend: metrics.spend,
+              leads: metrics.leads,
+              cpa: metrics.cpa ?? brief.dailyBudget,
+              syncedAt: FieldValue.serverTimestamp(),
+            },
+          },
+        },
+        { merge: true },
+      )
+
+      return res.status(200).json({
+        ok: true,
+        status: imported.status,
+        importedCampaignId: imported.campaignId,
+        importedCampaignName: imported.campaignName,
+      })
+    }
+
     if (!brief.location || !brief.landingPageUrl || !brief.headline || !brief.description) {
       return res.status(400).json({ error: 'Complete all campaign brief fields before launch.' })
     }

--- a/web/src/api/googleAdsAutomation.ts
+++ b/web/src/api/googleAdsAutomation.ts
@@ -101,3 +101,23 @@ export async function pauseOrResumeCampaign(input: { storeId: string; resume: bo
 
   return parseApiResult<{ ok: boolean; status: string }>(response)
 }
+
+export async function importExistingCampaign(input: { storeId: string; campaignId: string }) {
+  const headers = await getAuthHeaders()
+  const response = await fetch('/api/google-ads/campaign', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      storeId: input.storeId,
+      action: 'import',
+      campaignId: input.campaignId,
+    }),
+  })
+
+  return parseApiResult<{
+    ok: boolean
+    status: string
+    importedCampaignId: string
+    importedCampaignName: string
+  }>(response)
+}

--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -4,6 +4,7 @@ import { doc, onSnapshot, serverTimestamp, setDoc } from 'firebase/firestore'
 import {
   beginGoogleAdsOAuth,
   createOrUpdateCampaign,
+  importExistingCampaign,
   pauseOrResumeCampaign,
   saveCampaignBrief,
 } from '../api/googleAdsAutomation'
@@ -173,6 +174,7 @@ export default function AdsCampaigns() {
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
+  const [importCampaignId, setImportCampaignId] = useState('')
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -356,6 +358,34 @@ export default function AdsCampaigns() {
       setNotice(resume ? 'Campaign resumed.' : 'Campaign paused.')
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to change campaign state.'
+      setNotice(message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleImportCampaign() {
+    if (!storeId) return
+    if (!settings.connection.connected) {
+      setNotice('Connect Google Ads first.')
+      return
+    }
+    if (!importCampaignId.trim()) {
+      setNotice('Enter a Google Ads campaign ID to import.')
+      return
+    }
+
+    setSaving(true)
+    setNotice(null)
+    try {
+      const result = await importExistingCampaign({
+        storeId,
+        campaignId: importCampaignId,
+      })
+      setNotice(`Imported campaign ${result.importedCampaignName} (${result.importedCampaignId}).`)
+      setImportCampaignId('')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to import campaign.'
       setNotice(message)
     } finally {
       setSaving(false)
@@ -647,9 +677,39 @@ export default function AdsCampaigns() {
         </div>
       </section>
 
+      <section className="ads-campaigns__section" aria-labelledby="campaign-import">
+        <div>
+          <h2 id="campaign-import">4) Import existing Google Ads campaign</h2>
+          <p>Already running ads manually? Paste a campaign ID and pull it into this workspace.</p>
+        </div>
+        <form
+          onSubmit={event => {
+            event.preventDefault()
+            void handleImportCampaign()
+          }}
+          className="ads-campaigns__form-grid"
+          noValidate
+        >
+          <label>
+            <span>Google Ads campaign ID</span>
+            <input
+              type="text"
+              value={importCampaignId}
+              onChange={event => setImportCampaignId(event.target.value)}
+              placeholder="1234567890"
+            />
+          </label>
+          <div className="ads-campaigns__actions">
+            <button type="submit" className="button button--primary" disabled={saving || !settings.connection.connected}>
+              Import campaign
+            </button>
+          </div>
+        </form>
+      </section>
+
       <section className="ads-campaigns__section" aria-labelledby="campaign-control">
         <div>
-          <h2 id="campaign-control">4) Launch + controls</h2>
+          <h2 id="campaign-control">5) Launch + controls</h2>
           <p>{campaignStateLabel}</p>
         </div>
 


### PR DESCRIPTION
### Motivation
- Add the ability to import an existing Google Ads campaign into a workspace so running campaigns can be synced into the app instead of recreated.

### Description
- Add `fetchGoogleAdsCampaignById` in `web/api/_google-ads.ts` to query the Google Ads `googleAds:searchStream` endpoint and normalize campaign/ad group info and status.
- Extend the campaign handler in `web/api/google-ads/campaign.ts` to accept an `action: 'import'` path that uses `fetchGoogleAdsCampaignById` and `fetchGoogleAdsCampaignMetrics` to populate Firestore `googleAdsAutomation.campaign` and `googleAdsAutomation.metrics` fields.
- Add frontend support by introducing `importExistingCampaign` in `web/src/api/googleAdsAutomation.ts` and wiring an import UI in `web/src/pages/AdsCampaigns.tsx` including an input for `campaignId`, `handleImportCampaign` handler, and a new import section in the page.
- Update types and UI copy by adding the `import` action to `CampaignAction` and adjusting the section numbering/labels.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da101edaa48321857dbb2d26999aa4)