### PR TITLE
Revamp auth promo section with hub-and-spoke map, flow cards, and stronger CTA

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -555,59 +555,188 @@ body {
   line-height: 1.6;
 }
 
-.promo-map {
-  display: grid;
-  gap: 12px;
-  align-items: center;
-}
-
-.promo-map__source,
-.promo-map__target {
-  border-radius: 18px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  padding: 14px 16px;
-  text-align: center;
+.app__proof {
+  margin: 0;
+  color: rgba(167, 243, 208, 0.9);
+  font-size: 14px;
   font-weight: 600;
 }
 
+.promo-map {
+  display: grid;
+  gap: 14px;
+  justify-items: center;
+  align-items: center;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(2, 6, 23, 0.42);
+}
+
 .promo-map__source {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.4), rgba(14, 116, 144, 0.32));
-  color: #dbeafe;
+  border-radius: 999px;
+  border: 1px solid rgba(125, 211, 252, 0.45);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.5), rgba(14, 116, 144, 0.34));
+  color: #e0f2fe;
+  padding: 12px 24px;
+  font-weight: 700;
+  text-align: center;
+  min-width: 180px;
+}
+
+.promo-map__spokes {
+  width: min(100%, 380px);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.promo-map__connector {
+  height: 22px;
+  border-top: 2px dashed rgba(191, 219, 254, 0.55);
+}
+
+.promo-map__targets {
+  width: min(100%, 560px);
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .promo-map__target {
-  position: relative;
-  background: rgba(15, 23, 42, 0.66);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 12px;
+  text-align: center;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.72);
   color: var(--color-text-secondary);
 }
 
-.promo-map__target::before {
-  content: '↘';
-  position: absolute;
-  top: -16px;
-  left: 50%;
-  transform: translateX(-50%);
-  color: rgba(191, 219, 254, 0.8);
-  font-size: 15px;
-}
-
-.app__promo-pillars {
+.app__promo-flow {
   display: grid;
-  gap: 12px;
+  gap: 10px;
 }
 
+.app__promo-flow h3,
 .app__promo-pillars h3 {
   margin: 0;
   font-size: clamp(18px, 3vw, 24px);
 }
 
-.app__promo-pillars ul {
+.app__promo-flow ol {
   margin: 0;
-  padding-left: 20px;
+  padding: 0;
+  list-style: none;
   display: grid;
   gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  counter-reset: flow-step;
+}
+
+.app__promo-flow li {
+  counter-increment: flow-step;
+  padding: 10px 12px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 12px;
   color: var(--color-text-secondary);
-  line-height: 1.6;
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.app__promo-flow li::before {
+  content: counter(flow-step) '. ';
+  color: #bfdbfe;
+  font-weight: 700;
+}
+
+.app__promo-pillars {
+  display: grid;
+  gap: 14px;
+}
+
+.app__promo-pillars-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.app__promo-card {
+  margin: 0;
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.56);
+  display: grid;
+  gap: 8px;
+}
+
+.app__promo-card span {
+  font-size: 18px;
+}
+
+.app__promo-card h4 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.app__promo-card p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  font-size: 14px;
+}
+
+.app__promo-cta {
+  width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 18px;
+  border-radius: 12px;
+  text-decoration: none;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--color-accent-start), var(--color-accent-end));
+  color: #f8fafc;
+  box-shadow: 0 14px 26px -14px rgba(99, 102, 241, 0.9);
+}
+
+.app__promo-cta:hover,
+.app__promo-cta:focus-visible {
+  transform: translateY(-1px);
+}
+
+.app__capabilities-compact {
+  width: min(1280px, 100%);
+  display: grid;
+  gap: 14px;
+  padding: clamp(18px, 4vw, 24px);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 22px;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.app__capabilities-compact header h3,
+.app__capabilities-grid h4 {
+  margin: 0;
+}
+
+.app__capabilities-compact header p,
+.app__capabilities-grid p {
+  margin: 6px 0 0;
+  color: var(--color-text-secondary);
+}
+
+.app__capabilities-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.app__capabilities-grid article {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.48);
 }
 
 .app__features {
@@ -866,6 +995,11 @@ body {
   .app__promo-strategy {
     grid-template-columns: minmax(0, 1fr) minmax(320px, 440px);
     align-items: start;
+  }
+
+  .app__promo-flow,
+  .app__promo-pillars {
+    grid-column: 2;
   }
 
   .app__promo-strategy-header {
@@ -1394,6 +1528,17 @@ label {
 
   .app {
     padding: 22px;
+  }
+
+  .promo-map__targets,
+  .app__promo-pillars-grid,
+  .app__capabilities-grid,
+  .app__promo-flow ol {
+    grid-template-columns: 1fr;
+  }
+
+  .promo-map__spokes {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .app__visual {

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -1219,44 +1219,91 @@ export default function AuthPage() {
       <section className="app__promo-strategy" aria-label="Sedifex promo strategy">
         <header className="app__promo-strategy-header">
           <span className="app__pill">Sedifex Promo Strategy</span>
-          <h2>One product post. Every channel updated at the same time.</h2>
+          <h2>Post once in Sedifex. Publish everywhere instantly.</h2>
           <p>
-            Add your products once in Sedifex, sell with POS, and publish the same offer
-            across Sedifex Market, Google Merchant, your website, and social media.
+            Keep POS, inventory, and messaging fully synced while the same campaign goes live
+            across Sedifex Market, Google Merchant, your website, and social channels.
           </p>
+          <p className="app__proof">Trusted by growing stores to coordinate daily multichannel promos.</p>
         </header>
 
-        <div className="promo-map" role="img" aria-label="Sedifex post distribution map">
-          <div className="promo-map__source">Sedifex Inventory + POS</div>
-          <div className="promo-map__target">Sedifex Market</div>
-          <div className="promo-map__target">Google Merchant</div>
-          <div className="promo-map__target">Website</div>
-          <div className="promo-map__target">Social Channels</div>
+        <div className="promo-map" role="img" aria-label="Sedifex hub and spoke publishing map">
+          <div className="promo-map__source">Sedifex</div>
+          <div className="promo-map__spokes" aria-hidden="true">
+            <span className="promo-map__connector" />
+            <span className="promo-map__connector" />
+            <span className="promo-map__connector" />
+            <span className="promo-map__connector" />
+          </div>
+          <div className="promo-map__targets">
+            <div className="promo-map__target">Sedifex Market</div>
+            <div className="promo-map__target">Google Merchant</div>
+            <div className="promo-map__target">Website</div>
+            <div className="promo-map__target">Social</div>
+          </div>
+        </div>
+
+        <div className="app__promo-flow" aria-label="Example promo workflow">
+          <h3>Example promo flow</h3>
+          <ol>
+            <li>Add Product</li>
+            <li>AI generates caption</li>
+            <li>Publish to channels</li>
+            <li>Send branded SMS</li>
+          </ol>
         </div>
 
         <div className="app__promo-pillars">
           <h3>Promo pillars</h3>
-          <ul>
-            <li>
-              <strong>One-post distribution:</strong> one update in Sedifex pushes your
-              product story to every channel.
-            </li>
-            <li>
-              <strong>POS + inventory sync:</strong> sales, prices, and stock stay aligned
-              while campaigns are live.
-            </li>
-            <li>
-              <strong>AI content engine:</strong> generate branded social captions directly
-              from your own inventory data.
-            </li>
-            <li>
-              <strong>Branded SMS outreach:</strong> send company-branded bulk SMS offers to
-              your customer lists in minutes.
-            </li>
-          </ul>
-          <a className="app__partners-link" href="mailto:info@sedifex.com">
-            Book a Sedifex promo demo: info@sedifex.com
+          <div className="app__promo-pillars-grid">
+            <article className="app__promo-card">
+              <span aria-hidden="true">📣</span>
+              <h4>One-post distribution</h4>
+              <p>One update in Sedifex pushes your product story to every channel.</p>
+            </article>
+            <article className="app__promo-card">
+              <span aria-hidden="true">📦</span>
+              <h4>POS + inventory sync</h4>
+              <p>Sales, prices, and stock stay aligned while campaigns are live.</p>
+            </article>
+            <article className="app__promo-card">
+              <span aria-hidden="true">✨</span>
+              <h4>AI social generator</h4>
+              <p>Generate branded social captions directly from your inventory data.</p>
+            </article>
+            <article className="app__promo-card">
+              <span aria-hidden="true">💬</span>
+              <h4>Branded SMS campaigns</h4>
+              <p>Send company-branded bulk SMS offers to your customer list in minutes.</p>
+            </article>
+          </div>
+          <a className="app__promo-cta" href="mailto:info@sedifex.com?subject=Book%20Promo%20Demo">
+            Book Promo Demo
           </a>
+          <a className="app__partners-link" href="mailto:info@sedifex.com">
+            Or email info@sedifex.com
+          </a>
+        </div>
+      </section>
+
+      <section className="app__capabilities-compact" aria-label="Sedifex platform capabilities">
+        <header>
+          <h3>Explore the AI workspace</h3>
+          <p>Core tools your team can launch in one place.</p>
+        </header>
+        <div className="app__capabilities-grid">
+          <article>
+            <h4>Inventory + POS</h4>
+            <p>Track stock movement, sales, and low-stock actions live.</p>
+          </article>
+          <article>
+            <h4>Marketing automation</h4>
+            <p>Create channel-ready content and schedule branded customer outreach.</p>
+          </article>
+          <article>
+            <h4>Commerce visibility</h4>
+            <p>Publish products to Sedifex Market, Google Merchant, website, and social.</p>
+          </article>
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Make the login/promo area communicate a clear multichannel workflow: a hub-and-spoke visual that shows “Sedifex → channels” instead of the existing stacked list.  
- Improve conversion by tightening the headline, introducing a prominent CTA, and making the promo pillars scannable as cards.  
- Surface an actionable example flow and a compact platform capability block so new visitors can both understand strategy and explore product depth.  

### Description
- Replaced the stacked promo list with a hub-and-spoke layout and lighter proof text in `web/src/pages/AuthPage.tsx`, added an example promo flow, and tightened the main headline and supporting copy.  
- Transformed the four promo pillars into scannable card-style elements and added inline emoji icons and headings for each pillar in `web/src/pages/AuthPage.tsx`.  
- Added a prominent `Book Promo Demo` CTA (primary button) and preserved a secondary mailto link in `web/src/pages/AuthPage.tsx`.  
- Restored a compact `Explore the AI workspace` capability section under the promo block and implemented all required styling and responsive rules in `web/src/App.css` (new hub/spoke styles, promo cards, example flow layout, and mobile stacking rules).  

### Testing
- Attempted to run unit tests with `npm --prefix web run test -- AuthPage.test.tsx --runInBand`, but the `vitest` binary was not available before dependencies were installed and the runner failed (`vitest: not found`).  
- Attempted `npm --prefix web install` to install dev deps, but install failed due to registry access restrictions (`E403 Forbidden` for a dependency), so the test toolchain could not be installed in this environment.  
- No automated tests were executed successfully due to the environment package/registry restrictions described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb9f72d048322908bd54466207782)