### PR TITLE
Add admin script to force-update owner email by UID

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,8 @@
     "build": "rimraf lib && tsc",
     "clean": "rimraf lib",
     "serve": "firebase emulators:start --only functions",
-    "deploy": "firebase deploy --only functions --project sedifex-dev"
+    "deploy": "firebase deploy --only functions --project sedifex-dev",
+    "force-update-owner-email": "node scripts/forceUpdateOwnerEmailByUid.js"
   },
   "dependencies": {
     "firebase-admin": "^13.6.0",

--- a/functions/scripts/forceUpdateOwnerEmailByUid.js
+++ b/functions/scripts/forceUpdateOwnerEmailByUid.js
@@ -1,0 +1,191 @@
+const admin = require('firebase-admin')
+
+const uid = (process.argv[2] ?? '').trim()
+const nextEmail = (process.argv[3] ?? '').trim().toLowerCase()
+
+if (!uid || !nextEmail) {
+  console.error('Usage: npm run force-update-owner-email -- <uid> <new-email>')
+  process.exit(1)
+}
+
+if (!admin.apps.length) {
+  admin.initializeApp()
+}
+
+const auth = admin.auth()
+const db = admin.firestore()
+const timestamp = admin.firestore.FieldValue.serverTimestamp()
+
+async function updateAuthEmail() {
+  const userRecord = await auth.getUser(uid)
+  const currentEmail = (userRecord.email ?? '').trim().toLowerCase()
+
+  if (currentEmail === nextEmail) {
+    console.log(`[force-update-owner-email] Auth already set to ${nextEmail} for uid=${uid}`)
+    return
+  }
+
+  await auth.updateUser(uid, {
+    email: nextEmail,
+    emailVerified: false,
+  })
+
+  console.log(`[force-update-owner-email] Updated Auth email ${currentEmail || '(none)'} -> ${nextEmail} for uid=${uid}`)
+}
+
+async function patchCollectionByUid(collectionName) {
+  const snapshot = await db.collection(collectionName).where('ownerUid', '==', uid).get()
+  if (snapshot.empty) {
+    return 0
+  }
+
+  let updated = 0
+  let batch = db.batch()
+  let writes = 0
+
+  for (const doc of snapshot.docs) {
+    batch.set(
+      doc.ref,
+      {
+        ownerEmail: nextEmail,
+        email: nextEmail,
+        updatedAt: timestamp,
+      },
+      { merge: true },
+    )
+    writes += 1
+    updated += 1
+
+    if (writes >= 400) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+
+  if (writes > 0) {
+    await batch.commit()
+  }
+
+  return updated
+}
+
+async function patchCollectionByOwnerId(collectionName) {
+  const snapshot = await db.collection(collectionName).where('ownerId', '==', uid).get()
+  if (snapshot.empty) {
+    return 0
+  }
+
+  let updated = 0
+  let batch = db.batch()
+  let writes = 0
+
+  for (const doc of snapshot.docs) {
+    batch.set(
+      doc.ref,
+      {
+        ownerEmail: nextEmail,
+        email: nextEmail,
+        updatedAt: timestamp,
+      },
+      { merge: true },
+    )
+    writes += 1
+    updated += 1
+
+    if (writes >= 400) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+
+  if (writes > 0) {
+    await batch.commit()
+  }
+
+  return updated
+}
+
+async function patchTeamMembers() {
+  const uidRef = db.collection('teamMembers').doc(uid)
+  const uidDoc = await uidRef.get()
+
+  if (uidDoc.exists) {
+    await uidRef.set(
+      {
+        uid,
+        email: nextEmail,
+        firstSignupEmail: nextEmail,
+        updatedAt: timestamp,
+      },
+      { merge: true },
+    )
+  }
+
+  const querySnapshot = await db.collection('teamMembers').where('uid', '==', uid).get()
+
+  if (querySnapshot.empty) {
+    return uidDoc.exists ? 1 : 0
+  }
+
+  let updated = uidDoc.exists ? 1 : 0
+  let batch = db.batch()
+  let writes = 0
+
+  for (const doc of querySnapshot.docs) {
+    if (doc.id === uid && uidDoc.exists) {
+      continue
+    }
+
+    batch.set(
+      doc.ref,
+      {
+        uid,
+        email: nextEmail,
+        firstSignupEmail: nextEmail,
+        updatedAt: timestamp,
+      },
+      { merge: true },
+    )
+    writes += 1
+    updated += 1
+
+    if (writes >= 400) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+
+  if (writes > 0) {
+    await batch.commit()
+  }
+
+  return updated
+}
+
+async function run() {
+  await updateAuthEmail()
+
+  const [teamMembersUpdated, storesByUid, storesByOwnerId, workspacesByUid, workspacesByOwnerId] = await Promise.all([
+    patchTeamMembers(),
+    patchCollectionByUid('stores'),
+    patchCollectionByOwnerId('stores'),
+    patchCollectionByUid('workspaces'),
+    patchCollectionByOwnerId('workspaces'),
+  ])
+
+  console.log('[force-update-owner-email] Done', {
+    uid,
+    email: nextEmail,
+    teamMembersUpdated,
+    storesUpdated: storesByUid + storesByOwnerId,
+    workspacesUpdated: workspacesByUid + workspacesByOwnerId,
+  })
+}
+
+run().catch(error => {
+  console.error('[force-update-owner-email] Failed', error)
+  process.exit(1)
+})


### PR DESCRIPTION
### Motivation
- Provide an admin utility to force-change a Firebase Auth email for a given UID and keep related Firestore records consistent.
- This helps fix cases where Auth and Firestore owner/contact emails diverge and require a one-off bulk correction.

### Description
- Add `functions/scripts/forceUpdateOwnerEmailByUid.js`, a Node admin script that updates the Auth email for a UID and patches Firestore documents atomically using batched `set(..., { merge: true })`.
- The script updates the `teamMembers` doc at `teamMembers/<uid>` and any `teamMembers` documents where `uid == <uid>`, and it patches `stores` and `workspaces` documents found by either `ownerUid == <uid>` or `ownerId == <uid>` to set `ownerEmail`, `email`, and `updatedAt`.
- Add an npm helper script `force-update-owner-email` to `functions/package.json` so the tool can be run with `npm --prefix functions run force-update-owner-email -- <uid> <new-email>`.

### Testing
- Ran `npm --prefix functions run build` and the TypeScript build step completed successfully.
- Ran `node --check functions/scripts/forceUpdateOwnerEmailByUid.js` to verify the new script has no Node syntax errors and it passed.
- Executing the script without arguments produced the expected usage message `Usage: npm run force-update-owner-email -- <uid> <new-email>`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da376265c083219055164235d74ba4)