### PR TITLE
Add social media generator page and generateSocialPost callable

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -129,6 +129,13 @@ type GenerateAiAdvicePayload = {
   jsonContext?: unknown
 }
 
+type GenerateSocialPostPayload = {
+  storeId?: unknown
+  platform?: unknown
+  productId?: unknown
+  product?: unknown
+}
+
 const VALID_ROLES = new Set(['owner', 'staff'])
 const TRIAL_DAYS = 14
 const GRACE_DAYS = 7
@@ -193,6 +200,37 @@ function normalizeAiAdvicePayload(raw: GenerateAiAdvicePayload | undefined) {
       : {}
 
   return { question, storeId, jsonContext }
+}
+
+function normalizeSocialPostPayload(raw: GenerateSocialPostPayload | undefined) {
+  const storeId = typeof raw?.storeId === 'string' ? raw.storeId.trim() : ''
+  const platformRaw = typeof raw?.platform === 'string' ? raw.platform.trim().toLowerCase() : ''
+  const platform = platformRaw === 'tiktok' ? 'tiktok' : 'instagram'
+  const productId = typeof raw?.productId === 'string' ? raw.productId.trim() : ''
+
+  const productRaw =
+    raw?.product && typeof raw.product === 'object'
+      ? (raw.product as Record<string, unknown>)
+      : {}
+
+  const product = {
+    id: typeof productRaw.id === 'string' ? productRaw.id.trim() : '',
+    name: typeof productRaw.name === 'string' ? productRaw.name.trim() : '',
+    category: typeof productRaw.category === 'string' ? productRaw.category.trim() : '',
+    description: typeof productRaw.description === 'string' ? productRaw.description.trim() : '',
+    price: typeof productRaw.price === 'number' && Number.isFinite(productRaw.price) ? productRaw.price : null,
+    imageUrl: typeof productRaw.imageUrl === 'string' ? productRaw.imageUrl.trim() : '',
+    itemType:
+      productRaw.itemType === 'service' || productRaw.itemType === 'made_to_order'
+        ? (productRaw.itemType as 'service' | 'made_to_order')
+        : ('product' as const),
+  }
+
+  if (!productId && !product.id && !product.name) {
+    throw new functions.https.HttpsError('invalid-argument', 'Choose a product or service to generate a post')
+  }
+
+  return { storeId, platform, productId, product }
 }
 
 async function verifyOwnerEmail(uid: string) {
@@ -1201,6 +1239,208 @@ export const generateAiAdvice = functions.https.onCall(
       advice,
       storeId,
       dataPreview: jsonContext,
+    }
+  },
+)
+
+/** ============================================================================
+ *  CALLABLE: generateSocialPost
+ * ==========================================================================*/
+
+export const generateSocialPost = functions.https.onCall(
+  async (rawData: unknown, context: functions.https.CallableContext) => {
+    assertAuthenticated(context)
+
+    const { apiKey, model } = getOpenAiConfig()
+    if (!apiKey) {
+      throw new functions.https.HttpsError(
+        'failed-precondition',
+        'Social media generator is not configured yet. Missing OPENAI_API_KEY.',
+      )
+    }
+
+    const uid = context.auth!.uid
+    const { storeId: requestedStoreId, platform, productId, product } =
+      normalizeSocialPostPayload((rawData ?? {}) as GenerateSocialPostPayload)
+
+    const memberSnap = await db.collection('teamMembers').doc(uid).get()
+    const memberData = (memberSnap.data() ?? {}) as Record<string, unknown>
+    const memberStoreId = typeof memberData.storeId === 'string' ? memberData.storeId.trim() : ''
+
+    const storeId = requestedStoreId || memberStoreId
+    if (!storeId) {
+      throw new functions.https.HttpsError(
+        'failed-precondition',
+        'No workspace found for this account. Initialize your workspace first.',
+      )
+    }
+
+    if (requestedStoreId && memberStoreId && requestedStoreId !== memberStoreId) {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        'You do not have access to the requested workspace.',
+      )
+    }
+
+    let selectedProduct = product
+    const resolvedProductId = productId || product.id || ''
+
+    if (resolvedProductId) {
+      const productSnap = await db.collection('products').doc(resolvedProductId).get()
+      const productData = (productSnap.data() ?? {}) as Record<string, unknown>
+      const productStoreId = typeof productData.storeId === 'string' ? productData.storeId.trim() : ''
+
+      if (!productSnap.exists || productStoreId !== storeId) {
+        throw new functions.https.HttpsError('not-found', 'Product or service not found for your workspace.')
+      }
+
+      selectedProduct = {
+        id: resolvedProductId,
+        name: typeof productData.name === 'string' ? productData.name.trim() : '',
+        category: typeof productData.category === 'string' ? productData.category.trim() : '',
+        description: typeof productData.description === 'string' ? productData.description.trim() : '',
+        price: typeof productData.price === 'number' && Number.isFinite(productData.price) ? productData.price : null,
+        imageUrl: typeof productData.imageUrl === 'string' ? productData.imageUrl.trim() : '',
+        itemType:
+          productData.itemType === 'service' || productData.itemType === 'made_to_order'
+            ? (productData.itemType as 'service' | 'made_to_order')
+            : ('product' as const),
+      }
+    }
+
+    if (!selectedProduct.name) {
+      throw new functions.https.HttpsError('invalid-argument', 'Product name is required to generate content.')
+    }
+
+    const promptProduct = {
+      id: selectedProduct.id || null,
+      name: selectedProduct.name,
+      category: selectedProduct.category || null,
+      description: selectedProduct.description || null,
+      price: selectedProduct.price,
+      imageUrl: selectedProduct.imageUrl || null,
+      itemType: selectedProduct.itemType,
+    }
+
+    const systemPrompt =
+      'You are a social media strategist for retail and POS merchants. Return strict JSON only, no markdown. Keep copy concise, conversion-focused, and realistic.'
+    const userPrompt = [
+      `Workspace: ${storeId}`,
+      `Platform: ${platform}`,
+      'Return JSON schema:',
+      '{"platform":"instagram|tiktok","caption":"string","hashtags":["#tag"],"imagePrompt":"string","cta":"string","designSpec":{"aspectRatio":"string","safeTextZones":["string"],"visualStyle":"string"},"disclaimer":"string|null"}',
+      'Rules:',
+      '- caption max 220 chars for instagram, 150 chars for tiktok.',
+      '- hashtags: 5 to 10 relevant hashtags.',
+      '- include clear CTA.',
+      '- if price or measurable claim appears, add disclaimer; else null.',
+      '- designSpec must be practical for mobile-safe text placement.',
+      'Product JSON:',
+      JSON.stringify(promptProduct).slice(0, 3_000),
+    ].join('\n')
+
+    const aiResponse = await fetch(OPENAI_CHAT_COMPLETIONS_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 0.4,
+        max_tokens: 700,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+      }),
+    })
+
+    const payload = (await aiResponse.json().catch(() => null)) as
+      | {
+          error?: { message?: string }
+          choices?: Array<{ message?: { content?: string } }>
+        }
+      | null
+
+    if (!aiResponse.ok) {
+      const apiMessage =
+        payload?.error?.message && payload.error.message.trim() !== ''
+          ? payload.error.message
+          : `OpenAI request failed with status ${aiResponse.status}`
+      functions.logger.error('[generateSocialPost] OpenAI error', {
+        status: aiResponse.status,
+        apiMessage,
+      })
+      throw new functions.https.HttpsError('internal', 'Unable to generate social post right now.')
+    }
+
+    const content = payload?.choices?.[0]?.message?.content?.trim() || ''
+    if (!content) {
+      throw new functions.https.HttpsError('internal', 'AI returned an empty response.')
+    }
+
+    let parsed: Record<string, unknown> | null = null
+    try {
+      parsed = JSON.parse(content) as Record<string, unknown>
+    } catch (_error) {
+      const start = content.indexOf('{')
+      const end = content.lastIndexOf('}')
+      if (start >= 0 && end > start) {
+        parsed = JSON.parse(content.slice(start, end + 1)) as Record<string, unknown>
+      }
+    }
+
+    if (!parsed) {
+      throw new functions.https.HttpsError('internal', 'AI returned invalid JSON for social post.')
+    }
+
+    const safePlatform = parsed.platform === 'tiktok' ? 'tiktok' : 'instagram'
+    const safeHashtags = Array.isArray(parsed.hashtags)
+      ? parsed.hashtags
+          .map(tag => (typeof tag === 'string' ? tag.trim() : ''))
+          .filter(Boolean)
+          .slice(0, 10)
+      : []
+
+    return {
+      storeId,
+      productId: resolvedProductId || null,
+      product: promptProduct,
+      post: {
+        platform: safePlatform,
+        caption: typeof parsed.caption === 'string' ? parsed.caption.trim() : '',
+        hashtags: safeHashtags,
+        imagePrompt: typeof parsed.imagePrompt === 'string' ? parsed.imagePrompt.trim() : '',
+        cta: typeof parsed.cta === 'string' ? parsed.cta.trim() : '',
+        designSpec: {
+          aspectRatio:
+            parsed.designSpec &&
+            typeof parsed.designSpec === 'object' &&
+            typeof (parsed.designSpec as Record<string, unknown>).aspectRatio === 'string'
+              ? ((parsed.designSpec as Record<string, unknown>).aspectRatio as string).trim()
+              : '',
+          safeTextZones:
+            parsed.designSpec &&
+            typeof parsed.designSpec === 'object' &&
+            Array.isArray((parsed.designSpec as Record<string, unknown>).safeTextZones)
+              ? ((parsed.designSpec as Record<string, unknown>).safeTextZones as unknown[])
+                  .map(item => (typeof item === 'string' ? item.trim() : ''))
+                  .filter(Boolean)
+                  .slice(0, 6)
+              : [],
+          visualStyle:
+            parsed.designSpec &&
+            typeof parsed.designSpec === 'object' &&
+            typeof (parsed.designSpec as Record<string, unknown>).visualStyle === 'string'
+              ? ((parsed.designSpec as Record<string, unknown>).visualStyle as string).trim()
+              : '',
+        },
+        disclaimer:
+          typeof parsed.disclaimer === 'string' && parsed.disclaimer.trim()
+            ? parsed.disclaimer.trim()
+            : null,
+      },
     }
   },
 )

