### PR TITLE
Add public return policy page at /return-policy

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -30,4 +30,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
+  <url>
+    <loc>https://sedifex.com/return-policy</loc>
+    <priority>0.7</priority>
+    <changefreq>weekly</changefreq>
+  </url>
 </urlset>

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -35,4 +35,9 @@
     <priority>0.7</priority>
     <changefreq>weekly</changefreq>
   </url>
+  <url>
+    <loc>https://sedifex.com/return-policy</loc>
+    <priority>0.7</priority>
+    <changefreq>weekly</changefreq>
+  </url>
 </urlset>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,6 +46,7 @@ export default function App() {
     '/terms',
     '/cookies',
     '/refund',
+    '/return-policy',
   ]
 
   const isPublicRoute = publicPaths.some(path => location.pathname.startsWith(path))

--- a/web/src/components/CanonicalLink.tsx
+++ b/web/src/components/CanonicalLink.tsx
@@ -24,6 +24,7 @@ const PATH_CANONICAL_OVERRIDES: Record<string, string> = {
   '/legal/cookies': '/cookies',
   '/legal/refund': '/refund',
   '/legal/terms': '/terms',
+  '/legal/return-policy': '/return-policy',
 }
 
 /**

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -38,6 +38,7 @@ import PrivacyPage from './pages/legal/PrivacyPage'
 import CookiesPage from './pages/legal/CookiesPage'
 import RefundPage from './pages/legal/RefundPage'
 import TermsPage from './pages/legal/TermsPage'
+import ReturnPolicyPage from './pages/legal/ReturnPolicyPage'
 import IntegrationQuickstartPage from './pages/docs/IntegrationQuickstartPage'
 import WordpressInstallGuidePage from './pages/docs/WordpressInstallGuidePage'
 
@@ -111,6 +112,7 @@ const router = createBrowserRouter([
       { path: 'cookies', element: <CookiesPage /> },
       { path: 'refund', element: <RefundPage /> },
       { path: 'terms', element: <TermsPage /> },
+      { path: 'return-policy', element: <ReturnPolicyPage /> },
     ],
   },
 ])

--- a/web/src/pages/legal/ReturnPolicyPage.tsx
+++ b/web/src/pages/legal/ReturnPolicyPage.tsx
@@ -1,0 +1,59 @@
+export default function ReturnPolicyPage() {
+  const today = new Date().toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+
+  return (
+    <main className="prose prose-slate mx-auto max-w-3xl px-4 py-12">
+      <p className="text-sm font-semibold uppercase tracking-wide text-violet-600">Policy</p>
+
+      <h1 className="mb-2 text-3xl font-bold text-slate-900">Sedifex Return &amp; Exchange Policy</h1>
+
+      <p className="mb-8 text-sm text-slate-500">Last updated: {today}</p>
+
+      <p>
+        This page is a return-policy template for stores that use <strong>Sedifex</strong>. Sedifex
+        supports multi-merchant accounts and allows each merchant to publish their own public
+        return-policy link for customers.
+      </p>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">1. Return window</h2>
+        <p>
+          Returns are accepted within <strong>1 day</strong> of the purchase date.
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">2. Exchange condition</h2>
+        <p>
+          Exchange is possible only when the product is in <strong>good shape</strong>.
+        </p>
+        <ul>
+          <li>Item must be clean and unused.</li>
+          <li>Item must not be broken, altered, or damaged by misuse.</li>
+          <li>Original packaging or proof of purchase may be required by the merchant.</li>
+        </ul>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">3. Merchant-specific terms</h2>
+        <p>
+          Because Sedifex serves multiple merchants, each store can keep its own return-policy page
+          link and customer instructions. Shoppers should review the specific merchant policy before
+          purchase.
+        </p>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">4. Contact the merchant</h2>
+        <p>
+          For return approval, exchange requests, and product checks, contact the merchant directly
+          using the details on their Sedifex public store page.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a public, Sedifex-branded return and exchange page for multi-merchant stores so each merchant can link customers to a clear policy at `https://sedifex.com/return-policy`.
- Ensure the page is accessible without authentication and indexed correctly for SEO and discoverability.

### Description
- Added a new page component `web/src/pages/legal/ReturnPolicyPage.tsx` containing the Sedifex Return & Exchange Policy (returns accepted within `1 day`, exchanges allowed only when product is in `good shape`, and multi-merchant guidance).
- Exposed the route by importing the page in `web/src/main.tsx` and registering `{ path: 'return-policy', element: <ReturnPolicyPage /> }` under public routes.
- Allowed the path to bypass auth redirects by adding `'/return-policy'` to the public route list in `web/src/App.tsx` and added a canonical override for `/legal/return-policy` in `web/src/components/CanonicalLink.tsx`.
- Added `/return-policy` entries to both `web/public/sitemap.xml` and `public/sitemap.xml` so search engines can index the page.

### Testing
- Ran `npm --prefix web run lint` in this environment, which failed due to a missing ESLint dependency (`@eslint/js`) referenced by the project ESLint config.
- No other automated tests were run in this environment; code changes were committed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab78bbac4832280021ec775b44791)