### PR TITLE
Include storeName and storeCity in integration product responses

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -53,6 +53,8 @@ Query parameters:
     {
       "id": "product_1",
       "storeId": "store_123",
+      "storeName": "Sedifex Store",
+      "storeCity": "Accra",
       "name": "Item",
       "category": "Meals",
       "description": "Description",
@@ -68,6 +70,8 @@ Query parameters:
   ]
 }
 ```
+
+`storeName` and `storeCity` are included so marketplace consumers (e.g. Buy Sedifex) can render seller identity/location without making extra store lookup calls.
 
 ### `GET /v1IntegrationProducts?storeId=<storeId>` (authenticated)
 

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -2065,6 +2065,30 @@ function toTrimmedStringOrNull(value) {
     const trimmed = value.trim();
     return trimmed ? trimmed : null;
 }
+function pickStoreCity(storeData) {
+    return toTrimmedStringOrNull(storeData.city) ?? toTrimmedStringOrNull(storeData.town);
+}
+async function fetchStoreMetaByStoreId(storeIds) {
+    const normalizedStoreIds = Array.from(new Set(storeIds
+        .map(storeId => (typeof storeId === 'string' ? storeId.trim() : ''))
+        .filter(Boolean)));
+    const storeMeta = new Map();
+    if (normalizedStoreIds.length === 0) {
+        return storeMeta;
+    }
+    const storeRefs = normalizedStoreIds.map(storeId => firestore_1.defaultDb.collection('stores').doc(storeId));
+    const storeSnapshots = await firestore_1.defaultDb.getAll(...storeRefs);
+    for (const storeSnapshot of storeSnapshots) {
+        if (!storeSnapshot.exists)
+            continue;
+        const data = (storeSnapshot.data() ?? {});
+        storeMeta.set(storeSnapshot.id, {
+            storeName: toTrimmedStringOrNull(data.displayName) ?? toTrimmedStringOrNull(data.name),
+            storeCity: pickStoreCity(data),
+        });
+    }
+    return storeMeta;
+}
 function extractYoutubeVideoId(value) {
     if (!value)
         return null;
@@ -2223,6 +2247,10 @@ async function resolvePromoStoreForRead(req, res) {
         if (!authContext) {
             return null;
         }
+        if (!authContext.storeId) {
+            res.status(400).json({ error: 'missing-store-id' });
+            return null;
+        }
         const storeSnap = await firestore_1.defaultDb.collection('stores').doc(authContext.storeId).get();
         if (!storeSnap.exists) {
             res.status(404).json({ error: 'store-not-found' });
@@ -2318,22 +2346,47 @@ function normalizeTimestampIso(value) {
     }
     return null;
 }
-async function validateIntegrationTokenOrReply(req, res) {
+async function validateIntegrationTokenOrReply(req, res, options) {
     if (req.method !== 'GET') {
         res.status(405).json({ error: 'method-not-allowed' });
         return null;
     }
+    const requireStoreId = options?.requireStoreId !== false;
     const { apiKey, storeId } = getIntegrationAuthContext(req);
-    if (!apiKey || !storeId) {
-        res.status(400).json({ error: 'missing-api-key-or-store' });
+    if (!apiKey) {
+        res.status(400).json({ error: 'missing-api-key' });
         return null;
     }
     const expectedApiKey = getIntegrationMasterApiKey();
-    if (!expectedApiKey || apiKey !== expectedApiKey) {
+    if (expectedApiKey && apiKey === expectedApiKey) {
+        if (requireStoreId && !storeId) {
+            res.status(400).json({ error: 'missing-store-id' });
+            return null;
+        }
+        return { storeId: storeId || null, isMasterKey: true };
+    }
+    if (!storeId) {
+        res.status(400).json({ error: 'missing-store-id' });
+        return null;
+    }
+    const tokenHash = hashIntegrationSecret(apiKey);
+    const keySnapshot = await firestore_1.defaultDb
+        .collection('integrationApiKeys')
+        .where('storeId', '==', storeId)
+        .where('status', '==', 'active')
+        .where('keyHash', '==', tokenHash)
+        .limit(1)
+        .get();
+    if (keySnapshot.empty) {
         res.status(401).json({ error: 'invalid-api-key' });
         return null;
     }
-    return { storeId };
+    const keyDoc = keySnapshot.docs[0];
+    await keyDoc.ref.set({
+        lastUsedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+    }, { merge: true });
+    return { storeId, isMasterKey: false };
 }
 function toFiniteNumberOrNull(value) {
     return typeof value === 'number' && Number.isFinite(value) ? value : null;
@@ -2510,17 +2563,21 @@ exports.integrationProducts = functions.https.onRequest(async (req, res) => {
     if (!validateIntegrationContractVersionOrReply(req, res)) {
         return;
     }
-    const authContext = await validateIntegrationTokenOrReply(req, res);
+    const authContext = await validateIntegrationTokenOrReply(req, res, { requireStoreId: false });
     if (!authContext) {
         return;
     }
-    const { storeId } = authContext;
     const mapProductDoc = (docSnap) => {
         const data = docSnap.data();
         const normalizedName = normalizeProductName(data.name);
+        const storeId = typeof data.storeId === 'string' && data.storeId.trim() ? data.storeId.trim() : null;
+        if (!storeId)
+            return null;
         return {
             id: docSnap.id,
             storeId,
+            storeName: null,
+            storeCity: null,
             name: normalizedName || 'Untitled item',
             category: typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
             description: typeof data.description === 'string' && data.description.trim()
@@ -2538,13 +2595,24 @@ exports.integrationProducts = functions.https.onRequest(async (req, res) => {
         };
     };
     let productsSnap;
+    const scopeStoreId = authContext.storeId;
+    const isAllStoresRead = authContext.isMasterKey && !scopeStoreId;
     try {
-        productsSnap = await firestore_1.defaultDb
-            .collection('products')
-            .where('storeId', '==', storeId)
-            .orderBy('updatedAt', 'desc')
-            .limit(200)
-            .get();
+        if (isAllStoresRead) {
+            productsSnap = await firestore_1.defaultDb.collection('products').orderBy('updatedAt', 'desc').limit(2000).get();
+        }
+        else {
+            if (!scopeStoreId) {
+                res.status(400).json({ error: 'missing-store-id' });
+                return;
+            }
+            productsSnap = await firestore_1.defaultDb
+                .collection('products')
+                .where('storeId', '==', scopeStoreId)
+                .orderBy('updatedAt', 'desc')
+                .limit(200)
+                .get();
+        }
     }
     catch (error) {
         const code = error?.code;
@@ -2552,14 +2620,23 @@ exports.integrationProducts = functions.https.onRequest(async (req, res) => {
         if (!isMissingIndex) {
             throw error;
         }
-        console.warn('[integrationProducts] Missing Firestore index for ordered product query; falling back to unordered fetch', {
-            storeId,
-            code,
-        });
-        productsSnap = await firestore_1.defaultDb.collection('products').where('storeId', '==', storeId).limit(200).get();
+        if (isAllStoresRead) {
+            console.warn('[integrationProducts] Missing Firestore index for all-store ordered product query; falling back to unordered fetch', {
+                code,
+            });
+            productsSnap = await firestore_1.defaultDb.collection('products').limit(2000).get();
+        }
+        else {
+            console.warn('[integrationProducts] Missing Firestore index for ordered product query; falling back to unordered fetch', {
+                storeId: scopeStoreId,
+                code,
+            });
+            productsSnap = await firestore_1.defaultDb.collection('products').where('storeId', '==', scopeStoreId).limit(200).get();
+        }
     }
     const products = productsSnap.docs
         .map(mapProductDoc)
+        .filter(item => item !== null)
         .sort((a, b) => {
         if (!a.updatedAt && !b.updatedAt)
             return 0;
@@ -2569,24 +2646,41 @@ exports.integrationProducts = functions.https.onRequest(async (req, res) => {
             return -1;
         return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
     });
-    res.status(200).json({ storeId, products });
+    const storeMetaByStoreId = await fetchStoreMetaByStoreId(products.map(product => product.storeId));
+    const enrichedProducts = products.map(product => {
+        const storeMeta = storeMetaByStoreId.get(product.storeId);
+        return {
+            ...product,
+            storeName: storeMeta?.storeName ?? null,
+            storeCity: storeMeta?.storeCity ?? null,
+        };
+    });
+    res.status(200).json({
+        storeId: scopeStoreId ?? null,
+        scope: isAllStoresRead ? 'all-stores' : 'store',
+        products: enrichedProducts,
+    });
 });
 exports.v1IntegrationProducts = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);
     if (!validateIntegrationContractVersionOrReply(req, res)) {
         return;
     }
-    const authContext = await validateIntegrationTokenOrReply(req, res);
+    const authContext = await validateIntegrationTokenOrReply(req, res, { requireStoreId: false });
     if (!authContext) {
         return;
     }
-    const { storeId } = authContext;
     const mapProductDoc = (docSnap) => {
         const data = docSnap.data();
         const normalizedName = normalizeProductName(data.name);
+        const storeId = typeof data.storeId === 'string' && data.storeId.trim() ? data.storeId.trim() : null;
+        if (!storeId)
+            return null;
         return {
             id: docSnap.id,
             storeId,
+            storeName: null,
+            storeCity: null,
             name: normalizedName || 'Untitled item',
             category: typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
             description: typeof data.description === 'string' && data.description.trim()
@@ -2604,13 +2698,24 @@ exports.v1IntegrationProducts = functions.https.onRequest(async (req, res) => {
         };
     };
     let productsSnap;
+    const scopeStoreId = authContext.storeId;
+    const isAllStoresRead = authContext.isMasterKey && !scopeStoreId;
     try {
-        productsSnap = await firestore_1.defaultDb
-            .collection('products')
-            .where('storeId', '==', storeId)
-            .orderBy('updatedAt', 'desc')
-            .limit(200)
-            .get();
+        if (isAllStoresRead) {
+            productsSnap = await firestore_1.defaultDb.collection('products').orderBy('updatedAt', 'desc').limit(2000).get();
+        }
+        else {
+            if (!scopeStoreId) {
+                res.status(400).json({ error: 'missing-store-id' });
+                return;
+            }
+            productsSnap = await firestore_1.defaultDb
+                .collection('products')
+                .where('storeId', '==', scopeStoreId)
+                .orderBy('updatedAt', 'desc')
+                .limit(200)
+                .get();
+        }
     }
     catch (error) {
         const code = error?.code;
@@ -2618,14 +2723,23 @@ exports.v1IntegrationProducts = functions.https.onRequest(async (req, res) => {
         if (!isMissingIndex) {
             throw error;
         }
-        console.warn('[v1IntegrationProducts] Missing Firestore index for ordered product query; falling back to unordered fetch', {
-            storeId,
-            code,
-        });
-        productsSnap = await firestore_1.defaultDb.collection('products').where('storeId', '==', storeId).limit(200).get();
+        if (isAllStoresRead) {
+            console.warn('[v1IntegrationProducts] Missing Firestore index for all-store ordered product query; falling back to unordered fetch', {
+                code,
+            });
+            productsSnap = await firestore_1.defaultDb.collection('products').limit(2000).get();
+        }
+        else {
+            console.warn('[v1IntegrationProducts] Missing Firestore index for ordered product query; falling back to unordered fetch', {
+                storeId: scopeStoreId,
+                code,
+            });
+            productsSnap = await firestore_1.defaultDb.collection('products').where('storeId', '==', scopeStoreId).limit(200).get();
+        }
     }
     const products = productsSnap.docs
         .map(mapProductDoc)
+        .filter(item => item !== null)
         .sort((a, b) => {
         if (!a.updatedAt && !b.updatedAt)
             return 0;
@@ -2635,7 +2749,20 @@ exports.v1IntegrationProducts = functions.https.onRequest(async (req, res) => {
             return -1;
         return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
     });
-    res.status(200).json({ storeId, products });
+    const storeMetaByStoreId = await fetchStoreMetaByStoreId(products.map(product => product.storeId));
+    const enrichedProducts = products.map(product => {
+        const storeMeta = storeMetaByStoreId.get(product.storeId);
+        return {
+            ...product,
+            storeName: storeMeta?.storeName ?? null,
+            storeCity: storeMeta?.storeCity ?? null,
+        };
+    });
+    res.status(200).json({
+        storeId: scopeStoreId ?? null,
+        scope: isAllStoresRead ? 'all-stores' : 'store',
+        products: enrichedProducts,
+    });
 });
 exports.integrationPromo = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);
@@ -2786,6 +2913,10 @@ exports.integrationTikTokVideos = functions.https.onRequest(async (req, res) => 
         return;
     }
     const { storeId } = authContext;
+    if (!storeId) {
+        res.status(400).json({ error: 'missing-store-id' });
+        return;
+    }
     let videosSnapshot;
     try {
         videosSnapshot = await firestore_1.defaultDb
@@ -3011,6 +3142,10 @@ exports.integrationCustomers = functions.https.onRequest(async (req, res) => {
         return;
     }
     const { storeId } = authContext;
+    if (!storeId) {
+        res.status(400).json({ error: 'missing-store-id' });
+        return;
+    }
     let customersSnap;
     try {
         customersSnap = await firestore_1.defaultDb
@@ -3081,6 +3216,10 @@ exports.integrationTopSelling = functions.https.onRequest(async (req, res) => {
         return;
     }
     const { storeId } = authContext;
+    if (!storeId) {
+        res.status(400).json({ error: 'missing-store-id' });
+        return;
+    }
     const limitRaw = Number(req.query.limit ?? 10);
     const requestedLimit = Number.isFinite(limitRaw) ? Math.floor(limitRaw) : 10;
     const limit = Math.min(Math.max(requestedLimit, 1), 50);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2712,6 +2712,37 @@ function toTrimmedStringOrNull(value: unknown): string | null {
   return trimmed ? trimmed : null
 }
 
+function pickStoreCity(storeData: Record<string, unknown>): string | null {
+  return toTrimmedStringOrNull(storeData.city) ?? toTrimmedStringOrNull(storeData.town)
+}
+
+async function fetchStoreMetaByStoreId(storeIds: string[]): Promise<Map<string, { storeName: string | null; storeCity: string | null }>> {
+  const normalizedStoreIds = Array.from(
+    new Set(
+      storeIds
+        .map(storeId => (typeof storeId === 'string' ? storeId.trim() : ''))
+        .filter(Boolean),
+    ),
+  )
+  const storeMeta = new Map<string, { storeName: string | null; storeCity: string | null }>()
+  if (normalizedStoreIds.length === 0) {
+    return storeMeta
+  }
+
+  const storeRefs = normalizedStoreIds.map(storeId => db.collection('stores').doc(storeId))
+  const storeSnapshots = await db.getAll(...storeRefs)
+  for (const storeSnapshot of storeSnapshots) {
+    if (!storeSnapshot.exists) continue
+    const data = (storeSnapshot.data() ?? {}) as Record<string, unknown>
+    storeMeta.set(storeSnapshot.id, {
+      storeName: toTrimmedStringOrNull(data.displayName) ?? toTrimmedStringOrNull(data.name),
+      storeCity: pickStoreCity(data),
+    })
+  }
+
+  return storeMeta
+}
+
 function extractYoutubeVideoId(value: string | null): string | null {
   if (!value) return null
   try {
@@ -3268,6 +3299,8 @@ export const integrationProducts = functions.https.onRequest(async (req, res) =>
     return {
       id: docSnap.id,
       storeId,
+      storeName: null,
+      storeCity: null,
       name: normalizedName || 'Untitled item',
       category:
         typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
@@ -3337,10 +3370,20 @@ export const integrationProducts = functions.https.onRequest(async (req, res) =>
       return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
     })
 
+  const storeMetaByStoreId = await fetchStoreMetaByStoreId(products.map(product => product.storeId))
+  const enrichedProducts = products.map(product => {
+    const storeMeta = storeMetaByStoreId.get(product.storeId)
+    return {
+      ...product,
+      storeName: storeMeta?.storeName ?? null,
+      storeCity: storeMeta?.storeCity ?? null,
+    }
+  })
+
   res.status(200).json({
     storeId: scopeStoreId ?? null,
     scope: isAllStoresRead ? 'all-stores' : 'store',
-    products,
+    products: enrichedProducts,
   })
 })
 
@@ -3363,6 +3406,8 @@ export const v1IntegrationProducts = functions.https.onRequest(async (req, res) 
     return {
       id: docSnap.id,
       storeId,
+      storeName: null,
+      storeCity: null,
       name: normalizedName || 'Untitled item',
       category:
         typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
@@ -3433,10 +3478,20 @@ export const v1IntegrationProducts = functions.https.onRequest(async (req, res) 
       return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
     })
 
+  const storeMetaByStoreId = await fetchStoreMetaByStoreId(products.map(product => product.storeId))
+  const enrichedProducts = products.map(product => {
+    const storeMeta = storeMetaByStoreId.get(product.storeId)
+    return {
+      ...product,
+      storeName: storeMeta?.storeName ?? null,
+      storeCity: storeMeta?.storeCity ?? null,
+    }
+  })
+
   res.status(200).json({
     storeId: scopeStoreId ?? null,
     scope: isAllStoresRead ? 'all-stores' : 'store',
-    products,
+    products: enrichedProducts,
   })
 })
 

--- a/shared/integrationTypes.ts
+++ b/shared/integrationTypes.ts
@@ -3,6 +3,8 @@ export type IntegrationContractVersion = '2026-04-13'
 export interface IntegrationProduct {
   id: string
   storeId: string
+  storeName: string | null
+  storeCity: string | null
   name: string
   category: string | null
   description: string | null


### PR DESCRIPTION
### Motivation
- Marketplace clients using the admin/master integration key received product rows but lacked store identity/location fields, forcing extra lookups; adding store metadata allows clients (e.g. Buy Sedifex) to render seller name and city without additional calls.
- The integration contract and shared types needed to be extended so typed consumers can rely on the new fields.
- The endpoints must continue to support both store-scoped keys and master keys that read across stores.

### Description
- Enriched responses from `integrationProducts` and `v1IntegrationProducts` so each product now includes `storeName` and `storeCity` by loading `stores/{storeId}` docs and merging the fields (`functions/src/index.ts`).
- Added helper functions `fetchStoreMetaByStoreId` and `pickStoreCity`, and updated `validateIntegrationTokenOrReply` to accept `{ requireStoreId: false }` for master-key flows so the endpoints can return `scope: "all-stores"` when appropriate (`functions/src/index.ts`).
- Updated the shared contract type `IntegrationProduct` to include `storeName` and `storeCity` (`shared/integrationTypes.ts`).
- Documented the new fields and example in the integration guide (`docs/integration-api-guide.md`).

### Testing
- Ran the TypeScript build with `npm --prefix functions run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd71ff65608322adcba42f15fd0d6c)