### PR TITLE
Add Bookings page and auto-upsert booking contacts into Customers

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -176,6 +176,10 @@ Query parameters:
   - `quantity` (optional, defaults to `1`)
   - `notes` (optional)
   - `attributes` (optional flexible object for vertical-specific fields)
+- Customer auto-mapping:
+  - When `customer.phone` or `customer.email` is provided, Sedifex automatically upserts the contact into the store `customers` collection.
+  - Existing customer records are matched by `storeId + phone` first, then `storeId + email`.
+  - New customer records are tagged with `source: "integrationBooking"` for later segmentation.
 
 ## 4) Deduplication and caching
 

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -2632,6 +2632,85 @@ function mapIntegrationBookingDoc(docSnap) {
         updatedAt: normalizeTimestampIso(data.updatedAt),
     };
 }
+function normalizeIdentityValue(value) {
+    if (!value)
+        return null;
+    return value.trim().toLowerCase();
+}
+function normalizePhoneValue(value) {
+    if (!value)
+        return null;
+    const normalized = value.replace(/\s+/g, '').trim();
+    return normalized || null;
+}
+async function upsertBookingCustomerProfile(options) {
+    const { storeId, customerName, customerPhone, customerEmail, bookingId } = options;
+    const normalizedPhone = normalizePhoneValue(customerPhone);
+    const normalizedEmail = normalizeIdentityValue(customerEmail);
+    if (!normalizedPhone && !normalizedEmail) {
+        return;
+    }
+    const customerLookupSnapshots = await Promise.all([
+        normalizedPhone
+            ? firestore_1.defaultDb
+                .collection('customers')
+                .where('storeId', '==', storeId)
+                .where('phone', '==', normalizedPhone)
+                .limit(1)
+                .get()
+            : Promise.resolve(null),
+        normalizedEmail
+            ? firestore_1.defaultDb
+                .collection('customers')
+                .where('storeId', '==', storeId)
+                .where('email', '==', normalizedEmail)
+                .limit(1)
+                .get()
+            : Promise.resolve(null),
+    ]);
+    const existingCustomerDoc = customerLookupSnapshots[0]?.docs?.[0] ?? customerLookupSnapshots[1]?.docs?.[0] ?? null;
+    const now = firestore_1.admin.firestore.FieldValue.serverTimestamp();
+    const nameToPersist = customerName ?? customerEmail ?? customerPhone ?? 'Booking customer';
+    if (existingCustomerDoc) {
+        const existingData = (existingCustomerDoc.data() ?? {});
+        const updates = {
+            updatedAt: now,
+            lastBookingId: bookingId,
+            lastBookingAt: now,
+            lastBookingSource: 'integrationBooking',
+            bookingCount: firestore_1.admin.firestore.FieldValue.increment(1),
+        };
+        if (!toTrimmedStringOrNull(existingData.name) && customerName) {
+            updates.name = customerName;
+        }
+        if (!toTrimmedStringOrNull(existingData.displayName) && customerName) {
+            updates.displayName = customerName;
+        }
+        if (!toTrimmedStringOrNull(existingData.phone) && normalizedPhone) {
+            updates.phone = normalizedPhone;
+        }
+        if (!toTrimmedStringOrNull(existingData.email) && normalizedEmail) {
+            updates.email = normalizedEmail;
+        }
+        await existingCustomerDoc.ref.set(updates, { merge: true });
+        return;
+    }
+    const customerRef = firestore_1.defaultDb.collection('customers').doc();
+    await customerRef.set({
+        storeId,
+        name: nameToPersist,
+        displayName: nameToPersist,
+        phone: normalizedPhone,
+        email: normalizedEmail,
+        createdAt: now,
+        updatedAt: now,
+        source: 'integrationBooking',
+        firstBookingId: bookingId,
+        lastBookingId: bookingId,
+        lastBookingAt: now,
+        bookingCount: 1,
+    });
+}
 async function validateIntegrationTokenOrReply(req, res, options) {
     const allowedMethods = options?.allowedMethods ?? ['GET'];
     if (!allowedMethods.includes(req.method ?? '')) {
@@ -3335,6 +3414,13 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         await bookingRef.set(bookingData);
         const bookingSnap = await bookingRef.get();
         const booking = mapIntegrationBookingDoc(bookingSnap);
+        await upsertBookingCustomerProfile({
+            storeId: authContext.storeId,
+            customerName,
+            customerPhone,
+            customerEmail,
+            bookingId: bookingRef.id,
+        });
         res.status(201).json({
             booking,
         });
@@ -3386,6 +3472,13 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
     }
     const bookingSnap = await bookingRef.get();
     const booking = mapIntegrationBookingDoc(bookingSnap);
+    await upsertBookingCustomerProfile({
+        storeId: authContext.storeId,
+        customerName,
+        customerPhone,
+        customerEmail,
+        bookingId: bookingRef.id,
+    });
     res.status(201).json({
         booking,
     });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3427,6 +3427,99 @@ function mapIntegrationBookingDoc(
   }
 }
 
