### PR TITLE
Add Vercel rewrite for Google Business locations API

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,10 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
+      "source": "/api/google-business/locations",
+      "destination": "https://us-central1-sedifex-web.cloudfunctions.net/googleBusinessLocations"
+    },
+    {
       "source": "/((?!api/|assets/|.*\\..*).*)",
       "destination": "/index.html"
     }

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,6 +1,10 @@
 {
   "rewrites": [
     {
+      "source": "/api/google-business/locations",
+      "destination": "https://us-central1-sedifex-web.cloudfunctions.net/googleBusinessLocations"
+    },
+    {
       "source": "/((?!api/|assets/|.*\\..*).*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
### Motivation
- Proxy the frontend route `/api/google-business/locations` to the Firebase Function so the frontend can keep the same API path while requests are handled by the cloud function.
- Ensure both the root and `web` Vercel configs are aligned so deployments use the same routing behavior.

### Description
- Add a rewrite entry to the root `vercel.json` mapping `/api/google-business/locations` to `https://us-central1-sedifex-web.cloudfunctions.net/googleBusinessLocations`.
- Add the same rewrite entry to `web/vercel.json` and insert it before the SPA catch-all rewrite so the API route is proxied first.

### Testing
- No automated runtime tests are required because this is a configuration-only change.
- Validated the updated configs by inspecting the file diffs with `git diff -- vercel.json web/vercel.json` which show the new rewrite entries present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6787635c8322b9f898c63eff9fab)