### PR TITLE
Improve social media manual posting flow and CTA behavior

### DIFF
--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { FirebaseError } from 'firebase/app'
-import { collection, onSnapshot, query, where } from 'firebase/firestore'
+import { collection, doc, getDoc, onSnapshot, query, where } from 'firebase/firestore'
 import { db } from '../firebase'
 import PageSection from '../layout/PageSection'
 import { useActiveStore } from '../hooks/useActiveStore'
@@ -18,7 +18,7 @@ type ProductOption = {
   itemType: Product['itemType']
 }
 
-type RegenerateTarget = 'all' | 'caption' | 'hashtags' | 'cta'
+type RegenerateTarget = 'all' | 'caption' | 'hashtags'
 type CopyTarget = 'caption' | 'hashtags' | 'full'
 type ContentTone = 'standard' | 'playful' | 'professional'
 type ContentLength = 'short' | 'medium' | 'long'
@@ -36,6 +36,12 @@ type ParsedMarketingDescription = {
   keyBenefits: string[]
   bestUseCase: string | null
   closing: string | null
+}
+
+type StoreContactDetails = {
+  phone: string | null
+  email: string | null
+  website: string | null
 }
 
 function cleanRichText(value: string): string {
@@ -164,7 +170,11 @@ export default function SocialMediaPage() {
   const [productLoadError, setProductLoadError] = useState<string | null>(null)
   const [history, setHistory] = useState<SocialHistoryEntry[]>([])
   const [productSearchTerm, setProductSearchTerm] = useState('')
-  const contactCta = 'Call now with your phone number, email, and website (if available).'
+  const [storeContact, setStoreContact] = useState<StoreContactDetails>({
+    phone: null,
+    email: null,
+    website: null,
+  })
 
   useEffect(() => {
     if (!storeId) {
@@ -214,6 +224,58 @@ export default function SocialMediaPage() {
       setHistory([])
     }
   }, [storeId])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadStoreContactDetails() {
+      if (!storeId) {
+        setStoreContact({ phone: null, email: null, website: null })
+        return
+      }
+
+      try {
+        const snapshot = await getDoc(doc(db, 'stores', storeId))
+        if (!snapshot.exists() || cancelled) return
+        const data = snapshot.data()
+        const phone = typeof data.phone === 'string' && data.phone.trim() ? data.phone.trim() : null
+        const email =
+          typeof data.email === 'string' && data.email.trim()
+            ? data.email.trim()
+            : typeof data.ownerEmail === 'string' && data.ownerEmail.trim()
+              ? data.ownerEmail.trim()
+              : null
+        const websiteCandidates = [
+          typeof data.website === 'string' ? data.website.trim() : '',
+          typeof data.websiteUrl === 'string' ? data.websiteUrl.trim() : '',
+          typeof data.websiteLink === 'string' ? data.websiteLink.trim() : '',
+        ].filter(Boolean)
+        const website = websiteCandidates[0] || null
+        if (!cancelled) {
+          setStoreContact({ phone, email, website })
+        }
+      } catch (error) {
+        console.warn('[social-media] Failed to load store contact details', error)
+      }
+    }
+
+    void loadStoreContactDetails()
+    return () => {
+      cancelled = true
+    }
+  }, [storeId])
+
+  const contactCta = useMemo(() => {
+    const contactLines = [
+      storeContact.phone ? `Call now: ${storeContact.phone}` : null,
+      storeContact.email ? `Email: ${storeContact.email}` : null,
+      storeContact.website ? `Visit: ${storeContact.website}` : null,
+    ].filter(Boolean)
+    if (!contactLines.length) {
+      return 'Message us now to place your order and get full details.'
+    }
+    return contactLines.join(' • ')
+  }, [storeContact.email, storeContact.phone, storeContact.website])
 
   const selectedProduct = useMemo(
     () => products.find(product => product.id === selectedId) ?? null,
@@ -333,7 +395,6 @@ export default function SocialMediaPage() {
                 ...result.post,
                 ...(target === 'caption' ? { caption: styledResponse.post.caption } : {}),
                 ...(target === 'hashtags' ? { hashtags: styledResponse.post.hashtags } : {}),
-                ...(target === 'cta' ? { cta: styledResponse.post.cta } : {}),
               },
             }
 
@@ -374,21 +435,43 @@ export default function SocialMediaPage() {
     }
   }
 
