### PR TITLE
Render formatted product descriptions (paragraphs, bullets, bold)

### DIFF
--- a/web/src/pages/Products.css
+++ b/web/src/pages/Products.css
@@ -225,6 +225,33 @@
   min-width: 180px;
 }
 
+.products-page__description-preview {
+  white-space: normal;
+}
+
+.products-page__description-paragraph {
+  margin: 0 0 8px;
+  line-height: 1.45;
+}
+
+.products-page__description-preview .products-page__description-paragraph:last-child {
+  margin-bottom: 0;
+}
+
+.products-page__description-list {
+  margin: 0 0 8px;
+  padding-left: 18px;
+}
+
+.products-page__description-list li {
+  margin: 0 0 4px;
+  line-height: 1.45;
+}
+
+.products-page__description-preview .products-page__description-list:last-child {
+  margin-bottom: 0;
+}
+
 .products-page__receive-link {
   display: inline-flex;
   align-items: center;

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -119,6 +119,65 @@ function countWords(input: string): number {
   return input.trim().split(/\s+/).filter(Boolean).length
 }
 
+function renderDescriptionInline(text: string, keyPrefix: string): React.ReactNode {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g)
+  return parts.map((part, index) => {
+    const key = `${keyPrefix}-part-${index}`
+    if (part.startsWith('**') && part.endsWith('**')) {
+      return <strong key={key}>{part.slice(2, -2)}</strong>
+    }
+    return <React.Fragment key={key}>{part}</React.Fragment>
+  })
+}
+
+function renderProductDescription(description: string): React.ReactNode {
+  const lines = description.split('\n')
+  const content: React.ReactNode[] = []
+  let pendingBullets: string[] = []
+  let blockIndex = 0
+
+  const flushBullets = () => {
+    if (!pendingBullets.length) return
+    const listKey = `description-list-${blockIndex}`
+    content.push(
+      <ul key={listKey} className="products-page__description-list">
+        {pendingBullets.map((item, itemIndex) => (
+          <li key={`${listKey}-item-${itemIndex}`}>
+            {renderDescriptionInline(item, `${listKey}-${itemIndex}`)}
+          </li>
+        ))}
+      </ul>,
+    )
+    pendingBullets = []
+    blockIndex += 1
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line) {
+      flushBullets()
+      continue
+    }
+
+    if (line.startsWith('- ')) {
+      pendingBullets.push(line.slice(2).trim())
+      continue
+    }
+
+    flushBullets()
+    const paragraphKey = `description-paragraph-${blockIndex}`
+    content.push(
+      <p key={paragraphKey} className="products-page__description-paragraph">
+        {renderDescriptionInline(line, paragraphKey)}
+      </p>,
+    )
+    blockIndex += 1
+  }
+
+  flushBullets()
+  return content
+}
+
 function toDate(value: unknown): Date | null {
   if (!value) return null
   try {
@@ -2134,7 +2193,11 @@ export default function Products() {
                             </p>
                           </>
                         ) : (
-                          <p className="products-page__list-value">{product.description || '—'}</p>
+                          <div className="products-page__list-value products-page__description-preview">
+                            {product.description
+                              ? renderProductDescription(product.description)
+                              : '—'}
+                          </div>
                         )}
                       </div>
 


### PR DESCRIPTION
### Motivation
- Improve readability of product descriptions in the product details list by preserving paragraphs, bullet lines, and simple bold formatting in store listings.

### Description
- Add `renderDescriptionInline` and `renderProductDescription` helper functions to `web/src/pages/Products.tsx` to parse plain text descriptions into React nodes that preserve paragraphs, convert lines starting with `- ` into lists, and render `**bold**` segments as `<strong>`.
- Replace the plain text non-edit product description view with the formatted renderer so product cards display rich copy instead of raw text.
- Add CSS rules in `web/src/pages/Products.css` for `.products-page__description-preview`, `.products-page__description-paragraph`, and `.products-page__description-list` to control spacing, line-height, and list indentation for improved readability.

### Testing
- Ran `npm --prefix web run lint`, which failed in this environment due to a missing `@eslint/js` package required by the local ESLint configuration.
- Ran `npm --prefix web run test -- src/pages/__tests__/Products.test.tsx`, which failed because the `vitest` binary is not available in the environment's PATH.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9bbd81648322b70e76b43541b4e5)