### PR TITLE
Sync account email edits with auth login email update flow

### DIFF
--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -21,7 +21,7 @@ import {
   type DocumentSnapshot,
   type QueryDocumentSnapshot,
 } from 'firebase/firestore'
-import { deleteUser } from 'firebase/auth'
+import { deleteUser, verifyBeforeUpdateEmail } from 'firebase/auth'
 import { db, functions } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useMemberships, type Membership } from '../hooks/useMemberships'
@@ -747,13 +747,15 @@ export default function AccountOverview({
       setIsSavingProfile(true)
       const updatedAt = Timestamp.now()
       const ref = doc(db, 'stores', storeId)
+      const normalizedDraftEmail = normalizeInput(profileDraft.email)?.toLowerCase() ?? null
+      const normalizedCurrentUserEmail = user?.email?.trim().toLowerCase() ?? null
 
       const payload = {
         displayName: normalizeInput(profileDraft.displayName),
         name: normalizeInput(profileDraft.displayName),
-        email: normalizeInput(profileDraft.email),
+        email: normalizedDraftEmail,
         // ✅ keep ownerEmail in sync so billing can always use it
-        ownerEmail: normalizeInput(profileDraft.email),
+        ownerEmail: normalizedDraftEmail,
         phone: normalizeInput(normalizeGhanaPhoneE164(profileDraft.phone)),
         whatsappNumber: normalizeInput(normalizeGhanaPhoneDigits(profileDraft.phone)),
         addressLine1: normalizeInput(profileDraft.addressLine1),
@@ -768,6 +770,28 @@ export default function AccountOverview({
       }
 
       await setDoc(ref, payload, { merge: true })
+
+      if (
+        user &&
+        normalizedDraftEmail &&
+        normalizedDraftEmail !== normalizedCurrentUserEmail
+      ) {
+        try {
+          await verifyBeforeUpdateEmail(user, normalizedDraftEmail)
+          publish({
+            message:
+              'Verification sent to your new email. Confirm it before your next sign in with the new address.',
+            tone: 'info',
+          })
+        } catch (authError) {
+          console.error('[account] Failed to start auth email update', authError)
+          publish({
+            message:
+              'Workspace email updated, but login email could not be changed now. Please re-login and try again.',
+            tone: 'warning',
+          })
+        }
+      }
 
       setProfile(current =>
         current

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -77,8 +77,11 @@ vi.mock('../../controllers/dataDeletion', () => ({
 }))
 
 const deleteUserMock = vi.fn()
+const verifyBeforeUpdateEmailMock = vi.fn()
 vi.mock('firebase/auth', () => ({
   deleteUser: (...args: Parameters<typeof deleteUserMock>) => deleteUserMock(...args),
+  verifyBeforeUpdateEmail: (...args: Parameters<typeof verifyBeforeUpdateEmailMock>) =>
+    verifyBeforeUpdateEmailMock(...args),
 }))
 
 const httpsCallableMock = vi.fn()
@@ -140,6 +143,7 @@ describe('AccountOverview', () => {
     serverTimestampMock?.mockReset()
     deleteWorkspaceDataMock.mockReset()
     deleteUserMock.mockReset()
+    verifyBeforeUpdateEmailMock.mockReset()
     httpsCallableMock.mockReset()
 
     mockUseActiveStore.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
@@ -201,6 +205,7 @@ describe('AccountOverview', () => {
       ],
     })
     httpsCallableMock.mockReturnValue(async () => ({ data: { keys: [] } }))
+    verifyBeforeUpdateEmailMock.mockResolvedValue(undefined)
   })
 
   it('shows an edit control for owners when roster data is available', async () => {
@@ -324,6 +329,10 @@ describe('AccountOverview', () => {
     })
     expect(payload.updatedAt?.toDate).toBeInstanceOf(Function)
     expect(options).toEqual({ merge: true })
+    expect(verifyBeforeUpdateEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'owner@example.com' }),
+      'hello@sedifex.com',
+    )
     expect(mockPublish).toHaveBeenCalledWith({
       message: 'Workspace details updated.',
       tone: 'success',


### PR DESCRIPTION
### Motivation

- Changing a store email in the account UI only updated the `stores` document and did not update the signed-in user's Firebase Auth email, causing owners to still need the old address to sign in.

### Description

- Normalize and store the edited workspace email consistently as lowercase in the `stores` document by computing `normalizedDraftEmail` and using it for both `email` and `ownerEmail` in the payload to `setDoc` in `AccountOverview`.
- When the signed-in owner changes the workspace email to a different address, trigger `verifyBeforeUpdateEmail(user, newEmail)` so Firebase Auth sends a verification to the new address and the login email can be migrated after confirmation, and surface an info toast on success.
- Add a fallback warning toast and console error handling if starting the auth email update fails (e.g., re-login required) so the workspace metadata still updates but the user is informed.
- Update the component tests to mock `verifyBeforeUpdateEmail`, reset it in `beforeEach`, and assert it is invoked when the owner edits the workspace email.

### Testing

- Updated unit test file `web/src/pages/__tests__/AccountOverview.test.tsx` to include and assert the new `verifyBeforeUpdateEmail` call (tests modified but not executed here). 
- Attempted to run `cd web && npm test -- --run web/src/pages/__tests__/AccountOverview.test.tsx`, but the run failed in this environment because `vitest` was not found (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3294071083219395181d89d47a64)