-  function handleImageDownload() {
+  async function handleImageDownload() {
     const imageUrl = result?.product.imageUrl
     if (!imageUrl) {
       publish({ tone: 'error', message: 'No image available to download for this item yet.' })
       return
     }
 
+    const suggestedName = `social-image-${new Date().toISOString().slice(0, 10)}.jpg`
+
+    try {
+      const response = await fetch(imageUrl, { mode: 'cors' })
+      if (!response.ok) {
+        throw new Error(`Image download failed with status ${response.status}`)
+      }
+      const blob = await response.blob()
+      const blobUrl = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = blobUrl
+      link.download = suggestedName
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+      URL.revokeObjectURL(blobUrl)
+      publish({ tone: 'success', message: 'Image downloaded. Upload it in your social app next.' })
+      return
+    } catch (error) {
+      console.warn('[social-media] Blob image download failed, falling back to new tab', error)
+    }
+
     const link = document.createElement('a')
     link.href = imageUrl
     link.target = '_blank'
     link.rel = 'noopener noreferrer'
-    link.download = `social-image-${new Date().toISOString().slice(0, 10)}.jpg`
     document.body.appendChild(link)
     link.click()
     link.remove()
+    publish({ tone: 'success', message: 'Opened image in a new tab. Long-press or right-click to save it.' })
   }
 
   function handleDownload() {
@@ -397,6 +480,12 @@ export default function SocialMediaPage() {
       `Platform: ${result.post.platform}`,
       `Product: ${result.product.name}`,
       '',
+      'Manual upload steps:',
+      '1. Download image.',
+      `2. Upload image in the ${result.post.platform === 'instagram' ? 'Instagram' : 'TikTok'} app.`,
+      '3. Paste caption + hashtags.',
+      '',
+      'Draft content:',
       `Caption: ${result.post.caption}`,
       `CTA: ${contactCta}`,
       `Hashtags: ${result.post.hashtags.join(' ')}`,
@@ -527,13 +616,13 @@ export default function SocialMediaPage() {
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
               <button type="button" className="button secondary" onClick={() => void handleGenerate('caption')} disabled={loading}>Regenerate caption</button>
               <button type="button" className="button secondary" onClick={() => void handleGenerate('hashtags')} disabled={loading}>Regenerate hashtags</button>
-              <button type="button" className="button secondary" onClick={() => void handleGenerate('cta')} disabled={loading}>Regenerate CTA</button>
             </div>
             <p style={{ margin: 0 }}><strong>Caption:</strong> {result.post.caption}</p>
             <p style={{ margin: 0 }}><strong>CTA:</strong> {contactCta}</p>
             <p style={{ margin: 0 }}><strong>Hashtags:</strong> {result.post.hashtags.join(' ')}</p>
             {result.post.disclaimer ? <p style={{ margin: 0 }}><strong>Disclaimer:</strong> {result.post.disclaimer}</p> : null}
             <p style={{ margin: 0 }}><strong>Selected image:</strong> {result.product.imageUrl ? 'Ready to download and upload manually.' : 'No image URL on this item yet.'}</p>
+            <p style={{ margin: 0, fontSize: 13, opacity: 0.8 }}>Step 1: Download image. Step 2: Upload on Instagram/TikTok app. Step 3: Paste caption + hashtags.</p>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
               <button type="button" className="button secondary" onClick={() => void handleCopy('caption')}>Copy caption</button>
               <button type="button" className="button secondary" onClick={() => void handleCopy('hashtags')}>Copy hashtags</button>

--- a/web/src/pages/__tests__/SocialMediaPage.test.tsx
+++ b/web/src/pages/__tests__/SocialMediaPage.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SocialMediaPage from '../SocialMediaPage'
+
+const mockUseActiveStore = vi.fn()
+vi.mock('../../hooks/useActiveStore', () => ({
+  useActiveStore: () => mockUseActiveStore(),
+}))
+
+const mockPublish = vi.fn()
+vi.mock('../../components/ToastProvider', () => ({
+  useToast: () => ({ publish: mockPublish }),
+}))
+
+const mockRequestSocialPost = vi.fn()
+vi.mock('../../api/socialPost', () => ({
+  requestSocialPost: (...args: Parameters<typeof mockRequestSocialPost>) => mockRequestSocialPost(...args),
+}))
+
+const mockCollection = vi.fn()
+const mockWhere = vi.fn()
+const mockQuery = vi.fn()
+const mockOnSnapshot = vi.fn()
+const mockDoc = vi.fn()
+const mockGetDoc = vi.fn()
+
+vi.mock('firebase/firestore', () => ({
+  collection: (...args: Parameters<typeof mockCollection>) => mockCollection(...args),
+  where: (...args: Parameters<typeof mockWhere>) => mockWhere(...args),
+  query: (...args: Parameters<typeof mockQuery>) => mockQuery(...args),
+  onSnapshot: (...args: Parameters<typeof mockOnSnapshot>) => mockOnSnapshot(...args),
+  doc: (...args: Parameters<typeof mockDoc>) => mockDoc(...args),
+  getDoc: (...args: Parameters<typeof mockGetDoc>) => mockGetDoc(...args),
+}))
+
+vi.mock('../../firebase', () => ({
+  db: { __name: 'test-db' },
+}))
+
+describe('SocialMediaPage manual flow', () => {
+  beforeEach(() => {
+    mockUseActiveStore.mockReset()
+    mockPublish.mockReset()
+    mockRequestSocialPost.mockReset()
+    mockCollection.mockReset()
+    mockWhere.mockReset()
+    mockQuery.mockReset()
+    mockOnSnapshot.mockReset()
+    mockDoc.mockReset()
+    mockGetDoc.mockReset()
+
+    mockUseActiveStore.mockReturnValue({ storeId: 'store-1' })
+    mockCollection.mockImplementation((_db, name) => ({ name }))
+    mockWhere.mockImplementation((...args) => ({ args }))
+    mockQuery.mockImplementation((...parts) => ({ parts }))
+    mockDoc.mockImplementation((_db, collectionName, id) => ({ collectionName, id }))
+
+    mockOnSnapshot.mockImplementation((_query, onNext) => {
+      onNext({
+        docs: [
+          {
+            id: 'product-1',
+            data: () => ({
+              name: 'Zobo Mix',
+              category: 'Drinks',
+              description: 'Fresh and ready',
+              price: 15,
+              imageUrl: null,
+              itemType: 'product',
+            }),
+          },
+        ],
+      })
+      return vi.fn()
+    })
+
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        phone: '+233201234567',
+        email: 'hello@example.com',
+        website: 'https://example.com',
+      }),
+    })
+
+    mockRequestSocialPost.mockResolvedValue({
+      storeId: 'store-1',
+      productId: 'product-1',
+      product: {
+        id: 'product-1',
+        name: 'Zobo Mix',
+        category: 'Drinks',
+        description: 'Fresh and ready',
+        price: 15,
+        imageUrl: null,
+        itemType: 'product',
+      },
+      post: {
+        platform: 'instagram',
+        caption: 'Try our Zobo Mix today',
+        cta: 'Order now!',
+        hashtags: ['#zobo', '#ghana'],
+        disclaimer: null,
+      },
+    })
+  })
+
+  it('renders CTA from store contact details in the draft area', async () => {
+    const user = userEvent.setup()
+    render(<SocialMediaPage />)
+
+    await user.click(screen.getByRole('button', { name: /generate social post/i }))
+
+    expect(await screen.findByText(/CTA:/i)).toHaveTextContent(
+      'CTA: Call now: +233201234567 • Email: hello@example.com • Visit: https://example.com',
+    )
+  })
+
+  it('does not render image prompt or design spec fields in manual flow output', async () => {
+    const user = userEvent.setup()
+    render(<SocialMediaPage />)
+
+    await user.click(screen.getByRole('button', { name: /generate social post/i }))
+
+    await screen.findByText(/Caption:/i)
+    expect(screen.queryByText(/image prompt/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/design spec/i)).not.toBeInTheDocument()
+  })
+
+  it('disables download image button when image URL is missing', async () => {
+    const user = userEvent.setup()
+    render(<SocialMediaPage />)
+
+    await user.click(screen.getByRole('button', { name: /generate social post/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /download image/i })).toBeDisabled()
+    })
+  })
+})


