### PR TITLE
Add backfill script to copy `products` into `publicProducts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Set these in your Vercel project:
 - Run `node functions/scripts/migrateProductImageFields.js` from the repo root (with Firebase admin credentials available) to backfill old records:
   - set `imageUrl = null` when missing
   - set `imageAlt = product.name` when `imageUrl` exists and `imageAlt` is missing
+- Run `npm --prefix functions run backfill-public-products -- [storeId]` to copy `products` documents into `publicProducts` for public-catalog reads (optional `storeId` limits the backfill scope).
 
 ## Quick start (local dev)
 1) Install Node 20+.

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,8 @@
     "clean": "rimraf lib",
     "serve": "firebase emulators:start --only functions",
     "deploy": "firebase deploy --only functions --project sedifex-web --force",
-    "force-update-owner-email": "node scripts/forceUpdateOwnerEmailByUid.js"
+    "force-update-owner-email": "node scripts/forceUpdateOwnerEmailByUid.js",
+    "backfill-public-products": "node scripts/backfillPublicProducts.js"
   },
   "dependencies": {
     "firebase-admin": "^13.6.0",

--- a/functions/scripts/backfillPublicProducts.js
+++ b/functions/scripts/backfillPublicProducts.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const admin = require('firebase-admin')
+
+if (!admin.apps.length) {
+  admin.initializeApp()
+}
+
+const db = admin.firestore()
+
+function toTrimmedStringOrNull(value) {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+function toTrimmedStringArray(value) {
+  if (!Array.isArray(value)) return []
+  const unique = new Set()
+  for (const item of value) {
+    if (typeof item !== 'string') continue
+    const trimmed = item.trim()
+    if (!trimmed) continue
+    unique.add(trimmed)
+  }
+  return [...unique]
+}
+
+function extractProductImageSet(data) {
+  const primaryImageUrl = toTrimmedStringOrNull(data.imageUrl)
+  const imageUrls = toTrimmedStringArray(data.imageUrls)
+  if (primaryImageUrl && !imageUrls.includes(primaryImageUrl)) {
+    imageUrls.unshift(primaryImageUrl)
+  }
+
+  const fallbackImageUrl = imageUrls[0] ?? primaryImageUrl ?? null
+  if (fallbackImageUrl && !imageUrls.length) {
+    imageUrls.push(fallbackImageUrl)
+  }
+
+  return {
+    imageUrl: fallbackImageUrl,
+    imageUrls,
+    imageAlt: toTrimmedStringOrNull(data.imageAlt),
+  }
+}
+
+function toPublicProduct(productDoc) {
+  const data = productDoc.data() || {}
+  const storeId = toTrimmedStringOrNull(data.storeId)
+  const name = toTrimmedStringOrNull(data.name)
+
+  if (!storeId || !name) {
+    return null
+  }
+
+  return {
+    sourceProductId: productDoc.id,
+    storeId,
+    name,
+    description: toTrimmedStringOrNull(data.description),
+    category: toTrimmedStringOrNull(data.category),
+    price: typeof data.price === 'number' ? data.price : null,
+    stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
+    itemType:
+      data.itemType === 'service'
+        ? 'service'
+        : data.itemType === 'made_to_order'
+          ? 'made_to_order'
+          : 'product',
+    isPublished: data.isPublished !== false,
+    ...extractProductImageSet(data),
+    createdAt: data.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
+    sourceUpdatedAt: data.updatedAt ?? null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }
+}
+
+async function run() {
+  const targetStoreId = toTrimmedStringOrNull(process.argv[2])
+  let query = db.collection('products')
+
+  if (targetStoreId) {
+    query = query.where('storeId', '==', targetStoreId)
+    console.log(`[backfillPublicProducts] running for storeId=${targetStoreId}`)
+  } else {
+    console.log('[backfillPublicProducts] running for all stores')
+  }
+
+  const productsSnapshot = await query.get()
+  console.log(`[backfillPublicProducts] scanning ${productsSnapshot.size} products`)
+
+  let upserts = 0
+  let skipped = 0
+  let batch = db.batch()
+  let writes = 0
+
+  for (const productDoc of productsSnapshot.docs) {
+    const payload = toPublicProduct(productDoc)
+    if (!payload) {
+      skipped += 1
+      continue
+    }
+
+    const targetRef = db.collection('publicProducts').doc(productDoc.id)
+    batch.set(targetRef, payload, { merge: true })
+    upserts += 1
+    writes += 1
+
+    if (writes >= 450) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+
+  if (writes > 0) {
+    await batch.commit()
+  }
+
+  console.log(
+    `[backfillPublicProducts] done. upserts=${upserts}, skipped=${skipped}, total=${productsSnapshot.size}`,
+  )
+}
+
+run().catch(error => {
+  console.error('[backfillPublicProducts] failed', error)
+  process.exit(1)
+})


### PR DESCRIPTION
### Motivation
- Provide a one-time maintenance tool to populate the `publicProducts` collection from existing `products` so public catalog endpoints can read normalized product records.

### Description
- Add `functions/scripts/backfillPublicProducts.js` which reads `products`, normalizes and filters fields, and upserts records into `publicProducts` using the same document id and an optional `storeId` CLI arg to scope the run.
- The script normalizes image fields via `extractProductImageSet`, preserves timestamps (`createdAt`, `sourceUpdatedAt`, `updatedAt`), and sets `isPublished` (defaults to true unless explicitly false).
- Writes are batched with commit threshold at 450 writes per batch to avoid large batches and improve throughput.
- Add an npm script `backfill-public-products` in `functions/package.json` and document the command in `README.md` with usage: `npm --prefix functions run backfill-public-products -- [storeId]`.

### Testing
- Ran `node --check functions/scripts/backfillPublicProducts.js` to validate script syntax, which succeeded.
- Ran `npm --prefix functions run build` to ensure function package builds, which completed successfully (with a non-blocking npm env warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de81600e748321bf654d10213fc8bb)