### PR TITLE
Use category dropdowns on items page forms

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -538,6 +538,16 @@ export default function Products() {
   )
 
   const canManageProducts = activeMembership?.role === 'owner'
+  const categoryOptions = useMemo(() => {
+    const uniqueCategories = new Set<string>()
+    products.forEach(product => {
+      const category = product.category?.trim()
+      if (category) {
+        uniqueCategories.add(category)
+      }
+    })
+    return Array.from(uniqueCategories).sort((a, b) => a.localeCompare(b))
+  }, [products])
 
   /**
    * Load products for the active store
@@ -1599,12 +1609,23 @@ export default function Products() {
               <label className="field__label" htmlFor="add-category">
                 Category <span className="field__optional">(optional)</span>
               </label>
-              <input
+              <select
                 id="add-category"
-                placeholder="e.g. Beverages, Skin Care, Electronics"
                 value={categoryInput}
                 onChange={e => setCategoryInput(e.target.value)}
-              />
+              >
+                <option value="">Select a category</option>
+                {categoryOptions.map(category => (
+                  <option key={category} value={category}>
+                    {category}
+                  </option>
+                ))}
+              </select>
+              <p className="field__hint">
+                {categoryOptions.length
+                  ? 'Pick from existing categories to avoid spelling mistakes.'
+                  : 'Add your first item, then categories will appear here.'}
+              </p>
             </div>
 
             <div className="field">
@@ -2145,11 +2166,17 @@ export default function Products() {
                       <div className="products-page__list-field">
                         <label className="field__label">Category</label>
                         {isEditing ? (
-                          <input
+                          <select
                             value={editCategoryInput}
                             onChange={event => setEditCategoryInput(event.target.value)}
-                            placeholder="e.g. Beverages"
-                          />
+                          >
+                            <option value="">Select a category</option>
+                            {categoryOptions.map(category => (
+                              <option key={category} value={category}>
+                                {category}
+                              </option>
+                            ))}
+                          </select>
                         ) : (
                           <p className="products-page__list-value">{product.category || '—'}</p>
                         )}


### PR DESCRIPTION
### Motivation
- Reduce user typos and inconsistent category values by forcing selection instead of free-text entry. 
- Reuse existing product data to present meaningful category choices without extra configuration. 
- Surface a helpful hint so users understand why selecting an existing category is preferable.

### Description
- Added a derived `categoryOptions` array using `useMemo` that trims, de-duplicates, and alphabetically sorts categories from the loaded `products` list in `web/src/pages/Products.tsx`.
- Replaced the Add-item category free-text `input` with a `select` populated from `categoryOptions` and added contextual helper text under the field.
- Replaced the Edit-item category free-text `input` with the same `select` so editing uses the shared category options list.

### Testing
- Ran `npm --prefix web run lint`, which failed in this environment due to the ESLint configuration requiring the `@eslint/js` package that is not installed, so lint could not complete (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbafaff8c08322af1bd4fe7edc1401)