### PR TITLE
Improve SEO promo copy and simplify Social Media generation UI

### DIFF
--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -1219,10 +1219,12 @@ export default function AuthPage() {
       <section className="app__promo-strategy" aria-label="Sedifex promo strategy">
         <header className="app__promo-strategy-header">
           <span className="app__pill">Sedifex Promo Strategy</span>
-          <h2>One product post. Every channel updated at the same time.</h2>
+          <h2>Post once in Sedifex. Publish everywhere instantly.</h2>
           <p>
-            Add your products once in Sedifex, sell with POS, and publish the same offer
-            across Sedifex Market, Google Merchant, your website, and social media.
+            Every channel stays in sync from one update, so your stock, pricing, and messaging remain consistent everywhere customers discover your store.
+          </p>
+          <p>
+            One post can appear on Google Merchant, <a href="https://www.sedifexmarket.com" target="_blank" rel="noreferrer">www.sedifexmarket.com</a>, your website, and social pages for stronger Google presence. If your store already sells on Jumia or uses a Hubtel seller account, you can also connect those channels through Sedifex.
           </p>
         </header>
 
@@ -1233,6 +1235,12 @@ export default function AuthPage() {
           <div className="promo-map__target">Website</div>
           <div className="promo-map__target">Social Channels</div>
         </div>
+        <p>
+          Example flow: <strong>Add Product</strong> → <strong>AI generates caption</strong> → <strong>Publish to channels</strong> → <strong>Send branded SMS</strong>.
+        </p>
+        <p>
+          Trust signal: merchants can verify the same product listing across connected channels within minutes.
+        </p>
 
         <div className="app__promo-pillars">
           <h3>Promo pillars</h3>
@@ -1365,7 +1373,7 @@ const PRICING_PLANS = [
       'Up to 10 sales per day',
       'Buy SMS credits anytime (separate from plan)',
       'Customer display and QR pricing',
-      'Products can publish to buy.sedifex.com',
+      'Products can publish to www.sedifex.com',
     ],
     cta: {
       type: 'button' as const,

--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -43,6 +43,8 @@ type StoreContactDetails = {
   email: string | null
   website: string | null
 }
+const PRODUCT_PAGE_SIZE = 20
+const HISTORY_LIMIT = 5
 
 function cleanRichText(value: string): string {
   return value
@@ -195,6 +197,7 @@ export default function SocialMediaPage() {
   const [productLoadError, setProductLoadError] = useState<string | null>(null)
   const [history, setHistory] = useState<SocialHistoryEntry[]>([])
   const [productSearchTerm, setProductSearchTerm] = useState('')
+  const [productPage, setProductPage] = useState(1)
   const [storeContact, setStoreContact] = useState<StoreContactDetails>({
     phone: null,
     email: null,
@@ -244,7 +247,7 @@ export default function SocialMediaPage() {
         return
       }
       const parsed = JSON.parse(raw) as SocialHistoryEntry[]
-      setHistory(Array.isArray(parsed) ? parsed.slice(0, 8) : [])
+      setHistory(Array.isArray(parsed) ? parsed.slice(0, HISTORY_LIMIT) : [])
     } catch (_error) {
       setHistory([])
     }
@@ -323,12 +326,30 @@ export default function SocialMediaPage() {
   }, [productSearchTerm, products])
 
   useEffect(() => {
-    if (!filteredProducts.length) {
+    setProductPage(1)
+  }, [productSearchTerm])
+
+  const totalProductPages = useMemo(
+    () => Math.max(1, Math.ceil(filteredProducts.length / PRODUCT_PAGE_SIZE)),
+    [filteredProducts.length, PRODUCT_PAGE_SIZE],
+  )
+
+  useEffect(() => {
+    setProductPage(current => Math.min(Math.max(current, 1), totalProductPages))
+  }, [totalProductPages])
+
+  const paginatedProducts = useMemo(() => {
+    const startIndex = (productPage - 1) * PRODUCT_PAGE_SIZE
+    return filteredProducts.slice(startIndex, startIndex + PRODUCT_PAGE_SIZE)
+  }, [filteredProducts, productPage, PRODUCT_PAGE_SIZE])
+
+  useEffect(() => {
+    if (!paginatedProducts.length) {
       setSelectedId('')
       return
     }
-    setSelectedId(current => (current && filteredProducts.some(product => product.id === current) ? current : filteredProducts[0].id))
-  }, [filteredProducts])
+    setSelectedId(current => (current && paginatedProducts.some(product => product.id === current) ? current : paginatedProducts[0].id))
+  }, [paginatedProducts])
 
   const selectedPreview = useMemo(() => {
     if (!selectedProduct) return null
@@ -376,7 +397,7 @@ export default function SocialMediaPage() {
       productName: nextResult.product.name,
       post: nextResult.post,
     }
-    const nextHistory = [nextEntry, ...history].slice(0, 8)
+    const nextHistory = [nextEntry, ...history].slice(0, HISTORY_LIMIT)
     setHistory(nextHistory)
     try {
       window.localStorage.setItem(`social-history-${storeId}`, JSON.stringify(nextHistory))
@@ -563,9 +584,9 @@ export default function SocialMediaPage() {
 
         <label style={{ display: 'grid', gap: 6 }}>
           <span id="social-product-label">Product or service</span>
-          <select aria-labelledby="social-product-label" value={selectedId} onChange={event => setSelectedId(event.target.value)} disabled={!filteredProducts.length}>
-            {filteredProducts.length ? (
-              filteredProducts.map(product => (
+          <select aria-labelledby="social-product-label" value={selectedId} onChange={event => setSelectedId(event.target.value)} disabled={!paginatedProducts.length}>
+            {paginatedProducts.length ? (
+              paginatedProducts.map(product => (
                 <option key={product.id} value={product.id}>
                   {product.name} {product.itemType === 'service' ? '(service)' : ''}
                 </option>
@@ -575,6 +596,29 @@ export default function SocialMediaPage() {
             )}
           </select>
         </label>
+        {filteredProducts.length > PRODUCT_PAGE_SIZE ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <button
+              type="button"
+              className="button secondary"
+              onClick={() => setProductPage(current => Math.max(1, current - 1))}
+              disabled={productPage <= 1}
+            >
+              Previous
+            </button>
+            <span style={{ fontSize: 13, opacity: 0.85 }}>
+              Page {productPage} of {totalProductPages} · {filteredProducts.length} results
+            </span>
+            <button
+              type="button"
+              className="button secondary"
+              onClick={() => setProductPage(current => Math.min(totalProductPages, current + 1))}
+              disabled={productPage >= totalProductPages}
+            >
+              Next
+            </button>
+          </div>
+        ) : null}
         {productLoadError ? <p style={{ margin: 0, color: 'var(--danger, #c62828)' }}>{productLoadError}</p> : null}
 
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 8 }}>
@@ -667,41 +711,6 @@ export default function SocialMediaPage() {
           </div>
         ) : null}
 
-        {history.length ? (
-          <div style={{ display: 'grid', gap: 8 }}>
-            <strong>Recent generations</strong>
-            {history.map(entry => (
-              <button
-                key={entry.id}
-                type="button"
-                className="button secondary"
-                style={{ textAlign: 'left' }}
-                onClick={() =>
-                  setResult(current =>
-                    current
-                      ? { ...current, productId: entry.productId, product: { ...current.product, name: entry.productName }, post: entry.post }
-                      : {
-                          storeId: storeId || '',
-                          productId: entry.productId,
-                          product: {
-                            id: entry.productId ?? undefined,
-                            name: entry.productName,
-                            category: null,
-                            description: null,
-                            price: null,
-                            imageUrl: null,
-                            itemType: 'product',
-                          },
-                          post: entry.post,
-                        },
-                  )
-                }
-              >
-                {new Date(entry.createdAtIso).toLocaleString()} · {entry.platform} · {entry.productName}
-              </button>
-            ))}
-          </div>
-        ) : null}
       </div>
     </PageSection>
   )


### PR DESCRIPTION
### Motivation
- Improve landing SEO and marketing clarity by replacing the old headline and adding sync-focused, trust-reinforcing copy and a concrete example flow. 
- Replace internal `buy.sedifex.com` link with the public `www.sedifex.com` for better SEO/branding. 
- Make the Social Media generation UI more usable on stores with many products by removing the long, bottom "Recent generations" list and adding pagination and a smaller local history retention.

### Description
- Updated `web/src/pages/AuthPage.tsx` to use the new headline `Post once in Sedifex. Publish everywhere instantly.`, added a sync-focused supporting sentence, a channel/trust paragraph referencing Google Merchant, `www.sedifexmarket.com`, Jumia/Hubtel connectivity, and an example flow line and a short trust signal below the promo map. 
- Replaced the pricing copy reference `Products can publish to buy.sedifex.com` with `Products can publish to www.sedifex.com` in `web/src/pages/AuthPage.tsx`. 
- Updated `web/src/pages/SocialMediaPage.tsx` to add `PRODUCT_PAGE_SIZE` pagination and `HISTORY_LIMIT = 5`, switched product selection to use paginated results, reset page on search, and removed the rendered bottom "Recent generations" block while still persisting history (now capped at the latest 5 entries). 
- Adjusted selection/init logic and localStorage usage to respect the new pagination and history limits; added simple UI controls (`Previous` / `Next`) and page indicator when product results exceed the page size.

### Testing
- Ran the page unit test command `npm --prefix web run test -- src/pages/__tests__/SocialMediaPage.test.tsx` to validate `SocialMediaPage` behavior, but the test run failed in this environment because `vitest` is not available on PATH (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec0b61dac8322bfbcde1cd5d7da44)