### PR TITLE
Add store-aware barcode auto-fill and sequential SKU helpers

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -24,9 +24,14 @@ import {
   loadCachedProducts,
   saveCachedProducts,
 } from '../utils/offlineCache'
-import { normalizeBarcode } from '../utils/barcode'
+import {
+  buildNextStoreBarcodeCode,
+  buildStoreBarcodePrefix,
+  normalizeBarcode,
+} from '../utils/barcode'
 import { useStorePreferences } from '../hooks/useStorePreferences'
 import { useStoreBilling } from '../hooks/useStoreBilling'
+import { useWorkspaceIdentity } from '../hooks/useWorkspaceIdentity'
 import type { ItemType, Product } from '../types/product'
 import { ProductImageUploadError, uploadProductImage } from '../api/productImageUpload'
 import { requestAiAdvisor } from '../api/aiAdvisor'
@@ -447,6 +452,7 @@ export default function Products() {
   const user = useAuthUser()
   const { preferences } = useStorePreferences(activeStoreId)
   const { billing } = useStoreBilling()
+  const { name: workspaceName } = useWorkspaceIdentity()
   const { publish } = useToast()
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -460,6 +466,7 @@ export default function Products() {
   const [name, setName] = useState('')
   const [itemType, setItemType] = useState<ItemType>('product')
   const [sku, setSku] = useState('')
+  const [hasManualSkuOverride, setHasManualSkuOverride] = useState(false)
   const [categoryInput, setCategoryInput] = useState('')
   const [priceInput, setPriceInput] = useState('')
   const [descriptionInput, setDescriptionInput] = useState('')
@@ -548,6 +555,23 @@ export default function Products() {
     })
     return Array.from(uniqueCategories).sort((a, b) => a.localeCompare(b))
   }, [products])