--- a/web/src/api/socialPost.ts
+++ b/web/src/api/socialPost.ts
@@ -1,0 +1,46 @@
+import { httpsCallable } from 'firebase/functions'
+import { functions } from '../firebase'
+
+export type SocialPlatform = 'instagram' | 'tiktok'
+
+export type SocialPostProductPayload = {
+  id?: string
+  name: string
+  category?: string | null
+  description?: string | null
+  price?: number | null
+  imageUrl?: string | null
+  itemType?: 'product' | 'service' | 'made_to_order'
+}
+
+export type GenerateSocialPostPayload = {
+  storeId?: string
+  platform: SocialPlatform
+  productId?: string
+  product?: SocialPostProductPayload
+}
+
+export type GenerateSocialPostResponse = {
+  storeId: string
+  productId: string | null
+  product: SocialPostProductPayload
+  post: {
+    platform: SocialPlatform
+    caption: string
+    hashtags: string[]
+    imagePrompt: string
+    cta: string
+    designSpec: {
+      aspectRatio: string
+      safeTextZones: string[]
+      visualStyle: string
+    }
+    disclaimer: string | null
+  }
+}
+
+export async function requestSocialPost(payload: GenerateSocialPostPayload): Promise<GenerateSocialPostResponse> {
+  const callable = httpsCallable(functions, 'generateSocialPost')
+  const response = await callable(payload)
+  return (response.data ?? {}) as GenerateSocialPostResponse
+}

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -19,5 +19,5 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/finance', label: 'Invoice', parentTo: '/sell', roles: ['owner'] },
   { to: '/account', label: 'Account', roles: ['owner'] },
   { to: '/public-page', label: 'Public page', roles: ['owner'] },
