### PR TITLE
Add social post generator and sync/backfill publicProducts with store metadata

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -36,7 +36,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkMessage = exports.emitProductWebhooks = exports.enrichProductDataAfterSave = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.v1IntegrationPromo = exports.integrationPromo = exports.v1IntegrationProducts = exports.integrationProducts = exports.v1Products = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.manageStaffAccount = exports.generateAiAdvice = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSyncScheduled = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
+exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkMessage = exports.emitProductWebhooks = exports.enrichProductDataAfterSave = exports.syncPublicProducts = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.v1IntegrationPromo = exports.integrationPromo = exports.v1IntegrationProducts = exports.integrationProducts = exports.v1Products = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.manageStaffAccount = exports.generateSocialPost = exports.generateAiAdvice = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
 // functions/src/index.ts
 const functions = __importStar(require("firebase-functions/v1"));
 const crypto = __importStar(require("crypto"));
@@ -51,7 +51,6 @@ Object.defineProperty(exports, "googleAdsOAuthStart", { enumerable: true, get: f
 Object.defineProperty(exports, "googleAdsOAuthCallback", { enumerable: true, get: function () { return googleAds_1.googleAdsOAuthCallback; } });
 Object.defineProperty(exports, "googleAdsCampaign", { enumerable: true, get: function () { return googleAds_1.googleAdsCampaign; } });
 Object.defineProperty(exports, "googleAdsMetricsSync", { enumerable: true, get: function () { return googleAds_1.googleAdsMetricsSync; } });
-Object.defineProperty(exports, "googleAdsMetricsSyncScheduled", { enumerable: true, get: function () { return googleAds_1.googleAdsMetricsSyncScheduled; } });
 __exportStar(require("./googleShopping"), exports);
 var googleBusinessProfile_1 = require("./googleBusinessProfile");
 Object.defineProperty(exports, "googleBusinessLocations", { enumerable: true, get: function () { return googleBusinessProfile_1.googleBusinessLocations; } });
@@ -106,6 +105,30 @@ function normalizeAiAdvicePayload(raw) {
         ? raw.jsonContext
         : {};
     return { question, storeId, jsonContext };
+}
+function normalizeSocialPostPayload(raw) {
+    const storeId = typeof raw?.storeId === 'string' ? raw.storeId.trim() : '';
+    const platformRaw = typeof raw?.platform === 'string' ? raw.platform.trim().toLowerCase() : '';
+    const platform = platformRaw === 'tiktok' ? 'tiktok' : 'instagram';
+    const productId = typeof raw?.productId === 'string' ? raw.productId.trim() : '';
+    const productRaw = raw?.product && typeof raw.product === 'object'
+        ? raw.product
+        : {};
+    const product = {
+        id: typeof productRaw.id === 'string' ? productRaw.id.trim() : '',
+        name: typeof productRaw.name === 'string' ? productRaw.name.trim() : '',
+        category: typeof productRaw.category === 'string' ? productRaw.category.trim() : '',
+        description: typeof productRaw.description === 'string' ? productRaw.description.trim() : '',
+        price: typeof productRaw.price === 'number' && Number.isFinite(productRaw.price) ? productRaw.price : null,
+        imageUrl: typeof productRaw.imageUrl === 'string' ? productRaw.imageUrl.trim() : '',
+        itemType: productRaw.itemType === 'service' || productRaw.itemType === 'made_to_order'
+            ? productRaw.itemType
+            : 'product',
+    };
+    if (!productId && !product.id && !product.name) {
+        throw new functions.https.HttpsError('invalid-argument', 'Choose a product or service to generate a post');
+    }
+    return { storeId, platform, productId, product };
 }
 async function verifyOwnerEmail(uid) {
     try {
@@ -878,6 +901,163 @@ exports.generateAiAdvice = functions.https.onCall(async (rawData, context) => {
         advice,
         storeId,
         dataPreview: jsonContext,
+    };
+});
+/** ============================================================================
+ *  CALLABLE: generateSocialPost
+ * ==========================================================================*/
+exports.generateSocialPost = functions.https.onCall(async (rawData, context) => {
+    assertAuthenticated(context);
+    const { apiKey, model } = getOpenAiConfig();
+    if (!apiKey) {
+        throw new functions.https.HttpsError('failed-precondition', 'Social media generator is not configured yet. Missing OPENAI_API_KEY.');
+    }
+    const uid = context.auth.uid;
+    const { storeId: requestedStoreId, platform, productId, product } = normalizeSocialPostPayload((rawData ?? {}));
+    const memberSnap = await firestore_1.defaultDb.collection('teamMembers').doc(uid).get();
+    const memberData = (memberSnap.data() ?? {});
+    const memberStoreId = typeof memberData.storeId === 'string' ? memberData.storeId.trim() : '';
+    const storeId = requestedStoreId || memberStoreId;
+    if (!storeId) {
+        throw new functions.https.HttpsError('failed-precondition', 'No workspace found for this account. Initialize your workspace first.');
+    }
+    if (requestedStoreId && memberStoreId && requestedStoreId !== memberStoreId) {
+        throw new functions.https.HttpsError('permission-denied', 'You do not have access to the requested workspace.');
+    }
+    let selectedProduct = product;
+    const resolvedProductId = productId || product.id || '';
+    if (resolvedProductId) {
+        const productSnap = await firestore_1.defaultDb.collection('products').doc(resolvedProductId).get();
+        const productData = (productSnap.data() ?? {});
+        const productStoreId = typeof productData.storeId === 'string' ? productData.storeId.trim() : '';
+        if (!productSnap.exists || productStoreId !== storeId) {
+            throw new functions.https.HttpsError('not-found', 'Product or service not found for your workspace.');
+        }
+        selectedProduct = {
+            id: resolvedProductId,
+            name: typeof productData.name === 'string' ? productData.name.trim() : '',
+            category: typeof productData.category === 'string' ? productData.category.trim() : '',
+            description: typeof productData.description === 'string' ? productData.description.trim() : '',
+            price: typeof productData.price === 'number' && Number.isFinite(productData.price) ? productData.price : null,
+            imageUrl: typeof productData.imageUrl === 'string' ? productData.imageUrl.trim() : '',
+            itemType: productData.itemType === 'service' || productData.itemType === 'made_to_order'
+                ? productData.itemType
+                : 'product',
+        };
+    }
+    if (!selectedProduct.name) {
+        throw new functions.https.HttpsError('invalid-argument', 'Product name is required to generate content.');
+    }
+    const promptProduct = {
+        id: selectedProduct.id || null,
+        name: selectedProduct.name,
+        category: selectedProduct.category || null,
+        description: selectedProduct.description || null,
+        price: selectedProduct.price,
+        imageUrl: selectedProduct.imageUrl || null,
+        itemType: selectedProduct.itemType,
+    };
+    const systemPrompt = 'You are a social media strategist for retail and POS merchants. Return strict JSON only, no markdown. Keep copy concise, conversion-focused, and realistic.';
+    const userPrompt = [
+        `Workspace: ${storeId}`,
+        `Platform: ${platform}`,
+        'Return JSON schema:',
+        '{"platform":"instagram|tiktok","caption":"string","hashtags":["#tag"],"imagePrompt":"string","cta":"string","designSpec":{"aspectRatio":"string","safeTextZones":["string"],"visualStyle":"string"},"disclaimer":"string|null"}',
+        'Rules:',
+        '- caption max 220 chars for instagram, 150 chars for tiktok.',
+        '- hashtags: 5 to 10 relevant hashtags.',
+        '- include clear CTA.',
+        '- if price or measurable claim appears, add disclaimer; else null.',
+        '- designSpec must be practical for mobile-safe text placement.',
+        'Product JSON:',
+        JSON.stringify(promptProduct).slice(0, 3000),
+    ].join('\n');
+    const aiResponse = await fetch(OPENAI_CHAT_COMPLETIONS_URL, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            model,
+            temperature: 0.4,
+            max_tokens: 700,
+            messages: [
+                { role: 'system', content: systemPrompt },
+                { role: 'user', content: userPrompt },
+            ],
+        }),
+    });
+    const payload = (await aiResponse.json().catch(() => null));
+    if (!aiResponse.ok) {
+        const apiMessage = payload?.error?.message && payload.error.message.trim() !== ''
+            ? payload.error.message
+            : `OpenAI request failed with status ${aiResponse.status}`;
+        functions.logger.error('[generateSocialPost] OpenAI error', {
+            status: aiResponse.status,
+            apiMessage,
+        });
+        throw new functions.https.HttpsError('internal', 'Unable to generate social post right now.');
+    }
+    const content = payload?.choices?.[0]?.message?.content?.trim() || '';
+    if (!content) {
+        throw new functions.https.HttpsError('internal', 'AI returned an empty response.');
+    }
+    let parsed = null;
+    try {
+        parsed = JSON.parse(content);
+    }
+    catch (_error) {
+        const start = content.indexOf('{');
+        const end = content.lastIndexOf('}');
+        if (start >= 0 && end > start) {
+            parsed = JSON.parse(content.slice(start, end + 1));
+        }
+    }
+    if (!parsed) {
+        throw new functions.https.HttpsError('internal', 'AI returned invalid JSON for social post.');
+    }
+    const safePlatform = parsed.platform === 'tiktok' ? 'tiktok' : 'instagram';
+    const safeHashtags = Array.isArray(parsed.hashtags)
+        ? parsed.hashtags
+            .map(tag => (typeof tag === 'string' ? tag.trim() : ''))
+            .filter(Boolean)
+            .slice(0, 10)
+        : [];
+    return {
+        storeId,
+        productId: resolvedProductId || null,
+        product: promptProduct,
+        post: {
+            platform: safePlatform,
+            caption: typeof parsed.caption === 'string' ? parsed.caption.trim() : '',
+            hashtags: safeHashtags,
+            imagePrompt: typeof parsed.imagePrompt === 'string' ? parsed.imagePrompt.trim() : '',
+            cta: typeof parsed.cta === 'string' ? parsed.cta.trim() : '',
+            designSpec: {
+                aspectRatio: parsed.designSpec &&
+                    typeof parsed.designSpec === 'object' &&
+                    typeof parsed.designSpec.aspectRatio === 'string'
+                    ? parsed.designSpec.aspectRatio.trim()
+                    : '',
+                safeTextZones: parsed.designSpec &&
+                    typeof parsed.designSpec === 'object' &&
+                    Array.isArray(parsed.designSpec.safeTextZones)
+                    ? parsed.designSpec.safeTextZones
+                        .map(item => (typeof item === 'string' ? item.trim() : ''))
+                        .filter(Boolean)
+                        .slice(0, 6)
+                    : [],
+                visualStyle: parsed.designSpec &&
+                    typeof parsed.designSpec === 'object' &&
+                    typeof parsed.designSpec.visualStyle === 'string'
+                    ? parsed.designSpec.visualStyle.trim()
+                    : '',
+            },
+            disclaimer: typeof parsed.disclaimer === 'string' && parsed.disclaimer.trim()
+                ? parsed.disclaimer.trim()
+                : null,
+        },
     };
 });
 /** ============================================================================
@@ -2067,6 +2247,28 @@ function toTrimmedStringOrNull(value) {
 }
 function pickStoreCity(storeData) {
     return toTrimmedStringOrNull(storeData.city) ?? toTrimmedStringOrNull(storeData.town);
+}
+function buildStorePublicMeta(storeData) {
+    const promoSlug = toTrimmedStringOrNull(storeData.promoSlug);
+    return {
+        storeName: toTrimmedStringOrNull(storeData.displayName) ?? toTrimmedStringOrNull(storeData.name),
+        storeCity: pickStoreCity(storeData),
+        storePhone: toTrimmedStringOrNull(storeData.phone) ??
+            toTrimmedStringOrNull(storeData.phoneNumber) ??
+            toTrimmedStringOrNull(storeData.contactPhone),
+        websiteLink: toTrimmedStringOrNull(storeData.websiteLink) ??
+            toTrimmedStringOrNull(storeData.promoWebsiteUrl) ??
+            (promoSlug ? `https://www.sedifex.com/${encodeURIComponent(promoSlug)}` : null),
+    };
+}
+async function resolveStorePublicMetaByStoreId(storeId) {
+    const normalizedStoreId = typeof storeId === 'string' ? storeId.trim() : '';
+    if (!normalizedStoreId)
+        return null;
+    const storeSnap = await firestore_1.defaultDb.collection('stores').doc(normalizedStoreId).get();
+    if (!storeSnap.exists)
+        return null;
+    return buildStorePublicMeta((storeSnap.data() ?? {}));
 }
 async function fetchStoreMetaByStoreId(storeIds) {
     const normalizedStoreIds = Array.from(new Set(storeIds
@@ -3403,6 +3605,91 @@ function buildProductEnrichment(data) {
         reason: 'rule-based keyword enrichment',
     };
 }
+function isFirestoreTimestampLike(value) {
+    return (value instanceof firestore_1.admin.firestore.Timestamp ||
+        (typeof value === 'object' &&
+            value !== null &&
+            'toDate' in value &&
+            typeof value.toDate === 'function'));
+}
+function resolvePublicProductPublishedAt(source, existing) {
+    const candidates = [
+        source.publishedAt,
+        existing?.publishedAt,
+        source.createdAt,
+        source.updatedAt,
+        existing?.createdAt,
+        existing?.updatedAt,
+    ];
+    for (const candidate of candidates) {
+        if (isFirestoreTimestampLike(candidate) || typeof candidate === 'string') {
+            return candidate;
+        }
+    }
+    return firestore_1.admin.firestore.FieldValue.serverTimestamp();
+}
+function toPublicProductPayload(productId, source, existing, storeMeta) {
+    const storeId = typeof source.storeId === 'string' ? source.storeId.trim() : '';
+    const name = normalizeProductName(source.name);
+    if (!storeId || !name) {
+        return null;
+    }
+    return {
+        sourceProductId: productId,
+        storeId,
+        storeName: toTrimmedStringOrNull(source.storeName) ?? storeMeta?.storeName ?? null,
+        storeCity: toTrimmedStringOrNull(source.storeCity) ?? storeMeta?.storeCity ?? null,
+        storePhone: toTrimmedStringOrNull(source.storePhone) ?? storeMeta?.storePhone ?? null,
+        websiteLink: toTrimmedStringOrNull(source.websiteLink) ?? storeMeta?.websiteLink ?? null,
+        name,
+        description: typeof source.description === 'string' && source.description.trim() ? source.description.trim() : null,
+        category: typeof source.category === 'string' && source.category.trim() ? source.category.trim() : null,
+        sku: toTrimmedStringOrNull(source.sku),
+        barcode: toTrimmedStringOrNull(source.barcode),
+        manufacturerName: toTrimmedStringOrNull(source.manufacturerName),
+        price: typeof source.price === 'number' ? source.price : null,
+        stockCount: typeof source.stockCount === 'number' ? source.stockCount : null,
+        reorderPoint: typeof source.reorderPoint === 'number' ? source.reorderPoint : null,
+        taxRate: typeof source.taxRate === 'number' ? source.taxRate : null,
+        productionDate: isFirestoreTimestampLike(source.productionDate) || typeof source.productionDate === 'string' ? source.productionDate : null,
+        expiryDate: isFirestoreTimestampLike(source.expiryDate) || typeof source.expiryDate === 'string' ? source.expiryDate : null,
+        batchNumber: toTrimmedStringOrNull(source.batchNumber),
+        showOnReceipt: source.showOnReceipt === true,
+        itemType: source.itemType === 'service'
+            ? 'service'
+            : source.itemType === 'made_to_order'
+                ? 'made_to_order'
+                : 'product',
+        isPublished: source.isPublished !== false,
+        ...extractProductImageSet(source),
+        publishedAt: resolvePublicProductPublishedAt(source, existing),
+        createdAt: source.createdAt ?? existing?.createdAt ?? firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+        sourceUpdatedAt: source.updatedAt ?? null,
+        updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+    };
+}
+exports.syncPublicProducts = functions.firestore
+    .document('products/{productId}')
+    .onWrite(async (change, context) => {
+    const productId = context.params.productId;
+    const publicProductRef = firestore_1.defaultDb.collection('publicProducts').doc(productId);
+    if (!change.after.exists) {
+        await publicProductRef.delete().catch(() => undefined);
+        return;
+    }
+    const sourceData = (change.after.data() ?? {});
+    const existingPublicProductSnap = await publicProductRef.get();
+    const existingData = existingPublicProductSnap.exists
+        ? existingPublicProductSnap.data()
+        : null;
+    const storeMeta = await resolveStorePublicMetaByStoreId(typeof sourceData.storeId === 'string' ? sourceData.storeId : '');
+    const payload = toPublicProductPayload(productId, sourceData, existingData, storeMeta);
+    if (!payload) {
+        await publicProductRef.delete().catch(() => undefined);
+        return;
+    }
+    await publicProductRef.set(payload, { merge: true });
+});
 exports.enrichProductDataAfterSave = functions.firestore
     .document('products/{productId}')
     .onWrite(async (change, context) => {

--- a/functions/scripts/backfillPublicProducts.js
+++ b/functions/scripts/backfillPublicProducts.js
@@ -27,6 +27,33 @@ function toTrimmedStringArray(value) {
   return [...unique]
 }
 
+function isFirestoreTimestampLike(value) {
+  return (
+    value instanceof admin.firestore.Timestamp ||
+    (value && typeof value === 'object' && typeof value.toDate === 'function')
+  )
+}
+
+function pickStoreCity(storeData) {
+  return toTrimmedStringOrNull(storeData.city) || toTrimmedStringOrNull(storeData.town)
+}
+
+function buildStorePublicMeta(storeData) {
+  const promoSlug = toTrimmedStringOrNull(storeData.promoSlug)
+  return {
+    storeName: toTrimmedStringOrNull(storeData.displayName) || toTrimmedStringOrNull(storeData.name),
+    storeCity: pickStoreCity(storeData),
+    storePhone:
+      toTrimmedStringOrNull(storeData.phone) ||
+      toTrimmedStringOrNull(storeData.phoneNumber) ||
+      toTrimmedStringOrNull(storeData.contactPhone),
+    websiteLink:
+      toTrimmedStringOrNull(storeData.websiteLink) ||
+      toTrimmedStringOrNull(storeData.promoWebsiteUrl) ||
+      (promoSlug ? `https://www.sedifex.com/${encodeURIComponent(promoSlug)}` : null),
+  }
+}
+
 function extractProductImageSet(data) {
   const primaryImageUrl = toTrimmedStringOrNull(data.imageUrl)
   const imageUrls = toTrimmedStringArray(data.imageUrls)
@@ -46,10 +73,11 @@ function extractProductImageSet(data) {
   }
 }
 
-function toPublicProduct(productDoc) {
+function toPublicProduct(productDoc, storeMetaByStoreId) {
   const data = productDoc.data() || {}
   const storeId = toTrimmedStringOrNull(data.storeId)
   const name = toTrimmedStringOrNull(data.name)
+  const storeMeta = storeMetaByStoreId.get(storeId) || null
 
   if (!storeId || !name) {
     return null
@@ -58,11 +86,24 @@ function toPublicProduct(productDoc) {
   return {
     sourceProductId: productDoc.id,
     storeId,
+    storeName: toTrimmedStringOrNull(data.storeName) || storeMeta?.storeName || null,
+    storeCity: toTrimmedStringOrNull(data.storeCity) || storeMeta?.storeCity || null,
+    storePhone: toTrimmedStringOrNull(data.storePhone) || storeMeta?.storePhone || null,
+    websiteLink: toTrimmedStringOrNull(data.websiteLink) || storeMeta?.websiteLink || null,
     name,
     description: toTrimmedStringOrNull(data.description),
     category: toTrimmedStringOrNull(data.category),
+    sku: toTrimmedStringOrNull(data.sku),
+    barcode: toTrimmedStringOrNull(data.barcode),
+    manufacturerName: toTrimmedStringOrNull(data.manufacturerName),
     price: typeof data.price === 'number' ? data.price : null,
     stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
+    reorderPoint: typeof data.reorderPoint === 'number' ? data.reorderPoint : null,
+    taxRate: typeof data.taxRate === 'number' ? data.taxRate : null,
+    productionDate: isFirestoreTimestampLike(data.productionDate) || typeof data.productionDate === 'string' ? data.productionDate : null,
+    expiryDate: isFirestoreTimestampLike(data.expiryDate) || typeof data.expiryDate === 'string' ? data.expiryDate : null,
+    batchNumber: toTrimmedStringOrNull(data.batchNumber),
+    showOnReceipt: data.showOnReceipt === true,
     itemType:
       data.itemType === 'service'
         ? 'service'
@@ -116,13 +157,26 @@ async function run() {
   const productsSnapshot = await query.get()
   console.log(`[backfillPublicProducts] scanning ${productsSnapshot.size} products`)
 
+  const storeIds = new Set()
+  for (const productDoc of productsSnapshot.docs) {
+    const storeId = toTrimmedStringOrNull(productDoc.get('storeId'))
+    if (storeId) storeIds.add(storeId)
+  }
+
+  const storeMetaByStoreId = new Map()
+  for (const storeId of storeIds) {
+    const storeSnap = await db.collection('stores').doc(storeId).get()
+    if (!storeSnap.exists) continue
+    storeMetaByStoreId.set(storeId, buildStorePublicMeta(storeSnap.data() || {}))
+  }
+
   let upserts = 0
   let skipped = 0
   let batch = db.batch()
   let writes = 0
 
   for (const productDoc of productsSnapshot.docs) {
-    const payload = toPublicProduct(productDoc)
+    const payload = toPublicProduct(productDoc, storeMetaByStoreId)
     if (!payload) {
       skipped += 1
       continue

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2955,6 +2955,37 @@ function pickStoreCity(storeData: Record<string, unknown>): string | null {
   return toTrimmedStringOrNull(storeData.city) ?? toTrimmedStringOrNull(storeData.town)
 }
 
+type StorePublicMeta = {
+  storeName: string | null
+  storeCity: string | null
+  storePhone: string | null
+  websiteLink: string | null
+}
+
+function buildStorePublicMeta(storeData: Record<string, unknown>): StorePublicMeta {
+  const promoSlug = toTrimmedStringOrNull(storeData.promoSlug)
+  return {
+    storeName: toTrimmedStringOrNull(storeData.displayName) ?? toTrimmedStringOrNull(storeData.name),
+    storeCity: pickStoreCity(storeData),
+    storePhone:
+      toTrimmedStringOrNull(storeData.phone) ??
+      toTrimmedStringOrNull(storeData.phoneNumber) ??
+      toTrimmedStringOrNull(storeData.contactPhone),
+    websiteLink:
+      toTrimmedStringOrNull(storeData.websiteLink) ??
+      toTrimmedStringOrNull(storeData.promoWebsiteUrl) ??
+      (promoSlug ? `https://www.sedifex.com/${encodeURIComponent(promoSlug)}` : null),
+  }
+}
+
+async function resolveStorePublicMetaByStoreId(storeId: string): Promise<StorePublicMeta | null> {
+  const normalizedStoreId = typeof storeId === 'string' ? storeId.trim() : ''
+  if (!normalizedStoreId) return null
+  const storeSnap = await db.collection('stores').doc(normalizedStoreId).get()
+  if (!storeSnap.exists) return null
+  return buildStorePublicMeta((storeSnap.data() ?? {}) as Record<string, unknown>)
+}
+
 async function fetchStoreMetaByStoreId(storeIds: string[]): Promise<Map<string, { storeName: string | null; storeCity: string | null }>> {
   const normalizedStoreIds = Array.from(
     new Set(
@@ -4489,6 +4520,7 @@ function toPublicProductPayload(
   productId: string,
   source: Record<string, unknown>,
   existing: Record<string, unknown> | null,
+  storeMeta: StorePublicMeta | null,
 ) {
   const storeId = typeof source.storeId === 'string' ? source.storeId.trim() : ''
   const name = normalizeProductName(source.name)
@@ -4499,11 +4531,24 @@ function toPublicProductPayload(
   return {
     sourceProductId: productId,
     storeId,
+    storeName: toTrimmedStringOrNull(source.storeName) ?? storeMeta?.storeName ?? null,
+    storeCity: toTrimmedStringOrNull(source.storeCity) ?? storeMeta?.storeCity ?? null,
+    storePhone: toTrimmedStringOrNull(source.storePhone) ?? storeMeta?.storePhone ?? null,
+    websiteLink: toTrimmedStringOrNull(source.websiteLink) ?? storeMeta?.websiteLink ?? null,
     name,
     description: typeof source.description === 'string' && source.description.trim() ? source.description.trim() : null,
     category: typeof source.category === 'string' && source.category.trim() ? source.category.trim() : null,
+    sku: toTrimmedStringOrNull(source.sku),
+    barcode: toTrimmedStringOrNull(source.barcode),
+    manufacturerName: toTrimmedStringOrNull(source.manufacturerName),
     price: typeof source.price === 'number' ? source.price : null,
     stockCount: typeof source.stockCount === 'number' ? source.stockCount : null,
+    reorderPoint: typeof source.reorderPoint === 'number' ? source.reorderPoint : null,
+    taxRate: typeof source.taxRate === 'number' ? source.taxRate : null,
+    productionDate: isFirestoreTimestampLike(source.productionDate) || typeof source.productionDate === 'string' ? source.productionDate : null,
+    expiryDate: isFirestoreTimestampLike(source.expiryDate) || typeof source.expiryDate === 'string' ? source.expiryDate : null,
+    batchNumber: toTrimmedStringOrNull(source.batchNumber),
+    showOnReceipt: source.showOnReceipt === true,
     itemType:
       source.itemType === 'service'
         ? 'service'
@@ -4536,7 +4581,10 @@ export const syncPublicProducts = functions.firestore
       ? (existingPublicProductSnap.data() as Record<string, unknown>)
       : null
 
-    const payload = toPublicProductPayload(productId, sourceData, existingData)
+    const storeMeta = await resolveStorePublicMetaByStoreId(
+      typeof sourceData.storeId === 'string' ? sourceData.storeId : '',
+    )
+    const payload = toPublicProductPayload(productId, sourceData, existingData, storeMeta)
     if (!payload) {
       await publicProductRef.delete().catch(() => undefined)
       return


### PR DESCRIPTION
### Motivation
- Provide an AI-powered social media post generator as a callable function for merchants to create platform-specific posts. 
- Ensure `publicProducts` collection is consistently populated with richer product and store metadata when `products` documents change. 
- Improve the backfill script to include store-level metadata and additional product fields for public listing consistency.

### Description
- Added a new callable function `generateSocialPost` that validates payloads, resolves product/store context, calls OpenAI Chat Completions, and returns structured JSON for Instagram/TikTok posts. 
- Implemented `syncPublicProducts` Firestore trigger that converts `products/{productId}` writes into a normalized `publicProducts` document with expanded fields and robust timestamp resolution. 
- Introduced helper utilities: `normalizeSocialPostPayload`, `buildStorePublicMeta`, `resolveStorePublicMetaByStoreId`, `isFirestoreTimestampLike`, and `toPublicProductPayload` to consolidate logic for public product generation. 
- Updated `functions/scripts/backfillPublicProducts.js` to prefetch store metadata, populate additional fields (SKU, barcode, manufacturer, dates, phone/website), and use the new `buildStorePublicMeta` logic when generating `publicProducts` payloads.

### Testing
- Ran a TypeScript build to ensure the updated `functions/src` compiles (`npm run build`), which completed successfully. 
- Performed a smoke check of the updated backfill script by scanning local product snapshots and verifying payload construction (manual run), which produced expected `publicProducts` payload shapes. 
- No additional automated unit tests were added or modified in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8cf7024c832292c8f855cc2c4d9a)