### PR DESCRIPTION
### Motivation

- Replace the hardcoded CTA text with contact-aware copy built from the store profile so the CTA reflects real business contact data and hides missing fields gracefully.
- Remove confusing/unused CTA regeneration so regenerate actions match only editable/generated fields (caption/hashtags) and don’t mislead users.
- Make image downloads more reliable across browsers/CDNs and make copy/download outputs clearer for the manual upload workflow.

### Description

- Fetch store profile contact fields with `getDoc(doc(db, 'stores', storeId))` and store into a new `StoreContactDetails` state, then build `contactCta` via `useMemo` from `phone`, `email`/`ownerEmail`, and `website`/`websiteUrl`/`websiteLink`.
- Remove `cta` from the `RegenerateTarget` type and stop merging regenerated CTA into `result`, and remove the `Regenerate CTA` button so only `caption` and `hashtags` can be regenerated (`type RegenerateTarget = 'all' | 'caption' | 'hashtags'`).
- Improve image download in `handleImageDownload` by attempting `fetch -> blob -> URL.createObjectURL` and clicking a blob-backed anchor, with a fallback to opening the remote image in a new tab if blob download fails.
- Update `handleDownload` `.txt` export to include explicit section labels (`Manual upload steps:` and `Draft content:`) and add an inline single-line UX helper near the draft panel (`Step 1: Download image. Step 2: Upload on Instagram/TikTok app. Step 3: Paste caption + hashtags.`).
- Add focused unit tests in `web/src/pages/__tests__/SocialMediaPage.test.tsx` that assert the dynamic CTA is rendered from store contact details, that image prompt/design spec text is not present in the manual draft output, and that the `Download image` button is disabled when `imageUrl` is missing.

### Testing

- Added automated tests in `web/src/pages/__tests__/SocialMediaPage.test.tsx` covering CTA rendering, absence of image prompt/design spec in the manual flow, and `Download image` disabled state when no `imageUrl` is present (tests committed to the repo).
- Attempted to run `npm test -- --run web/src/pages/__tests__/SocialMediaPage.test.tsx` but the test runner failed here with `sh: 1: vitest: not found` because the `vitest` binary is not available in this environment.
- Attempted to install dev dependencies with `npm install` but the install failed due to registry access (`403 Forbidden`), so test tooling could not be installed and automated tests could not be executed in this runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea3a55a108322b55287d76dfba3eb)