### PR TITLE
Fix Scale Plus pricing display to reflect yearly billing

### DIFF
--- a/web/src/components/AccountBillingSection.tsx
+++ b/web/src/components/AccountBillingSection.tsx
@@ -27,7 +27,7 @@ const PLANS: PlanOption[] = [
   {
     id: 'scale_plus',
     label: 'Scale Plus',
-    monthlyAmountGhs: 2000,
+    monthlyAmountGhs: 2000 / 12,
     productLimit: 'Unlimited',
     dailySalesLimit: 'Unlimited',
   },

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -1504,8 +1504,8 @@ const PRICING_PLANS = [
   {
     name: 'Scale Plus',
     summary: 'Unlimited uploads and website creation for enterprise growth.',
-    amount: 'GHS 2000',
-    cadence: '/ month',
+    amount: 'GHS 166.67',
+    cadence: '/ month (billed yearly)',
     features: [
       'Unlimited active products',
       'Unlimited sales per day',
@@ -1516,6 +1516,7 @@ const PRICING_PLANS = [
       type: 'button' as const,
       label: 'Sign up',
     },
+    note: 'GHS 2000 / year billed upfront.',
   },
 ] as const
 

--- a/web/src/pages/PricingPage.tsx
+++ b/web/src/pages/PricingPage.tsx
@@ -71,7 +71,7 @@ const PLANS = [
       'Unlimited uploads',
       'Website creation support',
       'Enterprise onboarding and account management',
-      'Price: GHS 2000',
+      'Price: GHS 2000/year (GHS 166.67/month billed yearly)',
     ],
     cta: 'Talk to Sales',
     to: 'mailto:info@sedifex.com',


### PR DESCRIPTION
### Motivation
- The Scale Plus plan was incorrectly shown as `GHS 2000 / month` even though it is billed yearly, which is misleading for users.
- The UI needs to present a monthly equivalent alongside a clear yearly billing note so customers understand the upfront annual charge.

### Description
- Updated `web/src/pages/AuthPage.tsx` to show Scale Plus as `amount: 'GHS 166.67'` with `cadence: '/ month (billed yearly)'` and added `note: 'GHS 2000 / year billed upfront.'` to clarify annual billing.
- Updated `web/src/components/AccountBillingSection.tsx` so the Scale Plus plan uses `monthlyAmountGhs: 2000 / 12` and retained yearly resolution logic (`SCALE_PLUS_YEARLY_PRICE_GHS = 2000`) to keep checkout amounts correct.
- Updated `web/src/pages/PricingPage.tsx` to display Scale Plus as `Price: GHS 2000/year (GHS 166.67/month billed yearly)` to show both the annual cost and monthly equivalent.

### Testing
- Ran the project linter with `npm --prefix web run -s lint`, which failed in this environment due to a missing package (`@eslint/js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc12d98e888321bb41fc792a62352b)