### PR TITLE
Sync products to `publicProducts`, add backfill script, and update public catalog API

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Set these in your Vercel project:
 - Run `node functions/scripts/migrateProductImageFields.js` from the repo root (with Firebase admin credentials available) to backfill old records:
   - set `imageUrl = null` when missing
   - set `imageAlt = product.name` when `imageUrl` exists and `imageAlt` is missing
+- New/updated/deleted products are synced automatically to `publicProducts` by the `syncProductToPublicProducts` Cloud Function trigger.
+- Run `npm --prefix functions run backfill-public-products -- [storeId]` once to copy older existing `products` documents into `publicProducts` (optional `storeId` limits the backfill scope).
 
 ## Quick start (local dev)
 1) Install Node 20+.

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,8 @@
     "clean": "rimraf lib",
     "serve": "firebase emulators:start --only functions",
     "deploy": "firebase deploy --only functions --project sedifex-web --force",
-    "force-update-owner-email": "node scripts/forceUpdateOwnerEmailByUid.js"
+    "force-update-owner-email": "node scripts/forceUpdateOwnerEmailByUid.js",
+    "backfill-public-products": "node scripts/backfillPublicProducts.js"
   },
   "dependencies": {
     "firebase-admin": "^13.6.0",

--- a/functions/scripts/backfillPublicProducts.js
+++ b/functions/scripts/backfillPublicProducts.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const admin = require('firebase-admin')
+
+if (!admin.apps.length) {
+  admin.initializeApp()
+}
+
+const db = admin.firestore()
+
+function toTrimmedStringOrNull(value) {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+function toTrimmedStringArray(value) {
+  if (!Array.isArray(value)) return []
+  const unique = new Set()
+  for (const item of value) {
+    if (typeof item !== 'string') continue
+    const trimmed = item.trim()
+    if (!trimmed) continue
+    unique.add(trimmed)
+  }
+  return [...unique]
+}
+
+function extractProductImageSet(data) {
+  const primaryImageUrl = toTrimmedStringOrNull(data.imageUrl)
+  const imageUrls = toTrimmedStringArray(data.imageUrls)
+  if (primaryImageUrl && !imageUrls.includes(primaryImageUrl)) {
+    imageUrls.unshift(primaryImageUrl)
+  }
+
+  const fallbackImageUrl = imageUrls[0] ?? primaryImageUrl ?? null
+  if (fallbackImageUrl && !imageUrls.length) {
+    imageUrls.push(fallbackImageUrl)
+  }
+
+  return {
+    imageUrl: fallbackImageUrl,
+    imageUrls,
+    imageAlt: toTrimmedStringOrNull(data.imageAlt),
+  }
+}
+
+function toPublicProduct(productDoc) {
+  const data = productDoc.data() || {}
+  const storeId = toTrimmedStringOrNull(data.storeId)
+  const name = toTrimmedStringOrNull(data.name)
+
+  if (!storeId || !name) {
+    return null
+  }
+
+  return {
+    sourceProductId: productDoc.id,
+    storeId,
+    name,
+    description: toTrimmedStringOrNull(data.description),
+    category: toTrimmedStringOrNull(data.category),
+    price: typeof data.price === 'number' ? data.price : null,
+    stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
+    itemType:
+      data.itemType === 'service'
+        ? 'service'
+        : data.itemType === 'made_to_order'
+          ? 'made_to_order'
+          : 'product',
+    isPublished: data.isPublished !== false,
+    ...extractProductImageSet(data),
+    createdAt: data.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
+    sourceUpdatedAt: data.updatedAt ?? null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }
+}
+
+async function run() {
+  const targetStoreId = toTrimmedStringOrNull(process.argv[2])
+  let query = db.collection('products')
+
+  if (targetStoreId) {
+    query = query.where('storeId', '==', targetStoreId)
+    console.log(`[backfillPublicProducts] running for storeId=${targetStoreId}`)
+  } else {
+    console.log('[backfillPublicProducts] running for all stores')
+  }
+
+  const productsSnapshot = await query.get()
+  console.log(`[backfillPublicProducts] scanning ${productsSnapshot.size} products`)
+
+  let upserts = 0
+  let skipped = 0
+  let batch = db.batch()
+  let writes = 0
+
+  for (const productDoc of productsSnapshot.docs) {
+    const payload = toPublicProduct(productDoc)
+    if (!payload) {
+      skipped += 1
+      continue
+    }
+
+    const targetRef = db.collection('publicProducts').doc(productDoc.id)
+    batch.set(targetRef, payload, { merge: true })
+    upserts += 1
+    writes += 1
+
+    if (writes >= 450) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+
+  if (writes > 0) {
+    await batch.commit()
+  }
+
+  console.log(
+    `[backfillPublicProducts] done. upserts=${upserts}, skipped=${skipped}, total=${productsSnapshot.size}`,
+  )
+}
+
+run().catch(error => {
+  console.error('[backfillPublicProducts] failed', error)
+  process.exit(1)
+})

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3140,6 +3140,37 @@ function extractProductImageSet(data: Record<string, unknown>): { imageUrl: stri
   }
 }
 
+function toPublicProductPayload(
+  productId: string,
+  data: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const storeId = toTrimmedStringOrNull(data.storeId)
+  const name = normalizeProductName(data.name)
+  if (!storeId || !name) return null
+
+  return {
+    sourceProductId: productId,
+    storeId,
+    name: name || 'Untitled item',
+    description:
+      typeof data.description === 'string' && data.description.trim() ? data.description.trim() : null,
+    category: typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
+    price: typeof data.price === 'number' ? data.price : null,
+    stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
+    itemType:
+      data.itemType === 'service'
+        ? 'service'
+        : data.itemType === 'made_to_order'
+          ? 'made_to_order'
+          : 'product',
+    isPublished: data.isPublished !== false,
+    ...extractProductImageSet(data),
+    createdAt: data.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
+    sourceUpdatedAt: data.updatedAt ?? null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }
+}
+
 async function resolvePromoStoreForRead(
   req: functions.https.Request,
   res: functions.Response<any>,
@@ -4004,7 +4035,7 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
   let productsSnapshot: admin.firestore.QuerySnapshot
   try {
     productsSnapshot = await db
-      .collection('products')
+      .collection('publicProducts')
       .where('storeId', '==', storeId)
       .orderBy('updatedAt', 'desc')
       .limit(200)
@@ -4016,7 +4047,7 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
       throw error
     }
 
-    productsSnapshot = await db.collection('products').where('storeId', '==', storeId).limit(200).get()
+    productsSnapshot = await db.collection('publicProducts').where('storeId', '==', storeId).limit(200).get()
   }
 
   const products = productsSnapshot.docs
@@ -4480,6 +4511,23 @@ export const enrichProductDataAfterSave = functions.firestore
     if (!updates.category && !updates.manufacturerName) return
 
     await change.after.ref.set(updates, { merge: true })
+  })
+
+export const syncProductToPublicProducts = functions.firestore
+  .document('products/{productId}')
+  .onWrite(async (change, context) => {
+    const productId = context.params.productId as string
+    const targetRef = db.collection('publicProducts').doc(productId)
+
+    if (!change.after.exists) {
+      await targetRef.delete().catch(() => undefined)
+      return
+    }
+
+    const payload = toPublicProductPayload(productId, (change.after.data() ?? {}) as Record<string, unknown>)
+    if (!payload) return
+
+    await targetRef.set(payload, { merge: true })
   })
 
 export const emitProductWebhooks = functions.firestore


### PR DESCRIPTION
### Motivation
- Ensure public-facing product listings are served from a sanitized `publicProducts` collection and kept in sync with `products` for safer, indexed reads. 
- Provide a backfill utility to populate `publicProducts` from existing `products` documents for one-time migration.

### Description
- Added a Firestore trigger `syncProductToPublicProducts` (`functions.firestore.document('products/{productId}').onWrite`) that upserts/deletes a normalized public payload into `publicProducts` on product changes. 
- Introduced `toPublicProductPayload` helper to transform and sanitize `products` documents into the public schema. 
- Updated the public API `integrationPublicCatalog` to query `publicProducts` (with a fallback to the same collection on index errors). 
- Added a new backfill script `functions/scripts/backfillPublicProducts.js` and an npm script `backfill-public-products` in `functions/package.json`, and updated `README.md` with instructions for the automatic sync and the backfill command. 

### Testing
- Built the Functions package with `npm --prefix functions run build`, and the TypeScript build completed successfully. 
- No automated unit tests were added; no additional CI tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de81600e748321bf654d10213fc8bb)