### PR TITLE
Add storeId console logging in Google pages

### DIFF
--- a/web/src/pages/GoogleBusinessProfile.tsx
+++ b/web/src/pages/GoogleBusinessProfile.tsx
@@ -8,6 +8,7 @@ import './GoogleBusinessProfile.css'
 
 export default function GoogleBusinessProfile() {
   const { storeId } = useActiveStore()
+  console.log("STORE ID:", storeId)
   const {
     isLoading,
     isStartingOAuth,

--- a/web/src/pages/GoogleShopping.tsx
+++ b/web/src/pages/GoogleShopping.tsx
@@ -50,6 +50,7 @@ const STEP_LABELS: Record<WizardStep, string> = {
 
 export default function GoogleShopping() {
   const { storeId } = useActiveStore()
+  console.log("STORE ID:", storeId)
   const [step, setStep] = useState<WizardStep>('connect')
   const [integrationApiKey, setIntegrationApiKey] = useState('')
   const [integrationBaseUrl, setIntegrationBaseUrl] = useState(


### PR DESCRIPTION
### Motivation
- Add a temporary debug log to verify the active store context (`storeId`) at runtime in Google-related pages.

### Description
- Inserted `console.log("STORE ID:", storeId)` immediately after `const { storeId } = useActiveStore()` in `web/src/pages/GoogleBusinessProfile.tsx` and `web/src/pages/GoogleShopping.tsx`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5a52223c8322966ab4c7b36948d4)