### PR TITLE
Force-remove stale Firebase functions in non-interactive deploys

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -49,4 +49,4 @@ jobs:
           EOF
 
       - name: Deploy Firebase Functions
-        run: firebase deploy --only functions --project sedifex-web
+        run: firebase deploy --only functions --project sedifex-web --force

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "build": "rimraf lib && tsc",
     "clean": "rimraf lib",
     "serve": "firebase emulators:start --only functions",
-    "deploy": "firebase deploy --only functions --project sedifex-web",
+    "deploy": "firebase deploy --only functions --project sedifex-web --force",
     "force-update-owner-email": "node scripts/forceUpdateOwnerEmailByUid.js"
   },
   "dependencies": {


### PR DESCRIPTION
### Motivation
- CI deploys were aborting because orphaned functions exist in the Firebase project but not in local source, and the non-interactive deploy cannot confirm deletions.

### Description
- Add `--force` to the Firebase deploy command in `.github/workflows/deploy-functions.yml` and to the `deploy` script in `functions/package.json` so stale remote functions are deleted automatically during CI and local/scripted deploys remain consistent.

### Testing
- Ran `npm --prefix functions run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf9e3773c8322b78a8839ac85c162)