### PR TITLE
Show yearly billing totals across pricing tiers

### DIFF
--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -1455,7 +1455,7 @@ const PRICING_PLANS = [
     name: 'Starter',
     summary: 'Best first paid tier for new stores.',
     amount: 'GHS 20',
-    cadence: '/ month',
+    cadence: '/ month (billed yearly)',
     features: [
       'Up to 100 active products',
       'Up to 100 sales per day',
@@ -1466,12 +1466,13 @@ const PRICING_PLANS = [
       type: 'button' as const,
       label: 'Sign up',
     },
+    note: 'GHS 240 / year billed upfront.',
   },
   {
     name: 'Growth',
     summary: 'For stores with higher daily volume.',
     amount: 'GHS 50',
-    cadence: '/ month',
+    cadence: '/ month (billed yearly)',
     features: [
       'Up to 500 active products',
       'Up to 500 sales per day',
@@ -1482,13 +1483,14 @@ const PRICING_PLANS = [
       type: 'button' as const,
       label: 'Sign up',
     },
+    note: 'GHS 600 / year billed upfront.',
     isFeatured: true,
   },
   {
     name: 'Scale',
     summary: 'High limits for large operations.',
     amount: 'GHS 100',
-    cadence: '/ month',
+    cadence: '/ month (billed yearly)',
     features: [
       'Unlimited active products',
       'Unlimited sales per day',
@@ -1499,7 +1501,7 @@ const PRICING_PLANS = [
       type: 'button' as const,
       label: 'Sign up',
     },
-    note: 'Need more? Contact sales for custom limits.',
+    note: 'GHS 1200 / year billed upfront. Need more? Contact sales for custom limits.',
   },
   {
     name: 'Scale Plus',

--- a/web/src/pages/PricingPage.tsx
+++ b/web/src/pages/PricingPage.tsx
@@ -26,6 +26,7 @@ const PLANS = [
     name: 'Starter',
     subtitle: 'For small businesses getting started',
     points: [
+      'Price: GHS 20/month (GHS 240/year billed upfront)',
       'Core inventory management',
       'Basic reporting',
       'Free public store page',
@@ -39,6 +40,7 @@ const PLANS = [
     name: 'Growth',
     subtitle: 'For businesses scaling communication and operations',
     points: [
+      'Price: GHS 50/month (GHS 600/year billed upfront)',
       'Everything in Starter',
       'Branded Bulk SMS features',
       'Google Ads automation',
@@ -53,6 +55,7 @@ const PLANS = [
     name: 'Scale',
     subtitle: 'For multi-branch and high-volume operations',
     points: [
+      'Price: GHS 100/month (GHS 1200/year billed upfront)',
       'Everything in Growth',
       'Multi-branch support',
       'Higher SMS and usage capacity',


### PR DESCRIPTION
### Motivation
- Make billing cadence explicit by showing that monthly prices for paid tiers are billed yearly and display the upfront yearly total to reduce confusion.
- Align the homepage/Auth pricing cards and the dedicated pricing page with the existing Yearly presentation used for Scale Plus.

### Description
- Updated `web/src/pages/AuthPage.tsx` to change `cadence` for Starter, Growth, and Scale to `'/ month (billed yearly)'` and added `note` entries with yearly upfront totals for those tiers (Starter: GHS 240, Growth: GHS 600, Scale: GHS 1200). 
- Updated `web/src/pages/PricingPage.tsx` to prepend explicit price lines for Starter, Growth, and Scale showing `Price: GHS X/month (GHS Y/year billed upfront)`. 
- Left existing Scale Plus yearly display unchanged except to keep consistent formatting with other tiers. 
- Files modified: `web/src/pages/AuthPage.tsx` and `web/src/pages/PricingPage.tsx`.

### Testing
- Ran `npm --prefix web run lint`, which failed in this environment due to a missing dev dependency (`@eslint/js`) referenced by `web/eslint.config.js` and not available here.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc15df711c8321b83699ba0476ab79)