### PR TITLE
Move Sedifex Promo Strategy section to appear below login/signup

### DIFF
--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -1085,6 +1085,50 @@ export default function AuthPage() {
         </aside>
       </div>
 
+      <section className="app__promo-strategy" aria-label="Sedifex promo strategy">
+        <header className="app__promo-strategy-header">
+          <span className="app__pill">Sedifex Promo Strategy</span>
+          <h2>One product post. Every channel updated at the same time.</h2>
+          <p>
+            Add your products once in Sedifex, sell with POS, and publish the same offer
+            across Sedifex Market, Google Merchant, your website, and social media.
+          </p>
+        </header>
+
+        <div className="promo-map" role="img" aria-label="Sedifex post distribution map">
+          <div className="promo-map__source">Sedifex Inventory + POS</div>
+          <div className="promo-map__target">Sedifex Market</div>
+          <div className="promo-map__target">Google Merchant</div>
+          <div className="promo-map__target">Website</div>
+          <div className="promo-map__target">Social Channels</div>
+        </div>
+
+        <div className="app__promo-pillars">
+          <h3>Promo pillars</h3>
+          <ul>
+            <li>
+              <strong>One-post distribution:</strong> one update in Sedifex pushes your
+              product story to every channel.
+            </li>
+            <li>
+              <strong>POS + inventory sync:</strong> sales, prices, and stock stay aligned
+              while campaigns are live.
+            </li>
+            <li>
+              <strong>AI content engine:</strong> generate branded social captions directly
+              from your own inventory data.
+            </li>
+            <li>
+              <strong>Branded SMS outreach:</strong> send company-branded bulk SMS offers to
+              your customer lists in minutes.
+            </li>
+          </ul>
+          <a className="app__partners-link" href="mailto:info@sedifex.com">
+            Book a Sedifex promo demo: info@sedifex.com
+          </a>
+        </div>
+      </section>
+
       <section className="app__pricing" aria-label="Sedifex pricing plans">
         <header className="app__pricing-header">
           <span className="app__pill">Pricing</span>
@@ -1214,50 +1258,6 @@ export default function AuthPage() {
             </a>
           </>
         )}
-      </section>
-
-      <section className="app__promo-strategy" aria-label="Sedifex promo strategy">
-        <header className="app__promo-strategy-header">
-          <span className="app__pill">Sedifex Promo Strategy</span>
-          <h2>One product post. Every channel updated at the same time.</h2>
-          <p>
-            Add your products once in Sedifex, sell with POS, and publish the same offer
-            across Sedifex Market, Google Merchant, your website, and social media.
-          </p>
-        </header>
-
-        <div className="promo-map" role="img" aria-label="Sedifex post distribution map">
-          <div className="promo-map__source">Sedifex Inventory + POS</div>
-          <div className="promo-map__target">Sedifex Market</div>
-          <div className="promo-map__target">Google Merchant</div>
-          <div className="promo-map__target">Website</div>
-          <div className="promo-map__target">Social Channels</div>
-        </div>
-
-        <div className="app__promo-pillars">
-          <h3>Promo pillars</h3>
-          <ul>
-            <li>
-              <strong>One-post distribution:</strong> one update in Sedifex pushes your
-              product story to every channel.
-            </li>
-            <li>
-              <strong>POS + inventory sync:</strong> sales, prices, and stock stay aligned
-              while campaigns are live.
-            </li>
-            <li>
-              <strong>AI content engine:</strong> generate branded social captions directly
-              from your own inventory data.
-            </li>
-            <li>
-              <strong>Branded SMS outreach:</strong> send company-branded bulk SMS offers to
-              your customer lists in minutes.
-            </li>
-          </ul>
-          <a className="app__partners-link" href="mailto:info@sedifex.com">
-            Book a Sedifex promo demo: info@sedifex.com
-          </a>
-        </div>
       </section>
 
       <section className="app__info-grid" aria-label="Sedifex company information">


### PR DESCRIPTION
### Motivation
- Make the promotional messaging visible immediately after the authentication panel so visitors see the product-post distribution pitch right below the login/signup area.

### Description
- Moved the existing `app__promo-strategy` section in `web/src/pages/AuthPage.tsx` so it renders directly after the auth panel and before the pricing section.
- Preserved all provided promo copy, channel list, promo pillars, and the `mailto:info@sedifex.com` CTA unchanged.
- Did not modify CSS or introduce new components; layout and styles remain as-is and only the section order changed.

### Testing
- Ran `npm --prefix web run lint`, which failed in this environment due to a missing dev dependency (`@eslint/js`), not because of the markup reorder.
- Inspected the modified file with `nl`/`git diff` to verify the promo block was relocated and that no other content was altered; no automated tests were executed beyond the lint attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df63c181588321aed13373b2bc1a1a)