### PR TITLE
Centralize Google connection status on Google Connect page

### DIFF
--- a/web/src/pages/GoogleBusinessProfile.tsx
+++ b/web/src/pages/GoogleBusinessProfile.tsx
@@ -1,16 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import GoogleBusinessMediaUploader from '../components/GoogleBusinessMediaUploader'
-import GoogleConnectionStatusCard from '../components/GoogleConnectionStatusCard'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useGoogleIntegrationStatus } from '../hooks/useGoogleIntegrationStatus'
-import { clearGoogleOAuthQueryState, parseGoogleOAuthQueryState } from '../utils/googleOAuthCallback'
 import './GoogleShopping.css'
 
 export default function GoogleBusinessProfile() {
   const { storeId } = useActiveStore()
-  const [message, setMessage] = useState('')
-
   const {
     isLoading,
     isStartingOAuth,
@@ -18,32 +14,13 @@ export default function GoogleBusinessProfile() {
     hasGoogleConnection,
     buttonLabel,
     stateTitle,
-    error,
     startOAuth,
   } = useGoogleIntegrationStatus({
     integration: 'business',
     storeId,
   })
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const queryState = parseGoogleOAuthQueryState(window.location.search)
-    if (!queryState.status) return
 
-    if (queryState.status === 'success') {
-      setMessage(queryState.message || 'Google connected successfully.')
-    } else {
-      setMessage(queryState.message || 'Google OAuth failed.')
-    }
-
-    const nextUrl = clearGoogleOAuthQueryState(window.location.href)
-    window.history.replaceState({}, '', nextUrl)
-  }, [])
-
-  useEffect(() => {
-    if (!error) return
-    setMessage(error)
-  }, [error])
 
   return (
     <main className="google-shopping-page">
@@ -61,8 +38,6 @@ export default function GoogleBusinessProfile() {
         </section>
       ) : (
         <>
-          <GoogleConnectionStatusCard storeId={storeId} currentIntegration="business" message={message} />
-
           <section className="google-shopping-panel">
             <h2>{stateTitle}</h2>
             <p>

--- a/web/src/pages/GoogleConnect.tsx
+++ b/web/src/pages/GoogleConnect.tsx
@@ -1,4 +1,7 @@
 import React from 'react'
+
+import GoogleConnectionStatusCard from '../components/GoogleConnectionStatusCard'
+import { useActiveStore } from '../hooks/useActiveStore'
 import { Link, useLocation } from 'react-router-dom'
 
 import './GoogleConnect.css'
@@ -33,6 +36,7 @@ const TABS: GoogleToolTab[] = [
 
 export default function GoogleConnect() {
   const location = useLocation()
+  const { storeId } = useActiveStore()
 
   return (
     <main className="google-connect-page">
@@ -69,6 +73,8 @@ export default function GoogleConnect() {
           )
         })}
       </section>
+
+      {storeId ? <GoogleConnectionStatusCard storeId={storeId} /> : null}
 
       <section className="google-connect-page__panel" aria-label="Suggested sequence">
         <h3>Recommended setup order</h3>

--- a/web/src/pages/GoogleShopping.tsx
+++ b/web/src/pages/GoogleShopping.tsx
@@ -11,7 +11,6 @@ import {
 } from '../api/googleShopping'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
-import GoogleConnectionStatusCard from '../components/GoogleConnectionStatusCard'
 import { useGoogleIntegrationStatus } from '../hooks/useGoogleIntegrationStatus'
 import { clearGoogleOAuthQueryState, parseGoogleOAuthQueryState } from '../utils/googleOAuthCallback'
 import './GoogleShopping.css'
@@ -282,7 +281,6 @@ export default function GoogleShopping() {
 
       {step === 'connect' && (
         <>
-          {storeId ? <GoogleConnectionStatusCard storeId={storeId} currentIntegration="merchant" message={status} /> : null}
           <section className="google-shopping-panel">
             <h2>{stateTitle}</h2>
             <p>


### PR DESCRIPTION
### Motivation
- Reduce confusion by showing Google connection status once on a single central screen instead of duplicating the same status UI on each Google subpage.
- Keep feature pages (Shopping and Business) focused on their specific workflows (product sync and media posting) rather than on overall connection visibility.

### Description
- Added `GoogleConnectionStatusCard` to `web/src/pages/GoogleConnect.tsx` and show it when a store is selected (`useActiveStore()` is used to read `storeId`).
- Removed the top-level `GoogleConnectionStatusCard` usage and import from `web/src/pages/GoogleShopping.tsx` so the Shopping page no longer duplicates the global connection card.
- Removed the `GoogleConnectionStatusCard` import and the OAuth query-state handling + related `message` state from `web/src/pages/GoogleBusinessProfile.tsx` to rely on the central status card instead and simplify the page logic.
- Cleaned up unused imports/state in the modified Business Profile page and kept the per-page integration controls (connect button, state title) intact.

### Testing
- Ran the web linter with `cd web && npm run -s lint`, which failed due to a missing ESLint dependency (`@eslint/js`) in this environment, so lint did not complete successfully.
- No other automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1748e1bc8321946d047c33ecb7a9)