### PR TITLE
Google Business: short-term caching, debounce Load locations, and backend account-scoped location fetch

### DIFF
--- a/functions/src/googleBusinessProfile.ts
+++ b/functions/src/googleBusinessProfile.ts
@@ -525,15 +525,18 @@ async function listGoogleBusinessAccountsAndLocations(params: {
       if (!accountId) return null
       if (params.accountId && params.accountId !== accountId) return null
 
-      const locationsPayload = await googleApiRequest<{ locations?: Array<Record<string, unknown>> }>({
-        url: `${GOOGLE_BUSINESS_INFO_API_BASE}/accounts/${accountId}/locations?readMask=name,title`,
-        accessToken: params.accessToken,
-      })
+      let locations: GoogleBusinessLocation[] = []
+      if (params.accountId) {
+        const locationsPayload = await googleApiRequest<{ locations?: Array<Record<string, unknown>> }>({
+          url: `${GOOGLE_BUSINESS_INFO_API_BASE}/accounts/${accountId}/locations?readMask=name,title`,
+          accessToken: params.accessToken,
+        })
 
-      const locations = (Array.isArray(locationsPayload.locations) ? locationsPayload.locations : []).map((loc) => ({
-        name: normalizeString(loc.name),
-        title: normalizeString(loc.title),
-      }))
+        locations = (Array.isArray(locationsPayload.locations) ? locationsPayload.locations : []).map((loc) => ({
+          name: normalizeString(loc.name),
+          title: normalizeString(loc.title),
+        }))
+      }
 
       return {
         accountId,

--- a/web/src/api/googleBusinessProfile.ts
+++ b/web/src/api/googleBusinessProfile.ts
@@ -7,6 +7,11 @@ export type GoogleBusinessLocationOption = {
   locationName: string
 }
 
+export type GoogleBusinessAccountOption = {
+  accountId: string
+  accountName: string
+}
+
 export type GoogleBusinessUploadResult = {
   media?: {
     name?: string
@@ -120,21 +125,35 @@ export function parseGoogleBusinessApiError(error: unknown) {
   }
 }
 
-export async function listGoogleBusinessLocations(params: { storeId: string }): Promise<GoogleBusinessLocationOption[]> {
-  const headers = await getAuthHeader()
-  const response = await fetch('/api/google-business/locations', {
-    method: 'POST',
-    headers: {
-      ...headers,
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({ storeId: params.storeId }),
-  })
+const CACHE_TTL_MS = 60_000
 
-  const payload = await parseApiResponse<{
-    accounts?: Array<{ accountId?: string; accountName?: string; locations?: Array<{ name?: string; title?: string }> }>
-  }>(response)
+const accountsCache = new Map<string, { expiresAt: number; data: GoogleBusinessAccountOption[] }>()
+const locationsCache = new Map<string, { expiresAt: number; data: GoogleBusinessLocationOption[] }>()
 
+function getFreshCacheValue<T>(entry: { expiresAt: number; data: T } | undefined): T | null {
+  if (!entry) return null
+  if (Date.now() > entry.expiresAt) return null
+  return entry.data
+}
+
+function normalizeAccounts(payload: {
+  accounts?: Array<{ accountId?: string; accountName?: string; locations?: Array<{ name?: string; title?: string }> }>
+}): GoogleBusinessAccountOption[] {
+  return (payload.accounts ?? [])
+    .map((account) => {
+      const accountId = typeof account.accountId === 'string' ? account.accountId : ''
+      if (!accountId) return null
+      return {
+        accountId,
+        accountName: typeof account.accountName === 'string' ? account.accountName : accountId,
+      }
+    })
+    .filter((option): option is GoogleBusinessAccountOption => Boolean(option))
+}
+
+function normalizeLocations(payload: {
+  accounts?: Array<{ accountId?: string; accountName?: string; locations?: Array<{ name?: string; title?: string }> }>
+}): GoogleBusinessLocationOption[] {
   const options: GoogleBusinessLocationOption[] = []
 
   for (const account of payload.accounts ?? []) {
@@ -153,6 +172,63 @@ export async function listGoogleBusinessLocations(params: { storeId: string }): 
     }
   }
 
+  return options
+}
+
+export function clearGoogleBusinessCache() {
+  accountsCache.clear()
+  locationsCache.clear()
+}
+
+export async function listGoogleBusinessAccounts(params: { storeId: string; forceRefresh?: boolean }): Promise<GoogleBusinessAccountOption[]> {
+  const cacheKey = params.storeId
+  if (!params.forceRefresh) {
+    const cached = getFreshCacheValue(accountsCache.get(cacheKey))
+    if (cached) return cached
+  }
+
+  const headers = await getAuthHeader()
+  const response = await fetch('/api/google-business/locations', {
+    method: 'POST',
+    headers: {
+      ...headers,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ storeId: params.storeId }),
+  })
+
+  const payload = await parseApiResponse<{
+    accounts?: Array<{ accountId?: string; accountName?: string; locations?: Array<{ name?: string; title?: string }> }>
+  }>(response)
+
+  const accounts = normalizeAccounts(payload)
+  accountsCache.set(cacheKey, { data: accounts, expiresAt: Date.now() + CACHE_TTL_MS })
+  return accounts
+}
+
+export async function listGoogleBusinessLocations(params: { storeId: string; accountId: string; forceRefresh?: boolean }): Promise<GoogleBusinessLocationOption[]> {
+  const cacheKey = `${params.storeId}:${params.accountId}`
+  if (!params.forceRefresh) {
+    const cached = getFreshCacheValue(locationsCache.get(cacheKey))
+    if (cached) return cached
+  }
+
+  const headers = await getAuthHeader()
+  const response = await fetch('/api/google-business/locations', {
+    method: 'POST',
+    headers: {
+      ...headers,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ storeId: params.storeId, accountId: params.accountId }),
+  })
+
+  const payload = await parseApiResponse<{
+    accounts?: Array<{ accountId?: string; accountName?: string; locations?: Array<{ name?: string; title?: string }> }>
+  }>(response)
+
+  const options = normalizeLocations(payload)
+  locationsCache.set(cacheKey, { data: options, expiresAt: Date.now() + CACHE_TTL_MS })
   return options
 }
 

--- a/web/src/components/GoogleBusinessMediaUploader.tsx
+++ b/web/src/components/GoogleBusinessMediaUploader.tsx
@@ -1,9 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
+  listGoogleBusinessAccounts,
   listGoogleBusinessLocations,
   parseGoogleBusinessApiError,
   uploadGoogleBusinessLocationMedia,
+  type GoogleBusinessAccountOption,
   type GoogleBusinessLocationOption,
 } from '../api/googleBusinessProfile'
 
@@ -67,6 +69,8 @@ function getLocationMessage(state: LocationState, fallbackMessage: string): stri
 
 export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle, isReconnectingGoogle = false }: Props) {
   const [locations, setLocations] = useState<GoogleBusinessLocationOption[]>([])
+  const [accounts, setAccounts] = useState<GoogleBusinessAccountOption[]>([])
+  const [selectedAccountId, setSelectedAccountId] = useState('')
   const [selectedLocationKey, setSelectedLocationKey] = useState('')
   const [category, setCategory] = useState<(typeof CATEGORIES)[number]>('ADDITIONAL')
   const [file, setFile] = useState<File | null>(null)
@@ -76,21 +80,27 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
   const [locationState, setLocationState] = useState<LocationState>('idle')
   const [locationMessage, setLocationMessage] = useState('')
   const [uploadedResult, setUploadedResult] = useState<{ thumbnailUrl: string; googleUrl: string; uploadedAt: string } | null>(null)
+  const debounceTimerRef = useRef<number | null>(null)
 
-  const loadLocations = useCallback(async (): Promise<void> => {
+  const loadAccounts = useCallback(async (): Promise<void> => {
     setLocationState('loading')
     setLocationMessage('')
     try {
-      const options = await listGoogleBusinessLocations({ storeId })
-      setLocations(options)
-      setSelectedLocationKey(options[0] ? `${options[0].accountId}:${options[0].locationId}` : '')
+      const options = await listGoogleBusinessAccounts({ storeId })
+      setAccounts(options)
+      setSelectedAccountId((current) => {
+        if (current && options.some((option) => option.accountId === current)) return current
+        return options[0]?.accountId || ''
+      })
+      setLocations([])
+      setSelectedLocationKey('')
 
       if (!options.length) {
         setLocationState('empty')
         return
       }
 
-      setLocationState('ready')
+      setLocationState('idle')
     } catch (error) {
       const parsed = parseGoogleBusinessApiError(error)
       if (parsed.kind === 'not_connected') {
@@ -110,10 +120,41 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
     }
   }, [storeId])
 
+  const loadLocations = useCallback(async (params?: { forceRefresh?: boolean }): Promise<void> => {
+    if (!selectedAccountId) return
+    setLocationState('loading')
+    setLocationMessage('')
+    try {
+      const options = await listGoogleBusinessLocations({ storeId, accountId: selectedAccountId, forceRefresh: params?.forceRefresh })
+      setLocations(options)
+      setSelectedLocationKey((current) => {
+        if (current && options.some((option) => `${option.accountId}:${option.locationId}` === current)) return current
+        return options[0] ? `${options[0].accountId}:${options[0].locationId}` : ''
+      })
+      setLocationState(options.length ? 'ready' : 'empty')
+    } catch (error) {
+      const parsed = parseGoogleBusinessApiError(error)
+      if (parsed.kind === 'not_connected') {
+        setLocationState('not_connected')
+        setLocationMessage(getLocationMessage('not_connected', parsed.message))
+        return
+      }
+
+      if (parsed.kind === 'missing_scope') {
+        setLocationState('missing_scope')
+        setLocationMessage(getLocationMessage('missing_scope', parsed.message))
+        return
+      }
+
+      setLocationState('error')
+      setLocationMessage(parsed.message || getLocationMessage('error', ''))
+    }
+  }, [selectedAccountId, storeId])
+
   useEffect(() => {
     if (!storeId) return
-    void loadLocations()
-  }, [loadLocations, storeId])
+    void loadAccounts()
+  }, [loadAccounts, storeId])
 
   useEffect(() => {
     if (!file) {
@@ -131,7 +172,23 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
     return locations.find((option) => option.accountId === accountId && option.locationId === locationId) || null
   }, [locations, selectedLocationKey])
 
-  const uploadBlocked = locationState !== 'ready'
+  const uploadBlocked = locationState !== 'ready' || !selectedAccountId
+
+  const debouncedLoadLocations = useCallback(
+    (forceRefresh = false) => {
+      if (debounceTimerRef.current) window.clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = window.setTimeout(() => {
+        void loadLocations({ forceRefresh })
+      }, 300)
+    },
+    [loadLocations],
+  )
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) window.clearTimeout(debounceTimerRef.current)
+    }
+  }, [])
 
   async function handleUpload() {
     if (!selectedLocation) {
@@ -206,8 +263,40 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
       </div>
 
       <label>
+        <span>Google account</span>
+        <small className="google-shopping-panel__hint">Pick which Google Business account to load locations from.</small>
+        <select
+          value={selectedAccountId}
+          onChange={(event) => {
+            setSelectedAccountId(event.target.value)
+            setLocations([])
+            setSelectedLocationKey('')
+            setLocationState('idle')
+          }}
+          disabled={locationState === 'loading' || uploadState === 'loading'}
+        >
+          {!accounts.length && <option value="">No Google accounts available</option>}
+          {accounts.map((option) => (
+            <option key={option.accountId} value={option.accountId}>
+              {option.accountName}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="google-shopping-panel__actions">
+        <button
+          type="button"
+          onClick={() => debouncedLoadLocations(false)}
+          disabled={!selectedAccountId || locationState === 'loading' || uploadState === 'loading'}
+        >
+          Load locations
+        </button>
+      </div>
+
+      <label>
         <span>Business location</span>
-        <small className="google-shopping-panel__hint">Select the Google business location you want to update.</small>
+        <small className="google-shopping-panel__hint">Select the Google business location you want to update after loading.</small>
         <select
           value={selectedLocationKey}
           onChange={(event) => setSelectedLocationKey(event.target.value)}
@@ -276,7 +365,11 @@ export default function GoogleBusinessMediaUploader({ storeId, onReconnectGoogle
             </ul>
           ) : null}
           <div className="google-shopping-panel__actions">
-            <button type="button" onClick={() => void loadLocations()} disabled={isReconnectingGoogle || uploadState === 'loading'}>
+            <button
+              type="button"
+              onClick={() => debouncedLoadLocations(true)}
+              disabled={!selectedAccountId || isReconnectingGoogle || uploadState === 'loading'}
+            >
               Refresh locations
             </button>
           {onReconnectGoogle ? (

--- a/web/src/pages/GoogleBusinessProfile.test.tsx
+++ b/web/src/pages/GoogleBusinessProfile.test.tsx
@@ -7,6 +7,7 @@ import GoogleBusinessProfile from './GoogleBusinessProfile'
 
 const mockUseActiveStore = vi.fn()
 const mockUseGoogleIntegrationStatus = vi.fn()
+const mockListGoogleBusinessAccounts = vi.fn()
 const mockListGoogleBusinessLocations = vi.fn()
 const mockUploadGoogleBusinessLocationMedia = vi.fn()
 
@@ -19,6 +20,7 @@ vi.mock('../hooks/useGoogleIntegrationStatus', () => ({
 }))
 
 vi.mock('../api/googleBusinessProfile', () => ({
+  listGoogleBusinessAccounts: (...args: unknown[]) => mockListGoogleBusinessAccounts(...args),
   listGoogleBusinessLocations: (...args: unknown[]) => mockListGoogleBusinessLocations(...args),
   uploadGoogleBusinessLocationMedia: (...args: unknown[]) => mockUploadGoogleBusinessLocationMedia(...args),
   parseGoogleBusinessApiError: (error: unknown) => ({
@@ -33,10 +35,17 @@ describe('GoogleBusinessProfile', () => {
   beforeEach(() => {
     mockUseActiveStore.mockReset()
     mockUseGoogleIntegrationStatus.mockReset()
+    mockListGoogleBusinessAccounts.mockReset()
     mockListGoogleBusinessLocations.mockReset()
     mockUploadGoogleBusinessLocationMedia.mockReset()
 
     mockUseActiveStore.mockReturnValue({ storeId: 'store-1' })
+    mockListGoogleBusinessAccounts.mockResolvedValue([
+      {
+        accountId: 'acc-1',
+        accountName: 'Main Account',
+      },
+    ])
     mockListGoogleBusinessLocations.mockResolvedValue([
       {
         accountId: 'acc-1',
@@ -100,6 +109,7 @@ describe('GoogleBusinessProfile', () => {
       </MemoryRouter>,
     )
 
+    await user.click(await screen.findByRole('button', { name: /load locations/i }))
     const fileInput = await screen.findByLabelText(/choose photo/i)
     const file = new File(['image'], 'store.jpg', { type: 'image/jpeg' })
     await user.upload(fileInput, file)


### PR DESCRIPTION
### Motivation
- Reduce redundant requests and UI churn when loading Google Business accounts/locations by adding client-side short-term caching and requiring an explicit, debounced load of locations for a selected account.
- Prevent the backend from eagerly fetching locations for every account to avoid fan-out and unnecessary API calls.

### Description
- Add short-lived (60s) in-memory caches for Google Business accounts and locations and expose `listGoogleBusinessAccounts` and `listGoogleBusinessLocations` helpers with `forceRefresh` support in `web/src/api/googleBusinessProfile.ts`.
- Refactor the uploader UI in `web/src/components/GoogleBusinessMediaUploader.tsx` to load accounts first, require an explicit account selection, provide a debounced `Load locations` button (300ms), and avoid auto-refetching locations on render or tab changes.
- Update the backend listing logic in `functions/src/googleBusinessProfile.ts` so locations are only fetched for a specific `accountId` when provided, preventing location fan-out across all accounts.
- Update tests in `web/src/pages/GoogleBusinessProfile.test.tsx` to mock account loading and the explicit `Load locations` interaction before asserting upload behavior.

### Testing
- Updated `web/src/pages/GoogleBusinessProfile.test.tsx` to reflect the new flow and interactions; the test asserts the upload call uses the selected account/location.
- Attempted to run the focused test with `cd web && npm test -- GoogleBusinessProfile.test.tsx`, but the run failed in this environment because `vitest` is not available on PATH / dependencies are not installed (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7f788a48832291d7ec5b31d10c8f)