### PR TITLE
Docs: clarify API base URL and contract header; update example to use /v1IntegrationProducts

### DIFF
--- a/docs/integration-quickstart.md
+++ b/docs/integration-quickstart.md
@@ -172,6 +172,13 @@ It defines a pull + webhook model, contract versioning, reliability, and rollout
 
 ## Integration flow
 
+Base URL:
+
+- Use `https://us-central1-sedifex-web.cloudfunctions.net` as the production base URL.
+- In this repo, the canonical env name is `SEDIFEX_API_BASE_URL`.
+- If your other repo uses `SEDIFEX_INTEGRATION_API_BASE_URL`, set it to the same value (`https://us-central1-sedifex-web.cloudfunctions.net`).
+- Do not append a contract date/version segment to the base URL.
+
 1. Choose your key source:
    - Admin master key: set `SEDIFEX_INTEGRATION_API_KEY` in Firebase params (can pull all stores on integration product endpoints).
    - Store key: use the active store integration key created from account integrations (scoped to that store).
@@ -187,6 +194,19 @@ It defines a pull + webhook model, contract versioning, reliability, and rollout
 4. Return fallback data when external fetch fails.
 5. Render a grouped menu UI by category.
 6. Apply an appropriate cache strategy.
+
+### Common 404 fix (important)
+
+If your app logs a 404 such as:
+
+- `/2026-04-13/products`
+
+your URL builder is likely treating the contract version as a URL path segment. In Sedifex, `2026-04-13` is the **contract header value**, not an endpoint path. Use:
+
+- `GET /v1IntegrationProducts?storeId=<storeId>` (authenticated integration feed), or
+- `GET /v1/products` (public marketplace feed).
+
+Do **not** build routes like `/<contractVersion>/products`.
 
 ### Shared integration types
 
@@ -258,12 +278,13 @@ function dedupeProducts(products: Product[]): Product[] {
 async function fetchSedifexProducts(): Promise<Product[]> {
   try {
     const response = await fetch(
-      `${process.env.SEDIFEX_API_BASE_URL}/integrationProducts?storeId=${encodeURIComponent(
+      `${process.env.SEDIFEX_API_BASE_URL}/v1IntegrationProducts?storeId=${encodeURIComponent(
         process.env.SEDIFEX_STORE_ID ?? ''
       )}`,
       {
         headers: {
           'x-api-key': `${process.env.SEDIFEX_INTEGRATION_API_KEY ?? process.env.SEDIFEX_INTEGRATION_KEY}`,
+          'X-Sedifex-Contract-Version': process.env.SEDIFEX_CONTRACT_VERSION ?? '2026-04-13',
           Accept: 'application/json',
         },
         // ISR cache strategy (choose based on your catalog behavior)


### PR DESCRIPTION
### Motivation

- Prevent integrators from treating the contract version as a URL path segment and getting 404s by clarifying the base URL and contract header usage. 
- Align example code and environment variable guidance so integrations use the canonical base URL and include the required contract header.

### Description

- Add a `Base URL` section that specifies `https://us-central1-sedifex-web.cloudfunctions.net` as the production base and documents the canonical env name `SEDIFEX_API_BASE_URL` and the equivalent `SEDIFEX_INTEGRATION_API_BASE_URL` mapping. 
- Add a `Common 404 fix` section that explains `X-Sedifex-Contract-Version` is a header value (not a path segment) and shows correct endpoints (`GET /v1IntegrationProducts?storeId=<storeId>` and `GET /v1/products`).
- Update the Next.js example `fetchSedifexProducts` call to request ` /v1IntegrationProducts?storeId=...` and include the `X-Sedifex-Contract-Version` header using `process.env.SEDIFEX_CONTRACT_VERSION` with a `2026-04-13` fallback.

### Testing

- No automated tests were executed for this documentation and example update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd161f9a948321ab14781c47848534)