### PR TITLE
Add Google Merchant Feed endpoint and admin UI

### DIFF
--- a/docs/integration-quickstart.md
+++ b/docs/integration-quickstart.md
@@ -5,7 +5,7 @@ Use this guide to auto-load products from Sedifex into either:
 - a **WordPress** site, or
 - a **Next.js site hosted on Vercel**.
 
-This quickstart follows the current Sedifex downstream contract based on the `integrationProducts` HTTP endpoint and related integration endpoints (`integrationPromo`, `integrationGallery`, `integrationCustomers`, `integrationTopSelling`, and `integrationTikTokVideos`), plus the product shape documented in the root README.
+This quickstart follows the current Sedifex downstream contract based on the `integrationProducts` HTTP endpoint and related integration endpoints (`integrationPromo`, `integrationGallery`, `integrationCustomers`, `integrationTopSelling`, `integrationTikTokVideos`, and `integrationGoogleMerchantFeed`), plus the product shape documented in the root README.
 
 ## What you get
 

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -36,7 +36,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkMessage = exports.emitProductWebhooks = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.integrationPromo = exports.integrationProducts = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.manageStaffAccount = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSyncScheduled = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
+exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkMessage = exports.emitProductWebhooks = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.integrationPromo = exports.integrationProducts = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.manageStaffAccount = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSyncScheduled = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
 // functions/src/index.ts
 const functions = __importStar(require("firebase-functions/v1"));
 const crypto = __importStar(require("crypto"));
@@ -2044,6 +2044,25 @@ function toTrimmedStringArray(value) {
     }
     return [...unique];
 }
+function escapeXml(value) {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}
+function toGoogleMerchantAvailability(stockCount) {
+    return typeof stockCount === 'number' && Number.isFinite(stockCount) && stockCount > 0 ? 'in stock' : 'out of stock';
+}
+function toGoogleMerchantCondition(value) {
+    if (typeof value !== 'string')
+        return 'new';
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'used' || normalized === 'refurbished')
+        return normalized;
+    return 'new';
+}
 function extractProductImageSet(data) {
     const primaryImageUrl = toTrimmedStringOrNull(data.imageUrl);
     const imageUrls = toTrimmedStringArray(data.imageUrls);
@@ -2491,6 +2510,85 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
     })
         .filter(item => item !== null);
     res.status(200).json({ storeId, products });
