### PR TITLE
Refactor Google Shopping readiness states and setup UX

### DIFF
--- a/functions/src/googleShopping.ts
+++ b/functions/src/googleShopping.ts
@@ -726,6 +726,54 @@ async function deleteMerchantProduct(params: { merchantId: string; accessToken: 
   }
 }
 
+
+function buildValidationSummary(errors: Array<{ productId: string; reason: string }>) {
+  const summary = {
+    missingTitle: 0,
+    missingDescription: 0,
+    missingImage: 0,
+    missingPrice: 0,
+    missingBrand: 0,
+    missingGtinOrMpnOrSku: 0,
+    blockingCount: 0,
+  }
+
+  for (const error of errors) {
+    if (!error.reason.startsWith('missing:')) continue
+    const missing = error.reason.slice('missing:'.length).split(',').map((entry) => entry.trim())
+    let counted = false
+    for (const field of missing) {
+      if (field === 'title') {
+        summary.missingTitle += 1
+        counted = true
+      }
+      if (field === 'description') {
+        summary.missingDescription += 1
+        counted = true
+      }
+      if (field === 'image') {
+        summary.missingImage += 1
+        counted = true
+      }
+      if (field === 'price') {
+        summary.missingPrice += 1
+        counted = true
+      }
+      if (field === 'brand') {
+        summary.missingBrand += 1
+        counted = true
+      }
+      if (field === 'gtin_or_mpn') {
+        summary.missingGtinOrMpnOrSku += 1
+        counted = true
+      }
+    }
+    if (counted) summary.blockingCount += 1
+  }
+
+  return summary
+}
+
 async function persistSyncStatus(storeId: string, summary: SyncSummary, state: 'success' | 'error', message: string) {
   const settingsRef = db.collection('storeSettings').doc(storeId)
   const snapshot = await settingsRef.get()
@@ -757,6 +805,7 @@ async function persistSyncStatus(storeId: string, summary: SyncSummary, state: '
           errorCount: summary.errors.length,
           disapprovalCount: summary.disapproved,
           outOfStockMismatchCount: 0,
+          validationSummary: buildValidationSummary(summary.errors),
           message,
         },
         syncHistory: nextHistory,

--- a/web/api/google/status.ts
+++ b/web/api/google/status.ts
@@ -1,4 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db } from '../_firebase-admin.js'
 import { requireApiUser, requireStoreMembership } from '../_api-auth.js'
 import {
   GOOGLE_REQUIRED_SCOPE,
@@ -14,6 +15,16 @@ function requireStoreId(raw: unknown): string {
 
 const ALL_INTEGRATIONS: GoogleIntegration[] = ['ads', 'business', 'merchant']
 
+type ValidationSummary = {
+  missingTitle: number
+  missingDescription: number
+  missingImage: number
+  missingPrice: number
+  missingBrand: number
+  missingGtinOrMpnOrSku: number
+  blockingCount: number
+}
+
 function parseRequestedIntegrations(rawIntegration: unknown, rawIntegrations: unknown): GoogleIntegration[] {
   const requested = Array.isArray(rawIntegrations) ? rawIntegrations : [rawIntegration]
   const unique = new Set<GoogleIntegration>()
@@ -21,6 +32,19 @@ function parseRequestedIntegrations(rawIntegration: unknown, rawIntegrations: un
     if (entry === 'ads' || entry === 'business' || entry === 'merchant') unique.add(entry)
   }
   return unique.size ? Array.from(unique) : ALL_INTEGRATIONS
+}
+
+function toValidationSummary(raw: unknown): ValidationSummary {
+  const summary = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
+  return {
+    missingTitle: typeof summary.missingTitle === 'number' ? summary.missingTitle : 0,
+    missingDescription: typeof summary.missingDescription === 'number' ? summary.missingDescription : 0,
+    missingImage: typeof summary.missingImage === 'number' ? summary.missingImage : 0,
+    missingPrice: typeof summary.missingPrice === 'number' ? summary.missingPrice : 0,
+    missingBrand: typeof summary.missingBrand === 'number' ? summary.missingBrand : 0,
+    missingGtinOrMpnOrSku: typeof summary.missingGtinOrMpnOrSku === 'number' ? summary.missingGtinOrMpnOrSku : 0,
+    blockingCount: typeof summary.blockingCount === 'number' ? summary.blockingCount : 0,
+  }
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -48,10 +72,62 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       {} as Partial<Record<GoogleIntegration, { connected: boolean; hasRequiredScope: boolean }>>,
     )
 
+    const merchantHasScope = hasScope(granted, GOOGLE_REQUIRED_SCOPE.merchant)
+    const settingsSnap = await db().collection('storeSettings').doc(storeId).get()
+    const settings = (settingsSnap.data() ?? {}) as Record<string, unknown>
+    const googleShopping = (settings.googleShopping ?? {}) as Record<string, unknown>
+    const connection = (googleShopping.connection ?? {}) as Record<string, unknown>
+    const catalogSync = (googleShopping.catalogSync ?? {}) as Record<string, unknown>
+    const shoppingStatus = (googleShopping.status ?? {}) as Record<string, unknown>
+
+    const merchantId = typeof connection.merchantId === 'string' ? connection.merchantId.trim() : ''
+    const merchantAccountSelected = merchantId.length > 0
+    const refreshTokenPresent = typeof catalogSync.refreshToken === 'string' && catalogSync.refreshToken.trim().length > 0
+    const merchantConnected = connection.connected === true && merchantAccountSelected
+    const validationSummary = toValidationSummary(shoppingStatus.validationSummary)
+
+    let merchantState:
+      | 'google_not_connected'
+      | 'merchant_scope_missing'
+      | 'merchant_account_not_selected'
+      | 'refresh_token_missing'
+      | 'merchant_connected'
+      | 'product_sync_blocked_validation'
+      | 'sync_ready'
+
+    if (!connected) {
+      merchantState = 'google_not_connected'
+    } else if (!merchantHasScope) {
+      merchantState = 'merchant_scope_missing'
+    } else if (!merchantAccountSelected) {
+      merchantState = 'merchant_account_not_selected'
+    } else if (!refreshTokenPresent) {
+      merchantState = 'refresh_token_missing'
+    } else if (!merchantConnected) {
+      merchantState = 'merchant_connected'
+    } else if (validationSummary.blockingCount > 0) {
+      merchantState = 'product_sync_blocked_validation'
+    } else {
+      merchantState = 'sync_ready'
+    }
+
+    const syncReady = merchantState === 'sync_ready'
+
     return res.status(200).json({
       connected,
       grantedScopes,
       integrations,
+      merchant: {
+        state: merchantState,
+        googleConnected: connected,
+        hasMerchantScope: merchantHasScope,
+        merchantAccountSelected,
+        merchantId,
+        refreshTokenPresent,
+        merchantConnected,
+        syncReady,
+        validationSummary,
+      },
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'status-failed'

--- a/web/src/api/googleIntegrations.ts
+++ b/web/src/api/googleIntegrations.ts
@@ -2,10 +2,43 @@ import { auth } from '../firebase'
 
 export type GoogleIntegrationKey = 'business' | 'ads' | 'merchant'
 export type GoogleIntegrationStatus = 'Connected' | 'Needs permission' | 'Developer token required'
+
+export type MerchantConnectionState =
+  | 'google_not_connected'
+  | 'merchant_scope_missing'
+  | 'merchant_account_not_selected'
+  | 'refresh_token_missing'
+  | 'merchant_connected'
+  | 'product_sync_blocked_validation'
+  | 'sync_ready'
+
+export type MerchantValidationSummary = {
+  missingTitle: number
+  missingDescription: number
+  missingImage: number
+  missingPrice: number
+  missingBrand: number
+  missingGtinOrMpnOrSku: number
+  blockingCount: number
+}
+
+export type GoogleMerchantReadiness = {
+  state: MerchantConnectionState
+  googleConnected: boolean
+  hasMerchantScope: boolean
+  merchantAccountSelected: boolean
+  merchantId: string
+  refreshTokenPresent: boolean
+  merchantConnected: boolean
+  syncReady: boolean
+  validationSummary: MerchantValidationSummary
+}
+
 export type GoogleIntegrationOverview = {
   connected: boolean
   integrations: Record<GoogleIntegrationKey, { connected: boolean; hasRequiredScope: boolean }>
   grantedScopes: string[]
+  merchant: GoogleMerchantReadiness
 }
 
 async function authHeaders() {
@@ -82,10 +115,44 @@ export async function fetchGoogleIntegrationOverview(
     ? payload.grantedScopes.filter((scope): scope is string => typeof scope === 'string')
     : []
   const connected = payload.connected === true || grantedScopes.length > 0
+  const rawMerchant = (payload.merchant ?? {}) as Record<string, unknown>
+  const rawValidationSummary = (rawMerchant.validationSummary ?? {}) as Record<string, unknown>
 
   return {
     connected,
     integrations: integrationStates,
     grantedScopes,
+    merchant: {
+      state:
+        rawMerchant.state === 'google_not_connected' ||
+        rawMerchant.state === 'merchant_scope_missing' ||
+        rawMerchant.state === 'merchant_account_not_selected' ||
+        rawMerchant.state === 'refresh_token_missing' ||
+        rawMerchant.state === 'merchant_connected' ||
+        rawMerchant.state === 'product_sync_blocked_validation' ||
+        rawMerchant.state === 'sync_ready'
+          ? rawMerchant.state
+          : 'google_not_connected',
+      googleConnected: rawMerchant.googleConnected === true,
+      hasMerchantScope: rawMerchant.hasMerchantScope === true,
+      merchantAccountSelected: rawMerchant.merchantAccountSelected === true,
+      merchantId: typeof rawMerchant.merchantId === 'string' ? rawMerchant.merchantId : '',
+      refreshTokenPresent: rawMerchant.refreshTokenPresent === true,
+      merchantConnected: rawMerchant.merchantConnected === true,
+      syncReady: rawMerchant.syncReady === true,
+      validationSummary: {
+        missingTitle: typeof rawValidationSummary.missingTitle === 'number' ? rawValidationSummary.missingTitle : 0,
+        missingDescription:
+          typeof rawValidationSummary.missingDescription === 'number' ? rawValidationSummary.missingDescription : 0,
+        missingImage: typeof rawValidationSummary.missingImage === 'number' ? rawValidationSummary.missingImage : 0,
+        missingPrice: typeof rawValidationSummary.missingPrice === 'number' ? rawValidationSummary.missingPrice : 0,
+        missingBrand: typeof rawValidationSummary.missingBrand === 'number' ? rawValidationSummary.missingBrand : 0,
+        missingGtinOrMpnOrSku:
+          typeof rawValidationSummary.missingGtinOrMpnOrSku === 'number'
+            ? rawValidationSummary.missingGtinOrMpnOrSku
+            : 0,
+        blockingCount: typeof rawValidationSummary.blockingCount === 'number' ? rawValidationSummary.blockingCount : 0,
+      },
+    },
   }
 }

--- a/web/src/hooks/useGoogleIntegrationStatus.ts
+++ b/web/src/hooks/useGoogleIntegrationStatus.ts
@@ -4,6 +4,7 @@ import {
   fetchGoogleIntegrationOverview,
   startGoogleOAuth,
   type GoogleIntegrationKey,
+  type GoogleMerchantReadiness,
 } from '../api/googleIntegrations'
 
 const REQUIRED_SCOPE_BY_INTEGRATION: Record<GoogleIntegrationKey, string> = {
@@ -52,12 +53,50 @@ export function useGoogleIntegrationStatus(input: UseGoogleIntegrationStatusInpu
   const [isConnected, setIsConnected] = useState(false)
   const [grantedScopes, setGrantedScopes] = useState<string[]>([])
   const [error, setError] = useState<string | null>(null)
+  const [merchant, setMerchant] = useState<GoogleMerchantReadiness>({
+    state: 'google_not_connected',
+    googleConnected: false,
+    hasMerchantScope: false,
+    merchantAccountSelected: false,
+    merchantId: '',
+    refreshTokenPresent: false,
+    merchantConnected: false,
+    syncReady: false,
+    validationSummary: {
+      missingTitle: 0,
+      missingDescription: 0,
+      missingImage: 0,
+      missingPrice: 0,
+      missingBrand: 0,
+      missingGtinOrMpnOrSku: 0,
+      blockingCount: 0,
+    },
+  })
 
   useEffect(() => {
     if (!storeId) {
       setHasGoogleConnection(false)
       setIsConnected(false)
       setGrantedScopes([])
+      setMerchant({
+        state: 'google_not_connected',
+        googleConnected: false,
+        hasMerchantScope: false,
+        merchantAccountSelected: false,
+        merchantId: '',
+        refreshTokenPresent: false,
+        merchantConnected: false,
+        syncReady: false,
+        validationSummary: {
+          missingTitle: 0,
+          missingDescription: 0,
+          missingImage: 0,
+          missingPrice: 0,
+          missingBrand: 0,
+          missingGtinOrMpnOrSku: 0,
+          blockingCount: 0,
+        },
+      })
       return
     }
 
@@ -71,6 +110,7 @@ export function useGoogleIntegrationStatus(input: UseGoogleIntegrationStatusInpu
         setHasGoogleConnection(overview.connected)
         setIsConnected(overview.integrations[integration].connected)
         setGrantedScopes(overview.grantedScopes)
+        setMerchant(overview.merchant)
       })
       .catch((nextError) => {
         if (!mounted) return
@@ -132,6 +172,7 @@ export function useGoogleIntegrationStatus(input: UseGoogleIntegrationStatusInpu
     buttonLabel,
     requiredScope,
     error,
+    merchant,
     startOAuth,
   }
 }

--- a/web/src/pages/GoogleShopping.css
+++ b/web/src/pages/GoogleShopping.css
@@ -166,3 +166,13 @@
   display: grid;
   gap: 0.4rem;
 }
+
+
+.google-shopping-page__step.is-next {
+  border-color: #f59e0b;
+  background: #fff7ed;
+}
+
+.google-shopping-panel__status-list p {
+  margin: 0;
+}

--- a/web/src/pages/GoogleShopping.test.tsx
+++ b/web/src/pages/GoogleShopping.test.tsx
@@ -41,6 +41,26 @@ vi.mock('firebase/firestore', () => ({
 
 vi.mock('../firebase', () => ({ db: {} }))
 
+const baseMerchant = {
+  state: 'google_not_connected',
+  googleConnected: false,
+  hasMerchantScope: false,
+  merchantAccountSelected: false,
+  merchantId: '',
+  refreshTokenPresent: false,
+  merchantConnected: false,
+  syncReady: false,
+  validationSummary: {
+    missingTitle: 0,
+    missingDescription: 0,
+    missingImage: 0,
+    missingPrice: 0,
+    missingBrand: 0,
+    missingGtinOrMpnOrSku: 0,
+    blockingCount: 0,
+  },
+}
+
 describe('GoogleShopping', () => {
   beforeEach(() => {
     mockUseActiveStore.mockReset()
@@ -71,8 +91,8 @@ describe('GoogleShopping', () => {
       isStartingOAuth: false,
       hasGoogleConnection: false,
       hasRequiredScope: false,
-      isConnected: false,
       stateTitle: '1) Connect Google',
+      merchant: baseMerchant,
       error: null,
       startOAuth,
     })
@@ -99,8 +119,8 @@ describe('GoogleShopping', () => {
       isStartingOAuth: false,
       hasGoogleConnection: true,
       hasRequiredScope: true,
-      isConnected: true,
       stateTitle: '3) Connected',
+      merchant: { ...baseMerchant, state: 'sync_ready', googleConnected: true, hasMerchantScope: true, merchantConnected: true, merchantAccountSelected: true, merchantId: 'mc-1', refreshTokenPresent: true, syncReady: true },
       error: null,
       startOAuth: vi.fn(),
     })
@@ -128,8 +148,7 @@ describe('GoogleShopping', () => {
       </MemoryRouter>,
     )
 
-    await user.click(await screen.findByRole('button', { name: /2. sync products/i }))
-    await user.click(screen.getByRole('button', { name: /run initial full catalog upload/i }))
+    await user.click(await screen.findByRole('button', { name: /sync products/i }))
 
     await waitFor(() => {
       expect(mockTriggerGoogleShoppingSync).toHaveBeenCalledWith({ storeId: 'store-1', mode: 'full' })

--- a/web/src/pages/GoogleShopping.tsx
+++ b/web/src/pages/GoogleShopping.tsx
@@ -16,7 +16,7 @@ import { useGoogleIntegrationStatus } from '../hooks/useGoogleIntegrationStatus'
 import { clearGoogleOAuthQueryState, parseGoogleOAuthQueryState } from '../utils/googleOAuthCallback'
 import './GoogleShopping.css'
 
-type WizardStep = 'connect' | 'map' | 'fix' | 'status'
+type WizardStep = 'connect' | 'account' | 'readiness' | 'sync'
 
 type GoogleShoppingConnection = {
   connected: boolean
@@ -42,10 +42,10 @@ type GoogleShoppingHistoryEntry = {
 }
 
 const STEP_LABELS: Record<WizardStep, string> = {
-  connect: '1. Connect Google',
-  map: '2. Sync products',
-  fix: '3. Fix errors',
-  status: '4. View status',
+  connect: 'Step 1: Connect Google',
+  account: 'Step 2: Choose Merchant account',
+  readiness: 'Step 3: Check product readiness',
+  sync: 'Step 4: Sync to Google',
 }
 
 export default function GoogleShopping() {
@@ -71,22 +71,13 @@ export default function GoogleShopping() {
     isStartingOAuth,
     hasGoogleConnection,
     hasRequiredScope,
-    isConnected,
     stateTitle,
+    merchant,
     error: oauthError,
     startOAuth,
   } = useGoogleIntegrationStatus({ integration: 'merchant', storeId })
 
-  const checklist = useMemo(
-    () => [
-      'Business information complete in Merchant Center',
-      'Website claimed and verified in Merchant Center',
-      'Shipping settings configured',
-      'Tax settings configured for target markets',
-      'Google Merchant Center account is active and approved',
-    ],
-    [],
-  )
+  const hasBlockingValidation = merchant.validationSummary.blockingCount > 0
 
   useEffect(() => {
     const queryState = parseGoogleOAuthQueryState(window.location.search)
@@ -99,16 +90,15 @@ export default function GoogleShopping() {
     if (queryState.status === 'success' && includesMerchant) {
       if (queryState.pendingSelectionId) {
         setPendingSelectionId(queryState.pendingSelectionId)
-        setStatus('We found multiple Merchant accounts. Please choose the one you want to connect.')
+        setStatus('We found multiple Merchant accounts. Choose your Merchant Center account to continue.')
       } else if (queryState.merchantId) {
         const message = queryState.refreshTokenMissing
-          ? `Connected to Merchant ID ${queryState.merchantId}. Note: Google did not return a refresh token, so reconnect may be required later.`
-          : `Connected to Merchant ID ${queryState.merchantId}.`
+          ? `Merchant ID ${queryState.merchantId} selected. Reconnect Google to finish Merchant setup.`
+          : `Merchant ID ${queryState.merchantId} selected.`
         setStatus(message)
       } else {
         setStatus(queryState.message || 'Google Merchant connected successfully.')
       }
-      setStep('connect')
     }
 
     if (queryState.status) {
@@ -189,7 +179,7 @@ export default function GoogleShopping() {
         setPendingAccounts(payload.accounts)
         setSelectedMerchantId(payload.accounts[0]?.id || '')
         if (payload.refreshTokenMissing) {
-          setStatus('Google did not return a refresh token in this connection. You can still connect now.')
+          setStatus('Reconnect Google to finish Merchant setup.')
         }
       })
       .catch((error) => {
@@ -239,16 +229,6 @@ export default function GoogleShopping() {
     }
   }, [storeId])
 
-  async function copyApiKey() {
-    if (!integrationApiKey) return
-    try {
-      await navigator.clipboard.writeText(integrationApiKey)
-      setStatus('Store API key copied.')
-    } catch {
-      setStatus('Unable to copy Store API key from this browser. You can still select and copy it manually.')
-    }
-  }
-
   async function connectGoogleMerchant() {
     if (!storeId) {
       setStatus('Please select a store before connecting Google Merchant.')
@@ -275,8 +255,8 @@ export default function GoogleShopping() {
       })
 
       const message = payload.refreshTokenMissing
-        ? `Connected to Merchant ID ${payload.merchantId}. Note: Google did not return a refresh token, so reconnect may be required later.`
-        : `Connected to Merchant ID ${payload.merchantId}.`
+        ? `Merchant ID ${payload.merchantId} selected. Reconnect Google to finish Merchant setup.`
+        : `Merchant ID ${payload.merchantId} selected.`
       setStatus(message)
       setPendingSelectionId('')
       setPendingAccounts([])
@@ -289,22 +269,69 @@ export default function GoogleShopping() {
     }
   }
 
+  const nextIncompleteStep: WizardStep = useMemo(() => {
+    if (!hasGoogleConnection) return 'connect'
+    if (!hasRequiredScope || !merchant.hasMerchantScope) return 'connect'
+    if (!merchant.merchantAccountSelected) return 'account'
+    if (!merchant.refreshTokenPresent) return 'connect'
+    if (hasBlockingValidation) return 'readiness'
+    return 'sync'
+  }, [hasGoogleConnection, hasRequiredScope, merchant, hasBlockingValidation])
 
-  const merchantActionLabel = !hasGoogleConnection
-    ? 'Connect Google'
-    : !hasRequiredScope
-      ? 'Grant Google Merchant access'
-      : connection.connected
-        ? 'Connected'
-        : 'Connect Merchant account'
+  useEffect(() => {
+    setStep(nextIncompleteStep)
+  }, [nextIncompleteStep])
 
-  const merchantHealthLabel = !hasGoogleConnection
-    ? 'Needs permission'
-    : !hasRequiredScope
-      ? 'Needs permission'
-      : connection.connected
-        ? 'Connected'
-        : 'Action required'
+  const actionConfig = useMemo(() => {
+    if (merchant.state === 'google_not_connected') {
+      return {
+        title: 'Connect your Google account',
+        helper: 'Step 1: Connect Google so Sedifex can request Merchant permissions.',
+        cta: 'Connect Google',
+        onClick: connectGoogleMerchant,
+      }
+    }
+    if (merchant.state === 'merchant_scope_missing') {
+      return {
+        title: 'Grant Google Merchant access',
+        helper: 'Google is connected, but Merchant scope is missing. Grant Google Merchant access to continue.',
+        cta: 'Grant Google Merchant access',
+        onClick: connectGoogleMerchant,
+      }
+    }
+    if (merchant.state === 'merchant_account_not_selected') {
+      return {
+        title: 'Choose your Merchant Center account',
+        helper: 'Step 2: choose the Merchant Center account that Sedifex should sync to.',
+        cta: pendingAccounts.length > 1 ? 'Choose Merchant account' : 'Choose Merchant account',
+        onClick: pendingAccounts.length > 1 ? () => setStep('account') : connectGoogleMerchant,
+      }
+    }
+    if (merchant.state === 'refresh_token_missing') {
+      return {
+        title: 'Reconnect Google to finish Merchant setup',
+        helper:
+          'Google did not provide a long-term connection token, so Sedifex cannot keep your Merchant connection active.',
+        cta: 'Reconnect Google',
+        onClick: connectGoogleMerchant,
+      }
+    }
+    if (merchant.state === 'product_sync_blocked_validation') {
+      return {
+        title: 'Products need more details before they can sync',
+        helper: 'Fix product data issues first. This is not a Google connection problem.',
+        cta: 'Review product issues',
+        onClick: () => setStep('readiness'),
+      }
+    }
+
+    return {
+      title: 'Your Merchant connection is ready',
+      helper: 'Google OAuth, Merchant account selection, and long-term token are all in place.',
+      cta: 'Sync products',
+      onClick: () => setStep('sync'),
+    }
+  }, [merchant.state, pendingAccounts.length])
 
   const currentSummary = summary
   const hasPersistedStatus = Boolean(persistedStatus?.lastRunAt)
@@ -318,10 +345,10 @@ export default function GoogleShopping() {
       setSummary(nextSummary)
       setStatus(
         nextSummary.errors.length > 0
-          ? `Sync finished with ${nextSummary.errors.length} issue(s). Open “Fix errors” for product-level tasks.`
+          ? `Sync finished with ${nextSummary.errors.length} issue(s). Review product issues before the next sync.`
           : 'Sync completed successfully.',
       )
-      setStep(nextSummary.errors.length > 0 ? 'fix' : 'status')
+      setStep(nextSummary.errors.length > 0 ? 'readiness' : 'sync')
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Sync failed.'
       setStatus(message)
@@ -336,8 +363,8 @@ export default function GoogleShopping() {
         <p className="google-shopping-page__eyebrow">Google onboarding · Step 2 of 3</p>
         <h1>Google Shopping</h1>
         <p>
-          Connect your Merchant account once, then Sedifex can sync your catalog automatically. No
-          manual Merchant ID entry required.
+          This setup makes the connection state explicit so you always know what is connected, what is missing,
+          and what to do next.
         </p>
         <Link className="google-shopping-page__back-link" to="/google-connect">
           ← Back to Google Connect
@@ -349,7 +376,7 @@ export default function GoogleShopping() {
           <button
             key={stepKey}
             type="button"
-            className={`google-shopping-page__step ${step === stepKey ? 'is-active' : ''}`}
+            className={`google-shopping-page__step ${step === stepKey ? 'is-active' : ''} ${nextIncompleteStep === stepKey ? 'is-next' : ''}`}
             onClick={() => setStep(stepKey)}
           >
             {STEP_LABELS[stepKey]}
@@ -357,179 +384,111 @@ export default function GoogleShopping() {
         ))}
       </nav>
 
-      {step === 'connect' && (
-        <>
-          <section className="google-shopping-panel">
-            <h2>{stateTitle}</h2>
-            <p>
-              {!hasGoogleConnection
-                ? 'Connect your Google account to continue.'
-                : !hasRequiredScope
-                  ? 'Your Google account is connected. Grant Google Merchant access to continue.'
-                  : connection.connected
-                    ? 'Google Merchant is connected for this store.'
-                    : 'Google Merchant access is ready. Connect and choose your Merchant account.'}
-            </p>
+      <section className="google-shopping-panel">
+        <h2>{actionConfig.title}</h2>
+        <p>{actionConfig.helper}</p>
+        {oauthStatusLoading ? <p className="google-shopping-panel__hint">Checking Google connection…</p> : null}
+        <button type="button" disabled={isStartingOAuth || saving} onClick={actionConfig.onClick}>
+          {isStartingOAuth ? 'Connecting…' : actionConfig.cta}
+        </button>
+      </section>
 
-            {oauthStatusLoading ? <p className="google-shopping-panel__hint">Checking Google connection…</p> : null}
+      <section className="google-shopping-panel google-shopping-panel__status-list">
+        <h2>Merchant connection status</h2>
+        <p><strong>Google OAuth connected:</strong> {merchant.googleConnected ? 'Yes' : 'No'}</p>
+        <p><strong>Merchant scope granted:</strong> {merchant.hasMerchantScope ? 'Yes' : 'No'}</p>
+        <p><strong>Merchant account selected:</strong> {merchant.merchantAccountSelected ? 'Yes' : 'No'}</p>
+        <p><strong>Refresh token available:</strong> {merchant.refreshTokenPresent ? 'Yes' : 'No'}</p>
+        <p><strong>Backend Merchant connection:</strong> {merchant.merchantConnected ? 'Connected' : 'Action needed'}</p>
+        <p><strong>Product sync ready:</strong> {merchant.syncReady ? 'Ready' : 'Not ready yet'}</p>
+        {(merchant.merchantId || connection.merchantId) && (
+          <p>
+            <strong>Merchant ID:</strong> {merchant.merchantId || connection.merchantId}
+          </p>
+        )}
+      </section>
 
-            {!isConnected || !connection.connected ? (
-              <button type="button" disabled={isStartingOAuth || saving} onClick={connectGoogleMerchant}>
-                {isStartingOAuth ? 'Connecting…' : merchantActionLabel}
-              </button>
-            ) : null}
-
-            {connection.connected && (
-              <p className="google-shopping-panel__connected">Connected Merchant ID: <strong>{connection.merchantId}</strong></p>
-            )}
-
-            {pendingAccounts.length > 1 && (
-              <div className="google-shopping-panel__picker">
-                <h3>Choose your Merchant account</h3>
-                <label>
-                  Merchant account
-                  <select
-                    value={selectedMerchantId}
-                    onChange={(event) => setSelectedMerchantId(event.target.value)}
-                  >
-                    {pendingAccounts.map((account) => (
-                      <option key={account.id} value={account.id}>
-                        {account.displayName} ({account.id})
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <button type="button" disabled={saving} onClick={confirmMerchantSelection}>
-                  {saving ? 'Saving…' : 'Use this Merchant account'}
-                </button>
-              </div>
-            )}
-
-            <details className="google-shopping-panel__advanced">
-              <summary>Advanced settings</summary>
-              <p className="google-shopping-panel__hint">
-                These values are auto-managed by Sedifex and only needed for advanced troubleshooting.
-              </p>
-              <label>
-                Store API key
-                <input
-                  value={setupConfigLoading && !integrationApiKey ? 'Creating key…' : integrationApiKey}
-                  readOnly
-                />
-                <small className="google-shopping-panel__helper">
-                  Automatically created by Sedifex for Google sync.
-                </small>
-              </label>
-              <div className="google-shopping-panel__actions">
-                <button type="button" onClick={copyApiKey} disabled={!integrationApiKey}>
-                  Copy key
-                </button>
-              </div>
-              <label>
-                Integration feed base URL
-                <input value={integrationBaseUrl} readOnly />
-              </label>
-              <label className="google-shopping-panel__checkbox">
-                <input type="checkbox" checked={autoSyncEnabled} readOnly />
-                Scheduled incremental sync is enabled
-              </label>
-            </details>
-          </section>
-        </>
+      {step === 'account' && pendingAccounts.length > 1 && (
+        <section className="google-shopping-panel google-shopping-panel__picker">
+          <h2>Choose your Merchant Center account</h2>
+          <label>
+            Merchant account
+            <select value={selectedMerchantId} onChange={(event) => setSelectedMerchantId(event.target.value)}>
+              {pendingAccounts.map((account) => (
+                <option key={account.id} value={account.id}>
+                  {account.displayName} ({account.id})
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="button" disabled={saving} onClick={confirmMerchantSelection}>
+            {saving ? 'Saving…' : 'Use this Merchant account'}
+          </button>
+        </section>
       )}
 
-      {step === 'map' && (
+      {step === 'readiness' && (
         <section className="google-shopping-panel">
-          <h2>Sync products</h2>
+          <h2>Products that need attention before Google can accept them</h2>
           <ul>
-            <li>title ← name</li>
-            <li>description ← description</li>
-            <li>price ← price</li>
-            <li>availability ← stockCount</li>
-            <li>image_link ← imageUrl</li>
-            <li>brand ← manufacturerName</li>
-            <li>gtin/mpn ← barcode / sku</li>
-            <li>google_product_category ← category</li>
+            <li>Missing title: {merchant.validationSummary.missingTitle}</li>
+            <li>Missing description: {merchant.validationSummary.missingDescription}</li>
+            <li>Missing image: {merchant.validationSummary.missingImage}</li>
+            <li>Missing price: {merchant.validationSummary.missingPrice}</li>
+            <li>Missing brand: {merchant.validationSummary.missingBrand}</li>
+            <li>Missing GTIN/MPN or SKU: {merchant.validationSummary.missingGtinOrMpnOrSku}</li>
           </ul>
-          <p className="google-shopping-panel__hint">
-            Sedifex uses <code>integrationProducts</code> as the source feed for full and incremental sync.
-          </p>
+          {summary?.errors?.length ? (
+            <ul className="google-shopping-errors">
+              {summary.errors.slice(0, 20).map((error) => (
+                <li key={`${error.productId}-${error.reason}`} className="google-shopping-errors__item">
+                  <div>
+                    <strong>{error.productId}</strong>: {error.reason}
+                  </div>
+                  <div className="google-shopping-errors__actions">
+                    <Link to={`/products?search=${encodeURIComponent(error.productId)}`}>Open product</Link>
+                    <Link to={`/products?edit=${encodeURIComponent(error.productId)}`}>Edit missing fields</Link>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="google-shopping-panel__hint">
+              Run a sync to generate a fresh product issue list for this store.
+            </p>
+          )}
+        </section>
+      )}
+
+      {step === 'sync' && (
+        <section className="google-shopping-panel">
+          <h2>Sync to Google</h2>
           <div className="google-shopping-panel__actions">
-            <button type="button" disabled={saving || !connection.connected} onClick={() => runSync('full')}>
-              {saving ? 'Syncing…' : 'Run initial full catalog upload'}
+            <button type="button" disabled={saving || !merchant.syncReady} onClick={() => runSync('full')}>
+              {saving ? 'Syncing…' : 'Sync products'}
             </button>
-            <button
-              type="button"
-              disabled={saving || !connection.connected}
-              onClick={() => runSync('incremental')}
-            >
+            <button type="button" disabled={saving || !merchant.syncReady} onClick={() => runSync('incremental')}>
               {saving ? 'Syncing…' : 'Run incremental sync'}
             </button>
           </div>
-        </section>
-      )}
-
-      {step === 'fix' && (
-        <section className="google-shopping-panel">
-          <h2>Fix errors</h2>
-          <p>Products with missing fields or Merchant disapprovals are listed after each sync.</p>
-          <ul className="google-shopping-errors">
-            {summary?.errors?.slice(0, 20).map((error) => (
-              <li key={`${error.productId}-${error.reason}`} className="google-shopping-errors__item">
-                <div>
-                  <strong>{error.productId}</strong>: {error.reason}
-                </div>
-                <div className="google-shopping-errors__actions">
-                  <Link to={`/products?search=${encodeURIComponent(error.productId)}`}>Open product</Link>
-                  <Link to={`/products?edit=${encodeURIComponent(error.productId)}`}>Edit missing fields</Link>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
-
-      {step === 'status' && (
-        <section className="google-shopping-panel">
-          <h2>View sync status</h2>
+          {!merchant.syncReady ? (
+            <p className="google-shopping-panel__hint">Complete earlier setup steps before syncing products.</p>
+          ) : null}
           {currentSummary ? (
             <dl className="google-shopping-panel__status-grid">
-              <div>
-                <dt>Total products</dt>
-                <dd>{currentSummary.totalProducts}</dd>
-              </div>
-              <div>
-                <dt>Eligible</dt>
-                <dd>{currentSummary.eligibleProducts}</dd>
-              </div>
-              <div>
-                <dt>Created/Updated</dt>
-                <dd>{currentSummary.createdOrUpdated}</dd>
-              </div>
-              <div>
-                <dt>Removed</dt>
-                <dd>{currentSummary.removed}</dd>
-              </div>
-              <div>
-                <dt>Disapproved</dt>
-                <dd>{currentSummary.disapproved}</dd>
-              </div>
-              <div>
-                <dt>Errors</dt>
-                <dd>{currentSummary.errors.length}</dd>
-              </div>
+              <div><dt>Total products</dt><dd>{currentSummary.totalProducts}</dd></div>
+              <div><dt>Eligible</dt><dd>{currentSummary.eligibleProducts}</dd></div>
+              <div><dt>Created/Updated</dt><dd>{currentSummary.createdOrUpdated}</dd></div>
+              <div><dt>Removed</dt><dd>{currentSummary.removed}</dd></div>
+              <div><dt>Disapproved</dt><dd>{currentSummary.disapproved}</dd></div>
+              <div><dt>Errors</dt><dd>{currentSummary.errors.length}</dd></div>
             </dl>
           ) : (
-            <div>
-              <p>No sync has run in this browser yet.</p>
-              {hasPersistedStatus ? (
-                <p className="google-shopping-panel__hint">
-                  Last sync: {new Date(persistedStatus!.lastRunAt).toLocaleString()} ({persistedStatus!.state}).
-                </p>
-              ) : (
-                <p className="google-shopping-panel__hint">No sync has run yet for this store.</p>
-              )}
-            </div>
+            <p className="google-shopping-panel__hint">
+              {hasPersistedStatus
+                ? `Last sync: ${new Date(persistedStatus!.lastRunAt).toLocaleString()} (${persistedStatus!.state}).`
+                : 'No sync has run yet for this store.'}
+            </p>
           )}
 
           <h3>Sync history</h3>
@@ -544,20 +503,32 @@ export default function GoogleShopping() {
           ) : (
             <p className="google-shopping-panel__hint">History will appear here after your first sync.</p>
           )}
-
-          <h3>Merchant checklist</h3>
-          <ul>
-            {checklist.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
         </section>
       )}
 
+      <details className="google-shopping-panel__advanced">
+        <summary>Advanced settings</summary>
+        <label>
+          Store API key
+          <input value={setupConfigLoading && !integrationApiKey ? 'Creating key…' : integrationApiKey} readOnly />
+        </label>
+        <label>
+          Integration feed base URL
+          <input value={integrationBaseUrl} readOnly />
+        </label>
+        <label className="google-shopping-panel__checkbox">
+          <input type="checkbox" checked={autoSyncEnabled} readOnly />
+          Scheduled incremental sync is enabled
+        </label>
+      </details>
+
       {status && <p className="google-shopping-page__status">{status}</p>}
-      {!status && merchantHealthLabel === 'Action required' ? (
-        <p className="google-shopping-page__status">Action required: choose and connect a Merchant account for this store.</p>
+      {!status && merchant.state === 'refresh_token_missing' ? (
+        <p className="google-shopping-page__status">
+          Reconnect Google to finish Merchant setup. Google did not provide a long-term connection token, so Sedifex cannot keep your Merchant connection active.
+        </p>
       ) : null}
+      <p className="google-shopping-panel__hint">{stateTitle}</p>
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Clarify confusing Google/Merchant UI states by distinguishing OAuth connection, Merchant account selection, refresh token availability, backend connection, and product validation blockers. 
- Surface exact missing step to business users so they know what to do next without mistaking OAuth for full Merchant readiness.

### Description
- Added an explicit Merchant readiness model and API output in the status endpoint with states: `google_not_connected`, `merchant_scope_missing`, `merchant_account_not_selected`, `refresh_token_missing`, `merchant_connected`, `product_sync_blocked_validation`, and `sync_ready`, and booleans/summary (`googleConnected`, `hasMerchantScope`, `merchantAccountSelected`, `merchantId`, `refreshTokenPresent`, `merchantConnected`, `syncReady`, `validationSummary`) in `web/api/google/status.ts`.
- Persisted product-validation counts from sync errors in Cloud Functions and exposed them via `validationSummary` (counts for missing title/description/image/price/brand/GTIN/MPN/SKU and `blockingCount`) by adding `buildValidationSummary` and writing `validationSummary` during `persistSyncStatus` in `functions/src/googleShopping.ts`.
- Extended frontend API client and types to consume the new merchant readiness payload (`web/src/api/googleIntegrations.ts`) and updated the `useGoogleIntegrationStatus` hook to expose `merchant` readiness details (`web/src/hooks/useGoogleIntegrationStatus.ts`).
- Refactored the Google Shopping page into a step-by-step setup UX with explicit messaging and CTA logic: Step 1 Connect Google, Step 2 Choose Merchant account, Step 3 Check product readiness, Step 4 Sync to Google, plus a dedicated product-issues section and explicit refresh-token reconnect messaging (`web/src/pages/GoogleShopping.tsx` and `web/src/pages/GoogleShopping.css`).
- Updated unit tests for the Google Shopping page to use the new hook/merchant payload shape (`web/src/pages/GoogleShopping.test.tsx`).

### Testing
- Attempted to run the updated page tests with `cd web && npm run test -- GoogleShopping.test.tsx`, but the test runner invocation failed in this environment because `vitest` was not available in `node_modules` (test run could not be executed).
- Attempted `cd web && npm ci` to install dependencies, but `npm ci` failed due to registry access returning `403 Forbidden` for a dependency, preventing full local test execution.
- Unit tests in the repository were updated to the new API/hook shape and were exercised via local test attempts, but automated test execution could not be completed in this environment due to the dependency/install issues above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da336a96908321ac8d642355f76b9c)