-  { to: '/merchant-feed', label: 'Merchant feed', roles: ['owner'] },
+  { to: '/social-media', label: 'Social media', roles: ['owner'] },
 ]

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -28,7 +28,7 @@ import PricingPage from './pages/PricingPage'
 import DataTransfer from './pages/DataTransfer'
 import PromoLandingPage from './pages/PromoLandingPage'
 import PublicPageSettings from './pages/PublicPageSettings'
-import GoogleMerchantFeedPage from './pages/GoogleMerchantFeedPage'
+import SocialMediaPage from './pages/SocialMediaPage'
 
 // ✅ NEW: public receipt page used by QR/share
 import ReceiptView from './pages/ReceiptView'
@@ -88,7 +88,8 @@ const router = createBrowserRouter([
           { path: 'account', element: <AccountOverview /> },
           { path: 'account/overview', element: <AccountOverview /> },
           { path: 'public-page', element: <PublicPageSettings /> },
-          { path: 'merchant-feed', element: <GoogleMerchantFeedPage /> },
+          { path: 'social-media', element: <SocialMediaPage /> },
+          { path: 'merchant-feed', element: <Navigate to="/social-media" replace /> },
           { path: 'support', element: <Support /> },
         ],
       },

--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useState } from 'react'
+import { collection, onSnapshot, orderBy, query, where } from 'firebase/firestore'
+import { db } from '../firebase'
+import PageSection from '../layout/PageSection'
+import { useActiveStore } from '../hooks/useActiveStore'
+import { useToast } from '../components/ToastProvider'
+import { requestSocialPost, type GenerateSocialPostResponse, type SocialPlatform } from '../api/socialPost'
+import type { Product } from '../types/product'
+
+type ProductOption = {
+  id: string
+  name: string
+  category: string | null
+  description: string | null
+  price: number | null
+  imageUrl: string | null
+  itemType: Product['itemType']
+}
+
+function mapProduct(id: string, raw: Record<string, unknown>): ProductOption {
+  return {
+    id,
+    name: typeof raw.name === 'string' && raw.name.trim() ? raw.name.trim() : 'Untitled item',
+    category: typeof raw.category === 'string' ? raw.category.trim() : null,
+    description: typeof raw.description === 'string' ? raw.description.trim() : null,
+    price: typeof raw.price === 'number' && Number.isFinite(raw.price) ? raw.price : null,
+    imageUrl: typeof raw.imageUrl === 'string' && raw.imageUrl.trim() ? raw.imageUrl.trim() : null,
+    itemType: raw.itemType === 'service' || raw.itemType === 'made_to_order' ? raw.itemType : 'product',
+  }
+}
+
+export default function SocialMediaPage() {
+  const { storeId } = useActiveStore()
+  const { publish } = useToast()
+  const [products, setProducts] = useState<ProductOption[]>([])
+  const [selectedId, setSelectedId] = useState('')
+  const [platform, setPlatform] = useState<SocialPlatform>('instagram')
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<GenerateSocialPostResponse | null>(null)
+
+  useEffect(() => {
+    if (!storeId) {
+      setProducts([])
+      setSelectedId('')
+      return
+    }
+
+    const productsQuery = query(
+      collection(db, 'products'),
+      where('storeId', '==', storeId),
+      orderBy('updatedAt', 'desc'),
+      orderBy('createdAt', 'desc'),
+    )
+
+    const unsubscribe = onSnapshot(
+      productsQuery,
+      snapshot => {
+        const rows = snapshot.docs.map(entry => mapProduct(entry.id, entry.data() as Record<string, unknown>))
+        const sorted = rows.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+        setProducts(sorted)
+        setSelectedId(current => (current && sorted.some(item => item.id === current) ? current : sorted[0]?.id ?? ''))
+      },
+      error => {
+        console.error('[social-media] Failed to load products', error)
+        publish({ tone: 'error', message: 'Unable to load products for social generation.' })
+      },
+    )
+
+    return () => unsubscribe()
+  }, [publish, storeId])
+
+  const selectedProduct = useMemo(
+    () => products.find(product => product.id === selectedId) ?? null,
+    [products, selectedId],
+  )
+
+  async function handleGenerate() {
+    if (!storeId || !selectedProduct) return
+    setLoading(true)
+    try {
+      const response = await requestSocialPost({
+        storeId,
+        platform,
+        productId: selectedProduct.id,
+      })
+      setResult(response)
+      publish({ tone: 'success', message: 'Social post draft generated. Review before publishing.' })
+    } catch (error) {
+      console.error('[social-media] Failed to generate social post', error)
+      publish({ tone: 'error', message: 'Could not generate social draft right now. Please try again.' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <PageSection title="Social media" subtitle="Generate Instagram or TikTok-ready captions, hashtags, creative direction, and CTA from your existing product catalog.">
+      <div style={{ display: 'grid', gap: 12 }}>
+        <label style={{ display: 'grid', gap: 6 }}>
+          <span>Platform</span>
+          <select value={platform} onChange={event => setPlatform(event.target.value as SocialPlatform)}>
+            <option value="instagram">Instagram</option>
+            <option value="tiktok">TikTok</option>
+          </select>
+        </label>
+
+        <label style={{ display: 'grid', gap: 6 }}>
+          <span>Product or service</span>
+          <select value={selectedId} onChange={event => setSelectedId(event.target.value)} disabled={!products.length}>
+            {products.length ? (
+              products.map(product => (
+                <option key={product.id} value={product.id}>
+                  {product.name} {product.itemType === 'service' ? '(service)' : ''}
+                </option>
+              ))
+            ) : (
+              <option value="">No products found</option>
+            )}
+          </select>
+        </label>
+
+        <button className="button" type="button" onClick={handleGenerate} disabled={loading || !storeId || !selectedProduct}>
+          {loading ? 'Generating…' : 'Generate social post'}
+        </button>
+
+        {result ? (
+          <div style={{ display: 'grid', gap: 10, border: '1px solid var(--line, #ddd)', borderRadius: 12, padding: 14 }}>
+            <p style={{ margin: 0 }}><strong>Caption:</strong> {result.post.caption}</p>
+            <p style={{ margin: 0 }}><strong>CTA:</strong> {result.post.cta}</p>
+            <p style={{ margin: 0 }}><strong>Hashtags:</strong> {result.post.hashtags.join(' ')}</p>
+            <p style={{ margin: 0 }}><strong>Image prompt:</strong> {result.post.imagePrompt}</p>
+            <p style={{ margin: 0 }}><strong>Design spec:</strong> {result.post.designSpec.aspectRatio} · {result.post.designSpec.visualStyle}</p>
+            <ul style={{ margin: 0, paddingLeft: 20 }}>
+              {result.post.designSpec.safeTextZones.map(zone => (
+                <li key={zone}>{zone}</li>
+              ))}
+            </ul>
+            {result.post.disclaimer ? <p style={{ margin: 0 }}><strong>Disclaimer:</strong> {result.post.disclaimer}</p> : null}
+            <p style={{ margin: 0 }}><strong>Selected image:</strong> {result.product.imageUrl || 'No image URL on this item yet.'}</p>
+          </div>
+        ) : null}
+      </div>
+    </PageSection>
+  )
+}


### PR DESCRIPTION
### Motivation
- Replace the merchant feed entry with a Social Media tool so merchants can quickly draft platform-specific posts from existing product data. 
- Reuse the existing secure callable pattern used by `generateAiAdvice` to enforce auth, membership and OpenAI config while providing structured output for the frontend. 
- Use already-exposed product fields (name, category, description, price, imageUrl, itemType) so the AI prompt has good context without extra form burden.

### Description
- Add a new Firebase callable `generateSocialPost` in `functions/src/index.ts` that mirrors the `generateAiAdvice` pattern, resolves store and product context from Firestore or payload fallback, calls OpenAI, parses JSON output, and returns a stable schema (`platform`, `caption`, `hashtags`, `imagePrompt`, `cta`, `designSpec`, `disclaimer`).
- Add payload normalization helper `normalizeSocialPostPayload` and implement input validation, membership checks, product ownership checks, bounded prompt/context, and robust error handling in the callable. 
- Add client helper and type-safe contract `web/src/api/socialPost.ts` to call `generateSocialPost` and expose request/response types to the UI. 
- Create `web/src/pages/SocialMediaPage.tsx` to list store products, allow platform selection (Instagram/TikTok), call the callable, and render the structured response; and update navigation and routing (`web/src/config/navigation.ts`, `web/src/main.tsx`) to show the new "Social media" entry while preserving `/merchant-feed` as a redirect.

### Testing
- Built functions with `npm -C functions run build`, which completed successfully. 
- Attempted frontend build with `npm -C web run build`, which failed in this environment due to missing type definitions (`vite/client` and `vitest/globals`). 
- No additional automated tests were executed in this rollout beyond the build commands above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd793a5ad0832185547c2b5279a7ee)