### PR TITLE
Add legal policy links to landing page

### DIFF
--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -1369,6 +1369,31 @@ export default function AuthPage() {
             Prefer email? Reach us at info@sedifex.com.
           </p>
         </article>
+
+        <article className="info-card">
+          <h3>Policies &amp; legal</h3>
+          <p>
+            Review Sedifex policy pages before signup to understand billing, data
+            handling, and service terms.
+          </p>
+          <ul className="info-card__list">
+            <li>
+              <Link to="/privacy">Privacy Policy</Link>
+            </li>
+            <li>
+              <Link to="/refund">Subscription &amp; Refund Policy</Link>
+            </li>
+            <li>
+              <Link to="/terms">Terms of Service</Link>
+            </li>
+            <li>
+              <Link to="/cookies">Cookies Policy</Link>
+            </li>
+            <li>
+              <Link to="/return-policy">Return &amp; Exchange Policy</Link>
+            </li>
+          </ul>
+        </article>
       </section>
     </main>
   )


### PR DESCRIPTION
### Motivation
- Make the site legal pages (privacy, refund, terms, cookies, return policy) discoverable from the unauthenticated landing page so visitors can review policies before signing up.

### Description
- Add a new "Policies & legal" info card to the landing page UI in `web/src/pages/AuthPage.tsx` that lists links to ` /privacy `, ` /refund `, ` /terms `, ` /cookies `, and ` /return-policy ` using the existing `Link` component.

### Testing
- Attempted to run lint with `cd web && npm run lint`, but the check failed in this environment due to a missing ESLint dependency (`@eslint/js`), so automated lint/test validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac818a7208322a49735ee3dc3c2d8)