### PR TITLE
Backfill missing `publishedAt` and enforce it in public product sync

### DIFF
--- a/functions/scripts/backfillPublicProducts.js
+++ b/functions/scripts/backfillPublicProducts.js
@@ -71,10 +71,35 @@ function toPublicProduct(productDoc) {
           : 'product',
     isPublished: data.isPublished !== false,
     ...extractProductImageSet(data),
+    publishedAt: data.publishedAt ?? data.createdAt ?? data.updatedAt ?? admin.firestore.FieldValue.serverTimestamp(),
     createdAt: data.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
     sourceUpdatedAt: data.updatedAt ?? null,
     updatedAt: admin.firestore.FieldValue.serverTimestamp(),
   }
+}
+
+function hasPublishedAt(value) {
+  return (
+    value instanceof admin.firestore.Timestamp ||
+    typeof value === 'string' ||
+    (value && typeof value === 'object' && typeof value.toDate === 'function')
+  )
+}
+
+function resolvePublishedAtValue(data) {
+  if (hasPublishedAt(data.publishedAt)) {
+    return data.publishedAt
+  }
+  if (hasPublishedAt(data.createdAt)) {
+    return data.createdAt
+  }
+  if (hasPublishedAt(data.sourceUpdatedAt)) {
+    return data.sourceUpdatedAt
+  }
+  if (hasPublishedAt(data.updatedAt)) {
+    return data.updatedAt
+  }
+  return admin.firestore.FieldValue.serverTimestamp()
 }
 
 async function run() {
@@ -122,6 +147,47 @@ async function run() {
   console.log(
     `[backfillPublicProducts] done. upserts=${upserts}, skipped=${skipped}, total=${productsSnapshot.size}`,
   )
+
+  let publicProductsQuery = db.collection('publicProducts')
+  if (targetStoreId) {
+    publicProductsQuery = publicProductsQuery.where('storeId', '==', targetStoreId)
+  }
+  const publicProductsSnapshot = await publicProductsQuery.get()
+  console.log(`[backfillPublicProducts] scanning ${publicProductsSnapshot.size} publicProducts docs for publishedAt`)
+
+  let publishedAtBackfills = 0
+  batch = db.batch()
+  writes = 0
+
+  for (const publicProductDoc of publicProductsSnapshot.docs) {
+    const data = publicProductDoc.data() || {}
+    if (hasPublishedAt(data.publishedAt)) {
+      continue
+    }
+
+    batch.set(
+      publicProductDoc.ref,
+      {
+        publishedAt: resolvePublishedAtValue(data),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true },
+    )
+    publishedAtBackfills += 1
+    writes += 1
+
+    if (writes >= 450) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+
+  if (writes > 0) {
+    await batch.commit()
+  }
+
+  console.log(`[backfillPublicProducts] publishedAt backfill complete. updated=${publishedAtBackfills}`)
 }
 
 run().catch(error => {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4455,6 +4455,96 @@ function buildProductEnrichment(data: Record<string, unknown>): ProductEnrichmen
   }
 }
 
+function isFirestoreTimestampLike(value: unknown): boolean {
+  return (
+    value instanceof admin.firestore.Timestamp ||
+    (typeof value === 'object' &&
+      value !== null &&
+      'toDate' in value &&
+      typeof (value as { toDate?: unknown }).toDate === 'function')
+  )
+}
+
+function resolvePublicProductPublishedAt(
+  source: Record<string, unknown>,
+  existing: Record<string, unknown> | null,
+): admin.firestore.FieldValue | unknown {
+  const candidates = [
+    source.publishedAt,
+    existing?.publishedAt,
+    source.createdAt,
+    source.updatedAt,
+    existing?.createdAt,
+    existing?.updatedAt,
+  ]
+  for (const candidate of candidates) {
+    if (isFirestoreTimestampLike(candidate) || typeof candidate === 'string') {
+      return candidate
+    }
+  }
+  return admin.firestore.FieldValue.serverTimestamp()
+}
+
+function toPublicProductPayload(
+  productId: string,
+  source: Record<string, unknown>,
+  existing: Record<string, unknown> | null,
+) {
+  const storeId = typeof source.storeId === 'string' ? source.storeId.trim() : ''
+  const name = normalizeProductName(source.name)
+  if (!storeId || !name) {
+    return null
+  }
+
+  return {
+    sourceProductId: productId,
+    storeId,
+    name,
+    description: typeof source.description === 'string' && source.description.trim() ? source.description.trim() : null,
+    category: typeof source.category === 'string' && source.category.trim() ? source.category.trim() : null,
+    price: typeof source.price === 'number' ? source.price : null,
+    stockCount: typeof source.stockCount === 'number' ? source.stockCount : null,
+    itemType:
+      source.itemType === 'service'
+        ? 'service'
+        : source.itemType === 'made_to_order'
+          ? 'made_to_order'
+          : 'product',
+    isPublished: source.isPublished !== false,
+    ...extractProductImageSet(source),
+    publishedAt: resolvePublicProductPublishedAt(source, existing),
+    createdAt: source.createdAt ?? existing?.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
+    sourceUpdatedAt: source.updatedAt ?? null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }
+}
+
+export const syncPublicProducts = functions.firestore
+  .document('products/{productId}')
+  .onWrite(async (change, context) => {
+    const productId = context.params.productId
+    const publicProductRef = db.collection('publicProducts').doc(productId)
+
+    if (!change.after.exists) {
+      await publicProductRef.delete().catch(() => undefined)
+      return
+    }
+
+    const sourceData = (change.after.data() ?? {}) as Record<string, unknown>
+    const existingPublicProductSnap = await publicProductRef.get()
+    const existingData = existingPublicProductSnap.exists
+      ? (existingPublicProductSnap.data() as Record<string, unknown>)
+      : null
+
+    const payload = toPublicProductPayload(productId, sourceData, existingData)
+    if (!payload) {
+      await publicProductRef.delete().catch(() => undefined)
+      return
+    }
+
+    await publicProductRef.set(payload, { merge: true })
+  })
+
 export const enrichProductDataAfterSave = functions.firestore
   .document('products/{productId}')
   .onWrite(async (change, context) => {


### PR DESCRIPTION
### Motivation
- Ensure existing `publicProducts` documents have a reliable `publishedAt` value and make the sync pipeline always write `publishedAt` for new or updated public product docs.

### Description
- Added a Firestore trigger `syncPublicProducts` that mirrors `products/{productId}` to `publicProducts/{productId}` and removes the mirror when the source is deleted or invalid, always writing a `publishedAt` value resolved from source/existing timestamps with a `serverTimestamp()` fallback.
- Introduced helpers `resolvePublicProductPublishedAt`/`isFirestoreTimestampLike` and `toPublicProductPayload` to centralize publishedAt resolution and payload creation in `functions/src/index.ts`.
- Updated the backfill script `functions/scripts/backfillPublicProducts.js` to include `publishedAt` in upserts and added a second pass that scans existing `publicProducts` docs and backfills missing `publishedAt` values, honoring an optional `storeId` argument.
- Sync and backfill logic prefer existing `publishedAt`, then `createdAt`/`updatedAt`/`sourceUpdatedAt`, and otherwise use `admin.firestore.FieldValue.serverTimestamp()`.

### Testing
- Ran the functions TypeScript build with `npm --prefix functions run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5bde96b88322be61795cbf1d50ee)