### PR TITLE
Improve Google Business error messaging and clarify Post action

### DIFF
--- a/web/src/api/googleBusinessProfile.ts
+++ b/web/src/api/googleBusinessProfile.ts
@@ -59,7 +59,7 @@ function inferErrorKind(code: string, status: number): GoogleBusinessErrorKind {
     return 'missing_scope'
   }
 
-  if (code === 'not-authenticated' || status === 401) {
+  if (code === 'not-authenticated' || code === 'not_authenticated' || status === 401) {
     return 'not_authenticated'
   }
 
@@ -86,9 +86,13 @@ async function parseApiResponse<T>(response: Response): Promise<T> {
     const rawError = typeof body.error === 'string' ? body.error : ''
     const normalizedCode = rawError.trim().toLowerCase()
     const kind = inferErrorKind(normalizedCode, response.status)
+    const isCodeLikeError =
+      normalizedCode.length > 0 &&
+      !normalizedCode.includes(' ') &&
+      normalizedCode === rawError.trim()
 
     throw new GoogleBusinessApiError({
-      message: rawError || defaultErrorMessage(kind),
+      message: !rawError || isCodeLikeError ? defaultErrorMessage(kind) : rawError,
       code: normalizedCode || 'request-failed',
       status: response.status,
       kind,

--- a/web/src/components/GoogleBusinessMediaUploader.tsx
+++ b/web/src/components/GoogleBusinessMediaUploader.tsx
@@ -187,6 +187,11 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
         return
       }
 
+      if (parsed.kind === 'not_authenticated') {
+        setUploadMessage('Your session expired. Sign out, sign in again, then reconnect Google Business Profile.')
+        return
+      }
+
       setUploadMessage(parsed.message || 'Photo upload failed. Please try again.')
     }
   }
@@ -199,6 +204,14 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
       <p className="google-shopping-page__status">
         This uploads a photo to your Google Business Profile. It does not create a text post or promotion.
       </p>
+      <div className="google-shopping-panel__actions">
+        <button type="button" disabled title="Google Post publishing is coming soon.">
+          Post to Google (Coming soon)
+        </button>
+        <small className="google-shopping-panel__hint">
+          Need a text post? Not available yet in Sedifex. Use your Google Business Profile dashboard for now.
+        </small>
+      </div>
 
       <label>
         <span>Business location</span>


### PR DESCRIPTION
### Motivation
- Make Google Business API errors clearer to end users by mapping backend code-like errors to friendly messages and provide an actionable recovery for expired auth. 
- Reduce user confusion about the missing post publishing feature by surfacing an explicit UI affordance that indicates it is not yet available.

### Description
- Treat both `not-authenticated` and `not_authenticated` as authentication-expired errors in `web/src/api/googleBusinessProfile.ts` so they map to the `not_authenticated` kind. 
- In `parseApiResponse` replace raw code-like backend error strings with the appropriate friendly `defaultErrorMessage` when the backend returns a code-like error token. 
- In `web/src/components/GoogleBusinessMediaUploader.tsx` add explicit handling for `not_authenticated` upload failures with the message `Your session expired. Sign out, sign in again, then reconnect Google Business Profile.`. 
- Add a disabled `Post to Google (Coming soon)` button and helper hint to the Google Business uploader UI to indicate post publishing is not yet supported.

### Testing
- Ran `npm --prefix web run lint`, which failed in this environment due to a missing dev dependency (`@eslint/js`). 
- Ran `npm --prefix web run build`, which failed in this environment due to missing type definition packages (e.g. `vite/client` and `vitest/globals`). 
- No unit or integration tests were run successfully in this environment due to the above dependency issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1417402883218cb814e8a22c8f69)