### PR TITLE
Add AI-advisor fallback for social post generation and include full product payload

### DIFF
--- a/web/src/api/socialPost.ts
+++ b/web/src/api/socialPost.ts
@@ -1,5 +1,6 @@
 import { httpsCallable } from 'firebase/functions'
 import { functions } from '../firebase'
+import { requestAiAdvisor } from './aiAdvisor'
 
 export type SocialPlatform = 'instagram' | 'tiktok'
 
@@ -39,8 +40,107 @@ export type GenerateSocialPostResponse = {
   }
 }
 
+function parseFallbackJson(text: string): Record<string, unknown> | null {
+  const normalized = text.trim()
+  if (!normalized) return null
+
+  try {
+    return JSON.parse(normalized) as Record<string, unknown>
+  } catch (_error) {
+    const start = normalized.indexOf('{')
+    const end = normalized.lastIndexOf('}')
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(normalized.slice(start, end + 1)) as Record<string, unknown>
+      } catch (_innerError) {
+        return null
+      }
+    }
+    return null
+  }
+}
+
+async function requestSocialPostFallback(payload: GenerateSocialPostPayload): Promise<GenerateSocialPostResponse> {
+  const product = payload.product ?? { id: payload.productId, name: '' }
+  const question = [
+    'Generate a social media post draft as strict JSON only (no markdown, no prose).',
+    `Platform: ${payload.platform}`,
+    'Return this schema exactly:',
+    '{"platform":"instagram|tiktok","caption":"string","hashtags":["#tag"],"imagePrompt":"string","cta":"string","designSpec":{"aspectRatio":"string","safeTextZones":["string"],"visualStyle":"string"},"disclaimer":"string|null"}',
+    'Product JSON:',
+    JSON.stringify(product).slice(0, 3_000),
+  ].join('\n')
+
+  const fallback = await requestAiAdvisor({
+    question,
+    storeId: payload.storeId,
+    jsonContext: {
+      source: 'social-post-fallback',
+      platform: payload.platform,
+      product,
+    },
+  })
+
+  const parsed = parseFallbackJson(fallback.advice) ?? {}
+  const hashtags = Array.isArray(parsed.hashtags)
+    ? parsed.hashtags
+        .map(tag => (typeof tag === 'string' ? tag.trim() : ''))
+        .filter(Boolean)
+        .slice(0, 10)
+    : []
+
+  return {
+    storeId: fallback.storeId,
+    productId: typeof payload.productId === 'string' && payload.productId.trim() ? payload.productId.trim() : null,
+    product: {
+      id: typeof product.id === 'string' ? product.id : undefined,
+      name: typeof product.name === 'string' && product.name.trim() ? product.name.trim() : 'Selected product',
+      category: typeof product.category === 'string' ? product.category : null,
+      description: typeof product.description === 'string' ? product.description : null,
+      price: typeof product.price === 'number' ? product.price : null,
+      imageUrl: typeof product.imageUrl === 'string' ? product.imageUrl : null,
+      itemType: product.itemType === 'service' || product.itemType === 'made_to_order' ? product.itemType : 'product',
+    },
+    post: {
+      platform: parsed.platform === 'tiktok' ? 'tiktok' : payload.platform,
+      caption: typeof parsed.caption === 'string' ? parsed.caption.trim() : '',
+      hashtags,
+      imagePrompt: typeof parsed.imagePrompt === 'string' ? parsed.imagePrompt.trim() : '',
+      cta: typeof parsed.cta === 'string' ? parsed.cta.trim() : '',
+      designSpec:
+        parsed.designSpec && typeof parsed.designSpec === 'object'
+          ? {
+              aspectRatio:
+                typeof (parsed.designSpec as { aspectRatio?: unknown }).aspectRatio === 'string'
+                  ? ((parsed.designSpec as { aspectRatio: string }).aspectRatio ?? '4:5')
+                  : '4:5',
+              safeTextZones: Array.isArray((parsed.designSpec as { safeTextZones?: unknown }).safeTextZones)
+                ? ((parsed.designSpec as { safeTextZones: unknown[] }).safeTextZones
+                    .map(entry => (typeof entry === 'string' ? entry.trim() : ''))
+                    .filter(Boolean)
+                    .slice(0, 4) as string[])
+                : ['top 15%', 'bottom 20%'],
+              visualStyle:
+                typeof (parsed.designSpec as { visualStyle?: unknown }).visualStyle === 'string'
+                  ? ((parsed.designSpec as { visualStyle: string }).visualStyle ?? 'clean product-focused')
+                  : 'clean product-focused',
+            }
+          : {
+              aspectRatio: '4:5',
+              safeTextZones: ['top 15%', 'bottom 20%'],
+              visualStyle: 'clean product-focused',
+            },
+      disclaimer: typeof parsed.disclaimer === 'string' ? parsed.disclaimer.trim() : null,
+    },
+  }
+}
+
 export async function requestSocialPost(payload: GenerateSocialPostPayload): Promise<GenerateSocialPostResponse> {
-  const callable = httpsCallable(functions, 'generateSocialPost')
-  const response = await callable(payload)
-  return (response.data ?? {}) as GenerateSocialPostResponse
+  try {
+    const callable = httpsCallable(functions, 'generateSocialPost')
+    const response = await callable(payload)
+    return (response.data ?? {}) as GenerateSocialPostResponse
+  } catch (_error) {
+    return requestSocialPostFallback(payload)
+  }
 }

--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -305,6 +305,15 @@ export default function SocialMediaPage() {
         storeId,
         platform,
         productId: selectedProduct.id,
+        product: {
+          id: selectedProduct.id,
+          name: selectedProduct.name,
+          category: selectedProduct.category,
+          description: selectedProduct.description,
+          price: selectedProduct.price,
+          imageUrl: selectedProduct.imageUrl,
+          itemType: selectedProduct.itemType,
+        },
       })
       const styledPost = applyPresets(response.post)
       const styledResponse: GenerateSocialPostResponse = {


### PR DESCRIPTION
### Motivation

- Provide a resilient client-side fallback when the `generateSocialPost` Cloud Function fails or is unreachable by using an AI advisor to synthesize a JSON response.
- Ensure the social post generator has richer product context by sending the full `product` object from the UI instead of only `productId`.

### Description

- Add a new `requestSocialPostFallback` helper that queries `requestAiAdvisor` with a strict JSON prompt, parses the result with `parseFallbackJson`, and maps it to the `GenerateSocialPostResponse` shape. 
- Add `parseFallbackJson` to robustly extract JSON from advisor text (tries direct parse then slices between first `{` and last `}`).
- Wrap `requestSocialPost` in a `try/catch` so it first attempts the `httpsCallable(functions, 'generateSocialPost')` call and falls back to `requestSocialPostFallback` on error.
- Update `SocialMediaPage.tsx` to include a full `product` payload (`id`, `name`, `category`, `description`, `price`, `imageUrl`, `itemType`) when calling `requestSocialPost`.

### Testing

- Ran TypeScript build (`yarn build`) and the project compiled successfully. 
- Ran unit tests (`yarn test`) and all tests passed. 
- Ran project's linter (`yarn lint`) with no new linting errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de8eb4c6b88321975aa6fea2894dcd)