### PR TITLE
Clarify Google Ads billing consent, import guidance, and refresh Google Business locations

### DIFF
--- a/web/src/components/GoogleBusinessMediaUploader.tsx
+++ b/web/src/components/GoogleBusinessMediaUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import {
   listGoogleBusinessLocations,
@@ -77,51 +77,43 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
   const [locationMessage, setLocationMessage] = useState('')
   const [uploadedResult, setUploadedResult] = useState<{ thumbnailUrl: string; googleUrl: string; uploadedAt: string } | null>(null)
 
-  useEffect(() => {
-    if (!storeId) return
-    let mounted = true
-
+  const loadLocations = useCallback(async (): Promise<void> => {
     setLocationState('loading')
     setLocationMessage('')
+    try {
+      const options = await listGoogleBusinessLocations({ storeId })
+      setLocations(options)
+      setSelectedLocationKey(options[0] ? `${options[0].accountId}:${options[0].locationId}` : '')
 
-    listGoogleBusinessLocations({ storeId })
-      .then((options) => {
-        if (!mounted) return
+      if (!options.length) {
+        setLocationState('empty')
+        return
+      }
 
-        setLocations(options)
-        setSelectedLocationKey(options[0] ? `${options[0].accountId}:${options[0].locationId}` : '')
+      setLocationState('ready')
+    } catch (error) {
+      const parsed = parseGoogleBusinessApiError(error)
+      if (parsed.kind === 'not_connected') {
+        setLocationState('not_connected')
+        setLocationMessage(getLocationMessage('not_connected', parsed.message))
+        return
+      }
 
-        if (!options.length) {
-          setLocationState('empty')
-          return
-        }
+      if (parsed.kind === 'missing_scope') {
+        setLocationState('missing_scope')
+        setLocationMessage(getLocationMessage('missing_scope', parsed.message))
+        return
+      }
 
-        setLocationState('ready')
-      })
-      .catch((error) => {
-        if (!mounted) return
-
-        const parsed = parseGoogleBusinessApiError(error)
-        if (parsed.kind === 'not_connected') {
-          setLocationState('not_connected')
-          setLocationMessage(getLocationMessage('not_connected', parsed.message))
-          return
-        }
-
-        if (parsed.kind === 'missing_scope') {
-          setLocationState('missing_scope')
-          setLocationMessage(getLocationMessage('missing_scope', parsed.message))
-          return
-        }
-
-        setLocationState('error')
-        setLocationMessage(parsed.message || getLocationMessage('error', ''))
-      })
-
-    return () => {
-      mounted = false
+      setLocationState('error')
+      setLocationMessage(parsed.message || getLocationMessage('error', ''))
     }
   }, [storeId])
+
+  useEffect(() => {
+    if (!storeId) return
+    void loadLocations()
+  }, [loadLocations, storeId])
 
   useEffect(() => {
     if (!file) {
@@ -276,6 +268,17 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
         <article className="google-shopping-page__status" aria-live="polite">
           <h3>{locationState === 'empty' ? 'No Google Business locations found.' : 'Google Business setup needed'}</h3>
           <p>{getLocationMessage(locationState, locationMessage)}</p>
+          {locationState === 'empty' ? (
+            <ul>
+              <li>Confirm the connected Google account is an owner/manager of the Business Profile.</li>
+              <li>If the business was just created, wait a few minutes and refresh.</li>
+              <li>Make sure at least one location exists (single-location or location group).</li>
+            </ul>
+          ) : null}
+          <div className="google-shopping-panel__actions">
+            <button type="button" onClick={() => void loadLocations()} disabled={isReconnectingGoogle || uploadState === 'loading'}>
+              Refresh locations
+            </button>
           {onReconnectGoogle ? (
             <button type="button" onClick={onReconnectGoogle} disabled={isReconnectingGoogle}>
               {isReconnectingGoogle
@@ -285,6 +288,7 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
                   : 'Reconnect Google'}
             </button>
           ) : null}
+          </div>
         </article>
       )}
 

--- a/web/src/pages/AdsCampaigns.css
+++ b/web/src/pages/AdsCampaigns.css
@@ -109,6 +109,16 @@
   justify-content: flex-start;
 }
 
+.ads-campaigns__checkbox-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.ads-campaigns__checkbox-row input[type='checkbox'] {
+  margin-top: 2px;
+}
+
 .ads-campaigns__import-success {
   border: 1px solid #bbf7d0;
   background: #f0fdf4;

--- a/web/src/pages/AdsCampaigns.tsx
+++ b/web/src/pages/AdsCampaigns.tsx
@@ -29,6 +29,7 @@ type GoogleAdsConnection = {
 type BillingConfirmation = {
   confirmed: boolean
   legalName: string
+  consentChecked?: boolean
   confirmedAt?: unknown
 }
 
@@ -76,6 +77,7 @@ const DEFAULT_SETTINGS: AdsAutomationSettings = {
   billing: {
     confirmed: false,
     legalName: '',
+    consentChecked: false,
   },
   brief: {
     goal: 'leads',
@@ -139,6 +141,7 @@ function parseSettings(raw: Record<string, unknown> | undefined): AdsAutomationS
     billing: {
       confirmed: billingRaw.confirmed === true,
       legalName: typeof billingRaw.legalName === 'string' ? billingRaw.legalName : '',
+      consentChecked: billingRaw.consentChecked === true,
       confirmedAt: billingRaw.confirmedAt,
     },
     brief: {
@@ -327,6 +330,10 @@ export default function AdsCampaigns() {
   async function handleBillingConfirmClick() {
     if (!settings.billing.legalName.trim()) {
       setNotice('Enter the business legal name used for billing.')
+      return
+    }
+    if (!settings.billing.consentChecked) {
+      setNotice('Confirm consent to allow Sedifex to manage Google Ads spend for this business.')
       return
     }
 
@@ -540,7 +547,10 @@ export default function AdsCampaigns() {
       <section className="ads-campaigns__section" aria-labelledby="billing-ownership">
         <div>
           <h2 id="billing-ownership">2) Confirm billing ownership</h2>
-          <p>Capture consent before Sedifex starts spending ad budget.</p>
+          <p>
+            This step records internal approval for ad spend on this workspace. It does not open Google
+            and does not charge your card by itself.
+          </p>
         </div>
 
         <form
@@ -567,11 +577,33 @@ export default function AdsCampaigns() {
               placeholder="Sedifex Biz Ltd"
             />
           </label>
+          <div>
+            <span>Owner consent</span>
+            <div className="ads-campaigns__checkbox-row">
+              <input
+                id="billing-consent"
+                type="checkbox"
+                checked={settings.billing.consentChecked === true}
+                onChange={event =>
+                  setSettings(previous => ({
+                    ...previous,
+                    billing: {
+                      ...previous.billing,
+                      consentChecked: event.target.checked,
+                    },
+                  }))
+                }
+              />
+              <label htmlFor="billing-consent">
+                I confirm I own this billing profile (or have permission) and authorize Sedifex to manage Google Ads spend.
+              </label>
+            </div>
+          </div>
           <div className="ads-campaigns__actions">
             <button
               type="button"
               className="button button--primary"
-              disabled={saving}
+              disabled={saving || !settings.billing.legalName.trim() || !settings.billing.consentChecked}
               onClick={handleBillingConfirmClick}
             >
               Confirm billing ownership
@@ -735,6 +767,9 @@ export default function AdsCampaigns() {
           <p>
             Use this when your campaign is already running in Google Ads and you want Sedifex to manage it.
             In Google Ads, open the campaign list and copy the Campaign ID from the “ID” column.
+          </p>
+          <p className="ads-campaigns__muted-note">
+            Nothing happens unless all prerequisites are ready: Google Ads connected, correct Customer ID, and a campaign ID that belongs to that customer.
           </p>
         </div>
         <form


### PR DESCRIPTION
### Motivation
- Reduce user confusion where the billing confirmation step looked like it should open Google or charge a card by clarifying its purpose and requiring explicit consent. 
- Explain why importing a campaign can appear to do nothing when prerequisites are missing. 
- Make Google Business Profile uploads more robust when a connected account shows no locations by adding a refresh action and actionable guidance.

### Description
- Add an owner consent checkbox and client-side validation to the billing confirmation flow so the confirm action requires `consentChecked` and a legal name (`web/src/pages/AdsCampaigns.tsx`).
- Update the billing copy to explain the step is an internal approval and does not open Google or charge a card (`web/src/pages/AdsCampaigns.tsx`).
- Add an explicit guidance note for campaign import prerequisites (connected Ads, correct Customer ID, matching campaign ID) to reduce silent-failure confusion (`web/src/pages/AdsCampaigns.tsx`).
- Refactor Google Business location loading into a reusable `loadLocations` function with `useCallback`, add a `Refresh locations` button, and display troubleshooting tips when no locations are found (`web/src/components/GoogleBusinessMediaUploader.tsx`).
- Add CSS for the new consent checkbox layout (`web/src/pages/AdsCampaigns.css`).

### Testing
- Ran `npm --prefix web run lint` to validate frontend linting, but it failed in this environment due to a missing dependency (`@eslint/js`); no other automated tests were executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2602c5f88321853fbb76812b8acd)