### PR TITLE
Improve Google integration onboarding, CTA clarity, and Shopping sync persistence

### DIFF
--- a/functions/src/googleShopping.ts
+++ b/functions/src/googleShopping.ts
@@ -727,7 +727,25 @@ async function deleteMerchantProduct(params: { merchantId: string; accessToken: 
 }
 
 async function persistSyncStatus(storeId: string, summary: SyncSummary, state: 'success' | 'error', message: string) {
-  await db.collection('storeSettings').doc(storeId).set(
+  const settingsRef = db.collection('storeSettings').doc(storeId)
+  const snapshot = await settingsRef.get()
+  const settingsData = asRecord(snapshot.data())
+  const googleShopping = asRecord(settingsData.googleShopping)
+  const existingHistory = Array.isArray(googleShopping.syncHistory) ? googleShopping.syncHistory : []
+
+  const nextEntry = {
+    runAt: new Date().toISOString(),
+    mode: summary.mode,
+    state,
+    createdOrUpdated: summary.createdOrUpdated,
+    removed: summary.removed,
+    disapproved: summary.disapproved,
+    errorCount: summary.errors.length,
+  }
+
+  const nextHistory = [nextEntry, ...existingHistory].slice(0, 10)
+
+  await settingsRef.set(
     {
       googleShopping: {
         status: {
@@ -741,6 +759,7 @@ async function persistSyncStatus(storeId: string, summary: SyncSummary, state: '
           outOfStockMismatchCount: 0,
           message,
         },
+        syncHistory: nextHistory,
       },
     },
     { merge: true },

--- a/web/src/pages/GoogleBusinessProfile.css
+++ b/web/src/pages/GoogleBusinessProfile.css
@@ -1,0 +1,31 @@
+.google-business-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.google-business-page__header p {
+  color: #4b5563;
+}
+
+.google-business-page__eyebrow {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #0369a1;
+}
+
+.google-business-page__back-link {
+  width: fit-content;
+  color: #0f766e;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.google-business-page__back-link:hover {
+  text-decoration: underline;
+}

--- a/web/src/pages/GoogleBusinessProfile.tsx
+++ b/web/src/pages/GoogleBusinessProfile.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 import GoogleBusinessMediaUploader from '../components/GoogleBusinessMediaUploader'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useGoogleIntegrationStatus } from '../hooks/useGoogleIntegrationStatus'
-import './GoogleShopping.css'
+import './GoogleBusinessProfile.css'
 
 export default function GoogleBusinessProfile() {
   const { storeId } = useActiveStore()
@@ -20,16 +21,18 @@ export default function GoogleBusinessProfile() {
     storeId,
   })
 
-
-
   return (
-    <main className="google-shopping-page">
-      <header className="google-shopping-page__header">
+    <main className="google-business-page">
+      <header className="google-business-page__header">
+        <p className="google-business-page__eyebrow">Google onboarding · Step 3 of 3</p>
         <h1>Upload photos to your business on Google</h1>
         <p>
           Add photos to your Google business listing so customers can see them in Google Search and
           Google Maps.
         </p>
+        <Link className="google-business-page__back-link" to="/google-connect">
+          ← Back to Google Connect
+        </Link>
       </header>
 
       {!storeId ? (

--- a/web/src/pages/GoogleConnect.css
+++ b/web/src/pages/GoogleConnect.css
@@ -54,10 +54,22 @@
   background: #f9fafb;
 }
 
-.google-connect-card.is-active .google-connect-card__status {
-  border-color: #111827;
-  color: #111827;
-  background: #f3f4f6;
+.google-connect-card__status--connected {
+  border-color: #86efac;
+  color: #166534;
+  background: #f0fdf4;
+}
+
+.google-connect-card__status--needs-permission {
+  border-color: #fde68a;
+  color: #92400e;
+  background: #fffbeb;
+}
+
+.google-connect-card__status--action-required {
+  border-color: #fecaca;
+  color: #991b1b;
+  background: #fef2f2;
 }
 
 .google-connect-card p {

--- a/web/src/pages/GoogleConnect.tsx
+++ b/web/src/pages/GoogleConnect.tsx
@@ -1,6 +1,9 @@
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import GoogleConnectionStatusCard from '../components/GoogleConnectionStatusCard'
+import { fetchGoogleIntegrationOverview, type GoogleIntegrationKey } from '../api/googleIntegrations'
+import { doc, onSnapshot } from 'firebase/firestore'
+import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { Link, useLocation } from 'react-router-dom'
 
@@ -11,24 +14,28 @@ type GoogleToolTab = {
   label: string
   summary: string
   checklist: string[]
+  integration: GoogleIntegrationKey
 }
 
 const TABS: GoogleToolTab[] = [
   {
     to: '/ads',
     label: 'Google Ads',
+    integration: 'ads',
     summary: 'Create campaigns with AI-ready briefs and budget controls from one screen.',
     checklist: ['Connect account', 'Add billing details', 'Launch your first campaign'],
   },
   {
     to: '/google-shopping',
     label: 'Google Shopping',
+    integration: 'merchant',
     summary: 'Sync products to Merchant Center and resolve feed issues before they block sales.',
     checklist: ['Connect Merchant account', 'Map product fields', 'Run sync and fix warnings'],
   },
   {
     to: '/google-business',
     label: 'Google Business Profile',
+    integration: 'business',
     summary: 'Manage listing visibility, branches, and profile consistency for local discovery.',
     checklist: ['Authorize Business Profile', 'Choose account location', 'Review profile health'],
   },
@@ -37,6 +44,61 @@ const TABS: GoogleToolTab[] = [
 export default function GoogleConnect() {
   const location = useLocation()
   const { storeId } = useActiveStore()
+  const [integrationHealth, setIntegrationHealth] = useState<Record<GoogleIntegrationKey, string>>({
+    ads: 'Needs permission',
+    business: 'Needs permission',
+    merchant: 'Needs permission',
+  })
+  const [merchantStoreConnected, setMerchantStoreConnected] = useState(false)
+
+  useEffect(() => {
+    if (!storeId) return
+    let mounted = true
+
+    fetchGoogleIntegrationOverview(storeId)
+      .then((overview) => {
+        if (!mounted) return
+        setIntegrationHealth({
+          ads: overview.integrations.ads.hasRequiredScope ? 'Connected' : 'Needs permission',
+          business: overview.integrations.business.hasRequiredScope ? 'Connected' : 'Needs permission',
+          merchant: overview.integrations.merchant.hasRequiredScope ? 'Connected' : 'Needs permission',
+        })
+      })
+      .catch(() => {
+        if (!mounted) return
+        setIntegrationHealth({
+          ads: 'Needs permission',
+          business: 'Needs permission',
+          merchant: 'Needs permission',
+        })
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [storeId])
+
+  useEffect(() => {
+    if (!storeId) return
+    const unsubscribe = onSnapshot(doc(db, 'storeSettings', storeId), (snap) => {
+      const data = snap.data() as Record<string, any> | undefined
+      const googleShopping = (data?.googleShopping ?? {}) as Record<string, any>
+      const connection = (googleShopping.connection ?? {}) as Record<string, any>
+      setMerchantStoreConnected(connection.connected === true)
+    })
+    return () => unsubscribe()
+  }, [storeId])
+
+  const cardStatuses = useMemo(() => {
+    return {
+      ads: integrationHealth.ads,
+      business: integrationHealth.business,
+      merchant:
+        integrationHealth.merchant === 'Connected' && !merchantStoreConnected
+          ? 'Action required'
+          : integrationHealth.merchant,
+    } as Record<GoogleIntegrationKey, string>
+  }, [integrationHealth, merchantStoreConnected])
 
   return (
     <main className="google-connect-page">
@@ -49,19 +111,21 @@ export default function GoogleConnect() {
       </header>
 
       <section className="google-connect-page__cards" aria-label="Google integrations">
-        {TABS.map(tab => {
+        {TABS.map((tab) => {
           const active = location.pathname === tab.to
 
           return (
             <article key={tab.to} className={`google-connect-card ${active ? 'is-active' : ''}`}>
               <div className="google-connect-card__top">
                 <h2>{tab.label}</h2>
-                <span className="google-connect-card__status">{active ? 'Current' : 'Available'}</span>
+                <span className={`google-connect-card__status google-connect-card__status--${cardStatuses[tab.integration].toLowerCase().replace(/\s+/g, '-')}`}>
+                  {cardStatuses[tab.integration]}
+                </span>
               </div>
               <p>{tab.summary}</p>
 
               <ul>
-                {tab.checklist.map(item => (
+                {tab.checklist.map((item) => (
                   <li key={`${tab.to}-${item}`}>{item}</li>
                 ))}
               </ul>

--- a/web/src/pages/GoogleShopping.css
+++ b/web/src/pages/GoogleShopping.css
@@ -120,3 +120,49 @@
   border-radius: 8px;
   border: 1px solid #e5e7eb;
 }
+
+
+.google-shopping-page__eyebrow {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #0369a1;
+}
+
+.google-shopping-page__back-link {
+  width: fit-content;
+  color: #0f766e;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.google-shopping-page__back-link:hover {
+  text-decoration: underline;
+}
+
+.google-shopping-errors {
+  display: grid;
+  gap: 0.5rem;
+  padding-left: 1rem;
+}
+
+.google-shopping-errors__item {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.google-shopping-errors__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  font-size: 0.9rem;
+}
+
+.google-shopping-history {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.4rem;
+}

--- a/web/src/pages/GoogleShopping.tsx
+++ b/web/src/pages/GoogleShopping.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { doc, onSnapshot } from 'firebase/firestore'
 
 import {
@@ -20,6 +21,24 @@ type WizardStep = 'connect' | 'map' | 'fix' | 'status'
 type GoogleShoppingConnection = {
   connected: boolean
   merchantId: string
+}
+
+type GoogleShoppingStatusSnapshot = {
+  state: 'idle' | 'running' | 'success' | 'error'
+  message: string
+  lastRunAt: string
+  lastSuccessfulAt: string
+  errorCount: number
+}
+
+type GoogleShoppingHistoryEntry = {
+  runAt: string
+  mode: 'full' | 'incremental'
+  state: 'success' | 'error'
+  createdOrUpdated: number
+  removed: number
+  disapproved: number
+  errorCount: number
 }
 
 const STEP_LABELS: Record<WizardStep, string> = {
@@ -45,13 +64,14 @@ export default function GoogleShopping() {
   const [pendingAccounts, setPendingAccounts] = useState<GoogleMerchantAccount[]>([])
   const [selectedMerchantId, setSelectedMerchantId] = useState('')
   const [connection, setConnection] = useState<GoogleShoppingConnection>({ connected: false, merchantId: '' })
+  const [persistedStatus, setPersistedStatus] = useState<GoogleShoppingStatusSnapshot | null>(null)
+  const [syncHistory, setSyncHistory] = useState<GoogleShoppingHistoryEntry[]>([])
   const {
     isLoading: oauthStatusLoading,
     isStartingOAuth,
     hasGoogleConnection,
     hasRequiredScope,
     isConnected,
-    buttonLabel,
     stateTitle,
     error: oauthError,
     startOAuth,
@@ -105,11 +125,45 @@ export default function GoogleShopping() {
       const googleShopping = (data?.googleShopping ?? {}) as Record<string, any>
       const connectionRecord = (googleShopping.connection ?? {}) as Record<string, any>
       const catalogSync = (googleShopping.catalogSync ?? {}) as Record<string, any>
+      const statusSnapshot = (googleShopping.status ?? {}) as Record<string, any>
+      const history = Array.isArray(googleShopping.syncHistory) ? googleShopping.syncHistory : []
 
       setConnection({
         connected: connectionRecord.connected === true,
         merchantId: typeof connectionRecord.merchantId === 'string' ? connectionRecord.merchantId : '',
       })
+
+      setPersistedStatus({
+        state:
+          statusSnapshot.state === 'running' ||
+          statusSnapshot.state === 'success' ||
+          statusSnapshot.state === 'error'
+            ? statusSnapshot.state
+            : 'idle',
+        message: typeof statusSnapshot.message === 'string' ? statusSnapshot.message : '',
+        lastRunAt: typeof statusSnapshot.lastRunAt?.toDate === 'function' ? statusSnapshot.lastRunAt.toDate().toISOString() : '',
+        lastSuccessfulAt:
+          typeof statusSnapshot.lastSuccessfulAt?.toDate === 'function'
+            ? statusSnapshot.lastSuccessfulAt.toDate().toISOString()
+            : '',
+        errorCount: typeof statusSnapshot.errorCount === 'number' ? statusSnapshot.errorCount : 0,
+      })
+
+      const mappedHistory = history
+        .map((entry) => {
+          const item = entry as Record<string, any>
+          return {
+            runAt: typeof item.runAt === 'string' ? item.runAt : '',
+            mode: item.mode === 'incremental' ? 'incremental' : 'full',
+            state: item.state === 'error' ? 'error' : 'success',
+            createdOrUpdated: typeof item.createdOrUpdated === 'number' ? item.createdOrUpdated : 0,
+            removed: typeof item.removed === 'number' ? item.removed : 0,
+            disapproved: typeof item.disapproved === 'number' ? item.disapproved : 0,
+            errorCount: typeof item.errorCount === 'number' ? item.errorCount : 0,
+          } as GoogleShoppingHistoryEntry
+        })
+        .filter((entry) => entry.runAt)
+      setSyncHistory(mappedHistory)
 
       setIntegrationApiKey(typeof catalogSync.integrationApiKey === 'string' ? catalogSync.integrationApiKey : '')
       setIntegrationBaseUrl(
@@ -235,6 +289,26 @@ export default function GoogleShopping() {
     }
   }
 
+
+  const merchantActionLabel = !hasGoogleConnection
+    ? 'Connect Google'
+    : !hasRequiredScope
+      ? 'Grant Google Merchant access'
+      : connection.connected
+        ? 'Connected'
+        : 'Connect Merchant account'
+
+  const merchantHealthLabel = !hasGoogleConnection
+    ? 'Needs permission'
+    : !hasRequiredScope
+      ? 'Needs permission'
+      : connection.connected
+        ? 'Connected'
+        : 'Action required'
+
+  const currentSummary = summary
+  const hasPersistedStatus = Boolean(persistedStatus?.lastRunAt)
+
   async function runSync(mode: 'full' | 'incremental') {
     if (!storeId) return
     setSaving(true)
@@ -259,11 +333,15 @@ export default function GoogleShopping() {
   return (
     <main className="google-shopping-page">
       <header className="google-shopping-page__header">
+        <p className="google-shopping-page__eyebrow">Google onboarding · Step 2 of 3</p>
         <h1>Google Shopping</h1>
         <p>
           Connect your Merchant account once, then Sedifex can sync your catalog automatically. No
           manual Merchant ID entry required.
         </p>
+        <Link className="google-shopping-page__back-link" to="/google-connect">
+          ← Back to Google Connect
+        </Link>
       </header>
 
       <nav className="google-shopping-page__steps" aria-label="Google Shopping setup steps">
@@ -297,7 +375,7 @@ export default function GoogleShopping() {
 
             {!isConnected || !connection.connected ? (
               <button type="button" disabled={isStartingOAuth || saving} onClick={connectGoogleMerchant}>
-                {isStartingOAuth ? 'Connecting…' : buttonLabel}
+                {isStartingOAuth ? 'Connecting…' : merchantActionLabel}
               </button>
             ) : null}
 
@@ -395,10 +473,16 @@ export default function GoogleShopping() {
         <section className="google-shopping-panel">
           <h2>Fix errors</h2>
           <p>Products with missing fields or Merchant disapprovals are listed after each sync.</p>
-          <ul>
+          <ul className="google-shopping-errors">
             {summary?.errors?.slice(0, 20).map((error) => (
-              <li key={`${error.productId}-${error.reason}`}>
-                <strong>{error.productId}</strong>: {error.reason}
+              <li key={`${error.productId}-${error.reason}`} className="google-shopping-errors__item">
+                <div>
+                  <strong>{error.productId}</strong>: {error.reason}
+                </div>
+                <div className="google-shopping-errors__actions">
+                  <Link to={`/products?search=${encodeURIComponent(error.productId)}`}>Open product</Link>
+                  <Link to={`/products?edit=${encodeURIComponent(error.productId)}`}>Edit missing fields</Link>
+                </div>
               </li>
             ))}
           </ul>
@@ -408,35 +492,57 @@ export default function GoogleShopping() {
       {step === 'status' && (
         <section className="google-shopping-panel">
           <h2>View sync status</h2>
-          {summary ? (
+          {currentSummary ? (
             <dl className="google-shopping-panel__status-grid">
               <div>
                 <dt>Total products</dt>
-                <dd>{summary.totalProducts}</dd>
+                <dd>{currentSummary.totalProducts}</dd>
               </div>
               <div>
                 <dt>Eligible</dt>
-                <dd>{summary.eligibleProducts}</dd>
+                <dd>{currentSummary.eligibleProducts}</dd>
               </div>
               <div>
                 <dt>Created/Updated</dt>
-                <dd>{summary.createdOrUpdated}</dd>
+                <dd>{currentSummary.createdOrUpdated}</dd>
               </div>
               <div>
                 <dt>Removed</dt>
-                <dd>{summary.removed}</dd>
+                <dd>{currentSummary.removed}</dd>
               </div>
               <div>
                 <dt>Disapproved</dt>
-                <dd>{summary.disapproved}</dd>
+                <dd>{currentSummary.disapproved}</dd>
               </div>
               <div>
                 <dt>Errors</dt>
-                <dd>{summary.errors.length}</dd>
+                <dd>{currentSummary.errors.length}</dd>
               </div>
             </dl>
           ) : (
-            <p>No sync has run yet.</p>
+            <div>
+              <p>No sync has run in this browser yet.</p>
+              {hasPersistedStatus ? (
+                <p className="google-shopping-panel__hint">
+                  Last sync: {new Date(persistedStatus!.lastRunAt).toLocaleString()} ({persistedStatus!.state}).
+                </p>
+              ) : (
+                <p className="google-shopping-panel__hint">No sync has run yet for this store.</p>
+              )}
+            </div>
+          )}
+
+          <h3>Sync history</h3>
+          {syncHistory.length > 0 ? (
+            <ul className="google-shopping-history">
+              {syncHistory.map((entry) => (
+                <li key={`${entry.runAt}-${entry.mode}`}>
+                  <strong>{new Date(entry.runAt).toLocaleString()}</strong> — {entry.mode} · {entry.state} · updated {entry.createdOrUpdated}, errors {entry.errorCount}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="google-shopping-panel__hint">History will appear here after your first sync.</p>
           )}
 
           <h3>Merchant checklist</h3>
@@ -449,6 +555,9 @@ export default function GoogleShopping() {
       )}
 
       {status && <p className="google-shopping-page__status">{status}</p>}
+      {!status && merchantHealthLabel === 'Action required' ? (
+        <p className="google-shopping-page__status">Action required: choose and connect a Merchant account for this store.</p>
+      ) : null}
     </main>
   )
 }

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import {
   addDoc,
   collection,
@@ -351,6 +351,7 @@ export default function Products() {
   const { preferences } = useStorePreferences(activeStoreId)
   const { billing } = useStoreBilling()
   const { publish } = useToast()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const [products, setProducts] = useState<Product[]>([])
   const [sales, setSales] = useState<SaleRecord[]>([])
@@ -960,6 +961,30 @@ export default function Products() {
     setEditImageFileInput(null)
     setEditImageUploadError(null)
   }
+
+
+  useEffect(() => {
+    const searchQuery = searchParams.get('search')
+    if (searchQuery && searchText !== searchQuery) {
+      setActiveTab('search')
+      setSearchText(searchQuery)
+    }
+  }, [searchParams, searchText])
+
+  useEffect(() => {
+    const editProductId = searchParams.get('edit')
+    if (!editProductId || !canManageProducts || products.length === 0) return
+
+    const target = products.find((product) => product.id === editProductId)
+    if (!target) return
+
+    startEditing(target)
+    setSearchParams((current) => {
+      const next = new URLSearchParams(current)
+      next.delete('edit')
+      return next
+    })
+  }, [canManageProducts, products, searchParams, setSearchParams])
 
   function toggleExpandedProduct(productId: string) {
     setExpandedProductIds(prev => {


### PR DESCRIPTION
### Motivation
- Ensure the Google Shopping connect CTA and card status reflect store-level Merchant linking (not just OAuth scopes) to avoid showing a misleading “Connected” state.
- Decouple the Google Business Profile page styling from Shopping to reduce accidental coupling and ease future UI changes.
- Persist sync results and show history so users see the last sync after reloads instead of an in-memory-only summary.
- Make it faster for merchants to resolve product-level Shopping errors by surfacing direct actions and unifying onboarding flow language.

### Description
- Derive a store-aware Merchant action label and health state in `GoogleShopping.tsx` so the button shows `Connect Merchant account` / card shows `Action required` when OAuth scope is granted but the store-level `connection.connected` is not true, and surface that state in the page status area.
- Persist recent sync runs in `storeSettings.googleShopping.syncHistory` (capped to 10 entries) and extend `persistSyncStatus` in `functions/src/googleShopping.ts` to append history entries when saving status.
- Read persisted status and history in `web/src/pages/GoogleShopping.tsx` and show last-run info and a history list in the Status step; keep existing `status` fields intact.
- Add direct action links in the Shopping Fix step that deep-link into the Products page as `?search=<productId>` and `?edit=<productId>` to open or start editing a product, and implement query-param handling in `web/src/pages/Products.tsx` to support those flows.
- Move Business page styles into `web/src/pages/GoogleBusinessProfile.css`, update `GoogleBusinessProfile.tsx` to import the new CSS, and add consistent onboarding framing (eyebrow step label + "Back to Google Connect" link) to Shopping and Business pages.
- Add condensed integration health badges to Google Connect cards in `GoogleConnect.tsx` with styles in `GoogleConnect.css`, and consider merchant store-link when rendering Merchant as `Action required`.

### Testing
- Ran `cd web && npm run build`; TypeScript compilation progressed and surfaced that the environment is missing ambient type definitions (`vite/client`, `vitest/globals`), which prevented a full production build in this environment but is unrelated to the functional changes made here.
- No other automated test failures from the changes themselves were observed in this workspace run (build stopped due to missing ambient type defs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1a417b448321bbf114ebe4221882)