### PR TITLE
Move WhatsApp CTA to landing page and add expandable promo product descriptions

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -102,6 +102,35 @@ body {
   z-index: 1;
 }
 
+.app-whatsapp-float {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 60;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  border-radius: 999px;
+  padding: 10px 18px;
+  text-decoration: none;
+  font-weight: 700;
+  color: #ffffff;
+  background: linear-gradient(135deg, #16a34a, #15803d);
+  box-shadow:
+    0 16px 28px rgba(21, 128, 61, 0.33),
+    0 0 0 1px rgba(255, 255, 255, 0.22) inset;
+}
+
+.app-whatsapp-float:hover {
+  background: linear-gradient(135deg, #15803d, #166534);
+}
+
+.app-whatsapp-float:focus-visible {
+  outline: 3px solid rgba(22, 163, 74, 0.35);
+  outline-offset: 2px;
+}
+
 .app__pricing {
   width: min(1280px, 100%);
   display: grid;

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -40,6 +40,7 @@ const AUTH_VISUAL_IMAGE_URL =
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const PASSWORD_MIN_LENGTH = 8
 const MAX_BLOG_POSTS = 3
+const LANDING_WHATSAPP_NUMBER = '0205706589'
 
 type AuthMode = 'login' | 'signup'
 type StatusTone = 'idle' | 'loading' | 'success' | 'error'
@@ -736,6 +737,7 @@ export default function AuthPage() {
   }
 
   const appStyle: React.CSSProperties = { minHeight: '100dvh' }
+  const landingSupportWhatsappLink = `https://wa.me/${LANDING_WHATSAPP_NUMBER}?text=${encodeURIComponent('Hello Sedifex team, I need help getting started.')}`
 
   return (
     <main className="app" style={appStyle}>
@@ -1395,6 +1397,15 @@ export default function AuthPage() {
           </ul>
         </article>
       </section>
+      <a
+        className="app-whatsapp-float"
+        href={landingSupportWhatsappLink}
+        target="_blank"
+        rel="noreferrer noopener"
+        aria-label={`Reach out on WhatsApp at ${LANDING_WHATSAPP_NUMBER}`}
+      >
+        WhatsApp us: {LANDING_WHATSAPP_NUMBER}
+      </a>
     </main>
   )
 }

--- a/web/src/pages/PromoLandingPage.css
+++ b/web/src/pages/PromoLandingPage.css
@@ -11,37 +11,6 @@
     linear-gradient(180deg, #eef2ff 0%, #e2e8f0 100%);
 }
 
-.promo-whatsapp-float {
-  position: fixed;
-  left: 50%;
-  bottom: 18px;
-  transform: translateX(-50%);
-  z-index: 45;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 48px;
-  width: min(520px, calc(100vw - 28px));
-  border-radius: 999px;
-  padding: 10px 18px;
-  text-decoration: none;
-  font-weight: 700;
-  color: #ffffff;
-  background: linear-gradient(135deg, #16a34a, #15803d);
-  box-shadow:
-    0 16px 28px rgba(21, 128, 61, 0.33),
-    0 0 0 1px rgba(255, 255, 255, 0.22) inset;
-}
-
-.promo-whatsapp-float:hover {
-  background: linear-gradient(135deg, #15803d, #166534);
-}
-
-.promo-whatsapp-float:focus-visible {
-  outline: 3px solid rgba(22, 163, 74, 0.35);
-  outline-offset: 2px;
-}
-
 .promo-nav {
   display: flex;
   flex-wrap: wrap;
@@ -144,6 +113,20 @@
   color: #1e293b;
   line-height: 1.65;
   font-size: 1.03rem;
+}
+
+.promo-description-toggle {
+  border: 0;
+  background: transparent;
+  color: #4338ca;
+  font-weight: 700;
+  padding: 0;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.promo-description-toggle:hover {
+  color: #312e81;
 }
 
 .promo-contact-actions {

--- a/web/src/pages/PromoLandingPage.tsx
+++ b/web/src/pages/PromoLandingPage.tsx
@@ -101,6 +101,7 @@ type CatalogApiResponse = {
 }
 
 const CATALOG_PAGE_SIZE = 24
+const CATALOG_DESCRIPTION_PREVIEW_LENGTH = 220
 
 function normalizeSlug(value: string): string {
   return value
@@ -172,8 +173,6 @@ function buildWhatsAppLink(phone: string | null, storeName: string): string | nu
   return `https://wa.me/${normalized}?text=${text}`
 }
 
-const LANDING_WHATSAPP_NUMBER = '0205706589'
-
 function getIntegrationEndpoint(path: string): string {
   const functionsRegion = import.meta.env.VITE_FB_FUNCTIONS_REGION ?? 'us-central1'
   const projectId = import.meta.env.VITE_FB_PROJECT_ID
@@ -203,6 +202,7 @@ export default function PromoLandingPage() {
   const [activeGalleryImageId, setActiveGalleryImageId] = useState<string | null>(null)
   const [catalogSearchTerm, setCatalogSearchTerm] = useState('')
   const [catalogPage, setCatalogPage] = useState(1)
+  const [expandedCatalogDescriptions, setExpandedCatalogDescriptions] = useState<Record<string, boolean>>({})
 
   const activeGalleryIndex = useMemo(() => {
     if (!activeGalleryImageId) {
@@ -241,6 +241,23 @@ export default function PromoLandingPage() {
     const start = (currentCatalogPage - 1) * CATALOG_PAGE_SIZE
     return filteredCatalogItems.slice(start, start + CATALOG_PAGE_SIZE)
   }, [currentCatalogPage, filteredCatalogItems])
+
+  function getCatalogDescriptionPreview(value: string): { text: string; isTruncated: boolean } {
+    const normalized = value.replace(/\s+/g, ' ').trim()
+    if (normalized.length <= CATALOG_DESCRIPTION_PREVIEW_LENGTH) {
+      return { text: normalized, isTruncated: false }
+    }
+    const clipped = normalized.slice(0, CATALOG_DESCRIPTION_PREVIEW_LENGTH)
+    const safeClip = clipped.replace(/\s+\S*$/, '').trim()
+    return { text: `${safeClip}…`, isTruncated: true }
+  }
+
+  function toggleCatalogDescription(itemId: string) {
+    setExpandedCatalogDescriptions(previous => ({
+      ...previous,
+      [itemId]: !previous[itemId],
+    }))
+  }
 
   useEffect(() => {
     let isMounted = true
@@ -541,7 +558,6 @@ export default function PromoLandingPage() {
   const promoSummary = sanitizeSummary(profile.summary, profile.storeName)
   const directChatLink = profile.storePhone ? `sms:${profile.storePhone}` : null
   const whatsappLink = buildWhatsAppLink(profile.storePhone, profile.storeName)
-  const landingSupportWhatsappLink = buildWhatsAppLink(LANDING_WHATSAPP_NUMBER, 'Sedifex team')
   const primaryPromoVideoEmbedUrl = profile.youtubeVideos[0]?.embedUrl ?? profile.youtubeEmbedUrl
   return (
     <main className="promo-page">
@@ -776,9 +792,29 @@ export default function PromoLandingPage() {
                     ) : null}
                     <div>
                       <strong>{item.name}</strong>
-                      <p className="promo-summary">
-                        {item.description || `${item.itemType === 'service' ? 'Service' : 'Product'} available`}
-                      </p>
+                      {item.description ? (
+                        <>
+                          <p className="promo-summary">
+                            {expandedCatalogDescriptions[item.id]
+                              ? item.description
+                              : getCatalogDescriptionPreview(item.description).text}
+                          </p>
+                          {getCatalogDescriptionPreview(item.description).isTruncated ? (
+                            <button
+                              type="button"
+                              className="promo-description-toggle"
+                              onClick={() => toggleCatalogDescription(item.id)}
+                              aria-expanded={Boolean(expandedCatalogDescriptions[item.id])}
+                            >
+                              {expandedCatalogDescriptions[item.id] ? 'View less' : 'View more'}
+                            </button>
+                          ) : null}
+                        </>
+                      ) : (
+                        <p className="promo-summary">
+                          {`${item.itemType === 'service' ? 'Service' : 'Product'} available`}
+                        </p>
+                      )}
                       <p className="promo-meta">
                         {item.category || 'General'} · {item.itemType === 'service' ? 'Service' : 'Product'}
                         {typeof item.price === 'number' ? ` · ${item.price.toFixed(2)}` : ''}
@@ -820,17 +856,6 @@ export default function PromoLandingPage() {
             ) : null}
         </section>
       </article>
-      {landingSupportWhatsappLink ? (
-        <a
-          className="promo-whatsapp-float"
-          href={landingSupportWhatsappLink}
-          target="_blank"
-          rel="noreferrer noopener"
-          aria-label={`Reach out on WhatsApp at ${LANDING_WHATSAPP_NUMBER}`}
-        >
-          WhatsApp us: {LANDING_WHATSAPP_NUMBER}
-        </a>
-      ) : null}
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Reduce visual clutter on public store promo pages by removing the full-width WhatsApp support bar and surface support on the main landing where new clients and stores sign in. 
- Prevent long product descriptions from pushing content down the public promo page by truncating them with an explicit "View more / View less" control.

### Description
- Public promo page (`web/src/pages/PromoLandingPage.tsx`) now truncates long catalog item descriptions with a `CATALOG_DESCRIPTION_PREVIEW_LENGTH` threshold, adds per-item expanded state (`expandedCatalogDescriptions`), preview clipping logic (`getCatalogDescriptionPreview`) and a `toggleCatalogDescription` handler to render a `View more / View less` button when needed. 
- Removed the floating WhatsApp CTA from the promo page and deleted the `.promo-whatsapp-float` usage and styles. 
- Added a site-wide floating WhatsApp support CTA to the main auth/landing page (`web/src/pages/AuthPage.tsx`) using `landingSupportWhatsappLink` and placed it in the bottom-right corner. 
- Added `.app-whatsapp-float` styles to `web/src/App.css` and a `.promo-description-toggle` style to `web/src/pages/PromoLandingPage.css` for the new toggle control. 

### Testing
- Ran `npm run build` (in `web/`) which failed in this environment due to missing type definition files (`vite/client`, `vitest/globals`).
- Ran `npm ci` (in `web/`) which failed because `package-lock.json` is out of sync with `package.json` in this environment (pre-existing repo state).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd15393c188321a7902bbe0133cecf)