### PR TITLE
Add test coverage for Google integration pages

### DIFF
--- a/web/src/pages/GoogleBusinessProfile.test.tsx
+++ b/web/src/pages/GoogleBusinessProfile.test.tsx
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import GoogleBusinessProfile from './GoogleBusinessProfile'
+
+const mockUseActiveStore = vi.fn()
+const mockUseGoogleIntegrationStatus = vi.fn()
+const mockListGoogleBusinessLocations = vi.fn()
+const mockUploadGoogleBusinessLocationMedia = vi.fn()
+
+vi.mock('../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+vi.mock('../hooks/useGoogleIntegrationStatus', () => ({
+  useGoogleIntegrationStatus: (...args: unknown[]) => mockUseGoogleIntegrationStatus(...args),
+}))
+
+vi.mock('../api/googleBusinessProfile', () => ({
+  listGoogleBusinessLocations: (...args: unknown[]) => mockListGoogleBusinessLocations(...args),
+  uploadGoogleBusinessLocationMedia: (...args: unknown[]) => mockUploadGoogleBusinessLocationMedia(...args),
+  parseGoogleBusinessApiError: (error: unknown) => ({
+    kind: 'unknown',
+    message: error instanceof Error ? error.message : 'Request failed.',
+    code: '',
+    status: 0,
+  }),
+}))
+
+describe('GoogleBusinessProfile', () => {
+  beforeEach(() => {
+    mockUseActiveStore.mockReset()
+    mockUseGoogleIntegrationStatus.mockReset()
+    mockListGoogleBusinessLocations.mockReset()
+    mockUploadGoogleBusinessLocationMedia.mockReset()
+
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-1' })
+    mockListGoogleBusinessLocations.mockResolvedValue([
+      {
+        accountId: 'acc-1',
+        accountName: 'Main Account',
+        locationId: 'loc-1',
+        locationName: 'Main Shop',
+      },
+    ])
+  })
+
+  it('starts OAuth connection when not yet connected', async () => {
+    const startOAuth = vi.fn()
+    mockUseGoogleIntegrationStatus.mockReturnValue({
+      isLoading: false,
+      isStartingOAuth: false,
+      isConnected: false,
+      hasGoogleConnection: false,
+      buttonLabel: 'Connect Google',
+      stateTitle: '1) Connect Google',
+      startOAuth,
+    })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <GoogleBusinessProfile />
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /connect google/i }))
+    expect(startOAuth).toHaveBeenCalledTimes(1)
+  })
+
+  it('uploads a photo to Google Business when connected', async () => {
+    mockUseGoogleIntegrationStatus.mockReturnValue({
+      isLoading: false,
+      isStartingOAuth: false,
+      isConnected: true,
+      hasGoogleConnection: true,
+      buttonLabel: 'Connected',
+      stateTitle: '3) Connected',
+      startOAuth: vi.fn(),
+    })
+
+    mockUploadGoogleBusinessLocationMedia.mockResolvedValue({
+      media: {
+        thumbnailUrl: 'https://img.example/thumb.jpg',
+        googleUrl: 'https://business.google.com/media/1',
+      },
+    })
+
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    URL.createObjectURL = vi.fn(() => 'blob:preview')
+    URL.revokeObjectURL = vi.fn()
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <GoogleBusinessProfile />
+      </MemoryRouter>,
+    )
+
+    const fileInput = await screen.findByLabelText(/choose photo/i)
+    const file = new File(['image'], 'store.jpg', { type: 'image/jpeg' })
+    await user.upload(fileInput, file)
+    await user.click(screen.getByRole('button', { name: /upload photo to google/i }))
+
+    await waitFor(() => {
+      expect(mockUploadGoogleBusinessLocationMedia).toHaveBeenCalledWith(
+        expect.objectContaining({
+          storeId: 'store-1',
+          accountId: 'acc-1',
+          locationId: 'loc-1',
+          category: 'ADDITIONAL',
+          file,
+        }),
+      )
+    })
+
+    expect(screen.getByText(/your photo was uploaded to google business profile/i)).toBeInTheDocument()
+
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+  })
+})

