### PR TITLE
Add backfillProductStoreMeta script and persist store metadata with new products

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,8 @@
     "clean": "rimraf lib",
     "serve": "firebase emulators:start --only functions",
     "deploy": "firebase deploy --only functions --project sedifex-dev",
-    "force-update-owner-email": "node scripts/forceUpdateOwnerEmailByUid.js"
+    "force-update-owner-email": "node scripts/forceUpdateOwnerEmailByUid.js",
+    "backfill-product-store-meta": "node scripts/backfillProductStoreMeta.js"
   },
   "dependencies": {
     "firebase-admin": "^13.6.0",

--- a/functions/scripts/backfillProductStoreMeta.js
+++ b/functions/scripts/backfillProductStoreMeta.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const admin = require('firebase-admin')
+
+if (!admin.apps.length) {
+  admin.initializeApp()
+}
+
+const db = admin.firestore()
+
+function toNullableString(value) {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+function normalizeSlugPart(input) {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function buildPublicSlug(storeData, storeId) {
+  const explicit = toNullableString(storeData.promoSlug)
+  if (explicit) return normalizeSlugPart(explicit)
+
+  const candidates = [
+    toNullableString(storeData.displayName),
+    toNullableString(storeData.name),
+    storeId,
+  ]
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    const normalized = normalizeSlugPart(candidate)
+    if (normalized) return normalized
+  }
+  return null
+}
+
+function buildStoreMeta(storeData, storeId) {
+  const storeName = toNullableString(storeData.displayName) ?? toNullableString(storeData.name)
+  const storePhone = toNullableString(storeData.phone)
+  const storeCity = toNullableString(storeData.city)
+  const storeEmail =
+    toNullableString(storeData.ownerEmail) ?? toNullableString(storeData.email)
+  const slug = buildPublicSlug(storeData, storeId)
+
+  return {
+    storeName,
+    storePhone,
+    storeCity,
+    storeEmail,
+    websiteLink: slug ? `https://www.sedifex.com/${encodeURIComponent(slug)}` : null,
+  }
+}
+
+async function run() {
+  const productsSnapshot = await db.collection('products').get()
+  console.log(
+    `[backfillProductStoreMeta] scanning ${productsSnapshot.size} products`,
+  )
+
+  const storeIds = new Set()
+  for (const product of productsSnapshot.docs) {
+    const storeId = toNullableString(product.get('storeId'))
+    if (storeId) storeIds.add(storeId)
+  }
+  console.log(
+    `[backfillProductStoreMeta] loading metadata for ${storeIds.size} stores`,
+  )
+
+  const storeMetaById = new Map()
+  for (const storeId of storeIds) {
+    const storeSnapshot = await db.collection('stores').doc(storeId).get()
+    const storeData = storeSnapshot.exists ? storeSnapshot.data() || {} : {}
+    storeMetaById.set(storeId, buildStoreMeta(storeData, storeId))
+  }
+
+  let updated = 0
+  let skipped = 0
+  let batch = db.batch()
+  let opCount = 0
+
+  for (const product of productsSnapshot.docs) {
+    const storeId = toNullableString(product.get('storeId'))
+    if (!storeId) {
+      skipped += 1
+      continue
+    }
+
+    const meta = storeMetaById.get(storeId)
+    if (!meta) {
+      skipped += 1
+      continue
+    }
+
+    const updates = {
+      ...meta,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    }
+
+    batch.set(product.ref, updates, { merge: true })
+    updated += 1
+    opCount += 1
+
+    if (opCount >= 450) {
+      await batch.commit()
+      batch = db.batch()
+      opCount = 0
+    }
+  }
+
+  if (opCount > 0) {
+    await batch.commit()
+  }
+
+  console.log(
+    `[backfillProductStoreMeta] done. updated=${updated}, skipped=${skipped}, total=${productsSnapshot.size}`,
+  )
+}
+
+run().catch(error => {
+  console.error('[backfillProductStoreMeta] failed', error)
+  process.exit(1)
+})

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -5,6 +5,7 @@ import {
   collection,
   deleteDoc,
   doc,
+  getDoc,
   limit,
   onSnapshot,
   orderBy,
@@ -37,6 +38,7 @@ import { ProductImageUploadError, uploadProductImage } from '../api/productImage
 import { requestAiAdvisor } from '../api/aiAdvisor'
 import { useToast } from '../components/ToastProvider'
 import { playSound } from '../utils/sound'
+import { buildPromoSlug } from '../utils/promoSlug'
 
 type CachedProduct = Omit<Product, 'id'>
 type AbcBucket = 'A' | 'B' | 'C'
@@ -50,6 +52,13 @@ type SaleRecord = {
     type?: string | null
     isService?: boolean
   }>
+}
+type ProductStoreMeta = {
+  storeName: string | null
+  storePhone: string | null
+  storeCity: string | null
+  storeEmail: string | null
+  websiteLink: string | null
 }
 const EXACT_UPLOAD_LIMIT_HINT = 'Maximum upload size is 5 MB (5,242,880 bytes).'
 const DEFAULT_PRODUCT_IMAGE_URL = 'https://storage.googleapis.com/sedifeximage/stores/Y5ivjrJUBtWl7KzoR0aVszFu1c93/logo.jpg?v=1775656136764'
@@ -465,6 +474,13 @@ export default function Products() {
   const { name: workspaceName } = useWorkspaceIdentity()
   const { publish } = useToast()
   const [searchParams, setSearchParams] = useSearchParams()
+  const [productStoreMeta, setProductStoreMeta] = useState<ProductStoreMeta>({
+    storeName: null,
+    storePhone: null,
+    storeCity: null,
+    storeEmail: null,
+    websiteLink: null,
+  })
 
   const [products, setProducts] = useState<Product[]>([])
   const [sales, setSales] = useState<SaleRecord[]>([])
@@ -657,6 +673,65 @@ export default function Products() {
     return () => {
       cancelled = true
       unsubscribe()
+    }
+  }, [activeStoreId])
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!activeStoreId) {
+      setProductStoreMeta({
+        storeName: null,
+        storePhone: null,
+        storeCity: null,
+        storeEmail: null,
+        websiteLink: null,
+      })
+      return
+    }
+
+    ;(async () => {
+      try {
+        const snapshot = await getDoc(doc(db, 'stores', activeStoreId))
+        const data = snapshot.exists() ? (snapshot.data() as Record<string, unknown>) : null
+        if (!data || cancelled) return
+
+        const storeName =
+          typeof data.displayName === 'string' && data.displayName.trim()
+            ? data.displayName.trim()
+            : typeof data.name === 'string' && data.name.trim()
+              ? data.name.trim()
+              : null
+        const promoSlug = buildPromoSlug(
+          typeof data.promoSlug === 'string' ? data.promoSlug : null,
+          storeName,
+          typeof data.name === 'string' ? data.name : null,
+          activeStoreId,
+        )
+
+        setProductStoreMeta({
+          storeName,
+          storePhone:
+            typeof data.phone === 'string' && data.phone.trim() ? data.phone.trim() : null,
+          storeCity:
+            typeof data.city === 'string' && data.city.trim() ? data.city.trim() : null,
+          storeEmail:
+            typeof data.ownerEmail === 'string' && data.ownerEmail.trim()
+              ? data.ownerEmail.trim()
+              : typeof data.email === 'string' && data.email.trim()
+                ? data.email.trim()
+                : null,
+          websiteLink: promoSlug
+            ? `https://www.sedifex.com/${encodeURIComponent(promoSlug)}`
+            : null,
+        })
+      } catch (error) {
+        console.warn('[products] Failed to load store metadata for product defaults', error)
+      }
+    })()
+
+    return () => {
+      cancelled = true
     }
   }, [activeStoreId])
 
