### PR TITLE
Add configurable Google tag snippet to Sedifex web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Set these in your Vercel project:
 - `ADMIN_SERVICE_ACCOUNT_JSON` (recommended) or `FIREBASE_SERVICE_ACCOUNT_BASE64` (already required by existing API routes)
 - `IMAGE_UPLOAD_BUCKET` (for example: `sedifex-prod.appspot.com`)
 - `VITE_UPLOAD_API_URL` (optional; leave unset in production to use the same-origin default `/api/uploads`)
+- `VITE_GOOGLE_TAG_ID` (optional; your GA4 Measurement ID, e.g. `G-XXXXXXXXXX`, to enable Google tag loading in `web/index.html`)
 
 > Note: Firebase Functions `.env*` files reserve the `FIREBASE_*` prefix. Use non-reserved names like `IMAGE_UPLOAD_BUCKET` and `ADMIN_SERVICE_ACCOUNT_JSON` for deploy-safe config.
 

--- a/web/index.html
+++ b/web/index.html
@@ -10,6 +10,28 @@
 
     <!-- Paystack Inline (needed for card/mobile checkout) -->
     <script src="https://js.paystack.co/v1/inline.js"></script>
+
+    <!-- Google tag (gtag.js) -->
+    <script>
+      (function () {
+        const tagId = '%VITE_GOOGLE_TAG_ID%'
+        if (!tagId || tagId.includes('%VITE_GOOGLE_TAG_ID%')) return
+
+        const script = document.createElement('script')
+        script.async = true
+        script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(tagId)}`
+        document.head.appendChild(script)
+
+        window.dataLayer = window.dataLayer || []
+        function gtag() {
+          window.dataLayer.push(arguments)
+        }
+
+        gtag('js', new Date())
+        gtag('config', tagId)
+        window.gtag = gtag
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
### Motivation
- Allow optional GA4 measurement (Google tag) to be loaded by the PWA when `VITE_GOOGLE_TAG_ID` is provided while leaving environments without the variable unchanged.

### Description
- Add a bootstrap Google tag snippet to `web/index.html` that reads `VITE_GOOGLE_TAG_ID`, returns early if unset, injects the `gtag.js` script, initializes `window.dataLayer`, and calls `gtag('config', tagId)`.
- Document the new optional environment variable `VITE_GOOGLE_TAG_ID` in `README.md`.

### Testing
- Ran `npm --prefix web run build` which failed in this environment due to missing TypeScript type definitions for `vite/client` and `vitest/globals` (build failure unrelated to the snippet changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad37f0600832188a88bd06fec2142)