--- a/web/src/pages/GoogleConnect.test.tsx
+++ b/web/src/pages/GoogleConnect.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import GoogleConnect from './GoogleConnect'
+
+const mockUseActiveStore = vi.fn()
+const mockFetchGoogleIntegrationOverview = vi.fn()
+const mockOnSnapshot = vi.fn()
+const mockDoc = vi.fn()
+
+vi.mock('../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+vi.mock('../api/googleIntegrations', () => ({
+  fetchGoogleIntegrationOverview: (...args: unknown[]) => mockFetchGoogleIntegrationOverview(...args),
+}))
+
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: unknown[]) => mockDoc(...args),
+  onSnapshot: (...args: unknown[]) => mockOnSnapshot(...args),
+}))
+
+vi.mock('../firebase', () => ({
+  db: {},
+}))
+
+vi.mock('../components/GoogleConnectionStatusCard', () => ({
+  default: ({ storeId }: { storeId: string }) => <div data-testid="google-status-card">{storeId}</div>,
+}))
+
+describe('GoogleConnect', () => {
+  beforeEach(() => {
+    mockUseActiveStore.mockReset()
+    mockFetchGoogleIntegrationOverview.mockReset()
+    mockOnSnapshot.mockReset()
+    mockDoc.mockReset()
+
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-1' })
+    mockFetchGoogleIntegrationOverview.mockResolvedValue({
+      connected: true,
+      integrations: {
+        ads: { connected: true, hasRequiredScope: true },
+        business: { connected: true, hasRequiredScope: true },
+        merchant: { connected: true, hasRequiredScope: true },
+      },
+      grantedScopes: [],
+    })
+
+    mockDoc.mockReturnValue('store-settings-doc')
+    mockOnSnapshot.mockImplementation((_docRef, callback) => {
+      callback({
+        data: () => ({
+          googleShopping: { connection: { connected: false } },
+        }),
+      })
+      return vi.fn()
+    })
+  })
+
+  it('loads integration statuses and marks shopping as action required when merchant store is not linked', async () => {
+    render(
+      <MemoryRouter initialEntries={['/google-shopping']}>
+        <GoogleConnect />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(mockFetchGoogleIntegrationOverview).toHaveBeenCalledWith('store-1')
+    })
+
+    expect(screen.getByText('Google Ads')).toBeInTheDocument()
+    expect(screen.getByText('Google Business Profile')).toBeInTheDocument()
+    expect(screen.getByText('Google Shopping')).toBeInTheDocument()
+    expect(screen.getByText('Action required')).toBeInTheDocument()
+    expect(screen.getByTestId('google-status-card')).toHaveTextContent('store-1')
+  })
+})

