### PR TITLE
Improve mobile readability of staff roster and audit tables

### DIFF
--- a/web/src/pages/StaffManagement.css
+++ b/web/src/pages/StaffManagement.css
@@ -119,12 +119,46 @@
 }
 
 @media (max-width: 860px) {
+  .staff-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
   .staff-table__row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-auto-rows: auto;
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+
+  .staff-table__header {
+    display: none;
+  }
+
+  .staff-table__row [role='cell'] {
+    display: grid;
+    grid-template-columns: minmax(90px, 120px) 1fr;
+    gap: 0.5rem;
+    align-items: start;
+  }
+
+  .staff-table__row [role='cell']::before {
+    content: attr(data-label);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #5a6474;
+    font-weight: 600;
+  }
+
+  .staff-table__empty {
+    grid-column: auto;
+    display: block !important;
+  }
+
+  .staff-table__empty::before {
+    content: none !important;
   }
 
   .staff-table__actions {
-    justify-content: flex-start;
+    justify-content: flex-start !important;
   }
 }

--- a/web/src/pages/StaffManagement.tsx
+++ b/web/src/pages/StaffManagement.tsx
@@ -436,9 +436,11 @@ export default function StaffManagement({ headingLevel = 'h1' }: StaffManagement
                 key={member.id}
                 data-testid={`staff-member-${member.id}`}
               >
-                <span role="cell" className="staff-table__email">{member.email ?? '—'}</span>
-                <span role="cell">{member.role === 'owner' ? 'Owner' : 'Staff'}</span>
-                <span role="cell">
+                <span role="cell" className="staff-table__email" data-label="Email">
+                  {member.email ?? '—'}
+                </span>
+                <span role="cell" data-label="Role">{member.role === 'owner' ? 'Owner' : 'Staff'}</span>
+                <span role="cell" data-label="Status">
                   {member.status ? (
                     <span className="staff-table__status" data-variant={member.status}>
                       {member.status}
@@ -447,7 +449,9 @@ export default function StaffManagement({ headingLevel = 'h1' }: StaffManagement
                     'Active'
                   )}
                 </span>
-                <span role="cell">{formatDate(member.updatedAt ?? member.createdAt)}</span>
+                <span role="cell" data-label="Updated">
+                  {formatDate(member.updatedAt ?? member.createdAt)}
+                </span>
                 <span role="cell" className="staff-table__actions" data-label="Actions">
                   <button
                     type="button"
@@ -515,11 +519,11 @@ export default function StaffManagement({ headingLevel = 'h1' }: StaffManagement
           ) : (
             audits.map(entry => (
               <div className="staff-table__row" role="row" key={entry.id}>
-                <span role="cell">{formatDate(entry.createdAt)}</span>
-                <span role="cell">{entry.action}</span>
-                <span role="cell">{entry.targetEmail}</span>
-                <span role="cell">{entry.actorEmail ?? '—'}</span>
-                <span role="cell">
+                <span role="cell" data-label="When">{formatDate(entry.createdAt)}</span>
+                <span role="cell" data-label="Action">{entry.action}</span>
+                <span role="cell" data-label="Target">{entry.targetEmail}</span>
+                <span role="cell" data-label="By">{entry.actorEmail ?? '—'}</span>
+                <span role="cell" data-label="Outcome">
                   <span
                     className="staff-table__status"
                     data-variant={entry.outcome === 'success' ? 'active' : 'inactive'}


### PR DESCRIPTION
### Motivation

- The team roster and audit tables are hard to read on phones because columns collapse and headers become unclear, so mobile users need a stacked, labeled layout.

### Description

- Add `data-label` attributes to each roster and audit table cell in `web/src/pages/StaffManagement.tsx` so values can be rendered with per-field labels on small screens.
- Update `web/src/pages/StaffManagement.css` responsive rules to hide the desktop header at `<= 860px` and convert each `.staff-table__row` into stacked key/value blocks using the `data-label` content as the label.
- Adjust header layout and empty-state styling to keep action buttons aligned and prevent header labels from appearing for empty rows.
- No backend or behaviour changes; all edits are presentation-focused and maintain existing accessibility roles (`role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2d2189288321ba372f178ec08798)