### PR TITLE
Restart merchant OAuth when no pending accounts and update account selection UI

### DIFF
--- a/web/src/pages/GoogleShopping.test.tsx
+++ b/web/src/pages/GoogleShopping.test.tsx
@@ -113,6 +113,42 @@ describe('GoogleShopping', () => {
     expect(startOAuth).toHaveBeenCalledTimes(1)
   })
 
+  it('restarts merchant OAuth when no pending account list is available', async () => {
+    const startOAuth = vi.fn()
+    mockUseGoogleIntegrationStatus.mockReturnValue({
+      isLoading: false,
+      isStartingOAuth: false,
+      hasGoogleConnection: true,
+      hasRequiredScope: true,
+      stateTitle: '2) Choose merchant account',
+      merchant: {
+        ...baseMerchant,
+        state: 'merchant_account_not_selected',
+        googleConnected: true,
+        hasMerchantScope: true,
+      },
+      error: null,
+      startOAuth,
+    })
+
+    mockOnSnapshot.mockImplementation((_docRef, callback) => {
+      callback({ data: () => ({ googleShopping: { connection: { connected: false } } }) })
+      return vi.fn()
+    })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <GoogleShopping />
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('button', { name: /choose merchant account/i }))
+
+    expect(startOAuth).toHaveBeenCalledTimes(1)
+  })
+
+
   it('runs a full catalog sync from the sync step', async () => {
     mockUseGoogleIntegrationStatus.mockReturnValue({
       isLoading: false,

--- a/web/src/pages/GoogleShopping.tsx
+++ b/web/src/pages/GoogleShopping.tsx
@@ -50,7 +50,6 @@ const STEP_LABELS: Record<WizardStep, string> = {
 
 export default function GoogleShopping() {
   const { storeId } = useActiveStore()
-  console.log("STORE ID:", storeId)
   const [step, setStep] = useState<WizardStep>('connect')
   const [integrationApiKey, setIntegrationApiKey] = useState('')
   const [integrationBaseUrl, setIntegrationBaseUrl] = useState(
@@ -301,17 +300,14 @@ export default function GoogleShopping() {
       }
     }
     if (merchant.state === 'merchant_account_not_selected') {
+      const hasPendingSelection = Boolean(pendingSelectionId) || pendingAccounts.length > 0
       return {
         title: 'Choose your Merchant Center account',
-        helper: 'Step 2: choose the Merchant Center account that Sedifex should sync to.',
-        // Always present a consistent call‑to‑action label. Even when there is only
-        // one pending account, the user should be able to explicitly confirm
-        // selection in the account step rather than being sent through OAuth again.
+        helper: hasPendingSelection
+          ? 'Step 2: choose the Merchant Center account that Sedifex should sync to.'
+          : 'We need to reload your Merchant accounts before you can choose one.',
         cta: 'Choose Merchant account',
-        // Instead of re‑initiating the OAuth flow when there is a single pending
-        // account, always take the user to the account selection step. The UI
-        // will display the available account(s) and allow confirmation.
-        onClick: () => setStep('account'),
+        onClick: hasPendingSelection ? () => setStep('account') : connectGoogleMerchant,
       }
     }
     if (merchant.state === 'refresh_token_missing') {
@@ -338,7 +334,7 @@ export default function GoogleShopping() {
       cta: 'Sync products',
       onClick: () => setStep('sync'),
     }
-  }, [merchant.state, pendingAccounts.length])
+  }, [merchant.state, pendingSelectionId, pendingAccounts.length, connectGoogleMerchant])
 
   const currentSummary = summary
   const hasPersistedStatus = Boolean(persistedStatus?.lastRunAt)


### PR DESCRIPTION
### Motivation
- Ensure the merchant-account selection step handles cases where there are no pending accounts by re-starting the OAuth/account discovery flow instead of moving to an empty selection UI.
- Remove a stray debug `console.log` and make the action configuration react to the presence of a pending selection id.

### Description
- Change the `merchant_account_not_selected` branch in `GoogleShopping` to detect `pendingSelectionId` or `pendingAccounts.length` and show different helper text when no pending accounts are available.
- When no pending selection is present, make the account CTA restart the OAuth flow by calling `connectGoogleMerchant` instead of navigating to the account step; otherwise keep the existing `setStep('account')` behavior.
- Add `pendingSelectionId` and `connectGoogleMerchant` to the `useMemo` dependency array and remove the debug `console.log("STORE ID:", storeId)`.
- Add a unit test `restarts merchant OAuth when no pending account list is available` to `GoogleShopping.test.tsx` verifying that `startOAuth` is called when the pending account list is empty.

### Testing
- Ran the updated unit tests in `GoogleShopping.test.tsx` which include the new `restarts merchant OAuth when no pending account list is available` test, and the test passed.
- Ran the component test suite via `yarn test` and the relevant Google Shopping tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da81e417748322aeab0d680f5d0f3c)