--- a/web/src/pages/GoogleShopping.test.tsx
+++ b/web/src/pages/GoogleShopping.test.tsx
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import GoogleShopping from './GoogleShopping'
+
+const mockUseActiveStore = vi.fn()
+const mockUseGoogleIntegrationStatus = vi.fn()
+const mockEnsureGoogleShoppingSetupConfig = vi.fn()
+const mockTriggerGoogleShoppingSync = vi.fn()
+const mockOnSnapshot = vi.fn()
+const mockDoc = vi.fn()
+const mockParseOAuthState = vi.fn()
+const mockClearOAuthState = vi.fn()
+
+vi.mock('../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+vi.mock('../hooks/useGoogleIntegrationStatus', () => ({
+  useGoogleIntegrationStatus: (...args: unknown[]) => mockUseGoogleIntegrationStatus(...args),
+}))
+
+vi.mock('../api/googleShopping', () => ({
+  ensureGoogleShoppingSetupConfig: (...args: unknown[]) => mockEnsureGoogleShoppingSetupConfig(...args),
+  triggerGoogleShoppingSync: (...args: unknown[]) => mockTriggerGoogleShoppingSync(...args),
+  getGoogleMerchantPendingAccounts: vi.fn(),
+  selectGoogleMerchantAccount: vi.fn(),
+}))
+
+vi.mock('../utils/googleOAuthCallback', () => ({
+  parseGoogleOAuthQueryState: (...args: unknown[]) => mockParseOAuthState(...args),
+  clearGoogleOAuthQueryState: (...args: unknown[]) => mockClearOAuthState(...args),
+}))
+
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: unknown[]) => mockDoc(...args),
+  onSnapshot: (...args: unknown[]) => mockOnSnapshot(...args),
+}))
+
+vi.mock('../firebase', () => ({ db: {} }))
+
+describe('GoogleShopping', () => {
+  beforeEach(() => {
+    mockUseActiveStore.mockReset()
+    mockUseGoogleIntegrationStatus.mockReset()
+    mockEnsureGoogleShoppingSetupConfig.mockReset()
+    mockTriggerGoogleShoppingSync.mockReset()
+    mockOnSnapshot.mockReset()
+    mockDoc.mockReset()
+    mockParseOAuthState.mockReset()
+    mockClearOAuthState.mockReset()
+
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-1' })
+    mockParseOAuthState.mockReturnValue({ status: null, integrations: [] })
+    mockClearOAuthState.mockReturnValue('http://localhost/google-shopping')
+    mockEnsureGoogleShoppingSetupConfig.mockResolvedValue({
+      integrationApiKey: 'api-key',
+      integrationBaseUrl: 'https://example.com',
+      autoSyncEnabled: true,
+      generated: true,
+    })
+    mockDoc.mockReturnValue('store-settings-doc')
+  })
+
+  it('starts OAuth when connect button is clicked', async () => {
+    const startOAuth = vi.fn()
+    mockUseGoogleIntegrationStatus.mockReturnValue({
+      isLoading: false,
+      isStartingOAuth: false,
+      hasGoogleConnection: false,
+      hasRequiredScope: false,
+      isConnected: false,
+      stateTitle: '1) Connect Google',
+      error: null,
+      startOAuth,
+    })
+
+    mockOnSnapshot.mockImplementation((_docRef, callback) => {
+      callback({ data: () => ({ googleShopping: { connection: { connected: false } } }) })
+      return vi.fn()
+    })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <GoogleShopping />
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('button', { name: /connect google/i }))
+    expect(startOAuth).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs a full catalog sync from the sync step', async () => {
+    mockUseGoogleIntegrationStatus.mockReturnValue({
+      isLoading: false,
+      isStartingOAuth: false,
+      hasGoogleConnection: true,
+      hasRequiredScope: true,
+      isConnected: true,
+      stateTitle: '3) Connected',
+      error: null,
+      startOAuth: vi.fn(),
+    })
+
+    mockOnSnapshot.mockImplementation((_docRef, callback) => {
+      callback({ data: () => ({ googleShopping: { connection: { connected: true, merchantId: 'mc-1' } } }) })
+      return vi.fn()
+    })
+
+    mockTriggerGoogleShoppingSync.mockResolvedValue({
+      mode: 'full',
+      totalProducts: 2,
+      eligibleProducts: 2,
+      invalidProducts: 0,
+      createdOrUpdated: 2,
+      removed: 0,
+      disapproved: 0,
+      errors: [],
+    })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <GoogleShopping />
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('button', { name: /2. sync products/i }))
+    await user.click(screen.getByRole('button', { name: /run initial full catalog upload/i }))
+
+    await waitFor(() => {
+      expect(mockTriggerGoogleShoppingSync).toHaveBeenCalledWith({ storeId: 'store-1', mode: 'full' })
+    })
+    expect(screen.getByText(/sync completed successfully/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Motivation

- Add automated tests for the Google integration pages to verify account connection flows and that posting/uploading works for Google Business.
- Improve confidence in the Google Connect, Google Shopping, and Google Business Profile UX and API interactions by mocking integration state and simulating user actions.

### Description

- Add `web/src/pages/GoogleConnect.test.tsx`, `web/src/pages/GoogleShopping.test.tsx`, and `web/src/pages/GoogleBusinessProfile.test.tsx` with mocked hooks/APIs and Firestore snapshots to exercise UI flows.
- `GoogleConnect` test verifies integration overview fetch, rendering of integration cards, and that Google Shopping shows an "Action required" state when merchant store is not linked.
- `GoogleShopping` test asserts that clicking the connect button triggers OAuth start and that the full catalog sync action calls the sync API and surfaces success.
- `GoogleBusinessProfile` test verifies OAuth start when not connected and a successful photo upload flow invoking the upload API and showing success UI.

### Testing

- Ran `cd web && npm test -- src/pages/GoogleConnect.test.tsx src/pages/GoogleShopping.test.tsx src/pages/GoogleBusinessProfile.test.tsx`, which failed in this environment because `vitest` was not found.
- Attempted `cd web && npm ci` to install dev dependencies, but `npm ci` failed due to a registry `403 Forbidden` response (environment policy), preventing test execution here.
- The new tests were added and committed to the repository and are ready to run in a development or CI environment with dependencies installed (successful run not possible in this constrained environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da289f29988321b253c04d15e0215f)