### PR TITLE
Normalize social draft output and improve manual image workflow

### DIFF
--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -156,6 +156,31 @@ function mapProduct(id: string, raw: Record<string, unknown>): ProductOption {
   }
 }
 
+function normalizeGeneratedPost(post: GenerateSocialPostResponse['post']): GenerateSocialPostResponse['post'] {
+  const normalizedCaption = post.caption.replace(/\r\n/g, '\n').trim()
+  const captionMatch = normalizedCaption.match(
+    /(?:^|\n)\s*caption\s*:\s*([\s\S]*?)(?=\n\s*(?:cta|hashtags|image prompt|design spec|selected image)\s*:|$)/i,
+  )
+  const hashtagsMatch = normalizedCaption.match(/(?:^|\n)\s*hashtags\s*:\s*([^\n]+)/i)
+
+  const cleanCaption = (captionMatch?.[1] ?? normalizedCaption).trim()
+  const parsedHashtags =
+    post.hashtags.length > 0
+      ? post.hashtags
+      : (hashtagsMatch?.[1] ?? '')
+          .split(/[,\s]+/)
+          .map(tag => tag.trim())
+          .filter(Boolean)
+          .map(tag => (tag.startsWith('#') ? tag : `#${tag}`))
+          .slice(0, 10)
+
+  return {
+    ...post,
+    caption: cleanCaption,
+    hashtags: parsedHashtags,
+  }
+}
+
 export default function SocialMediaPage() {
   const { storeId } = useActiveStore()
   const { publish } = useToast()
@@ -327,16 +352,17 @@ export default function SocialMediaPage() {
     const maxCaption: Record<ContentLength, number> = { short: 90, medium: 170, long: 220 }
     const hashtagLimit: Record<ContentLength, number> = { short: 5, medium: 7, long: 10 }
 
-    const cleanCaption = post.caption.trim()
+    const normalizedPost = normalizeGeneratedPost(post)
+    const cleanCaption = normalizedPost.caption.trim()
     const maxLen = maxCaption[lengthPreset]
     const trimmedCaption =
       cleanCaption.length > maxLen ? `${cleanCaption.slice(0, Math.max(maxLen - 1, 1)).trimEnd()}…` : cleanCaption
 
     return {
-      ...post,
+      ...normalizedPost,
       caption: `${tonePrefix[tone]}${trimmedCaption}`.trim(),
-      hashtags: post.hashtags.slice(0, hashtagLimit[lengthPreset]),
-      cta: tone === 'professional' ? post.cta.replace('!', '.').trim() : post.cta,
+      hashtags: normalizedPost.hashtags.slice(0, hashtagLimit[lengthPreset]),
+      cta: tone === 'professional' ? normalizedPost.cta.replace('!', '.').trim() : normalizedPost.cta,
     }
   }
 
@@ -622,6 +648,14 @@ export default function SocialMediaPage() {
             <p style={{ margin: 0 }}><strong>Hashtags:</strong> {result.post.hashtags.join(' ')}</p>
             {result.post.disclaimer ? <p style={{ margin: 0 }}><strong>Disclaimer:</strong> {result.post.disclaimer}</p> : null}
             <p style={{ margin: 0 }}><strong>Selected image:</strong> {result.product.imageUrl ? 'Ready to download and upload manually.' : 'No image URL on this item yet.'}</p>
+            {result.product.imageUrl ? (
+              <p style={{ margin: 0, fontSize: 13 }}>
+                <strong>Image URL:</strong>{' '}
+                <a href={result.product.imageUrl} target="_blank" rel="noopener noreferrer">
+                  Open original image
+                </a>
+              </p>
+            ) : null}
             <p style={{ margin: 0, fontSize: 13, opacity: 0.8 }}>Step 1: Download image. Step 2: Upload on Instagram/TikTok app. Step 3: Paste caption + hashtags.</p>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
               <button type="button" className="button secondary" onClick={() => void handleCopy('caption')}>Copy caption</button>

--- a/web/src/pages/__tests__/SocialMediaPage.test.tsx
+++ b/web/src/pages/__tests__/SocialMediaPage.test.tsx
@@ -138,4 +138,40 @@ describe('SocialMediaPage manual flow', () => {
       expect(screen.getByRole('button', { name: /download image/i })).toBeDisabled()
     })
   })
+
+  it('normalizes mixed draft text so only caption and hashtags are shown', async () => {
+    const user = userEvent.setup()
+    mockRequestSocialPost.mockResolvedValueOnce({
+      storeId: 'store-1',
+      productId: 'product-1',
+      product: {
+        id: 'product-1',
+        name: 'Zobo Mix',
+        category: 'Drinks',
+        description: 'Fresh and ready',
+        price: 15,
+        imageUrl: 'https://example.com/image.jpg',
+        itemType: 'product',
+      },
+      post: {
+        platform: 'instagram',
+        caption:
+          'Caption: Transform your skincare routine with our Anti Pimples Face Soap Big!\nCTA: Order now.\nHashtags: #AntiPimples #ClearSkin',
+        cta: 'Order now!',
+        hashtags: [],
+        imagePrompt: 'ignored',
+        designSpec: { aspectRatio: '1:1', safeTextZones: ['10% top'], visualStyle: 'bright' },
+        disclaimer: null,
+      },
+    })
+    render(<SocialMediaPage />)
+
+    await user.click(screen.getByRole('button', { name: /generate social post/i }))
+
+    expect(await screen.findByText(/Caption:/i)).toHaveTextContent(
+      'Caption: Transform your skincare routine with our Anti Pimples Face Soap Big!',
+    )
+    expect(screen.getByText(/Hashtags:/i)).toHaveTextContent('Hashtags: #AntiPimples #ClearSkin')
+    expect(screen.getByRole('button', { name: /download image/i })).toBeEnabled()
+  })
 })


### PR DESCRIPTION
### Motivation
- The AI backend sometimes returns mixed labeled content (e.g. `Caption: ... CTA: ... Hashtags: ...`) inside the `caption` field, which makes the UI/copy/export flows noisy and inconsistent.
- Provide a reliable manual fallback for image download/save when browser/CORS/download behavior is unreliable.

### Description
- Add `normalizeGeneratedPost` to parse mixed draft text and extract a clean `caption` and `hashtags` when the AI embeds labeled sections inside `post.caption`.
- Update `applyPresets` to use the normalized post so trimming, hashtag limits and CTA adjustments apply to cleaned data (`caption`, `hashtags`, `cta`).
- Add an explicit "Open original image" link in the draft panel when `result.product.imageUrl` exists to make manual saving/opening easier.
- Add a unit test in `web/src/pages/__tests__/SocialMediaPage.test.tsx` that covers a mixed-output scenario and verifies caption normalization, hashtag extraction, and that the `Download image` button is enabled when an image URL is present.

### Testing
- Ran `npm --prefix web test -- SocialMediaPage.test.tsx` but the test run failed because the `vitest` binary was not available in this environment. (automated test run failed)
- Attempted `npm --prefix web install` to install dev dependencies so tests could run, but install failed due to an upstream npm registry policy (`403` fetching `@azure/msal-browser`), blocking dependency installation and test execution. (automated install failed)
- The new/updated unit test file is included in the changes and should pass in CI once dev dependencies are installed and `vitest` is available. (tests not executed successfully here)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea79a2d9883229d51cd96b01845f8)