### PR TITLE
Unify Merchant Center source-of-truth fields and token refresh behavior

### DIFF
--- a/functions/src/googleShopping.ts
+++ b/functions/src/googleShopping.ts
@@ -423,6 +423,8 @@ async function saveGoogleMerchantConnection(params: {
   const settingsData = asRecord(settingsSnap.data())
   const googleShopping = asRecord(settingsData.googleShopping)
   const catalogSync = asRecord(googleShopping.catalogSync)
+  const integrations = asRecord(settingsData.integrations)
+  const existingGoogleMerchant = asRecord(integrations.googleMerchant)
 
   const accessToken = normalizeString(params.tokenPayload.access_token)
   const refreshToken = normalizeString(params.tokenPayload.refresh_token)
@@ -438,6 +440,7 @@ async function saveGoogleMerchantConnection(params: {
   })
   const existingIntegrationBaseUrl = normalizeString(catalogSync.integrationBaseUrl)
   const existingAutoSyncEnabled = catalogSync.autoSyncEnabled === false ? false : true
+  const canonicalRefreshToken = refreshToken || normalizeString(existingGoogleMerchant.refreshToken)
 
   const catalogSyncUpdate: Record<string, unknown> = {
     accessToken,
@@ -456,6 +459,18 @@ async function saveGoogleMerchantConnection(params: {
 
   await settingsRef.set(
     {
+      integrations: {
+        googleMerchant: {
+          selectedMerchantId: params.merchantId,
+          accessToken,
+          refreshToken: canonicalRefreshToken || FieldValue.delete(),
+          tokenType: tokenType || 'Bearer',
+          scope,
+          oauthUserId: params.uid,
+          updatedAt: FieldValue.serverTimestamp(),
+          ...(tokenExpiry ? { expiresAt: tokenExpiry } : {}),
+        },
+      },
       googleShopping: {
         connection: {
           connected: true,
@@ -549,18 +564,20 @@ async function resolveGoogleMerchantAuth(storeId: string): Promise<{ accessToken
   const settingsRef = db.collection('storeSettings').doc(storeId)
   const settingsSnap = await settingsRef.get()
   const settingsData = asRecord(settingsSnap.data())
+  const integrations = asRecord(settingsData.integrations)
+  const googleMerchant = asRecord(integrations.googleMerchant)
   const googleShopping = asRecord(settingsData.googleShopping)
   const connection = asRecord(googleShopping.connection)
   const catalogSync = asRecord(googleShopping.catalogSync)
 
-  const merchantId = normalizeString(connection.merchantId)
+  const merchantId = normalizeString(googleMerchant.selectedMerchantId) || normalizeString(connection.merchantId)
   if (connection.connected !== true || !merchantId) {
     throw new Error('merchant-not-connected')
   }
 
-  let accessToken = normalizeString(catalogSync.accessToken)
-  const refreshToken = normalizeString(catalogSync.refreshToken)
-  const tokenExpiryRaw = catalogSync.tokenExpiry
+  let accessToken = normalizeString(googleMerchant.accessToken) || normalizeString(catalogSync.accessToken)
+  const refreshToken = normalizeString(googleMerchant.refreshToken) || normalizeString(catalogSync.refreshToken)
+  const tokenExpiryRaw = googleMerchant.expiresAt || catalogSync.tokenExpiry
 
   const expiryMillis = tokenExpiryMillis(tokenExpiryRaw)
   const tokenExpiringSoon = expiryMillis > 0 && expiryMillis <= Date.now() + 30_000
@@ -583,6 +600,13 @@ async function resolveGoogleMerchantAuth(storeId: string): Promise<{ accessToken
 
     await settingsRef.set(
       {
+        integrations: {
+          googleMerchant: {
+            accessToken: refreshedAccessToken,
+            updatedAt: FieldValue.serverTimestamp(),
+            ...(refreshedTokenExpiry ? { expiresAt: refreshedTokenExpiry } : {}),
+          },
+        },
         googleShopping: {
           catalogSync: {
             accessToken: refreshedAccessToken,
@@ -590,10 +614,6 @@ async function resolveGoogleMerchantAuth(storeId: string): Promise<{ accessToken
             tokenScope: refreshedScope,
             tokenUpdatedAt: FieldValue.serverTimestamp(),
             ...(refreshedTokenExpiry ? { tokenExpiry: refreshedTokenExpiry } : {}),
-          },
-          status: {
-            updatedAt: FieldValue.serverTimestamp(),
-            refreshTokenMissing: false,
           },
         },
       },

--- a/web/api/google/status.ts
+++ b/web/api/google/status.ts
@@ -8,6 +8,9 @@ import {
   type GoogleIntegration,
 } from '../_google-oauth.js'
 
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const GOOGLE_MERCHANT_API_BASE = 'https://shoppingcontent.googleapis.com/content/v2.1'
+
 function requireStoreId(raw: unknown): string {
   if (typeof raw !== 'string' || !raw.trim()) throw new Error('invalid-store-id')
   return raw.trim()
@@ -47,6 +50,67 @@ function toValidationSummary(raw: unknown): ValidationSummary {
   }
 }
 
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function parseExpiryMillis(value: unknown): number {
+  if (!value) return 0
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  if (typeof value === 'object') {
+    const candidate = value as { toMillis?: () => number }
+    if (typeof candidate.toMillis === 'function') return candidate.toMillis()
+  }
+  return 0
+}
+
+function getOAuthConfig() {
+  const clientId = process.env.GOOGLE_CLIENT_ID?.trim() || process.env.GOOGLE_ADS_CLIENT_ID?.trim() || ''
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim() || process.env.GOOGLE_ADS_CLIENT_SECRET?.trim() || ''
+  if (!clientId || !clientSecret) throw new Error('google-oauth-config-missing')
+  return { clientId, clientSecret }
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<{ accessToken: string; expiresAt: number }> {
+  const { clientId, clientSecret } = getOAuthConfig()
+  const body = new URLSearchParams({
+    refresh_token: refreshToken,
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'refresh_token',
+  })
+
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>
+  if (!response.ok) throw new Error(`token-refresh-failed:${String(payload.error || response.status)}`)
+
+  const accessToken = normalizeString(payload.access_token)
+  const expiresIn = typeof payload.expires_in === 'number' ? payload.expires_in : Number(payload.expires_in || 0)
+  if (!accessToken) throw new Error('token-refresh-missing-access-token')
+  return { accessToken, expiresAt: Date.now() + (Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn * 1000 : 3600_000) }
+}
+
+async function canCallMerchantApi(accessToken: string, merchantId: string): Promise<boolean> {
+  const authInfoRes = await fetch(`${GOOGLE_MERCHANT_API_BASE}/accounts/authinfo`, {
+    method: 'GET',
+    headers: { authorization: `Bearer ${accessToken}`, 'content-type': 'application/json' },
+  })
+  if (!authInfoRes.ok) return false
+
+  const productsRes = await fetch(`${GOOGLE_MERCHANT_API_BASE}/${merchantId}/products?maxResults=1`, {
+    method: 'GET',
+    headers: { authorization: `Bearer ${accessToken}`, 'content-type': 'application/json' },
+  })
+  return productsRes.ok
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed. Use POST.' })
 
@@ -75,16 +139,45 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const merchantHasScope = hasScope(granted, GOOGLE_REQUIRED_SCOPE.merchant)
     const settingsSnap = await db().collection('storeSettings').doc(storeId).get()
     const settings = (settingsSnap.data() ?? {}) as Record<string, unknown>
+    const integrationsRoot = (settings.integrations ?? {}) as Record<string, unknown>
+    const googleOAuth = (integrationsRoot.googleOAuth ?? {}) as Record<string, unknown>
+    const googleMerchant = (integrationsRoot.googleMerchant ?? {}) as Record<string, unknown>
     const googleShopping = (settings.googleShopping ?? {}) as Record<string, unknown>
-    const connection = (googleShopping.connection ?? {}) as Record<string, unknown>
-    const catalogSync = (googleShopping.catalogSync ?? {}) as Record<string, unknown>
     const shoppingStatus = (googleShopping.status ?? {}) as Record<string, unknown>
 
-    const merchantId = typeof connection.merchantId === 'string' ? connection.merchantId.trim() : ''
-    const merchantAccountSelected = merchantId.length > 0
-    const refreshTokenPresent = typeof catalogSync.refreshToken === 'string' && catalogSync.refreshToken.trim().length > 0
-    const merchantConnected = connection.connected === true && merchantAccountSelected
+    const oauthConnected = Object.keys(googleOAuth).length > 0
+    const hasContentScope = merchantHasScope
+    const merchantId = normalizeString(googleMerchant.selectedMerchantId)
+    const hasSelectedMerchant = merchantId.length > 0
+    const refreshToken = normalizeString(googleMerchant.refreshToken)
+    const hasRefreshToken = refreshToken.length > 0
     const validationSummary = toValidationSummary(shoppingStatus.validationSummary)
+    let merchantConnected = false
+
+    if (oauthConnected && hasContentScope && hasSelectedMerchant && hasRefreshToken) {
+      let accessToken = normalizeString(googleMerchant.accessToken)
+      const expiresAt = parseExpiryMillis(googleMerchant.expiresAt)
+      const tokenExpiringSoon = expiresAt > 0 && expiresAt <= Date.now() + 30_000
+
+      if (!accessToken || tokenExpiringSoon) {
+        const refreshed = await refreshAccessToken(refreshToken)
+        accessToken = refreshed.accessToken
+        await db().collection('storeSettings').doc(storeId).set(
+          {
+            integrations: {
+              googleMerchant: {
+                accessToken: refreshed.accessToken,
+                expiresAt: new Date(refreshed.expiresAt),
+                updatedAt: new Date(),
+              },
+            },
+          },
+          { merge: true },
+        )
+      }
+
+      merchantConnected = await canCallMerchantApi(accessToken, merchantId)
+    }
 
     let merchantState:
       | 'google_not_connected'
@@ -95,13 +188,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       | 'product_sync_blocked_validation'
       | 'sync_ready'
 
-    if (!connected) {
+    if (!oauthConnected) {
       merchantState = 'google_not_connected'
-    } else if (!merchantHasScope) {
+    } else if (!hasContentScope) {
       merchantState = 'merchant_scope_missing'
-    } else if (!merchantAccountSelected) {
+    } else if (!hasSelectedMerchant) {
       merchantState = 'merchant_account_not_selected'
-    } else if (!refreshTokenPresent) {
+    } else if (!hasRefreshToken) {
       merchantState = 'refresh_token_missing'
     } else if (!merchantConnected) {
       merchantState = 'merchant_connected'
@@ -119,11 +212,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       integrations,
       merchant: {
         state: merchantState,
-        googleConnected: connected,
-        hasMerchantScope: merchantHasScope,
-        merchantAccountSelected,
+        googleConnected: oauthConnected,
+        hasMerchantScope: hasContentScope,
+        merchantAccountSelected: hasSelectedMerchant,
         merchantId,
-        refreshTokenPresent,
+        refreshTokenPresent: hasRefreshToken,
         merchantConnected,
         syncReady,
         validationSummary,


### PR DESCRIPTION
### Motivation
- Centralize Merchant account and token state so backend and status UI read the same canonical fields under `integrations.googleMerchant`.
- Persist user-selected Merchant account ID in a single canonical field and avoid losing refresh tokens when Google does not return a new one.
- Make connection-status checks run against the actual backend source-of-truth and validate live Merchant API access where possible.

### Description
- Persist selected Merchant ID to `integrations.googleMerchant.selectedMerchantId` during account selection while still updating legacy `googleShopping.connection` for compatibility (`functions/src/googleShopping.ts`).
- Use `integrations.googleMerchant` as the preferred source for `accessToken`, `refreshToken`, and `expiresAt` when resolving Merchant auth; fall back to `googleShopping.catalogSync` only if needed (`functions/src/googleShopping.ts`).
- When saving tokens from OAuth, keep an existing canonical refresh token if Google did not return one by using the existing `integrations.googleMerchant.refreshToken` (do not overwrite with `null`/`undefined`) (`functions/src/googleShopping.ts`).
- On access-token refresh, update only runtime token fields (`accessToken`, `expiresAt`, `updatedAt`) in the canonical `integrations.googleMerchant` document and preserve the canonical `refreshToken` (`functions/src/googleShopping.ts`).
- Update the status endpoint to compute readiness from backend canonical fields: determine `oauthConnected` from `integrations.googleOAuth`, `hasContentScope` from granted scopes, `hasSelectedMerchant` from `integrations.googleMerchant.selectedMerchantId`, and `hasRefreshToken` from `integrations.googleMerchant.refreshToken` (`web/api/google/status.ts`).
- Add token-refresh and live API checks in status flow: refresh merchant access tokens when missing/expiring and verify Merchant API connectivity by calling `accounts/authinfo` and a `products.list` probe (`web/api/google/status.ts`).

### Testing
- Ran `npm --prefix functions run build`, which completed successfully.
- Attempted `npm --prefix web run test -- GoogleShopping`, which failed in this environment because the `vitest` executable is not available (test runner missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da829238588322a7fa59451b0e8ead)