@@ -1004,6 +1079,11 @@ export default function Products() {
 
       await setDoc(productRef, {
         storeId: activeStoreId,
+        storeName: productStoreMeta.storeName,
+        storePhone: productStoreMeta.storePhone,
+        storeCity: productStoreMeta.storeCity,
+        storeEmail: productStoreMeta.storeEmail,
+        websiteLink: productStoreMeta.websiteLink,
         name: normalizedProductName,
         itemType,
         category: trimmedCategory || null,


### PR DESCRIPTION
### Motivation
- Ensure product documents include denormalized store metadata (name, contact, city, email, and website link) for display and linking purposes.
- Provide a one-off script to backfill existing products with the new store metadata fields derived from the corresponding stores.

### Description
- Added `functions/scripts/backfillProductStoreMeta.js`, a Node script that scans all `products`, loads referenced `stores`, builds normalized store metadata and `websiteLink`, and writes the metadata back to products in batched commits.
- Added a new npm script `backfill-product-store-meta` to `functions/package.json` to run the backfill script.
- Updated `web/src/pages/Products.tsx` to load the active store document with `getDoc` and `buildPromoSlug`, store product-level `ProductStoreMeta` in component state, and include `storeName`, `storePhone`, `storeCity`, `storeEmail`, and `websiteLink` when creating new product documents.
- Introduced a `ProductStoreMeta` type and defensive normalization for store fields and slug-to-URL formation in the UI.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd782ec138832285363d3baf983aaa)