+
+  const barcodePrefix = useMemo(
+    () => buildStoreBarcodePrefix({ workspaceName, storeId: activeStoreId }),
+    [activeStoreId, workspaceName],
+  )
+
+  const nextAutoSku = useMemo(
+    () =>
+      buildNextStoreBarcodeCode({
+        workspaceName,
+        storeId: activeStoreId,
+        existingCodes: products
+          .filter(product => product.itemType === 'product')
+          .map(product => product.barcode ?? product.sku),
+      }),
+    [activeStoreId, products, workspaceName],
+  )
 
   /**
    * Load products for the active store
@@ -1004,6 +1028,7 @@ export default function Products() {
       setName('')
       setItemType('product')
       setSku('')
+      setHasManualSkuOverride(false)
       setCategoryInput('')
       setPriceInput('')
       setDescriptionInput('')
@@ -1090,6 +1115,7 @@ export default function Products() {
     if (value === 'service') {
       // services should not have barcodes
       setSku('')
+      setHasManualSkuOverride(false)
       setExpiryInput('')
       setManufacturerInput('')
       setProductionDateInput('')
@@ -1101,6 +1127,12 @@ export default function Products() {
   const isService = itemType === 'service'
   const isStockTracked = itemType === 'product'
   const activityActor = user?.displayName || user?.email || 'Team member'
+
+  useEffect(() => {
+    if (itemType !== 'product') return
+    if (hasManualSkuOverride) return
+    setSku(nextAutoSku)
+  }, [hasManualSkuOverride, itemType, nextAutoSku])
 
   async function logInventoryActivity(summary: string, detail: string) {
     if (!activeStoreId) return
@@ -1534,14 +1566,16 @@ export default function Products() {
                 </label>
                 <input
                   id="add-sku"
-                  placeholder="Scan or type the barcode, or use an internal code"
+                  placeholder={`Auto-fills like ${barcodePrefix}0001 (you can edit it)`}
                   value={sku}
-                  onChange={e => setSku(e.target.value)}
+                  onChange={e => {
+                    setSku(e.target.value)
+                    setHasManualSkuOverride(true)
+                  }}
                 />
                 <p className="field__hint">
-                  If you scan barcodes, this should match the code on the product. We
-                  also store a normalized version (letters + digits) so camera scans work even if
-                  you add spaces or dashes.
+                  Barcode values auto-fill from your store prefix ({barcodePrefix}) plus sequential
+                  numbers (for example {barcodePrefix}0001). You can overwrite this any time.
                 </p>
               </div>
             )}

--- a/web/src/utils/barcode.test.ts
+++ b/web/src/utils/barcode.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildNextStoreBarcodeCode,
+  buildStoreBarcodePrefix,
+  normalizeBarcode,
+} from './barcode'
+
+describe('store barcode helpers', () => {
+  it('builds a deterministic prefix from workspace identity and store id', () => {
+    expect(buildStoreBarcodePrefix({ workspaceName: 'Abena Beauty', storeId: 'store-001' })).toBe('ABEN')
+    expect(buildStoreBarcodePrefix({ workspaceName: '', storeId: 'st-9' })).toBe('ST9I')
+  })
+
+  it('computes next sequential store barcode from existing prefixed codes', () => {
+    const nextCode = buildNextStoreBarcodeCode({
+      workspaceName: 'Abena Beauty',
+      storeId: 'store-001',
+      existingCodes: ['ABEN0001', 'ABEN0008', 'ab en-0003'],
+    })
+
+    expect(nextCode).toBe('ABEN0009')
+  })
+
+  it('starts at 0001 when no matching codes exist', () => {
+    expect(
+      buildNextStoreBarcodeCode({
+        workspaceName: 'Fresh Foods',
+        storeId: 's-22',
+        existingCodes: ['OTHER0007', normalizeBarcode('something')],
+      }),
+    ).toBe('FRES0001')
+  })
+})

--- a/web/src/utils/barcode.ts
+++ b/web/src/utils/barcode.ts
@@ -21,3 +21,57 @@ export function formatBarcodeForDisplay(
   // you can get fancy here later (grouping), for now just return digits
   return code
 }
+
+type StoreBarcodeIdentity = {
+  workspaceName?: string | null
+  storeId?: string | null
+}
+
+const DEFAULT_BARCODE_PREFIX = 'ITEM'
+const BARCODE_PREFIX_LENGTH = 4
+
+function sanitizeIdentity(value: string | null | undefined): string {
+  if (!value) return ''
+  return value.toUpperCase().replace(/[^A-Z0-9]/g, '')
+}
+
+export function buildStoreBarcodePrefix(identity: StoreBarcodeIdentity): string {
+  const workspaceIdentity = sanitizeIdentity(identity.workspaceName)
+  const storeIdentity = sanitizeIdentity(identity.storeId)
+
+  const combined = `${workspaceIdentity}${storeIdentity}`
+  if (!combined) return DEFAULT_BARCODE_PREFIX
+
+  return combined
+    .slice(0, BARCODE_PREFIX_LENGTH)
+    .padEnd(BARCODE_PREFIX_LENGTH, DEFAULT_BARCODE_PREFIX.slice(0, BARCODE_PREFIX_LENGTH))
+}
+
+export function buildNextStoreBarcodeCode(input: {
+  workspaceName?: string | null
+  storeId?: string | null
+  existingCodes: Array<string | null | undefined>
+  minimumDigits?: number
+}): string {
+  const prefix = buildStoreBarcodePrefix({
+    workspaceName: input.workspaceName,
+    storeId: input.storeId,
+  })
+
+  const minimumDigits = Math.max(1, Math.floor(input.minimumDigits ?? 4))
+  let nextSequence = 1
+
+  input.existingCodes.forEach((code) => {
+    const normalized = normalizeBarcode(code)
+    if (!normalized.startsWith(prefix)) return
+
+    const suffix = normalized.slice(prefix.length)
+    if (!/^\d+$/.test(suffix)) return
+
+    const sequence = Number.parseInt(suffix, 10)
+    if (!Number.isFinite(sequence)) return
+    nextSequence = Math.max(nextSequence, sequence + 1)
+  })
+
+  return `${prefix}${String(nextSequence).padStart(minimumDigits, '0')}`
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic store/workspace prefix and automatic sequential barcode generation so physical product barcodes can be auto-populated per store (e.g. `ABCD0001`).
- Integrate workspace identity into the Products UI so auto-generated SKUs reflect the active workspace/store and do not conflict with existing product codes.
- Keep the SKU field editable and track manual overrides so users can freely type their own codes without being overwritten.

### Description
- Added barcode utilities in `web/src/utils/barcode.ts`: `buildStoreBarcodePrefix(...)` to derive a normalized 4-character prefix and `buildNextStoreBarcodeCode(...)` to compute the next sequential prefixed code (with zero padding); kept `normalizeBarcode`/`formatBarcodeForDisplay` in the same module.
- Integrated workspace identity and auto-SKU logic into `web/src/pages/Products.tsx`: imported `useWorkspaceIdentity`, computed `barcodePrefix` and `nextAutoSku`, introduced `hasManualSkuOverride` state, and wired an effect to auto-fill `sku` when appropriate.
- Updated add-item behaviors in `Products.tsx` to clear `hasManualSkuOverride` after successful save and when switching the item type to `service` so the auto-fill restarts as expected.
- Changed the SKU/Barcode input: placeholder now shows an example using the computed prefix via ``placeholder={`Auto-fills like ${barcodePrefix}0001 (you can edit it)`}``, input `onChange` sets `hasManualSkuOverride`, and help copy explains the prefix + sequential number auto-fill while preserving editability.
- Added unit tests for the new helpers in `web/src/utils/barcode.test.ts` covering prefix derivation and next-sequence computation.

### Testing
- Created `web/src/utils/barcode.test.ts` with unit cases for `buildStoreBarcodePrefix` and `buildNextStoreBarcodeCode`; the tests were added but not executed due to environment constraints.
- Attempted to run `npm test -- src/utils/barcode.test.ts` in `web/`, but the local `vitest` binary was not available (dependencies not installed), so tests could not be run (`vitest: not found`).
- Attempted `npm ci` in `web/` to install dependencies, but the install failed with a registry access error (`403 Forbidden` for `@azure/msal-browser`), preventing automated test runs in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb2565bf483228f188741869ab414)