### PR TITLE
Add store-diverse sorting and pagination for marketplace `/v1/products`

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -30,6 +30,43 @@ This guide explains how third-party clients (including Buy Sedifex) should authe
 
 ## 3) Endpoint response shapes
 
+### `GET /v1/products` (public marketplace feed)
+
+Query parameters:
+
+- `sort`: `store-diverse` | `newest` | `price` | `featured`
+  - `store-diverse` groups products by `storeId`, sorts within each store by `featuredRank desc`, then `updatedAt desc`, and interleaves stores round-robin before pagination.
+- `page`: 1-based page number (default `1`).
+- `pageSize` or `limit`: products per page (default `24`, max `60`).
+- `maxPerStore` (optional): cap how many products from the same store may appear on a single page.
+
+```json
+{
+  "sort": "store-diverse",
+  "page": 1,
+  "pageSize": 24,
+  "maxPerStore": 2,
+  "total": 324,
+  "products": [
+    {
+      "id": "product_1",
+      "storeId": "store_123",
+      "name": "Item",
+      "category": "Meals",
+      "description": "Description",
+      "price": 45,
+      "stockCount": 10,
+      "itemType": "product",
+      "imageUrl": "https://...",
+      "imageUrls": ["https://..."],
+      "imageAlt": "Item image",
+      "featuredRank": 12,
+      "updatedAt": "2026-04-13T00:00:00.000Z"
+    }
+  ]
+}
+```
+
 ### `GET /v1IntegrationProducts?storeId=<storeId>` (authenticated)
 
 ```json

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -36,7 +36,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkMessage = exports.emitProductWebhooks = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.v1IntegrationPromo = exports.integrationPromo = exports.v1IntegrationProducts = exports.integrationProducts = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.manageStaffAccount = exports.generateAiAdvice = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSyncScheduled = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
+exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkMessage = exports.emitProductWebhooks = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.v1IntegrationPromo = exports.integrationPromo = exports.v1IntegrationProducts = exports.integrationProducts = exports.v1Products = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.manageStaffAccount = exports.generateAiAdvice = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSyncScheduled = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
 // functions/src/index.ts
 const functions = __importStar(require("firebase-functions/v1"));
 const crypto = __importStar(require("crypto"));
@@ -2331,6 +2331,176 @@ async function validateIntegrationTokenOrReply(req, res) {
     }, { merge: true });
     return { storeId };
 }
+function toFiniteNumberOrNull(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+function getSortMode(value) {
+    if (value === 'price' || value === 'featured' || value === 'store-diverse')
+        return value;
+    return 'newest';
+}
+function compareByFeaturedThenUpdated(a, b) {
+    if (a.featuredRank !== b.featuredRank)
+        return b.featuredRank - a.featuredRank;
+    if (!a.updatedAt && !b.updatedAt)
+        return 0;
+    if (!a.updatedAt)
+        return 1;
+    if (!b.updatedAt)
+        return -1;
+    return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
+}
+function isMarketplaceVisibleProduct(data, name) {
+    if (!name)
+        return false;
+    if (data.deleted === true || data.isDeleted === true)
+        return false;
+    if (data.archived === true || data.isArchived === true)
+        return false;
+    if (data.hidden === true || data.isHidden === true)
+        return false;
+    if (data.visible === false || data.isVisible === false)
+        return false;
+    return true;
+}
+function interleaveStoreDiverse(products) {
+    const byStore = new Map();
+    for (const product of products) {
+        const rows = byStore.get(product.storeId) ?? [];
+        rows.push(product);
+        byStore.set(product.storeId, rows);
+    }
+    const stores = [...byStore.keys()].sort((a, b) => a.localeCompare(b));
+    for (const storeId of stores) {
+        const rows = byStore.get(storeId);
+        if (!rows)
+            continue;
+        rows.sort(compareByFeaturedThenUpdated);
+    }
+    const interleaved = [];
+    let keepGoing = true;
+    while (keepGoing) {
+        keepGoing = false;
+        for (const storeId of stores) {
+            const rows = byStore.get(storeId);
+            if (!rows || rows.length === 0)
+                continue;
+            const next = rows.shift();
+            if (!next)
+                continue;
+            interleaved.push(next);
+            keepGoing = true;
+        }
+    }
+    return interleaved;
+}
+function paginateProducts(products, page, pageSize, maxPerStore) {
+    if (!maxPerStore) {
+        const start = (page - 1) * pageSize;
+        return products.slice(start, start + pageSize);
+    }
+    const pages = [];
+    let currentPage = [];
+    let perStoreCounter = new Map();
+    for (const product of products) {
+        if (currentPage.length >= pageSize) {
+            pages.push(currentPage);
+            currentPage = [];
+            perStoreCounter = new Map();
+        }
+        const currentStoreCount = perStoreCounter.get(product.storeId) ?? 0;
+        if (currentStoreCount >= maxPerStore) {
+            continue;
+        }
+        currentPage.push(product);
+        perStoreCounter.set(product.storeId, currentStoreCount + 1);
+    }
+    if (currentPage.length)
+        pages.push(currentPage);
+    return pages[page - 1] ?? [];
+}
+exports.v1Products = functions.https.onRequest(async (req, res) => {
+    setIntegrationResponseHeaders(res);
+    if (req.method !== 'GET') {
+        res.status(405).json({ error: 'method-not-allowed' });
+        return;
+    }
+    const sort = getSortMode(req.query.sort);
+    const pageRaw = Number(req.query.page ?? 1);
+    const requestedPage = Number.isFinite(pageRaw) ? Math.floor(pageRaw) : 1;
+    const page = Math.max(1, requestedPage);
+    const pageSizeRaw = Number(req.query.pageSize ?? req.query.limit ?? 24);
+    const requestedPageSize = Number.isFinite(pageSizeRaw) ? Math.floor(pageSizeRaw) : 24;
+    const pageSize = Math.min(Math.max(requestedPageSize, 1), 60);
+    const maxPerStoreRaw = Number(req.query.maxPerStore ?? 0);
+    const maxPerStoreCandidate = Number.isFinite(maxPerStoreRaw) ? Math.floor(maxPerStoreRaw) : 0;
+    const maxPerStore = maxPerStoreCandidate > 0 ? maxPerStoreCandidate : null;
+    let productsSnap;
+    try {
+        productsSnap = await firestore_1.defaultDb.collection('products').orderBy('updatedAt', 'desc').limit(2000).get();
+    }
+    catch (error) {
+        const code = error?.code;
+        const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition';
+        if (!isMissingIndex)
+            throw error;
+        productsSnap = await firestore_1.defaultDb.collection('products').limit(2000).get();
+    }
+    const visibleProducts = productsSnap.docs
+        .map(docSnap => {
+        const data = docSnap.data();
+        const storeId = typeof data.storeId === 'string' ? data.storeId.trim() : '';
+        const name = normalizeProductName(data.name);
+        if (!storeId || !isMarketplaceVisibleProduct(data, name))
+            return null;
+        return {
+            id: docSnap.id,
+            storeId,
+            name: name || 'Untitled item',
+            category: typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
+            description: typeof data.description === 'string' && data.description.trim() ? data.description.trim() : null,
+            price: typeof data.price === 'number' ? data.price : null,
+            stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
+            itemType: data.itemType === 'service'
+                ? 'service'
+                : data.itemType === 'made_to_order'
+                    ? 'made_to_order'
+                    : 'product',
+            ...extractProductImageSet(data),
+            featuredRank: toFiniteNumberOrNull(data.featuredRank) ?? 0,
+            updatedAt: normalizeTimestampIso(data.updatedAt),
+        };
+    })
+        .filter((item) => item !== null);
+    const sortedProducts = sort === 'store-diverse'
+        ? interleaveStoreDiverse(visibleProducts)
+        : [...visibleProducts].sort((a, b) => {
+            if (sort === 'featured')
+                return compareByFeaturedThenUpdated(a, b);
+            if (sort === 'price') {
+                const aPrice = typeof a.price === 'number' ? a.price : Number.POSITIVE_INFINITY;
+                const bPrice = typeof b.price === 'number' ? b.price : Number.POSITIVE_INFINITY;
+                if (aPrice !== bPrice)
+                    return aPrice - bPrice;
+            }
+            if (!a.updatedAt && !b.updatedAt)
+                return 0;
+            if (!a.updatedAt)
+                return 1;
+            if (!b.updatedAt)
+                return -1;
+            return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
+        });
+    const products = paginateProducts(sortedProducts, page, pageSize, maxPerStore);
+    res.status(200).json({
+        sort,
+        page,
+        pageSize,
+        maxPerStore,
+        total: sortedProducts.length,
+        products,
+    });
+});
 exports.integrationProducts = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);
     if (!validateIntegrationContractVersionOrReply(req, res)) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3015,6 +3015,198 @@ async function validateIntegrationTokenOrReply(
   return { storeId }
 }
 
+type MarketplaceSortMode = 'newest' | 'price' | 'featured' | 'store-diverse'
+
+type MarketplaceProductRow = {
+  id: string
+  storeId: string
+  name: string
+  category: string | null
+  description: string | null
+  price: number | null
+  stockCount: number | null
+  itemType: 'product' | 'service' | 'made_to_order'
+  imageUrl: string | null
+  imageUrls: string[]
+  imageAlt: string | null
+  featuredRank: number
+  updatedAt: string | null
+}
+
+function toFiniteNumberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function getSortMode(value: unknown): MarketplaceSortMode {
+  if (value === 'price' || value === 'featured' || value === 'store-diverse') return value
+  return 'newest'
+}
+
+function compareByFeaturedThenUpdated(a: MarketplaceProductRow, b: MarketplaceProductRow): number {
+  if (a.featuredRank !== b.featuredRank) return b.featuredRank - a.featuredRank
+  if (!a.updatedAt && !b.updatedAt) return 0
+  if (!a.updatedAt) return 1
+  if (!b.updatedAt) return -1
+  return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
+}
+
+function isMarketplaceVisibleProduct(data: Record<string, unknown>, name: string): boolean {
+  if (!name) return false
+  if (data.deleted === true || data.isDeleted === true) return false
+  if (data.archived === true || data.isArchived === true) return false
+  if (data.hidden === true || data.isHidden === true) return false
+  if (data.visible === false || data.isVisible === false) return false
+  return true
+}
+
+function interleaveStoreDiverse(products: MarketplaceProductRow[]): MarketplaceProductRow[] {
+  const byStore = new Map<string, MarketplaceProductRow[]>()
+  for (const product of products) {
+    const rows = byStore.get(product.storeId) ?? []
+    rows.push(product)
+    byStore.set(product.storeId, rows)
+  }
+  const stores = [...byStore.keys()].sort((a, b) => a.localeCompare(b))
+  for (const storeId of stores) {
+    const rows = byStore.get(storeId)
+    if (!rows) continue
+    rows.sort(compareByFeaturedThenUpdated)
+  }
+
+  const interleaved: MarketplaceProductRow[] = []
+  let keepGoing = true
+  while (keepGoing) {
+    keepGoing = false
+    for (const storeId of stores) {
+      const rows = byStore.get(storeId)
+      if (!rows || rows.length === 0) continue
+      const next = rows.shift()
+      if (!next) continue
+      interleaved.push(next)
+      keepGoing = true
+    }
+  }
+  return interleaved
+}
+
+function paginateProducts(
+  products: MarketplaceProductRow[],
+  page: number,
+  pageSize: number,
+  maxPerStore: number | null,
+): MarketplaceProductRow[] {
+  if (!maxPerStore) {
+    const start = (page - 1) * pageSize
+    return products.slice(start, start + pageSize)
+  }
+
+  const pages: MarketplaceProductRow[][] = []
+  let currentPage: MarketplaceProductRow[] = []
+  let perStoreCounter = new Map<string, number>()
+
+  for (const product of products) {
+    if (currentPage.length >= pageSize) {
+      pages.push(currentPage)
+      currentPage = []
+      perStoreCounter = new Map<string, number>()
+    }
+    const currentStoreCount = perStoreCounter.get(product.storeId) ?? 0
+    if (currentStoreCount >= maxPerStore) {
+      continue
+    }
+    currentPage.push(product)
+    perStoreCounter.set(product.storeId, currentStoreCount + 1)
+  }
+  if (currentPage.length) pages.push(currentPage)
+  return pages[page - 1] ?? []
+}
+
+export const v1Products = functions.https.onRequest(async (req, res) => {
+  setIntegrationResponseHeaders(res)
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'method-not-allowed' })
+    return
+  }
+
+  const sort = getSortMode(req.query.sort)
+  const pageRaw = Number(req.query.page ?? 1)
+  const requestedPage = Number.isFinite(pageRaw) ? Math.floor(pageRaw) : 1
+  const page = Math.max(1, requestedPage)
+  const pageSizeRaw = Number(req.query.pageSize ?? req.query.limit ?? 24)
+  const requestedPageSize = Number.isFinite(pageSizeRaw) ? Math.floor(pageSizeRaw) : 24
+  const pageSize = Math.min(Math.max(requestedPageSize, 1), 60)
+  const maxPerStoreRaw = Number(req.query.maxPerStore ?? 0)
+  const maxPerStoreCandidate = Number.isFinite(maxPerStoreRaw) ? Math.floor(maxPerStoreRaw) : 0
+  const maxPerStore = maxPerStoreCandidate > 0 ? maxPerStoreCandidate : null
+
+  let productsSnap: admin.firestore.QuerySnapshot
+  try {
+    productsSnap = await db.collection('products').orderBy('updatedAt', 'desc').limit(2000).get()
+  } catch (error) {
+    const code = (error as { code?: number | string } | null)?.code
+    const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition'
+    if (!isMissingIndex) throw error
+    productsSnap = await db.collection('products').limit(2000).get()
+  }
+
+  const visibleProducts = productsSnap.docs
+    .map(docSnap => {
+      const data = docSnap.data() as Record<string, unknown>
+      const storeId = typeof data.storeId === 'string' ? data.storeId.trim() : ''
+      const name = normalizeProductName(data.name)
+      if (!storeId || !isMarketplaceVisibleProduct(data, name)) return null
+
+      return {
+        id: docSnap.id,
+        storeId,
+        name: name || 'Untitled item',
+        category:
+          typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
+        description:
+          typeof data.description === 'string' && data.description.trim() ? data.description.trim() : null,
+        price: typeof data.price === 'number' ? data.price : null,
+        stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
+        itemType:
+          data.itemType === 'service'
+            ? 'service'
+            : data.itemType === 'made_to_order'
+              ? 'made_to_order'
+              : 'product',
+        ...extractProductImageSet(data),
+        featuredRank: toFiniteNumberOrNull(data.featuredRank) ?? 0,
+        updatedAt: normalizeTimestampIso(data.updatedAt),
+      } as MarketplaceProductRow
+    })
+    .filter((item): item is MarketplaceProductRow => item !== null)
+
+  const sortedProducts =
+    sort === 'store-diverse'
+      ? interleaveStoreDiverse(visibleProducts)
+      : [...visibleProducts].sort((a, b) => {
+          if (sort === 'featured') return compareByFeaturedThenUpdated(a, b)
+          if (sort === 'price') {
+            const aPrice = typeof a.price === 'number' ? a.price : Number.POSITIVE_INFINITY
+            const bPrice = typeof b.price === 'number' ? b.price : Number.POSITIVE_INFINITY
+            if (aPrice !== bPrice) return aPrice - bPrice
+          }
+          if (!a.updatedAt && !b.updatedAt) return 0
+          if (!a.updatedAt) return 1
+          if (!b.updatedAt) return -1
+          return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
+        })
+
+  const products = paginateProducts(sortedProducts, page, pageSize, maxPerStore)
+
+  res.status(200).json({
+    sort,
+    page,
+    pageSize,
+    maxPerStore,
+    total: sortedProducts.length,
+    products,
+  })
+})
+
 export const integrationProducts = functions.https.onRequest(async (req, res) => {
   setIntegrationResponseHeaders(res)
   if (!validateIntegrationContractVersionOrReply(req, res)) {


### PR DESCRIPTION
### Motivation

- Prevent a single store from dominating the public marketplace feed by mixing products from multiple stores on the homepage and preserve balanced pagination across pages.
- Expose a server-side `store-diverse` sort mode so clients (e.g. Buy Sedifex) can request a mixed-store feed without client-side merging.

### Description

- Added a new public Cloud Function endpoint `v1Products` in `functions/src/index.ts` that supports query params `sort`, `page`, `pageSize`/`limit`, and optional `maxPerStore` and defaults to `newest` when unspecified.
- Implemented `store-diverse` flow which filters marketplace-visible products, groups by `storeId`, sorts each store bucket by `featuredRank desc` then `updatedAt desc`, interleaves stores round-robin, and only then paginates (with optional per-page `maxPerStore` enforcement).
- Kept existing sort modes (`newest`, `price`, `featured`) for backward compatibility and implemented tie-breakers by `updatedAt` where appropriate.
- Documented the new public endpoint and query parameters in `docs/integration-api-guide.md` and emitted compiled JS at `functions/lib/index.js` when building.

### Testing

- Ran the functions TypeScript build with `cd functions && npm run build` to verify compilation and generation of `functions/lib/index.js`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcac946a388322ba3ce8e5ca498afe)