### PR TITLE
Limit Firebase deploy to exported functions to avoid scheduler delete permission errors

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -51,5 +51,15 @@ jobs:
       - name: Delete removed legacy functions
         run: firebase functions:delete exportDailyStoreReports --region us-central1 --project sedifex-web --force || true
 
+      - name: Build and list functions to deploy
+        run: |
+          npm --prefix functions run build
+          FUNCTIONS_LIST=$(node -e "const fn = require('./functions/lib/index.js'); process.stdout.write(Object.keys(fn).join(','));")
+          if [ -z "$FUNCTIONS_LIST" ]; then
+            echo "No exported functions found in functions/lib/index.js"
+            exit 1
+          fi
+          echo "FUNCTIONS_ONLY=$(printf '%s' "$FUNCTIONS_LIST" | sed 's/[^,]*/functions:&/g')" >> "$GITHUB_ENV"
+
       - name: Deploy Firebase Functions
-        run: firebase deploy --only functions --project sedifex-web --force
+        run: firebase deploy --only "$FUNCTIONS_ONLY" --project sedifex-web --force


### PR DESCRIPTION
### Motivation
- CI deploys were failing because the Firebase CLI attempted to delete removed scheduled functions and the CI service account lacked the `cloudscheduler.jobs.delete` permission.
- The intent is to avoid broad deploy operations that trigger scheduler deletions by deploying only the functions currently exported by the build output.

### Description
- Add a workflow step that runs `npm --prefix functions run build` and reads `Object.keys(require('./functions/lib/index.js'))` to compute the exported function names.
- Store a `FUNCTIONS_ONLY` environment variable containing a comma-separated `functions:<name>` list constructed from the exported names.
- Change the deploy step to run `firebase deploy --only "$FUNCTIONS_ONLY" --project sedifex-web --force` instead of `--only functions` so only active exports are deployed.
- Keep the existing legacy delete step for `exportDailyStoreReports` but prevent blanket deploy operations from causing scheduler delete attempts.

### Testing
- Ran `npm --prefix functions run build && node -e "const fn = require('./functions/lib/index.js'); console.log(Object.keys(fn).slice(0,5)); console.log('count',Object.keys(fn).length);"` which completed successfully and printed a sample list of exported functions and `count 49`.
- Verified the workflow file changes by running the build/list command locally and confirming `FUNCTIONS_ONLY` would be generated from the build output without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de022c54408322a99c134927d1ac25)