+});
+exports.integrationGoogleMerchantFeed = functions.https.onRequest(async (req, res) => {
+    setIntegrationResponseHeaders(res);
+    if (req.method === 'OPTIONS') {
+        res.status(204).send('');
+        return;
+    }
+    const storeContext = await resolvePromoStoreForRead(req, res);
+    if (!storeContext) {
+        return;
+    }
+    const { storeId, data: storeData } = storeContext;
+    let productsSnapshot;
+    try {
+        productsSnapshot = await firestore_1.defaultDb
+            .collection('products')
+            .where('storeId', '==', storeId)
+            .orderBy('updatedAt', 'desc')
+            .limit(200)
+            .get();
+    }
+    catch (error) {
+        const code = error?.code;
+        const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition';
+        if (!isMissingIndex) {
+            throw error;
+        }
+        productsSnapshot = await firestore_1.defaultDb.collection('products').where('storeId', '==', storeId).limit(200).get();
+    }
+    const storeName = toTrimmedStringOrNull(storeData.displayName) ?? toTrimmedStringOrNull(storeData.name) ?? 'Sedifex Store';
+    const promoSlug = toTrimmedStringOrNull(storeData.promoSlug);
+    const storeUrl = toTrimmedStringOrNull(storeData.promoWebsiteUrl) ??
+        (promoSlug ? `https://www.sedifex.com/${encodeURIComponent(promoSlug)}` : 'https://www.sedifex.com');
+    const itemsXml = productsSnapshot.docs
+        .map(docSnap => {
+        const productData = docSnap.data();
+        const name = toTrimmedStringOrNull(productData.name);
+        if (!name)
+            return null;
+        const { imageUrl } = extractProductImageSet(productData);
+        const description = toTrimmedStringOrNull(productData.description) ?? name;
+        const category = toTrimmedStringOrNull(productData.category);
+        const productLink = `${storeUrl.replace(/\/$/, '')}?product=${encodeURIComponent(docSnap.id)}`;
+        const priceValue = typeof productData.price === 'number' && Number.isFinite(productData.price) && productData.price >= 0
+            ? productData.price
+            : 0;
+        const content = [
+            '<item>',
+            `<g:id>${escapeXml(docSnap.id)}</g:id>`,
+            `<title>${escapeXml(name)}</title>`,
+            `<description>${escapeXml(description)}</description>`,
+            `<link>${escapeXml(productLink)}</link>`,
+            `<g:price>${escapeXml(priceValue.toFixed(2))} GHS</g:price>`,
+            `<g:availability>${escapeXml(toGoogleMerchantAvailability(productData.stockCount))}</g:availability>`,
+            `<g:condition>${escapeXml(toGoogleMerchantCondition(productData.condition))}</g:condition>`,
+            `<g:brand>${escapeXml(storeName)}</g:brand>`,
+        ];
+        if (imageUrl) {
+            content.push(`<g:image_link>${escapeXml(imageUrl)}</g:image_link>`);
+        }
+        if (category) {
+            content.push(`<g:product_type>${escapeXml(category)}</g:product_type>`);
+        }
+        content.push('</item>');
+        return content.join('');
+    })
+        .filter((item) => Boolean(item))
+        .join('');
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:g="http://base.google.com/ns/1.0">
+  <channel>
+    <title>${escapeXml(storeName)}</title>
+    <link>${escapeXml(storeUrl)}</link>
+    <description>${escapeXml(`${storeName} product feed for Google Merchant Center`)}</description>
+    ${itemsXml}
+  </channel>
+</rss>`;
+    res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+    res.status(200).send(xml);
 });
 exports.integrationCustomers = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2637,6 +2637,26 @@ function toTrimmedStringArray(value: unknown): string[] {
   return [...unique]
 }
 
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function toGoogleMerchantAvailability(stockCount: unknown): 'in stock' | 'out of stock' {
+  return typeof stockCount === 'number' && Number.isFinite(stockCount) && stockCount > 0 ? 'in stock' : 'out of stock'
+}
+
+function toGoogleMerchantCondition(value: unknown): 'new' | 'used' | 'refurbished' {
+  if (typeof value !== 'string') return 'new'
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'used' || normalized === 'refurbished') return normalized
+  return 'new'
+}
+
 function extractProductImageSet(data: Record<string, unknown>): { imageUrl: string | null; imageUrls: string[]; imageAlt: string | null } {
   const primaryImageUrl = toTrimmedStringOrNull(data.imageUrl)
   const imageUrls = toTrimmedStringArray(data.imageUrls)
@@ -3143,6 +3163,97 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
     .filter(item => item !== null)
 
   res.status(200).json({ storeId, products })
+})
+
+export const integrationGoogleMerchantFeed = functions.https.onRequest(async (req, res) => {
+  setIntegrationResponseHeaders(res)
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('')
+    return
+  }
+  const storeContext = await resolvePromoStoreForRead(req, res)
+  if (!storeContext) {
+    return
+  }
+  const { storeId, data: storeData } = storeContext
+
+  let productsSnapshot: admin.firestore.QuerySnapshot
+  try {
+    productsSnapshot = await db
+      .collection('products')
+      .where('storeId', '==', storeId)
+      .orderBy('updatedAt', 'desc')
+      .limit(200)
+      .get()
+  } catch (error) {
+    const code = (error as { code?: number | string } | null)?.code
+    const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition'
+    if (!isMissingIndex) {
+      throw error
+    }
+
+    productsSnapshot = await db.collection('products').where('storeId', '==', storeId).limit(200).get()
+  }
+
+  const storeName =
+    toTrimmedStringOrNull(storeData.displayName) ?? toTrimmedStringOrNull(storeData.name) ?? 'Sedifex Store'
+  const promoSlug = toTrimmedStringOrNull(storeData.promoSlug)
+  const storeUrl =
+    toTrimmedStringOrNull(storeData.promoWebsiteUrl) ??
+    (promoSlug ? `https://www.sedifex.com/${encodeURIComponent(promoSlug)}` : 'https://www.sedifex.com')
+
+  const itemsXml = productsSnapshot.docs
+    .map(docSnap => {
+      const productData = docSnap.data() as Record<string, unknown>
+      const name = toTrimmedStringOrNull(productData.name)
+      if (!name) return null
+
+      const { imageUrl } = extractProductImageSet(productData)
+      const description = toTrimmedStringOrNull(productData.description) ?? name
+      const category = toTrimmedStringOrNull(productData.category)
+      const productLink = `${storeUrl.replace(/\/$/, '')}?product=${encodeURIComponent(docSnap.id)}`
+
+      const priceValue =
+        typeof productData.price === 'number' && Number.isFinite(productData.price) && productData.price >= 0
+          ? productData.price
+          : 0
+
+      const content: string[] = [
+        '<item>',
+        `<g:id>${escapeXml(docSnap.id)}</g:id>`,
+        `<title>${escapeXml(name)}</title>`,
+        `<description>${escapeXml(description)}</description>`,
+        `<link>${escapeXml(productLink)}</link>`,
+        `<g:price>${escapeXml(priceValue.toFixed(2))} GHS</g:price>`,
+        `<g:availability>${escapeXml(toGoogleMerchantAvailability(productData.stockCount))}</g:availability>`,
+        `<g:condition>${escapeXml(toGoogleMerchantCondition(productData.condition))}</g:condition>`,
+        `<g:brand>${escapeXml(storeName)}</g:brand>`,
+      ]
+
+      if (imageUrl) {
+        content.push(`<g:image_link>${escapeXml(imageUrl)}</g:image_link>`)
+      }
+      if (category) {
+        content.push(`<g:product_type>${escapeXml(category)}</g:product_type>`)
+      }
+      content.push('</item>')
+      return content.join('')
+    })
+    .filter((item): item is string => Boolean(item))
+    .join('')
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:g="http://base.google.com/ns/1.0">
+  <channel>
+    <title>${escapeXml(storeName)}</title>
+    <link>${escapeXml(storeUrl)}</link>
+    <description>${escapeXml(`${storeName} product feed for Google Merchant Center`)}</description>
+    ${itemsXml}
+  </channel>
+</rss>`
+
+  res.setHeader('Content-Type', 'application/xml; charset=utf-8')
+  res.status(200).send(xml)
 })
 
 export const integrationCustomers = functions.https.onRequest(async (req, res) => {

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -19,4 +19,5 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/finance', label: 'Invoice', parentTo: '/sell', roles: ['owner'] },
   { to: '/account', label: 'Account', roles: ['owner'] },
   { to: '/public-page', label: 'Public page', roles: ['owner'] },
+  { to: '/merchant-feed', label: 'Merchant feed', roles: ['owner'] },
 ]

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -28,6 +28,7 @@ import PricingPage from './pages/PricingPage'
 import DataTransfer from './pages/DataTransfer'
 import PromoLandingPage from './pages/PromoLandingPage'
 import PublicPageSettings from './pages/PublicPageSettings'
+import GoogleMerchantFeedPage from './pages/GoogleMerchantFeedPage'
 
 // ✅ NEW: public receipt page used by QR/share
 import ReceiptView from './pages/ReceiptView'
@@ -86,6 +87,7 @@ const router = createBrowserRouter([
           { path: 'account', element: <AccountOverview /> },
           { path: 'account/overview', element: <AccountOverview /> },
           { path: 'public-page', element: <PublicPageSettings /> },
+          { path: 'merchant-feed', element: <GoogleMerchantFeedPage /> },
           { path: 'support', element: <Support /> },
         ],
       },

--- a/web/src/pages/GoogleMerchantFeedPage.tsx
+++ b/web/src/pages/GoogleMerchantFeedPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from 'react'
+import { doc, getDoc } from 'firebase/firestore'
+import PageSection from '../layout/PageSection'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import { useToast } from '../components/ToastProvider'
+
+const PUBLIC_SEDIFEX_API_BASE_URL = 'https://us-central1-sedifex-web.cloudfunctions.net'
+
+type StoreFeedState = {
+  name: string
+  promoSlug: string
+  promoWebsiteUrl: string
+}
+
+function buildPublicStoreUrl(state: StoreFeedState): string | null {
+  if (state.promoWebsiteUrl) return state.promoWebsiteUrl
+  if (!state.promoSlug) return null
+  return `https://www.sedifex.com/${encodeURIComponent(state.promoSlug)}`
+}
+
+function buildMerchantFeedUrl(state: StoreFeedState): string | null {
+  if (!state.promoSlug) return null
+  return `${PUBLIC_SEDIFEX_API_BASE_URL}/integrationGoogleMerchantFeed?slug=${encodeURIComponent(state.promoSlug)}`
+}
+
+async function copyText(value: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value)
+    return
+  }
+  throw new Error('Clipboard is unavailable in this browser.')
+}
+
+export default function GoogleMerchantFeedPage() {
+  const { storeId } = useActiveStore()
+  const { publish } = useToast()
+  const [loading, setLoading] = useState(true)
+  const [state, setState] = useState<StoreFeedState>({
+    name: 'Your store',
+    promoSlug: '',
+    promoWebsiteUrl: '',
+  })
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadStore() {
+      if (!storeId) {
+        setLoading(false)
+        return
+      }
+      setLoading(true)
+      try {
+        const storeRef = doc(db, 'stores', storeId)
+        const snapshot = await getDoc(storeRef)
+        const data = (snapshot.data() ?? {}) as Record<string, unknown>
+        if (cancelled) return
+        setState({
+          name:
+            (typeof data.displayName === 'string' && data.displayName.trim()) ||
+            (typeof data.name === 'string' && data.name.trim()) ||
+            'Your store',
+          promoSlug: typeof data.promoSlug === 'string' ? data.promoSlug.trim() : '',
+          promoWebsiteUrl: typeof data.promoWebsiteUrl === 'string' ? data.promoWebsiteUrl.trim() : '',
+        })
+      } catch (error) {
+        console.error('[merchant-feed] Failed to load store profile', error)
+        if (!cancelled) {
+          publish({ tone: 'error', message: 'Unable to load store details for Merchant feed.' })
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    loadStore()
+    return () => {
+      cancelled = true
+    }
+  }, [publish, storeId])
+
+  const publicStoreUrl = useMemo(() => buildPublicStoreUrl(state), [state])
+  const merchantFeedUrl = useMemo(() => buildMerchantFeedUrl(state), [state])
+
+  return (
+    <PageSection
+      title="Google Merchant feed"
+      subtitle="Share one XML URL with Google Merchant Center. Google will keep fetching updated products from that single feed link."
+    >
+      <div style={{ display: 'grid', gap: 14 }}>
+        <p style={{ margin: 0 }}>
+          <strong>Store:</strong> {state.name}
+        </p>
+        <p style={{ margin: 0 }}>
+          <strong>Promo slug:</strong> {state.promoSlug || 'Not set yet'}
+        </p>
+        <p style={{ margin: 0 }}>
+          <strong>Public store URL:</strong>{' '}
+          {publicStoreUrl ? <code>{publicStoreUrl}</code> : 'Set your Public page slug first.'}
+        </p>
+        <p style={{ margin: 0 }}>
+          <strong>Merchant feed URL:</strong>{' '}
+          {merchantFeedUrl ? <code>{merchantFeedUrl}</code> : 'Set your promo slug first.'}
+        </p>
+
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+          <button
+            type="button"
+            className="button button--secondary"
+            onClick={() => {
+              if (!merchantFeedUrl) {
+                publish({ tone: 'error', message: 'Set your promo slug before copying the feed URL.' })
+                return
+              }
+              copyText(merchantFeedUrl)
+                .then(() => publish({ tone: 'success', message: 'Merchant feed URL copied.' }))
+                .catch(() => publish({ tone: 'error', message: 'Unable to copy Merchant feed URL.' }))
+            }}
+            disabled={loading}
+          >
+            Copy merchant feed URL
+          </button>
+          {merchantFeedUrl ? (
+            <a className="button button--ghost" href={merchantFeedUrl} target="_blank" rel="noreferrer">
+              Preview XML
+            </a>
+          ) : null}
+        </div>
+
+        <ol style={{ margin: '8px 0 0', paddingLeft: 20 }}>
+          <li>Open Google Merchant Center and add a data source.</li>
+          <li>Choose scheduled fetch and paste the Merchant feed URL above.</li>
+          <li>Set the fetch frequency (for example: daily).</li>
+          <li>Use diagnostics in Merchant Center to fix any field warnings.</li>
+        </ol>
+      </div>
+    </PageSection>
+  )
+}

--- a/web/src/pages/docs/IntegrationQuickstartPage.tsx
+++ b/web/src/pages/docs/IntegrationQuickstartPage.tsx
@@ -12,7 +12,7 @@ export default function IntegrationQuickstartPage() {
         <ul>
           <li>Product fields: <code>id</code>, <code>storeId</code>, <code>name</code>, <code>category</code>, <code>description</code>, <code>price</code>, <code>stockCount</code>, and media metadata.</li>
           <li>Integration flow with API key auth via <code>GET /integrationProducts?storeId=&lt;storeId&gt;</code>.</li>
-          <li>Companion endpoints for promotions, promo galleries, customers, and top sellers: <code>GET /integrationPromo?storeId=&lt;storeId&gt;</code>, <code>GET /integrationGallery?storeId=&lt;storeId&gt;</code>, <code>GET /integrationCustomers?storeId=&lt;storeId&gt;</code>, and <code>GET /integrationTopSelling?storeId=&lt;storeId&gt;&amp;days=30&amp;limit=10</code>.</li>
+          <li>Companion endpoints for promotions, promo galleries, customers, top sellers, and Google Merchant XML feed: <code>GET /integrationPromo?storeId=&lt;storeId&gt;</code>, <code>GET /integrationGallery?storeId=&lt;storeId&gt;</code>, <code>GET /integrationCustomers?storeId=&lt;storeId&gt;</code>, <code>GET /integrationTopSelling?storeId=&lt;storeId&gt;&amp;days=30&amp;limit=10</code>, and <code>GET /integrationGoogleMerchantFeed?slug=&lt;promoSlug&gt;</code>.</li>
           <li>Dedupe, fallback data, category grouping, and cache strategy recommendations.</li>
         </ul>
       </section>


### PR DESCRIPTION
### Motivation

- Provide a machine-readable product feed compatible with Google Merchant Center so stores can publish products via a single XML URL using their promo slug.
- Surface the feed URL in the web admin so store owners can copy/preview the feed and configure scheduled fetches in Merchant Center.

### Description

- Added `integrationGoogleMerchantFeed` Cloud Function that serves an XML RSS/GMC feed for a store's products with proper escaping and mapped fields (id, title, description, link, price, availability, condition, brand, image, product_type). 
- Implemented helpers `escapeXml`, `toGoogleMerchantAvailability`, and `toGoogleMerchantCondition`, and added the endpoint to the exported functions list. 
- Updated docs (`docs/integration-quickstart.md` and the docs page) to mention the Merchant feed endpoint and usage. 
- Added a new admin page and route (`GoogleMerchantFeedPage`, navigation item, and route `/merchant-feed`) to preview and copy the public merchant feed URL built from a store's promo slug.

### Testing

- Performed a TypeScript/web build (`yarn build`) which completed successfully. 
- Ran the test suite (`yarn test`) and linter (`yarn lint`) in CI locally and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9c674db08322a7e880dee2c00328)