### PR TITLE
Stabilize Firebase Functions deploy workflow

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: functions/package-lock.json
 
@@ -47,6 +47,9 @@ jobs:
           cat <<'EOF' > functions/.env.sedifex-web
           ${{ secrets.FUNCTIONS_ENV_SEDIFEX_WEB }}
           EOF
+
+      - name: Delete removed legacy functions
+        run: firebase functions:delete exportDailyStoreReports --region us-central1 --project sedifex-web --force || true
 
       - name: Deploy Firebase Functions
         run: firebase deploy --only functions --project sedifex-web --force

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "sedifex-functions",
   "private": true,
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
### Motivation
- The Firebase deploy was aborting in non-interactive CI because a remote function `exportDailyStoreReports` existed but was not present in the local source, causing deletion to require interactive confirmation. 
- The GitHub Actions runtime and functions engine were pinned to Node.js 20 which is being deprecated and needs to be upgraded to avoid future deployment failures.

### Description
- Updated the GitHub Actions Firebase Functions deploy workflow at `.github/workflows/deploy-functions.yml` to use Node.js 22 instead of Node.js 20. 
- Added a pre-deploy cleanup step to the workflow that force-deletes the legacy `exportDailyStoreReports` function in `us-central1` with `firebase functions:delete exportDailyStoreReports --region us-central1 --project sedifex-web --force || true` so non-interactive deploys no longer abort. 
- Updated the Cloud Functions runtime engine in `functions/package.json` from `"node": "20"` to `"node": "22"` to align the local engine with the runner.

### Testing
- Ran `npm --prefix functions run build` and the TypeScript build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfd8306e883228bced8c5f1c45912)