### PR TITLE
docs: add Google Sheets sync guide for bookings and customers

### DIFF
--- a/docs/integration-quickstart.md
+++ b/docs/integration-quickstart.md
@@ -227,6 +227,109 @@ Booking/registration note:
 - Put vertical-specific data (e.g., school/travel extras) inside `attributes` in the booking payload.
 - Keep API keys server-side; submit booking requests from your website backend only.
 
+### Sync bookings/customers into Google Sheets
+
+Some stores need a live operational sheet for customer support, call centers, or back-office teams. You can enable this without adding a new backend service by pulling Sedifex integration endpoints from Google Apps Script.
+
+Recommended flow:
+
+1. Create a Google Sheet with tabs like:
+   - `bookings_raw`
+   - `customers_raw`
+2. Open **Extensions → Apps Script** and add a script that:
+   - Calls `GET /v1IntegrationBookings?storeId=<storeId>&limit=200`
+   - Calls `GET /integrationCustomers?storeId=<storeId>`
+   - Uses headers:
+     - `x-api-key: <integration_key>`
+     - `X-Sedifex-Contract-Version: 2026-04-13`
+   - Rewrites the tab rows each run (header row + current records).
+3. Add a time-driven trigger in Apps Script (for example every 5 or 15 minutes).
+4. Keep the integration key in script properties, not in sheet cells.
+
+Minimal Apps Script example:
+
+```javascript
+const API_BASE_URL = 'https://us-central1-sedifex-web.cloudfunctions.net'
+const STORE_ID = 'YOUR_STORE_ID'
+const CONTRACT_VERSION = '2026-04-13'
+
+function syncSedifexToSheets() {
+  const apiKey = PropertiesService.getScriptProperties().getProperty('SEDIFEX_INTEGRATION_KEY')
+  if (!apiKey) throw new Error('Missing SEDIFEX_INTEGRATION_KEY script property')
+
+  const bookings = fetchJson_(
+    `${API_BASE_URL}/v1IntegrationBookings?storeId=${encodeURIComponent(STORE_ID)}&limit=200`,
+    apiKey,
+  ).bookings || []
+
+  const customers = fetchJson_(
+    `${API_BASE_URL}/integrationCustomers?storeId=${encodeURIComponent(STORE_ID)}`,
+    apiKey,
+  ).customers || []
+
+  writeRows_('bookings_raw', [
+    ['id', 'serviceId', 'slotId', 'status', 'customerName', 'customerPhone', 'customerEmail', 'quantity', 'createdAt', 'updatedAt'],
+    ...bookings.map((b) => [
+      b.id || '',
+      b.serviceId || '',
+      b.slotId || '',
+      b.status || '',
+      (b.customer && b.customer.name) || '',
+      (b.customer && b.customer.phone) || '',
+      (b.customer && b.customer.email) || '',
+      b.quantity || '',
+      b.createdAt || '',
+      b.updatedAt || '',
+    ]),
+  ])
+
+  writeRows_('customers_raw', [
+    ['id', 'name', 'displayName', 'phone', 'email', 'updatedAt'],
+    ...customers.map((c) => [
+      c.id || '',
+      c.name || '',
+      c.displayName || '',
+      c.phone || '',
+      c.email || '',
+      c.updatedAt || '',
+    ]),
+  ])
+}
+
+function fetchJson_(url, apiKey) {
+  const response = UrlFetchApp.fetch(url, {
+    method: 'get',
+    muteHttpExceptions: true,
+    headers: {
+      'x-api-key': apiKey,
+      'X-Sedifex-Contract-Version': CONTRACT_VERSION,
+      Accept: 'application/json',
+    },
+  })
+  const code = response.getResponseCode()
+  const bodyText = response.getContentText()
+  if (code < 200 || code >= 300) {
+    throw new Error(`Sedifex request failed (${code}): ${bodyText}`)
+  }
+  return JSON.parse(bodyText)
+}
+
+function writeRows_(sheetName, rows) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet()
+  const sheet = ss.getSheetByName(sheetName) || ss.insertSheet(sheetName)
+  sheet.clearContents()
+  if (rows.length) {
+    sheet.getRange(1, 1, rows.length, rows[0].length).setValues(rows)
+  }
+}
+```
+
+Notes:
+
+- For high-volume stores, keep `bookings_raw` as a rolling window (e.g., last 200) and move historical analytics to BigQuery or your data warehouse.
+- Use one integration key per store and rotate it when staff ownership changes.
+- If Google Sheets is not required, this same pull model can write into any CRM or customer sheet backend.
+
 ### Common 404 fix (important)
 
 If your app logs a 404 such as:

--- a/web/src/pages/docs/IntegrationQuickstartPage.tsx
+++ b/web/src/pages/docs/IntegrationQuickstartPage.tsx
@@ -13,6 +13,8 @@ export default function IntegrationQuickstartPage() {
           <li>Product fields: <code>id</code>, <code>storeId</code>, <code>name</code>, <code>category</code>, <code>description</code>, <code>price</code>, <code>stockCount</code>, and media metadata.</li>
           <li>Integration flow with API key auth via <code>GET /integrationProducts?storeId=&lt;storeId&gt;</code>.</li>
           <li>Companion endpoints for promotions, promo galleries, customers, top sellers, and Google Merchant XML feed: <code>GET /integrationPromo?storeId=&lt;storeId&gt;</code>, <code>GET /integrationGallery?storeId=&lt;storeId&gt;</code>, <code>GET /integrationCustomers?storeId=&lt;storeId&gt;</code>, <code>GET /integrationTopSelling?storeId=&lt;storeId&gt;&amp;days=30&amp;limit=10</code>, and <code>GET /integrationGoogleMerchantFeed?slug=&lt;promoSlug&gt;</code>.</li>
+          <li>Booking endpoints for service businesses: <code>GET /v1IntegrationBookings?storeId=&lt;storeId&gt;</code> and <code>POST /v1IntegrationBookings?storeId=&lt;storeId&gt;</code>.</li>
+          <li>Google Sheets sync workflow for bookings/customers via Google Apps Script pull jobs (see docs page for script template).</li>
           <li>Dedupe, fallback data, category grouping, and cache strategy recommendations.</li>
         </ul>
       </section>


### PR DESCRIPTION
### Motivation

- Provide a simple, no-backend-change way for stores to keep booking and customer data in operational sheets for support/ops using existing integration endpoints.

### Description

- Added a `Sync bookings/customers into Google Sheets` section to `docs/integration-quickstart.md` with a recommended flow, required headers, security notes, and a ready-to-copy Google Apps Script that pulls `GET /v1IntegrationBookings?storeId=...` and `GET /integrationCustomers?storeId=...` and writes `bookings_raw` and `customers_raw` tabs.
- Updated the in-app docs page `web/src/pages/docs/IntegrationQuickstartPage.tsx` to mention booking endpoints (`GET /v1IntegrationBookings`, `POST /v1IntegrationBookings`) and the Sheets sync workflow so the guidance appears in the UI documentation.
- No backend or API changes were made; this is documentation and docs-page content only.

### Testing

- Attempted to run the web linter with `npm --prefix web run -s lint`, which failed in this environment due to a missing ESLint peer dependency (`@eslint/js`).
- Verified the intended files were staged/committed and the doc pages renderable changes were applied (local repo checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08a33c2e88322a4f4bf52b27aefbd)