### PR TITLE
Expand product category suggestions and allow manual category input

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -62,6 +62,16 @@ const DESCRIPTION_TEMPLATE_OPTIONS: Array<{ value: DescriptionTemplate; label: s
   { value: 'fashion', label: 'Fashion' },
   { value: 'electronics', label: 'Electronics' },
 ]
+const SUGGESTED_PRODUCT_CATEGORIES = [
+  'Supplements',
+  'Skin care',
+  'Hair care',
+  'Food & beverages',
+  'Household',
+  'Baby care',
+  'Electronics',
+  'Fashion',
+] as const
 
 function buildDescriptionPrompt(input: {
   itemName: string
@@ -548,6 +558,7 @@ export default function Products() {
   const canManageProducts = activeMembership?.role === 'owner'
   const categoryOptions = useMemo(() => {
     const uniqueCategories = new Set<string>()
+    SUGGESTED_PRODUCT_CATEGORIES.forEach(category => uniqueCategories.add(category))
     products.forEach(product => {
       const category = product.category?.trim()
       if (category) {
@@ -1656,22 +1667,25 @@ export default function Products() {
               <label className="field__label" htmlFor="add-category">
                 Category <span className="field__optional">(optional)</span>
               </label>
-              <select
+              <input
                 id="add-category"
+                type="text"
                 value={categoryInput}
                 onChange={e => setCategoryInput(e.target.value)}
-              >
-                <option value="">Select a category</option>
+                list="category-options-add"
+                placeholder="Select or type a category"
+              />
+              <datalist id="category-options-add">
                 {categoryOptions.map(category => (
                   <option key={category} value={category}>
                     {category}
                   </option>
                 ))}
-              </select>
+              </datalist>
               <p className="field__hint">
                 {categoryOptions.length
-                  ? 'Pick from existing categories to avoid spelling mistakes.'
-                  : 'Add your first item, then categories will appear here.'}
+                  ? 'Pick from suggestions or type your own category.'
+                  : 'Type your first category to get started.'}
               </p>
             </div>
 
@@ -2228,19 +2242,24 @@ export default function Products() {
                       <div className="products-page__list-field">
                         <label className="field__label">Category</label>
                         {isEditing ? (
-                          <select
+                          <input
+                            type="text"
                             value={editCategoryInput}
                             onChange={event => setEditCategoryInput(event.target.value)}
-                          >
-                            <option value="">Select a category</option>
+                            list="category-options-edit"
+                            placeholder="Select or type a category"
+                          />
+                        ) : (
+                          <p className="products-page__list-value">{product.category || '—'}</p>
+                        )}
+                        {isEditing && (
+                          <datalist id="category-options-edit">
                             {categoryOptions.map(category => (
                               <option key={category} value={category}>
                                 {category}
                               </option>
                             ))}
-                          </select>
-                        ) : (
-                          <p className="products-page__list-value">{product.category || '—'}</p>
+                          </datalist>
                         )}
                       </div>
 


### PR DESCRIPTION
### Motivation
- Improve the product category UX by providing a richer default set of categories instead of a very small list.
- Let merchants pick suggested categories or enter arbitrary custom categories to avoid forcing exact matches and reduce friction.
- Preserve and surface existing store categories while offering useful out-of-the-box suggestions.

### Description
- Added a built-in `SUGGESTED_PRODUCT_CATEGORIES` array with 8 entries (including `Supplements`) in `web/src/pages/Products.tsx`.
- Merged the suggested categories with existing store categories when building `categoryOptions` so suggestions and historical categories are combined and sorted.
- Replaced the category `<select>` controls in the Add and Edit product flows with text `<input>` fields backed by `<datalist>` suggestions (`category-options-add` and `category-options-edit`) so users can pick or type a category.
- Updated the helper hint copy to explain the new “select or type” behaviour.

### Testing
- Attempted to run the product tests with `npm test -- --run web/src/pages/__tests__/Products.test.tsx`, but the test run failed in this environment because `vitest` was not available on PATH (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbdc7497888322b0c27bc8ab9c4562)