+function normalizeIdentityValue(value: string | null): string | null {
+  if (!value) return null
+  return value.trim().toLowerCase()
+}
+
+function normalizePhoneValue(value: string | null): string | null {
+  if (!value) return null
+  const normalized = value.replace(/\s+/g, '').trim()
+  return normalized || null
+}
+
+async function upsertBookingCustomerProfile(options: {
+  storeId: string
+  customerName: string | null
+  customerPhone: string | null
+  customerEmail: string | null
+  bookingId: string
+}): Promise<void> {
+  const { storeId, customerName, customerPhone, customerEmail, bookingId } = options
+  const normalizedPhone = normalizePhoneValue(customerPhone)
+  const normalizedEmail = normalizeIdentityValue(customerEmail)
+
+  if (!normalizedPhone && !normalizedEmail) {
+    return
+  }
+
+  const customerLookupSnapshots = await Promise.all([
+    normalizedPhone
+      ? db
+          .collection('customers')
+          .where('storeId', '==', storeId)
+          .where('phone', '==', normalizedPhone)
+          .limit(1)
+          .get()
+      : Promise.resolve(null),
+    normalizedEmail
+      ? db
+          .collection('customers')
+          .where('storeId', '==', storeId)
+          .where('email', '==', normalizedEmail)
+          .limit(1)
+          .get()
+      : Promise.resolve(null),
+  ])
+
+  const existingCustomerDoc =
+    customerLookupSnapshots[0]?.docs?.[0] ?? customerLookupSnapshots[1]?.docs?.[0] ?? null
+
+  const now = admin.firestore.FieldValue.serverTimestamp()
+  const nameToPersist = customerName ?? customerEmail ?? customerPhone ?? 'Booking customer'
+
+  if (existingCustomerDoc) {
+    const existingData = (existingCustomerDoc.data() ?? {}) as Record<string, unknown>
+    const updates: Record<string, unknown> = {
+      updatedAt: now,
+      lastBookingId: bookingId,
+      lastBookingAt: now,
+      lastBookingSource: 'integrationBooking',
+      bookingCount: admin.firestore.FieldValue.increment(1),
+    }
+    if (!toTrimmedStringOrNull(existingData.name) && customerName) {
+      updates.name = customerName
+    }
+    if (!toTrimmedStringOrNull(existingData.displayName) && customerName) {
+      updates.displayName = customerName
+    }
+    if (!toTrimmedStringOrNull(existingData.phone) && normalizedPhone) {
+      updates.phone = normalizedPhone
+    }
+    if (!toTrimmedStringOrNull(existingData.email) && normalizedEmail) {
+      updates.email = normalizedEmail
+    }
+    await existingCustomerDoc.ref.set(updates, { merge: true })
+    return
+  }
+
+  const customerRef = db.collection('customers').doc()
+  await customerRef.set({
+    storeId,
+    name: nameToPersist,
+    displayName: nameToPersist,
+    phone: normalizedPhone,
+    email: normalizedEmail,
+    createdAt: now,
+    updatedAt: now,
+    source: 'integrationBooking',
+    firstBookingId: bookingId,
+    lastBookingId: bookingId,
+    lastBookingAt: now,
+    bookingCount: 1,
+  })
+}
+
 async function validateIntegrationTokenOrReply(
   req: functions.https.Request,
   res: functions.Response<any>,
@@ -4189,6 +4282,13 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     await bookingRef.set(bookingData)
     const bookingSnap = await bookingRef.get()
     const booking = mapIntegrationBookingDoc(bookingSnap)
+    await upsertBookingCustomerProfile({
+      storeId: authContext.storeId,
+      customerName,
+      customerPhone,
+      customerEmail,
+      bookingId: bookingRef.id,
+    })
     res.status(201).json({
       booking,
     })
@@ -4250,6 +4350,13 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
 
   const bookingSnap = await bookingRef.get()
   const booking = mapIntegrationBookingDoc(bookingSnap)
+  await upsertBookingCustomerProfile({
+    storeId: authContext.storeId,
+    customerName,
+    customerPhone,
+    customerEmail,
+    bookingId: bookingRef.id,
+  })
   res.status(201).json({
     booking,
   })

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -14,6 +14,7 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/sell', label: 'Sell', roles: ['owner', 'staff'] },
   { to: '/close-day', label: 'Close day', parentTo: '/sell', roles: ['owner', 'staff'] },
   { to: '/customers', label: 'Customers', roles: ['owner', 'staff'] },
+  { to: '/bookings', label: 'Bookings', roles: ['owner', 'staff'] },
   { to: '/social-media', label: 'Social media', roles: ['owner'] },
   { to: '/bulk-messaging', label: 'SMS', roles: ['owner'] },
   { to: '/finance', label: 'Invoice', parentTo: '/sell', roles: ['owner'] },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,6 +11,7 @@ import Products from './pages/Products'
 import Sell from './pages/Sell'
 import CloseDay from './pages/CloseDay'
 import Customers from './pages/Customers'
+import Bookings from './pages/Bookings'
 import Logi from './pages/Logi'
 import Onboarding from './pages/Onboarding'
 import AccountOverview from './pages/AccountOverview'
@@ -70,6 +71,7 @@ const router = createBrowserRouter([
           { path: 'products', element: <Products /> },
           { path: 'sell', element: <Sell /> },
           { path: 'customers', element: <Customers /> },
+          { path: 'bookings', element: <Bookings /> },
           { path: 'data-transfer', element: <DataTransfer /> },
           { path: 'bulk-messaging', element: <BulkMessaging /> },
           { path: 'logi', element: <Logi /> },

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { collection, limit, onSnapshot, orderBy, query } from 'firebase/firestore'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+
+type BookingRecord = {
+  id: string
+  serviceId: string
+  status: string
+  quantity: number
+  customerName: string | null
+  customerPhone: string | null
+  customerEmail: string | null
+  notes: string | null
+  createdAt: Date | null
+}
+
+function formatDate(value: Date | null): string {
+  if (!value) return '—'
+  return `${value.toLocaleDateString()} ${value.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+}
+
+export default function Bookings() {
+  const { storeId } = useActiveStore()
+  const [loading, setLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [bookings, setBookings] = useState<BookingRecord[]>([])
+
+  useEffect(() => {
+    if (!storeId) {
+      setBookings([])
+      setLoading(false)
+      setErrorMessage('Select a workspace to view bookings.')
+      return
+    }
+
+    setLoading(true)
+    setErrorMessage(null)
+    const bookingsQuery = query(
+      collection(db, 'stores', storeId, 'integrationBookings'),
+      orderBy('createdAt', 'desc'),
+      limit(100),
+    )
+
+    const unsubscribe = onSnapshot(
+      bookingsQuery,
+      snapshot => {
+        const rows = snapshot.docs.map(docSnap => {
+          const data = docSnap.data() as Record<string, any>
+          const customer =
+            data.customer && typeof data.customer === 'object'
+              ? (data.customer as Record<string, unknown>)
+              : {}
+          const createdAtValue =
+            data.createdAt && typeof data.createdAt === 'object' && typeof data.createdAt.toDate === 'function'
+              ? data.createdAt.toDate()
+              : null
+          return {
+            id: docSnap.id,
+            serviceId: typeof data.serviceId === 'string' ? data.serviceId : '—',
+            status: typeof data.status === 'string' ? data.status : 'confirmed',
+            quantity:
+              typeof data.quantity === 'number' && Number.isFinite(data.quantity)
+                ? Math.max(1, Math.floor(data.quantity))
+                : 1,
+            customerName:
+              typeof customer.name === 'string' && customer.name.trim() ? customer.name.trim() : null,
+            customerPhone:
+              typeof customer.phone === 'string' && customer.phone.trim() ? customer.phone.trim() : null,
+            customerEmail:
+              typeof customer.email === 'string' && customer.email.trim() ? customer.email.trim() : null,
+            notes: typeof data.notes === 'string' && data.notes.trim() ? data.notes.trim() : null,
+            createdAt: createdAtValue,
+          } satisfies BookingRecord
+        })
+        setBookings(rows)
+        setLoading(false)
+      },
+      error => {
+        console.error('[bookings] Failed to load bookings', error)
+        setErrorMessage('Unable to load bookings right now. Please try again.')
+        setLoading(false)
+      },
+    )
+
+    return () => unsubscribe()
+  }, [storeId])
+
+  const confirmedCount = useMemo(
+    () => bookings.filter(booking => booking.status.toLowerCase() === 'confirmed').length,
+    [bookings],
+  )
+
+  return (
+    <main className="page">
+      <section className="card stack gap-4">
+        <header className="stack gap-1">
+          <h1>Bookings</h1>
+          <p className="form__hint">
+            Website bookings appear here. New booking contact details are automatically mapped into Customers when they include a phone or email.
+          </p>
+        </header>
+
+        {loading && <p className="form__hint">Loading bookings…</p>}
+        {!loading && errorMessage && <p className="form__error">{errorMessage}</p>}
+        {!loading && !errorMessage && (
+          <>
+            <p className="form__hint">
+              Total bookings: <strong>{bookings.length}</strong> • Confirmed: <strong>{confirmedCount}</strong>
+            </p>
+            {bookings.length ? (
+              <div className="table-wrap">
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>Created</th>
+                      <th>Service</th>
+                      <th>Customer</th>
+                      <th>Qty</th>
+                      <th>Status</th>
+                      <th>Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {bookings.map(booking => (
+                      <tr key={booking.id}>
+                        <td>{formatDate(booking.createdAt)}</td>
+                        <td>{booking.serviceId}</td>
+                        <td>
+                          {[booking.customerName, booking.customerPhone, booking.customerEmail]
+                            .filter(Boolean)
+                            .join(' • ') || '—'}
+                        </td>
+                        <td>{booking.quantity}</td>
+                        <td>{booking.status}</td>
+                        <td>{booking.notes ?? '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="form__hint">No bookings yet.</p>
+            )}
+          </>
+        )}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a first-class in-app view for website bookings so staff/owners can manage reservations from the Shell. 
- Automatically persist booking contact info as a Customer so booking leads are captured without manual work. 

### Description
- Added a new `Bookings` page component that subscribes to `stores/{storeId}/integrationBookings` and renders booking rows with created time, service, customer, quantity, status and notes. 
- Wired the new page into routing at `/bookings` and added a `Bookings` entry to `NAV_ITEMS` so it appears in the app shell for `owner` and `staff`. 
- Implemented `upsertBookingCustomerProfile` server-side and invoked it from the `v1IntegrationBookings` POST flow so bookings with `customer.phone` or `customer.email` are matched/created in the `customers` collection (match order: `storeId + phone` then `storeId + email`), updating metadata like `lastBookingId`, `lastBookingAt`, and incrementing `bookingCount`, or creating a new record with `source: 'integrationBooking'`. 
- Documented the new customer auto-mapping behavior in the integration API guide. 

### Testing
- Built the functions bundle with `npm --prefix functions run build` and the TypeScript compile passed (build succeeded). 
- Attempted a web build with `npm --prefix web run build` and it failed in this environment due to missing type definitions for `vite/client` and `vitest/globals` (environment-only issue, unrelated to the new code).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08761077883228c05e1d729b0a745)