### PR TITLE
Improve social-media AI failure diagnostics for backend deployment issues

### DIFF
--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -35,6 +35,7 @@ function getCallableErrorMessage(error: unknown): string | null {
   if (!(error instanceof FirebaseError)) return null
 
   const callableError = error as FirebaseError & {
+    code?: string
     customData?: {
       body?: {
         error?: {
@@ -42,6 +43,20 @@ function getCallableErrorMessage(error: unknown): string | null {
         }
       }
     }
+  }
+
+  const errorCode = typeof callableError.code === 'string' ? callableError.code.trim() : ''
+  if (errorCode === 'functions/unavailable') {
+    return 'AI backend is unreachable right now. Confirm Firebase Functions is deployed and the project config points to the right environment.'
+  }
+  if (errorCode === 'functions/not-found') {
+    return 'AI endpoint is missing. Deploy the latest Firebase Functions so generateSocialPost is available.'
+  }
+  if (errorCode === 'functions/internal') {
+    return 'The AI service is online but failed to generate content. Please retry in a moment.'
+  }
+  if (errorCode === 'functions/failed-precondition') {
+    return 'AI generator is not fully configured yet. Verify OPENAI_API_KEY is set for Firebase Functions.'
   }
 
   const bodyMessage = callableError.customData?.body?.error?.message
@@ -249,8 +264,16 @@ export default function SocialMediaPage() {
     } catch (error) {
       console.error('[social-media] Failed to generate social post', error)
       const serverMessage = getCallableErrorMessage(error)
-      publish({ tone: 'error', message: serverMessage || 'Could not generate social draft right now. Please try again.' })
-      setInlineError(serverMessage || 'Generation failed. Check your network and try again.')
+      publish({
+        tone: 'error',
+        message:
+          serverMessage ||
+          'Could not generate social draft right now. Please check backend deployment/configuration and try again.',
+      })
+      setInlineError(
+        serverMessage ||
+          'Generation failed. Confirm the AI backend (Firebase Functions) is deployed and reachable, then retry.',
+      )
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
### Motivation
- Users saw a generic "Generation failed" message when AI generation failed, which made backend configuration or deployment problems hard to diagnose. 
- Provide actionable error text so operators can quickly determine whether the issue is network, functions deployment, or missing config (e.g., `OPENAI_API_KEY`).

### Description
- Added callable error-code detection in `web/src/pages/SocialMediaPage.tsx` by inspecting `error.code` and mapping `functions/unavailable`, `functions/not-found`, `functions/internal`, and `functions/failed-precondition` to actionable messages. 
- Preserved existing parsing of `customData.body.error.message` and legacy Firebase message normalization as fallback. 
- Updated toast and inline fallback copy to explicitly advise verifying Firebase Functions deployment and AI backend reachability when generation fails. 

### Testing
- Ran `npm -C web run lint`, which failed in this environment due to missing ESLint peer packages (error: `Cannot find package '@eslint/js'`).
- Ran `npm -C web run build`, which failed in this environment due to missing local type packages (`vite/client` and `vitest/globals`) and unrelated local dev-dependency issues.
- No unit tests were modified; existing app-level behavior was exercised via static review and local build attempts which indicated failures are environment-specific and not caused by the changes above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2fe215fc832287909a8cedbea579)