### PR TITLE
Add v1 integration contract headers, versioned endpoints, and shared integration types

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -1,0 +1,120 @@
+# Sedifex Integration API Guide (v1)
+
+This guide explains how third-party clients (including Buy Sedifex) should authenticate, call endpoints, cache/deduplicate responses, and migrate safely as the API evolves.
+
+## 1) Authentication and API keys
+
+1. Create a per-store integration key from Sedifex account settings.
+2. Store keys server-side only (never in browser bundles).
+3. Call authenticated endpoints with:
+   - `Authorization: Bearer <integration_api_key>`
+   - `X-Sedifex-Contract-Version: 2026-04-13`
+4. Rotate keys regularly (recommended quarterly or immediately on incident).
+
+## 2) Versioning contract
+
+- Current contract version: `2026-04-13`.
+- Request header: `X-Sedifex-Contract-Version`.
+- Response headers:
+  - `x-sedifex-contract-version`
+  - `x-sedifex-request-id`
+- If versions mismatch, API returns `400`:
+
+```json
+{
+  "error": "contract-version-mismatch",
+  "expectedVersion": "2026-04-13",
+  "receivedVersion": "2026-01-01"
+}
+```
+
+## 3) Endpoint response shapes
+
+### `GET /v1IntegrationProducts?storeId=<storeId>` (authenticated)
+
+```json
+{
+  "storeId": "store_123",
+  "products": [
+    {
+      "id": "product_1",
+      "storeId": "store_123",
+      "name": "Item",
+      "category": "Meals",
+      "description": "Description",
+      "price": 45,
+      "stockCount": 10,
+      "itemType": "product",
+      "imageUrl": "https://...",
+      "imageUrls": ["https://..."],
+      "imageAlt": "Item image",
+      "updatedAt": "2026-04-13T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+### `GET /v1IntegrationPromo?storeId=<storeId>` (authenticated) or `?slug=<promoSlug>` (public)
+
+```json
+{
+  "storeId": "store_123",
+  "promo": {
+    "enabled": true,
+    "slug": "my-store",
+    "title": "Promo title",
+    "summary": "Promo summary",
+    "startDate": "2026-04-01",
+    "endDate": "2026-04-30",
+    "websiteUrl": "https://example.com",
+    "youtubeUrl": null,
+    "youtubeEmbedUrl": null,
+    "youtubeChannelId": null,
+    "youtubeVideos": [],
+    "imageUrl": null,
+    "imageAlt": null,
+    "phone": "+233...",
+    "storeName": "Sedifex Store",
+    "updatedAt": "2026-04-13T00:00:00.000Z"
+  }
+}
+```
+
+## 4) Deduplication and caching
+
+- Deduplicate by product `id` (and optionally `updatedAt` when merging data sources).
+- Recommended cache policy:
+  - Products/top-selling: 30s cache + 120s stale-while-revalidate.
+  - Promo/gallery: 60s cache + 300s stale-while-revalidate.
+- Always keep a small fallback dataset so storefront pages can render during transient failures.
+
+## 5) Error handling
+
+Common status codes:
+
+- `400` malformed request (`missing-token-or-store`, `contract-version-mismatch`)
+- `401` invalid integration token
+- `404` unknown store/promo slug
+- `405` unsupported method
+
+Client guidance:
+
+1. Retry idempotent GET failures with exponential backoff.
+2. Include and log `x-sedifex-request-id` for support/tracing.
+3. On `401`, rotate or re-issue key and retry.
+4. On `contract-version-mismatch`, deploy client version compatible with `expectedVersion`.
+
+## 6) Migration when fields are added
+
+- Additive fields can appear at any time in the same contract version.
+- Consumers should ignore unknown fields.
+- For breaking changes, Sedifex will publish a new contract version and allow overlap during migration.
+
+## 7) Shared types
+
+Use `shared/integrationTypes.ts` as the shared source of truth for:
+
+- `IntegrationProduct`
+- `IntegrationPromo`
+- `IntegrationProductsResponse`
+- `IntegrationPromoResponse`

--- a/docs/integration-quickstart.md
+++ b/docs/integration-quickstart.md
@@ -5,7 +5,7 @@ Use this guide to auto-load products from Sedifex into either:
 - a **WordPress** site, or
 - a **Next.js site hosted on Vercel**.
 
-This quickstart follows the current Sedifex downstream contract based on the `integrationProducts` HTTP endpoint and related integration endpoints (`integrationPromo`, `integrationGallery`, `integrationCustomers`, `integrationTopSelling`, `integrationTikTokVideos`, and `integrationGoogleMerchantFeed`), plus the product shape documented in the root README.
+This quickstart follows the current **versioned** Sedifex downstream contract based on `/v1IntegrationProducts` and related integration endpoints (`/v1IntegrationPromo`, `/integrationGallery`, `/integrationCustomers`, `/integrationTopSelling`, `/integrationTikTokVideos`, and `/integrationGoogleMerchantFeed`), plus the product shape documented in the root README.
 
 ## What you get
 
@@ -171,8 +171,10 @@ It defines a pull + webhook model, contract versioning, reliability, and rollout
 ## Integration flow
 
 1. Create an integration API key in **Account overview → Integrations → Website integrations**.
-2. Call `GET /integrationProducts?storeId=<storeId>` with `Authorization: Bearer <integration_key>`.
-   - Promo data: `GET /integrationPromo?storeId=<storeId>`
+2. Call `GET /v1IntegrationProducts?storeId=<storeId>` with:
+   - `Authorization: Bearer <integration_key>`
+   - `X-Sedifex-Contract-Version: 2026-04-13`
+   - Promo data: `GET /v1IntegrationPromo?storeId=<storeId>`
    - Promo gallery data: `GET /integrationGallery?storeId=<storeId>`
    - Customer data: `GET /integrationCustomers?storeId=<storeId>`
    - Top-selling products: `GET /integrationTopSelling?storeId=<storeId>&days=30&limit=10`
@@ -181,6 +183,17 @@ It defines a pull + webhook model, contract versioning, reliability, and rollout
 4. Return fallback data when external fetch fails.
 5. Render a grouped menu UI by category.
 6. Apply an appropriate cache strategy.
+
+### Shared integration types
+
+Import shared interfaces from `shared/integrationTypes.ts` in both Sedifex and Buy Sedifex projects to avoid field drift:
+
+- `IntegrationProduct`
+- `IntegrationPromo`
+- `IntegrationProductsResponse`
+- `IntegrationPromoResponse`
+
+If you publish these to npm, keep the package version aligned with the contract header date (`X-Sedifex-Contract-Version`).
 
 ---
 

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -36,7 +36,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkMessage = exports.emitProductWebhooks = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.integrationPromo = exports.integrationProducts = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.manageStaffAccount = exports.generateAiAdvice = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSyncScheduled = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
+exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkMessage = exports.emitProductWebhooks = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.v1IntegrationPromo = exports.integrationPromo = exports.v1IntegrationProducts = exports.integrationProducts = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.manageStaffAccount = exports.generateAiAdvice = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSyncScheduled = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
 // functions/src/index.ts
 const functions = __importStar(require("firebase-functions/v1"));
 const crypto = __importStar(require("crypto"));
@@ -66,6 +66,9 @@ const SMS_SEGMENT_SIZE = 160;
 const OPENAI_API_KEY = (0, params_1.defineString)('OPENAI_API_KEY', { default: '' });
 const OPENAI_MODEL = (0, params_1.defineString)('OPENAI_MODEL', { default: 'gpt-4o-mini' });
 const OPENAI_CHAT_COMPLETIONS_URL = 'https://api.openai.com/v1/chat/completions';
+const INTEGRATION_CONTRACT_VERSION = (0, params_1.defineString)('INTEGRATION_CONTRACT_VERSION', {
+    default: '2026-04-13',
+});
 /** ============================================================================
  *  HELPERS
  * ==========================================================================*/
@@ -1921,12 +1924,32 @@ exports.tiktokOAuthCallback = functions.https.onRequest(async (req, res) => {
 });
 function setIntegrationResponseHeaders(res) {
     const configuredApiBaseUrl = SEDIFEX_API_BASE_URL.value().trim();
+    const contractVersion = INTEGRATION_CONTRACT_VERSION.value().trim() || '2026-04-13';
+    const requestId = crypto.randomUUID();
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Authorization,Content-Type');
+    res.setHeader('Access-Control-Allow-Headers', 'Authorization,Content-Type,X-Sedifex-Contract-Version');
+    res.setHeader('x-sedifex-contract-version', contractVersion);
+    res.setHeader('x-sedifex-request-id', requestId);
     if (configuredApiBaseUrl) {
         res.setHeader('x-sedifex-api-base-url', configuredApiBaseUrl);
     }
+}
+function validateIntegrationContractVersionOrReply(req, res) {
+    const requestedVersion = typeof req.headers['x-sedifex-contract-version'] === 'string'
+        ? req.headers['x-sedifex-contract-version'].trim()
+        : '';
+    if (!requestedVersion)
+        return true;
+    const currentVersion = INTEGRATION_CONTRACT_VERSION.value().trim() || '2026-04-13';
+    if (requestedVersion === currentVersion)
+        return true;
+    res.status(400).json({
+        error: 'contract-version-mismatch',
+        expectedVersion: currentVersion,
+        receivedVersion: requestedVersion,
+    });
+    return false;
 }
 function getIntegrationAuthContext(req) {
     const authHeader = typeof req.headers.authorization === 'string' ? req.headers.authorization : '';
@@ -2310,6 +2333,9 @@ async function validateIntegrationTokenOrReply(req, res) {
 }
 exports.integrationProducts = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);
+    if (!validateIntegrationContractVersionOrReply(req, res)) {
+        return;
+    }
     const authContext = await validateIntegrationTokenOrReply(req, res);
     if (!authContext) {
         return;
@@ -2371,8 +2397,77 @@ exports.integrationProducts = functions.https.onRequest(async (req, res) => {
     });
     res.status(200).json({ storeId, products });
 });
+exports.v1IntegrationProducts = functions.https.onRequest(async (req, res) => {
+    setIntegrationResponseHeaders(res);
+    if (!validateIntegrationContractVersionOrReply(req, res)) {
+        return;
+    }
+    const authContext = await validateIntegrationTokenOrReply(req, res);
+    if (!authContext) {
+        return;
+    }
+    const { storeId } = authContext;
+    const mapProductDoc = (docSnap) => {
+        const data = docSnap.data();
+        const normalizedName = normalizeProductName(data.name);
+        return {
+            id: docSnap.id,
+            storeId,
+            name: normalizedName || 'Untitled item',
+            category: typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
+            description: typeof data.description === 'string' && data.description.trim()
+                ? data.description.trim()
+                : null,
+            price: typeof data.price === 'number' ? data.price : null,
+            stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
+            itemType: data.itemType === 'service'
+                ? 'service'
+                : data.itemType === 'made_to_order'
+                    ? 'made_to_order'
+                    : 'product',
+            ...extractProductImageSet(data),
+            updatedAt: data.updatedAt instanceof firestore_1.admin.firestore.Timestamp ? data.updatedAt.toDate().toISOString() : null,
+        };
+    };
+    let productsSnap;
+    try {
+        productsSnap = await firestore_1.defaultDb
+            .collection('products')
+            .where('storeId', '==', storeId)
+            .orderBy('updatedAt', 'desc')
+            .limit(200)
+            .get();
+    }
+    catch (error) {
+        const code = error?.code;
+        const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition';
+        if (!isMissingIndex) {
+            throw error;
+        }
+        console.warn('[v1IntegrationProducts] Missing Firestore index for ordered product query; falling back to unordered fetch', {
+            storeId,
+            code,
+        });
+        productsSnap = await firestore_1.defaultDb.collection('products').where('storeId', '==', storeId).limit(200).get();
+    }
+    const products = productsSnap.docs
+        .map(mapProductDoc)
+        .sort((a, b) => {
+        if (!a.updatedAt && !b.updatedAt)
+            return 0;
+        if (!a.updatedAt)
+            return 1;
+        if (!b.updatedAt)
+            return -1;
+        return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
+    });
+    res.status(200).json({ storeId, products });
+});
 exports.integrationPromo = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);
+    if (!validateIntegrationContractVersionOrReply(req, res)) {
+        return;
+    }
     if (req.method === 'OPTIONS') {
         res.status(204).send('');
         return;
@@ -2391,6 +2486,57 @@ exports.integrationPromo = functions.https.onRequest(async (req, res) => {
         }
         catch (error) {
             console.warn('[integrationPromo] Unable to fetch YouTube channel videos', {
+                storeId,
+                youtubeChannelId,
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+    res.status(200).json({
+        storeId,
+        promo: {
+            enabled: data.promoEnabled === true,
+            slug: toTrimmedStringOrNull(data.promoSlug),
+            title: toTrimmedStringOrNull(data.promoTitle),
+            summary: toTrimmedStringOrNull(data.promoSummary),
+            startDate: toTrimmedStringOrNull(data.promoStartDate),
+            endDate: toTrimmedStringOrNull(data.promoEndDate),
+            websiteUrl: toTrimmedStringOrNull(data.promoWebsiteUrl),
+            youtubeUrl,
+            youtubeEmbedUrl: toYoutubeEmbedUrl(youtubeUrl),
+            youtubeChannelId,
+            youtubeVideos,
+            imageUrl: toTrimmedStringOrNull(data.promoImageUrl),
+            imageAlt: toTrimmedStringOrNull(data.promoImageAlt),
+            phone: toTrimmedStringOrNull(data.whatsappNumber) ?? toTrimmedStringOrNull(data.phone),
+            storeName: toTrimmedStringOrNull(data.displayName) ?? toTrimmedStringOrNull(data.name) ?? 'Sedifex Store',
+            updatedAt: normalizeTimestampIso(data.updatedAt),
+        },
+    });
+});
+exports.v1IntegrationPromo = functions.https.onRequest(async (req, res) => {
+    setIntegrationResponseHeaders(res);
+    if (!validateIntegrationContractVersionOrReply(req, res)) {
+        return;
+    }
+    if (req.method === 'OPTIONS') {
+        res.status(204).send('');
+        return;
+    }
+    const storeContext = await resolvePromoStoreForRead(req, res);
+    if (!storeContext) {
+        return;
+    }
+    const { storeId, data } = storeContext;
+    const youtubeUrl = toTrimmedStringOrNull(data.promoYoutubeUrl);
+    const youtubeChannelId = toYoutubeChannelIdOrNull(toTrimmedStringOrNull(data.promoYoutubeChannelId));
+    let youtubeVideos = [];
+    if (youtubeChannelId) {
+        try {
+            youtubeVideos = await fetchYoutubeChannelVideos(youtubeChannelId, 5);
+        }
+        catch (error) {
+            console.warn('[v1IntegrationPromo] Unable to fetch YouTube channel videos', {
                 storeId,
                 youtubeChannelId,
                 error: error instanceof Error ? error.message : String(error),

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -139,6 +139,9 @@ const SMS_SEGMENT_SIZE = 160
 const OPENAI_API_KEY = defineString('OPENAI_API_KEY', { default: '' })
 const OPENAI_MODEL = defineString('OPENAI_MODEL', { default: 'gpt-4o-mini' })
 const OPENAI_CHAT_COMPLETIONS_URL = 'https://api.openai.com/v1/chat/completions'
+const INTEGRATION_CONTRACT_VERSION = defineString('INTEGRATION_CONTRACT_VERSION', {
+  default: '2026-04-13',
+})
 /** ============================================================================
  *  HELPERS
  * ==========================================================================*/
@@ -2544,12 +2547,39 @@ export const tiktokOAuthCallback = functions.https.onRequest(async (req, res) =>
 
 function setIntegrationResponseHeaders(res: functions.Response<any>) {
   const configuredApiBaseUrl = SEDIFEX_API_BASE_URL.value().trim()
+  const contractVersion = INTEGRATION_CONTRACT_VERSION.value().trim() || '2026-04-13'
+  const requestId = crypto.randomUUID()
   res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS')
-  res.setHeader('Access-Control-Allow-Headers', 'Authorization,Content-Type')
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Authorization,Content-Type,X-Sedifex-Contract-Version',
+  )
+  res.setHeader('x-sedifex-contract-version', contractVersion)
+  res.setHeader('x-sedifex-request-id', requestId)
   if (configuredApiBaseUrl) {
     res.setHeader('x-sedifex-api-base-url', configuredApiBaseUrl)
   }
+}
+
+function validateIntegrationContractVersionOrReply(
+  req: functions.https.Request,
+  res: functions.Response<any>,
+): boolean {
+  const requestedVersion = typeof req.headers['x-sedifex-contract-version'] === 'string'
+    ? req.headers['x-sedifex-contract-version'].trim()
+    : ''
+  if (!requestedVersion) return true
+
+  const currentVersion = INTEGRATION_CONTRACT_VERSION.value().trim() || '2026-04-13'
+  if (requestedVersion === currentVersion) return true
+
+  res.status(400).json({
+    error: 'contract-version-mismatch',
+    expectedVersion: currentVersion,
+    receivedVersion: requestedVersion,
+  })
+  return false
 }
 
 function getIntegrationAuthContext(req: functions.https.Request) {
@@ -2987,6 +3017,9 @@ async function validateIntegrationTokenOrReply(
 
 export const integrationProducts = functions.https.onRequest(async (req, res) => {
   setIntegrationResponseHeaders(res)
+  if (!validateIntegrationContractVersionOrReply(req, res)) {
+    return
+  }
   const authContext = await validateIntegrationTokenOrReply(req, res)
   if (!authContext) {
     return
@@ -3053,8 +3086,83 @@ export const integrationProducts = functions.https.onRequest(async (req, res) =>
   res.status(200).json({ storeId, products })
 })
 
+export const v1IntegrationProducts = functions.https.onRequest(async (req, res) => {
+  setIntegrationResponseHeaders(res)
+  if (!validateIntegrationContractVersionOrReply(req, res)) {
+    return
+  }
+  const authContext = await validateIntegrationTokenOrReply(req, res)
+  if (!authContext) {
+    return
+  }
+  const { storeId } = authContext
+
+  const mapProductDoc = (docSnap: admin.firestore.QueryDocumentSnapshot) => {
+    const data = docSnap.data() as Record<string, unknown>
+    const normalizedName = normalizeProductName(data.name)
+    return {
+      id: docSnap.id,
+      storeId,
+      name: normalizedName || 'Untitled item',
+      category:
+        typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
+      description:
+        typeof data.description === 'string' && data.description.trim()
+          ? data.description.trim()
+          : null,
+      price: typeof data.price === 'number' ? data.price : null,
+      stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
+      itemType:
+        data.itemType === 'service'
+          ? 'service'
+          : data.itemType === 'made_to_order'
+            ? 'made_to_order'
+            : 'product',
+      ...extractProductImageSet(data),
+      updatedAt:
+        data.updatedAt instanceof admin.firestore.Timestamp ? data.updatedAt.toDate().toISOString() : null,
+    }
+  }
+
+  let productsSnap: admin.firestore.QuerySnapshot
+  try {
+    productsSnap = await db
+      .collection('products')
+      .where('storeId', '==', storeId)
+      .orderBy('updatedAt', 'desc')
+      .limit(200)
+      .get()
+  } catch (error) {
+    const code = (error as { code?: number | string } | null)?.code
+    const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition'
+    if (!isMissingIndex) {
+      throw error
+    }
+
+    console.warn('[v1IntegrationProducts] Missing Firestore index for ordered product query; falling back to unordered fetch', {
+      storeId,
+      code,
+    })
+    productsSnap = await db.collection('products').where('storeId', '==', storeId).limit(200).get()
+  }
+
+  const products = productsSnap.docs
+    .map(mapProductDoc)
+    .sort((a, b) => {
+      if (!a.updatedAt && !b.updatedAt) return 0
+      if (!a.updatedAt) return 1
+      if (!b.updatedAt) return -1
+      return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
+    })
+
+  res.status(200).json({ storeId, products })
+})
+
 export const integrationPromo = functions.https.onRequest(async (req, res) => {
   setIntegrationResponseHeaders(res)
+  if (!validateIntegrationContractVersionOrReply(req, res)) {
+    return
+  }
   if (req.method === 'OPTIONS') {
     res.status(204).send('')
     return
@@ -3096,6 +3204,58 @@ export const integrationPromo = functions.https.onRequest(async (req, res) => {
       imageAlt: toTrimmedStringOrNull(data.promoImageAlt),
       phone: toTrimmedStringOrNull(data.whatsappNumber) ?? toTrimmedStringOrNull(data.phone),
       storeName: toTrimmedStringOrNull(data.displayName) ?? toTrimmedStringOrNull(data.name) ?? 'Sedifex Store',
+      updatedAt: normalizeTimestampIso(data.updatedAt),
+    },
+  })
+})
+
+export const v1IntegrationPromo = functions.https.onRequest(async (req, res) => {
+  setIntegrationResponseHeaders(res)
+  if (!validateIntegrationContractVersionOrReply(req, res)) {
+    return
+  }
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('')
+    return
+  }
+  const storeContext = await resolvePromoStoreForRead(req, res)
+  if (!storeContext) {
+    return
+  }
+  const { storeId, data } = storeContext
+  const youtubeUrl = toTrimmedStringOrNull(data.promoYoutubeUrl)
+  const youtubeChannelId = toYoutubeChannelIdOrNull(toTrimmedStringOrNull(data.promoYoutubeChannelId))
+  let youtubeVideos: YoutubeFeedVideo[] = []
+  if (youtubeChannelId) {
+    try {
+      youtubeVideos = await fetchYoutubeChannelVideos(youtubeChannelId, 5)
+    } catch (error) {
+      console.warn('[v1IntegrationPromo] Unable to fetch YouTube channel videos', {
+        storeId,
+        youtubeChannelId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+  res.status(200).json({
+    storeId,
+    promo: {
+      enabled: data.promoEnabled === true,
+      slug: toTrimmedStringOrNull(data.promoSlug),
+      title: toTrimmedStringOrNull(data.promoTitle),
+      summary: toTrimmedStringOrNull(data.promoSummary),
+      startDate: toTrimmedStringOrNull(data.promoStartDate),
+      endDate: toTrimmedStringOrNull(data.promoEndDate),
+      websiteUrl: toTrimmedStringOrNull(data.promoWebsiteUrl),
+      youtubeUrl,
+      youtubeEmbedUrl: toYoutubeEmbedUrl(youtubeUrl),
+      youtubeChannelId,
+      youtubeVideos,
+      imageUrl: toTrimmedStringOrNull(data.promoImageUrl),
+      imageAlt: toTrimmedStringOrNull(data.promoImageAlt),
+      phone: toTrimmedStringOrNull(data.whatsappNumber) ?? toTrimmedStringOrNull(data.phone),
+      storeName:
+        toTrimmedStringOrNull(data.displayName) ?? toTrimmedStringOrNull(data.name) ?? 'Sedifex Store',
       updatedAt: normalizeTimestampIso(data.updatedAt),
     },
   })

--- a/shared/integrationTypes.ts
+++ b/shared/integrationTypes.ts
@@ -1,0 +1,53 @@
+export type IntegrationContractVersion = '2026-04-13'
+
+export interface IntegrationProduct {
+  id: string
+  storeId: string
+  name: string
+  category: string | null
+  description: string | null
+  price: number | null
+  stockCount: number | null
+  itemType: 'product' | 'service' | 'made_to_order'
+  imageUrl: string | null
+  imageUrls: string[]
+  imageAlt: string | null
+  updatedAt: string | null
+}
+
+export interface IntegrationPromo {
+  enabled: boolean
+  slug: string | null
+  title: string | null
+  summary: string | null
+  startDate: string | null
+  endDate: string | null
+  websiteUrl: string | null
+  youtubeUrl: string | null
+  youtubeEmbedUrl: string | null
+  youtubeChannelId: string | null
+  youtubeVideos: Array<{
+    videoId: string
+    title: string
+    description: string | null
+    thumbnailUrl: string | null
+    publishedAt: string | null
+    videoUrl: string
+    embedUrl: string
+  }>
+  imageUrl: string | null
+  imageAlt: string | null
+  phone: string | null
+  storeName: string
+  updatedAt: string | null
+}
+
+export interface IntegrationProductsResponse {
+  storeId: string
+  products: IntegrationProduct[]
+}
+
+export interface IntegrationPromoResponse {
+  storeId: string
+  promo: IntegrationPromo
+}


### PR DESCRIPTION
### Motivation

- Provide a clear, versioned integration contract so external clients can depend on a stable API surface and safely migrate when fields change. 
- Share a typed contract between Sedifex and Buy Sedifex to avoid field drift and make client implementations safer. 

### Description

- Added `INTEGRATION_CONTRACT_VERSION` Cloud Functions param and return headers `x-sedifex-contract-version` and `x-sedifex-request-id`, and extended CORS `Access-Control-Allow-Headers` to include `X-Sedifex-Contract-Version`. 
- Validate incoming `X-Sedifex-Contract-Version` requests with `validateIntegrationContractVersionOrReply` and return a structured `400` `contract-version-mismatch` error when versions differ. 
- Introduced versioned endpoint aliases `v1IntegrationProducts` and `v1IntegrationPromo` while keeping existing unversioned endpoints for backwards compatibility. 
- Added shared TypeScript types in `shared/integrationTypes.ts` (`IntegrationProduct`, `IntegrationPromo`, and response wrappers) and documentation updates in `docs/integration-quickstart.md` and new `docs/integration-api-guide.md` describing authentication, headers, response shapes, caching, error handling, and migration guidance. 

### Testing

- Ran build for Cloud Functions with `npm --prefix functions run build`, which completed successfully. 
- Attempted to run an existing function test with `node functions/test/updateStoreProfile.test.js`, which failed in this environment due to a missing `ts-node/register/transpile-only` dependency and not because of functional regressions in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9d774f0883229918d39294451c78)