### PR TITLE
Refine social post output formatting and broaden store phone fallbacks

### DIFF
--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -44,6 +44,13 @@ type StoreContactDetails = {
   website: string | null
 }
 
+function firstNonEmptyString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
 function cleanRichText(value: string): string {
   return value
     .replace(/\*\*(.*?)\*\*/g, '$1')
@@ -263,17 +270,25 @@ export default function SocialMediaPage() {
         const snapshot = await getDoc(doc(db, 'stores', storeId))
         if (!snapshot.exists() || cancelled) return
         const data = snapshot.data()
-        const phone = typeof data.phone === 'string' && data.phone.trim() ? data.phone.trim() : null
-        const email =
-          typeof data.email === 'string' && data.email.trim()
-            ? data.email.trim()
-            : typeof data.ownerEmail === 'string' && data.ownerEmail.trim()
-              ? data.ownerEmail.trim()
-              : null
+        const contactInfo =
+          typeof data.contactInfo === 'object' && data.contactInfo
+            ? (data.contactInfo as Record<string, unknown>)
+            : null
+        const phone = firstNonEmptyString(
+          data.phone,
+          data.phoneNumber,
+          data.mobile,
+          data.whatsappNumber,
+          contactInfo?.phone,
+          contactInfo?.phoneNumber,
+          contactInfo?.mobile,
+        )
+        const email = firstNonEmptyString(data.email, data.ownerEmail, contactInfo?.email)
         const websiteCandidates = [
           typeof data.website === 'string' ? data.website.trim() : '',
           typeof data.websiteUrl === 'string' ? data.websiteUrl.trim() : '',
           typeof data.websiteLink === 'string' ? data.websiteLink.trim() : '',
+          typeof contactInfo?.website === 'string' ? contactInfo.website.trim() : '',
         ].filter(Boolean)
         const website = websiteCandidates[0] || null
         if (!cancelled) {
@@ -447,11 +462,7 @@ export default function SocialMediaPage() {
 
   async function handleCopy(target: CopyTarget) {
     if (!result) return
-    const fullText = [
-      `Caption: ${result.post.caption}`,
-      `CTA: ${contactCta}`,
-      `Hashtags: ${result.post.hashtags.join(' ')}`,
-    ].join('\n')
+    const fullText = [result.post.caption, contactCta, result.post.hashtags.join(' ')].filter(Boolean).join('\n\n')
     const text = target === 'caption' ? result.post.caption : target === 'hashtags' ? result.post.hashtags.join(' ') : fullText
     try {
       await navigator.clipboard.writeText(text)
@@ -512,9 +523,9 @@ export default function SocialMediaPage() {
       '3. Paste caption + hashtags.',
       '',
       'Draft content:',
-      `Caption: ${result.post.caption}`,
-      `CTA: ${contactCta}`,
-      `Hashtags: ${result.post.hashtags.join(' ')}`,
+      result.post.caption,
+      contactCta,
+      result.post.hashtags.join(' '),
       result.post.disclaimer ? `Disclaimer: ${result.post.disclaimer}` : '',
     ]
       .filter(Boolean)
@@ -643,9 +654,9 @@ export default function SocialMediaPage() {
               <button type="button" className="button secondary" onClick={() => void handleGenerate('caption')} disabled={loading}>Regenerate caption</button>
               <button type="button" className="button secondary" onClick={() => void handleGenerate('hashtags')} disabled={loading}>Regenerate hashtags</button>
             </div>
-            <p style={{ margin: 0 }}><strong>Caption:</strong> {result.post.caption}</p>
-            <p style={{ margin: 0 }}><strong>CTA:</strong> {contactCta}</p>
-            <p style={{ margin: 0 }}><strong>Hashtags:</strong> {result.post.hashtags.join(' ')}</p>
+            <p style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{result.post.caption}</p>
+            <p style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{contactCta}</p>
+            <p style={{ margin: 0, color: 'var(--muted, #555)' }}>{result.post.hashtags.join(' ')}</p>
             {result.post.disclaimer ? <p style={{ margin: 0 }}><strong>Disclaimer:</strong> {result.post.disclaimer}</p> : null}
             <p style={{ margin: 0 }}><strong>Selected image:</strong> {result.product.imageUrl ? 'Ready to download and upload manually.' : 'No image URL on this item yet.'}</p>
             {result.product.imageUrl ? (

--- a/web/src/pages/__tests__/SocialMediaPage.test.tsx
+++ b/web/src/pages/__tests__/SocialMediaPage.test.tsx
@@ -106,15 +106,14 @@ describe('SocialMediaPage manual flow', () => {
     })
   })
 
-  it('renders CTA from store contact details in the draft area', async () => {
+  it('renders phone contact details in the draft area without CTA label text', async () => {
     const user = userEvent.setup()
     render(<SocialMediaPage />)
 
     await user.click(screen.getByRole('button', { name: /generate social post/i }))
 
-    expect(await screen.findByText(/CTA:/i)).toHaveTextContent(
-      'CTA: Call now: +233201234567 • Email: hello@example.com • Visit: https://example.com',
-    )
+    expect(await screen.findByText('Call now: +233201234567 • Email: hello@example.com • Visit: https://example.com')).toBeInTheDocument()
+    expect(screen.queryByText(/^CTA:/i)).not.toBeInTheDocument()
   })
 
   it('does not render image prompt or design spec fields in manual flow output', async () => {
@@ -123,9 +122,26 @@ describe('SocialMediaPage manual flow', () => {
 
     await user.click(screen.getByRole('button', { name: /generate social post/i }))
 
-    await screen.findByText(/Caption:/i)
+    await screen.findByText('Try our Zobo Mix today')
     expect(screen.queryByText(/image prompt/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/design spec/i)).not.toBeInTheDocument()
+  })
+
+  it('falls back to phoneNumber field when phone is missing in store profile', async () => {
+    const user = userEvent.setup()
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({
+        phone: '',
+        phoneNumber: '+15551234567',
+        email: 'hello@example.com',
+      }),
+    })
+
+    render(<SocialMediaPage />)
+    await user.click(screen.getByRole('button', { name: /generate social post/i }))
+
+    expect(await screen.findByText('Call now: +15551234567 • Email: hello@example.com')).toBeInTheDocument()
   })
 
   it('disables download image button when image URL is missing', async () => {
@@ -168,10 +184,10 @@ describe('SocialMediaPage manual flow', () => {
 
     await user.click(screen.getByRole('button', { name: /generate social post/i }))
 
-    expect(await screen.findByText(/Caption:/i)).toHaveTextContent(
-      'Caption: Transform your skincare routine with our Anti Pimples Face Soap Big!',
-    )
-    expect(screen.getByText(/Hashtags:/i)).toHaveTextContent('Hashtags: #AntiPimples #ClearSkin')
+    expect(await screen.findByText('Transform your skincare routine with our Anti Pimples Face Soap Big!')).toBeInTheDocument()
+    expect(screen.getByText('#AntiPimples #ClearSkin')).toBeInTheDocument()
+    expect(screen.queryByText(/^Caption:/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Hashtags:/i)).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /download image/i })).toBeEnabled()
   })
 })


### PR DESCRIPTION
### Motivation
- Make generated social post drafts cleaner and ready-to-paste by removing redundant label prefixes and exporting plain content blocks.
- Ensure contact phone is reliably surfaced from stores that use alternative fields or nested `contactInfo` objects so CTAs include a usable phone number.

### Description
- Reworked the result panel to display plain caption text, a single contact line, and hashtags without `Caption:`, `CTA:`, or `Hashtags:` prefixes and adjusted styling for proper wrapping (`whiteSpace: 'pre-wrap'`) in `web/src/pages/SocialMediaPage.tsx`.
- Changed the clipboard copy and `.txt` download assembly to export plain content blocks (caption, contact line, hashtags) separated by blank lines instead of label-prefixed lines.
- Added helper `firstNonEmptyString` and expanded the store contact lookup to check `phoneNumber`, `mobile`, `whatsappNumber`, and nested `contactInfo` fields for phone/email/website fallbacks.
- Updated tests in `web/src/pages/__tests__/SocialMediaPage.test.tsx` to assert the new no-label output format and added a test case validating fallback to `phoneNumber` when `phone` is empty.

### Testing
- Ran `cd web && npm test -- SocialMediaPage.test.tsx`, which failed due to `vitest` not being available in the environment (test runner not installed).
- Attempted `cd web && npm install`, which failed with registry access errors (`403 Forbidden`) so dependencies could not be installed and tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df34b4b5d483219bc53b4b193a12ef)