### PR TITLE
Reorder owner navigation items (Social media, Data, Account)

### DIFF
--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -14,10 +14,10 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/sell', label: 'Sell', roles: ['owner', 'staff'] },
   { to: '/close-day', label: 'Close day', parentTo: '/sell', roles: ['owner', 'staff'] },
   { to: '/customers', label: 'Customers', roles: ['owner', 'staff'] },
-  { to: '/data-transfer', label: 'Data', roles: ['owner'] },
+  { to: '/social-media', label: 'Social media', roles: ['owner'] },
   { to: '/bulk-messaging', label: 'SMS', roles: ['owner'] },
   { to: '/finance', label: 'Invoice', parentTo: '/sell', roles: ['owner'] },
-  { to: '/account', label: 'Account', roles: ['owner'] },
+  { to: '/data-transfer', label: 'Data', roles: ['owner'] },
   { to: '/public-page', label: 'Public page', roles: ['owner'] },
-  { to: '/social-media', label: 'Social media', roles: ['owner'] },
+  { to: '/account', label: 'Account', roles: ['owner'] },
 ]


### PR DESCRIPTION
### Motivation
- Update the owner navigation order to place Social media where Data was, Data where Account was, and Account where Social media was to match the requested swap.

### Description
- Reordered entries in `NAV_ITEMS` in `web/src/config/navigation.ts` to cycle `Social media` → `Data` → `Account` while keeping routes and labels unchanged.

### Testing
- Attempted to run `npm --prefix web test -- --run web/src/layout/Shell.test.tsx` but tests could not execute because `vitest` is not available in this environment (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df47507b2883229cd652a898eac939)