### PR TITLE
Harden Google Business auth error handling and preserve refresh tokens

### DIFF
--- a/functions/src/googleBusinessProfile.ts
+++ b/functions/src/googleBusinessProfile.ts
@@ -54,6 +54,43 @@ function normalizeError(error: unknown): string {
   return error instanceof Error ? error.message : 'unknown-error'
 }
 
+function classifyGoogleBusinessApiError(payload: unknown, status: number): string {
+  const bodyRecord = asRecord(payload)
+  const directError = normalizeString(bodyRecord.error)
+  const directMessage = normalizeString(bodyRecord.error_description || bodyRecord.message)
+  const nestedError = asRecord(bodyRecord.error)
+  const nestedStatus = normalizeString(nestedError.status)
+  const nestedCode = normalizeString(nestedError.code)
+  const nestedMessage = normalizeString(nestedError.message)
+
+  const details = Array.isArray(nestedError.details) ? nestedError.details : []
+  const detailTexts = details
+    .map((detail) => {
+      const detailRecord = asRecord(detail)
+      return [
+        normalizeString(detailRecord.reason),
+        normalizeString(detailRecord.domain),
+        normalizeString(detailRecord.message),
+      ]
+        .filter(Boolean)
+        .join(':')
+    })
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+
+  const joined = [directError, directMessage, nestedStatus, nestedCode, nestedMessage, detailTexts].join(' ').toLowerCase()
+  if (joined.includes('business.manage') || joined.includes('insufficient authentication scopes') || joined.includes('insufficientpermissions')) {
+    return 'google-business-missing-scope'
+  }
+  if (status === 403 && (joined.includes('permission_denied') || joined.includes('forbidden'))) {
+    return 'google-business-permission-denied'
+  }
+
+  const message = nestedMessage || directMessage || directError
+  return message ? `google-business-api-failed:${message}` : `google-business-api-failed:${status}`
+}
+
 function setCors(res: functions.Response<any>) {
   res.set('Access-Control-Allow-Origin', '*')
   res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
@@ -377,9 +414,7 @@ async function googleApiRequest<T>(params: {
 
   const payload = await response.json().catch(() => ({}))
   if (!response.ok) {
-    const bodyRecord = asRecord(payload)
-    const message = normalizeString(bodyRecord.error_description || bodyRecord.error || bodyRecord.message)
-    throw new Error(message ? `google-business-api-failed:${message}` : `google-business-api-failed:${response.status}`)
+    throw new Error(classifyGoogleBusinessApiError(payload, response.status))
   }
 
   return payload as T
@@ -593,7 +628,7 @@ export const googleBusinessLocations = functions.https.onRequest(async (req, res
       return
     }
     if (message === 'store-access-denied') {
-      res.status(403).json({ error: 'store-access-denied' })
+      res.status(400).json({ error: 'store-access-denied' })
       return
     }
     if (message === 'google-business-reconnect-required') {
@@ -697,7 +732,7 @@ export const googleBusinessUploadLocationMedia = functions.https.onRequest(async
       return
     }
     if (message === 'store-access-denied') {
-      res.status(403).json({ error: 'store-access-denied' })
+      res.status(400).json({ error: 'store-access-denied' })
       return
     }
     if (message === 'unsupported-mime-type') {

--- a/web/api/_google-oauth.ts
+++ b/web/api/_google-oauth.ts
@@ -214,8 +214,17 @@ export async function storeUnifiedGoogleTokens(params: {
 
   const accessToken = typeof params.tokenPayload.access_token === 'string' ? params.tokenPayload.access_token : ''
   const refreshToken = typeof params.tokenPayload.refresh_token === 'string' ? params.tokenPayload.refresh_token : ''
+  const existingRefreshTokens = [
+    existingGoogleOAuth.refreshToken,
+    existingGoogleBusiness.refreshToken,
+    existingGoogleAds.refreshToken,
+    existingGoogleMerchant.refreshToken,
+  ]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .filter(Boolean)
+  const fallbackRefreshToken = existingRefreshTokens[0] || ''
   const sharedRefreshToken =
-    refreshToken || (typeof existingGoogleOAuth.refreshToken === 'string' ? existingGoogleOAuth.refreshToken : '')
+    refreshToken || (typeof existingGoogleOAuth.refreshToken === 'string' ? existingGoogleOAuth.refreshToken : '') || fallbackRefreshToken
   const tokenType = typeof params.tokenPayload.token_type === 'string' ? params.tokenPayload.token_type : 'Bearer'
   const scope = typeof params.tokenPayload.scope === 'string' ? params.tokenPayload.scope : ''
   if (!accessToken) throw new Error('missing-access-token')
@@ -235,7 +244,10 @@ export async function storeUnifiedGoogleTokens(params: {
 
   if (params.integrationHints.includes('business')) {
     const businessRefreshToken =
-      refreshToken || (typeof existingGoogleBusiness.refreshToken === 'string' ? existingGoogleBusiness.refreshToken : '')
+      refreshToken ||
+      (typeof existingGoogleBusiness.refreshToken === 'string' ? existingGoogleBusiness.refreshToken : '') ||
+      sharedRefreshToken ||
+      fallbackRefreshToken
     integrations.googleBusinessProfile = {
       accessToken,
       refreshToken: businessRefreshToken || FieldValue.delete(),
@@ -248,7 +260,10 @@ export async function storeUnifiedGoogleTokens(params: {
   }
   if (params.integrationHints.includes('ads')) {
     const adsRefreshToken =
-      refreshToken || (typeof existingGoogleAds.refreshToken === 'string' ? existingGoogleAds.refreshToken : '')
+      refreshToken ||
+      (typeof existingGoogleAds.refreshToken === 'string' ? existingGoogleAds.refreshToken : '') ||
+      sharedRefreshToken ||
+      fallbackRefreshToken
     integrations.googleAds = {
       accessToken,
       refreshToken: adsRefreshToken || FieldValue.delete(),
@@ -264,7 +279,10 @@ export async function storeUnifiedGoogleTokens(params: {
   }
   if (params.integrationHints.includes('merchant')) {
     const merchantRefreshToken =
-      refreshToken || (typeof existingGoogleMerchant.refreshToken === 'string' ? existingGoogleMerchant.refreshToken : '')
+      refreshToken ||
+      (typeof existingGoogleMerchant.refreshToken === 'string' ? existingGoogleMerchant.refreshToken : '') ||
+      sharedRefreshToken ||
+      fallbackRefreshToken
     integrations.googleMerchant = {
       accessToken,
       refreshToken: merchantRefreshToken || FieldValue.delete(),


### PR DESCRIPTION
### Motivation
- Improve classification of Google Business API failures so missing `business.manage` consent and other permission issues surface as distinct error codes for clearer handling. 
- Ensure store/user alignment errors for Google Business endpoints return the requested client error code when the authenticated user is not a member of the target store. 
- Prevent losing a saved refresh token on incremental Google consent responses that omit `refresh_token` by preferring existing stored tokens.

### Description
- Added `classifyGoogleBusinessApiError()` and wired it into the shared Google request helper so API failures can map to `google-business-missing-scope`, `google-business-permission-denied`, or `google-business-api-failed:*` as appropriate (`functions/src/googleBusinessProfile.ts`).
- Changed Google Business handlers to return HTTP 400 with `{ error: 'store-access-denied' }` when the user is not a member of the requested store to align with the desired client behavior (`functions/src/googleBusinessProfile.ts`).
- Updated `storeUnifiedGoogleTokens()` to collect existing refresh tokens from `googleOAuth`, `googleBusinessProfile`, `googleAds`, and `googleMerchant` and use a fallback when the token response omits `refresh_token`, so existing refresh tokens are preserved instead of overwritten (`web/api/_google-oauth.ts`).
- Verified that the OAuth start flow already includes the required `https://www.googleapis.com/auth/business.manage` scope for the `business` integration and that scope aggregation remains unchanged (`web/api/_google-oauth.ts`).

### Testing
- Ran `npm run -s build` in the `functions/` package and it completed successfully. 
- Ran `npm run -s lint` in the `web/` package which failed in this environment due to a missing dev dependency (`@eslint/js`).
- Ran `npm run -s build` in the `web/` package which failed in this environment due to missing type definitions (`vite/client`, `vitest/globals`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da78075c248322b628e0d948335b99)