### PR TITLE
Enhance bookings page with actions, filtering, and cursor pagination

### DIFF
--- a/web/src/pages/Bookings.css
+++ b/web/src/pages/Bookings.css
@@ -1,0 +1,65 @@
+.bookings-page__filters {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  align-items: end;
+}
+
+.bookings-page__filters label {
+  display: grid;
+  gap: 6px;
+  font-size: 13px;
+  color: #374151;
+}
+
+.bookings-page__filters select,
+.bookings-page__filters input {
+  width: 100%;
+}
+
+.bookings-page__search {
+  min-width: 220px;
+}
+
+.bookings-page__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.bookings-page__status--confirmed {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.bookings-page__status--rescheduled {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.bookings-page__status--cancelled {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.bookings-page__status--completed {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+
+.bookings-page__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.bookings-page__pagination {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 12px;
+}

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -1,11 +1,27 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { collection, limit, onSnapshot, orderBy, query } from 'firebase/firestore'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  collection,
+  doc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+  Timestamp,
+  updateDoc,
+  where,
+  type DocumentData,
+  type QueryDocumentSnapshot,
+} from 'firebase/firestore'
+import { Link } from 'react-router-dom'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
+import './Bookings.css'
 
 type BookingRecord = {
   id: string
   serviceId: string
+  serviceName: string
   status: string
   quantity: number
   customerName: string | null
@@ -15,84 +31,269 @@ type BookingRecord = {
   createdAt: Date | null
 }
 
+type ServiceRecord = {
+  id: string
+  name: string
+}
+
+const PAGE_SIZE = 25
+const STATUS_ALL = 'all'
+const SERVICE_ALL = 'all'
+
+const ACTIONABLE_STATUS = ['confirmed', 'rescheduled'] as const
+const STATUS_ACTIONS: Record<string, Array<{ label: string; nextStatus: string }>> = {
+  confirmed: [
+    { label: 'Reschedule', nextStatus: 'rescheduled' },
+    { label: 'Complete', nextStatus: 'completed' },
+    { label: 'Cancel', nextStatus: 'cancelled' },
+  ],
+  rescheduled: [
+    { label: 'Confirm', nextStatus: 'confirmed' },
+    { label: 'Complete', nextStatus: 'completed' },
+    { label: 'Cancel', nextStatus: 'cancelled' },
+  ],
+}
+
 function formatDate(value: Date | null): string {
   if (!value) return '—'
   return `${value.toLocaleDateString()} ${value.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+}
+
+function normalizeStatus(rawStatus: unknown): string {
+  if (typeof rawStatus !== 'string' || !rawStatus.trim()) return 'confirmed'
+  return rawStatus.trim().toLowerCase()
+}
+
+function statusLabel(status: string): string {
+  if (!status) return 'Unknown'
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}
+
+function dateToTimestamp(date: string, useDayEnd = false): Timestamp {
+  const parsedDate = new Date(date)
+  if (useDayEnd) {
+    parsedDate.setHours(23, 59, 59, 999)
+  } else {
+    parsedDate.setHours(0, 0, 0, 0)
+  }
+  return Timestamp.fromDate(parsedDate)
 }
 
 export default function Bookings() {
   const { storeId } = useActiveStore()
   const [loading, setLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [diagnosticsId, setDiagnosticsId] = useState<string | null>(null)
   const [bookings, setBookings] = useState<BookingRecord[]>([])
+  const [services, setServices] = useState<ServiceRecord[]>([])
+  const [statusFilter, setStatusFilter] = useState(STATUS_ALL)
+  const [serviceFilter, setServiceFilter] = useState(SERVICE_ALL)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [lastCursor, setLastCursor] = useState<QueryDocumentSnapshot<DocumentData> | null>(null)
+  const [cursorStack, setCursorStack] = useState<Array<QueryDocumentSnapshot<DocumentData> | null>>([])
+  const [hasNextPage, setHasNextPage] = useState(false)
+  const [pageNumber, setPageNumber] = useState(1)
+  const [updatingBookingId, setUpdatingBookingId] = useState<string | null>(null)
+
+  const hydrateBooking = useCallback((docSnap: QueryDocumentSnapshot<DocumentData>, serviceMap: Map<string, string>) => {
+    const data = docSnap.data() as Record<string, unknown>
+    const customer =
+      data.customer && typeof data.customer === 'object'
+        ? (data.customer as Record<string, unknown>)
+        : {}
+    const createdAtValue =
+      data.createdAt && typeof data.createdAt === 'object' && typeof (data.createdAt as Timestamp).toDate === 'function'
+        ? (data.createdAt as Timestamp).toDate()
+        : null
+    const serviceId = typeof data.serviceId === 'string' && data.serviceId.trim() ? data.serviceId.trim() : '—'
+
+    return {
+      id: docSnap.id,
+      serviceId,
+      serviceName: serviceMap.get(serviceId) ?? serviceId,
+      status: normalizeStatus(data.status),
+      quantity:
+        typeof data.quantity === 'number' && Number.isFinite(data.quantity)
+          ? Math.max(1, Math.floor(data.quantity))
+          : 1,
+      customerName:
+        typeof customer.name === 'string' && customer.name.trim() ? customer.name.trim() : null,
+      customerPhone:
+        typeof customer.phone === 'string' && customer.phone.trim() ? customer.phone.trim() : null,
+      customerEmail:
+        typeof customer.email === 'string' && customer.email.trim() ? customer.email.trim() : null,
+      notes: typeof data.notes === 'string' && data.notes.trim() ? data.notes.trim() : null,
+      createdAt: createdAtValue,
+    } satisfies BookingRecord
+  }, [])
+
+  const loadServices = useCallback(async (activeStoreId: string): Promise<Map<string, string>> => {
+    const serviceMap = new Map<string, string>()
+    const potentialCollections = ['services', 'integrationServices']
+
+    for (const collectionName of potentialCollections) {
+      const servicesSnapshot = await getDocs(collection(db, 'stores', activeStoreId, collectionName))
+      servicesSnapshot.forEach(serviceDoc => {
+        const data = serviceDoc.data() as Record<string, unknown>
+        const candidates = [data.name, data.title, data.serviceName]
+        const selectedName = candidates.find(value => typeof value === 'string' && value.trim()) as string | undefined
+        if (selectedName) {
+          serviceMap.set(serviceDoc.id, selectedName.trim())
+        }
+      })
+    }
+
+    const nextServices: ServiceRecord[] = Array.from(serviceMap.entries())
+      .map(([id, name]) => ({ id, name }))
+      .sort((left, right) => left.name.localeCompare(right.name))
+    setServices(nextServices)
+
+    return serviceMap
+  }, [])
+
+  const buildBookingsQuery = useCallback(
+    (activeStoreId: string, serviceFilterValue: string, statusFilterValue: string, startAfterDoc: QueryDocumentSnapshot<DocumentData> | null) => {
+      const queryConstraints: Array<
+        ReturnType<typeof where> | ReturnType<typeof orderBy> | ReturnType<typeof limit> | ReturnType<typeof startAfter>
+      > = [orderBy('createdAt', 'desc'), limit(PAGE_SIZE + 1)]
+
+      if (statusFilterValue !== STATUS_ALL) {
+        queryConstraints.unshift(where('status', '==', statusFilterValue))
+      }
+
+      if (serviceFilterValue !== SERVICE_ALL) {
+        queryConstraints.unshift(where('serviceId', '==', serviceFilterValue))
+      }
+
+      if (startDate) {
+        queryConstraints.unshift(where('createdAt', '>=', dateToTimestamp(startDate)))
+      }
+
+      if (endDate) {
+        queryConstraints.unshift(where('createdAt', '<=', dateToTimestamp(endDate, true)))
+      }
+
+      if (startAfterDoc) {
+        queryConstraints.push(startAfter(startAfterDoc))
+      }
+
+      return query(collection(db, 'stores', activeStoreId, 'integrationBookings'), ...queryConstraints)
+    },
+    [endDate, startDate],
+  )
+
+  const loadBookingsPage = useCallback(
+    async (startAfterDoc: QueryDocumentSnapshot<DocumentData> | null, nextPageNumber: number, nextCursorStack: Array<QueryDocumentSnapshot<DocumentData> | null>) => {
+      if (!storeId) return
+
+      setLoading(true)
+      setErrorMessage(null)
+      setDiagnosticsId(null)
+
+      try {
+        const serviceMap = await loadServices(storeId)
+        const bookingsQuery = buildBookingsQuery(storeId, serviceFilter, statusFilter, startAfterDoc)
+        const snapshot = await getDocs(bookingsQuery)
+        const docs = snapshot.docs
+        const hasMore = docs.length > PAGE_SIZE
+        const pageDocs = hasMore ? docs.slice(0, PAGE_SIZE) : docs
+        const nextLastCursor = pageDocs.length ? pageDocs[pageDocs.length - 1] : null
+
+        setBookings(pageDocs.map(docSnap => hydrateBooking(docSnap, serviceMap)))
+        setLastCursor(nextLastCursor)
+        setHasNextPage(hasMore)
+        setCursorStack(nextCursorStack)
+        setPageNumber(nextPageNumber)
+      } catch (error) {
+        console.error('[bookings] Failed to load bookings', error)
+        const diagCode = `BK-${Date.now()}-${Math.random().toString(16).slice(2, 8).toUpperCase()}`
+        setDiagnosticsId(diagCode)
+        setErrorMessage('Unable to load bookings right now. Please try again.')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [buildBookingsQuery, hydrateBooking, loadServices, serviceFilter, statusFilter, storeId],
+  )
 
   useEffect(() => {
     if (!storeId) {
       setBookings([])
+      setServices([])
       setLoading(false)
       setErrorMessage('Select a workspace to view bookings.')
       return
     }
 
-    setLoading(true)
-    setErrorMessage(null)
-    const bookingsQuery = query(
-      collection(db, 'stores', storeId, 'integrationBookings'),
-      orderBy('createdAt', 'desc'),
-      limit(100),
-    )
+    void loadBookingsPage(null, 1, [])
+  }, [loadBookingsPage, storeId])
 
-    const unsubscribe = onSnapshot(
-      bookingsQuery,
-      snapshot => {
-        const rows = snapshot.docs.map(docSnap => {
-          const data = docSnap.data() as Record<string, any>
-          const customer =
-            data.customer && typeof data.customer === 'object'
-              ? (data.customer as Record<string, unknown>)
-              : {}
-          const createdAtValue =
-            data.createdAt && typeof data.createdAt === 'object' && typeof data.createdAt.toDate === 'function'
-              ? data.createdAt.toDate()
-              : null
-          return {
-            id: docSnap.id,
-            serviceId: typeof data.serviceId === 'string' ? data.serviceId : '—',
-            status: typeof data.status === 'string' ? data.status : 'confirmed',
-            quantity:
-              typeof data.quantity === 'number' && Number.isFinite(data.quantity)
-                ? Math.max(1, Math.floor(data.quantity))
-                : 1,
-            customerName:
-              typeof customer.name === 'string' && customer.name.trim() ? customer.name.trim() : null,
-            customerPhone:
-              typeof customer.phone === 'string' && customer.phone.trim() ? customer.phone.trim() : null,
-            customerEmail:
-              typeof customer.email === 'string' && customer.email.trim() ? customer.email.trim() : null,
-            notes: typeof data.notes === 'string' && data.notes.trim() ? data.notes.trim() : null,
-            createdAt: createdAtValue,
-          } satisfies BookingRecord
+  const handleNextPage = useCallback(() => {
+    if (!hasNextPage || !lastCursor) return
+    const nextStack = [...cursorStack, lastCursor]
+    void loadBookingsPage(lastCursor, pageNumber + 1, nextStack)
+  }, [cursorStack, hasNextPage, lastCursor, loadBookingsPage, pageNumber])
+
+  const handlePreviousPage = useCallback(() => {
+    if (pageNumber <= 1) return
+    const previousStack = cursorStack.slice(0, -1)
+    const previousCursor = previousStack.length ? previousStack[previousStack.length - 1] : null
+    void loadBookingsPage(previousCursor, pageNumber - 1, previousStack)
+  }, [cursorStack, loadBookingsPage, pageNumber])
+
+  const handleRetry = useCallback(() => {
+    void loadBookingsPage(pageNumber <= 1 ? null : cursorStack[cursorStack.length - 1] ?? null, pageNumber, cursorStack)
+  }, [cursorStack, loadBookingsPage, pageNumber])
+
+  const handleStatusUpdate = useCallback(
+    async (bookingId: string, nextStatus: string) => {
+      if (!storeId) return
+      setUpdatingBookingId(bookingId)
+      try {
+        await updateDoc(doc(db, 'stores', storeId, 'integrationBookings', bookingId), {
+          status: nextStatus,
+          updatedAt: Timestamp.now(),
         })
-        setBookings(rows)
-        setLoading(false)
-      },
-      error => {
-        console.error('[bookings] Failed to load bookings', error)
-        setErrorMessage('Unable to load bookings right now. Please try again.')
-        setLoading(false)
-      },
-    )
 
-    return () => unsubscribe()
-  }, [storeId])
+        setBookings(previous =>
+          previous.map(booking =>
+            booking.id === bookingId
+              ? {
+                  ...booking,
+                  status: nextStatus,
+                }
+              : booking,
+          ),
+        )
+      } catch (error) {
+        console.error('[bookings] Failed to update booking status', error)
+        setErrorMessage('Status update failed. Please retry.')
+      } finally {
+        setUpdatingBookingId(null)
+      }
+    },
+    [storeId],
+  )
+
+  const filteredBookings = useMemo(() => {
+    const queryText = searchTerm.trim().toLowerCase()
+    if (!queryText) return bookings
+
+    return bookings.filter(booking => {
+      const fields = [booking.customerName, booking.customerPhone, booking.customerEmail]
+      return fields.some(value => typeof value === 'string' && value.toLowerCase().includes(queryText))
+    })
+  }, [bookings, searchTerm])
 
   const confirmedCount = useMemo(
-    () => bookings.filter(booking => booking.status.toLowerCase() === 'confirmed').length,
+    () => bookings.filter(booking => booking.status === 'confirmed').length,
     [bookings],
   )
 
   return (
-    <main className="page">
+    <main className="page bookings-page">
       <section className="card stack gap-4">
         <header className="stack gap-1">
           <h1>Bookings</h1>
@@ -101,46 +302,140 @@ export default function Bookings() {
           </p>
         </header>
 
+        <div className="bookings-page__filters">
+          <label>
+            <span>Status</span>
+            <select value={statusFilter} onChange={event => setStatusFilter(event.target.value)}>
+              <option value={STATUS_ALL}>All statuses</option>
+              <option value="confirmed">Confirmed</option>
+              <option value="rescheduled">Rescheduled</option>
+              <option value="cancelled">Cancelled</option>
+              <option value="completed">Completed</option>
+            </select>
+          </label>
+          <label>
+            <span>Service</span>
+            <select value={serviceFilter} onChange={event => setServiceFilter(event.target.value)}>
+              <option value={SERVICE_ALL}>All services</option>
+              {services.map(service => (
+                <option key={service.id} value={service.id}>
+                  {service.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>From</span>
+            <input type="date" value={startDate} onChange={event => setStartDate(event.target.value)} />
+          </label>
+          <label>
+            <span>To</span>
+            <input type="date" value={endDate} onChange={event => setEndDate(event.target.value)} />
+          </label>
+          <label className="bookings-page__search">
+            <span>Search customer</span>
+            <input
+              type="search"
+              placeholder="Name, phone, or email"
+              value={searchTerm}
+              onChange={event => setSearchTerm(event.target.value)}
+            />
+          </label>
+          <button className="btn btn-secondary" type="button" onClick={() => void loadBookingsPage(null, 1, [])}>
+            Apply filters
+          </button>
+        </div>
+
         {loading && <p className="form__hint">Loading bookings…</p>}
-        {!loading && errorMessage && <p className="form__error">{errorMessage}</p>}
+        {!loading && errorMessage && (
+          <div className="stack gap-2">
+            <p className="form__error">{errorMessage}</p>
+            {diagnosticsId && <p className="form__hint">Diagnostics ID: {diagnosticsId}</p>}
+            <button className="btn btn-secondary" type="button" onClick={handleRetry}>
+              Retry
+            </button>
+          </div>
+        )}
         {!loading && !errorMessage && (
           <>
             <p className="form__hint">
-              Total bookings: <strong>{bookings.length}</strong> • Confirmed: <strong>{confirmedCount}</strong>
+              Total bookings: <strong>{bookings.length}</strong> • Confirmed: <strong>{confirmedCount}</strong> • Page:{' '}
+              <strong>{pageNumber}</strong>
             </p>
-            {bookings.length ? (
-              <div className="table-wrap">
-                <table className="table">
-                  <thead>
-                    <tr>
-                      <th>Created</th>
-                      <th>Service</th>
-                      <th>Customer</th>
-                      <th>Qty</th>
-                      <th>Status</th>
-                      <th>Notes</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {bookings.map(booking => (
-                      <tr key={booking.id}>
-                        <td>{formatDate(booking.createdAt)}</td>
-                        <td>{booking.serviceId}</td>
-                        <td>
-                          {[booking.customerName, booking.customerPhone, booking.customerEmail]
-                            .filter(Boolean)
-                            .join(' • ') || '—'}
-                        </td>
-                        <td>{booking.quantity}</td>
-                        <td>{booking.status}</td>
-                        <td>{booking.notes ?? '—'}</td>
+            {filteredBookings.length ? (
+              <>
+                <div className="table-wrap">
+                  <table className="table">
+                    <thead>
+                      <tr>
+                        <th>Created</th>
+                        <th>Service</th>
+                        <th>Customer</th>
+                        <th>Qty</th>
+                        <th>Status</th>
+                        <th>Notes</th>
+                        <th>Actions</th>
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+                    </thead>
+                    <tbody>
+                      {filteredBookings.map(booking => (
+                        <tr key={booking.id}>
+                          <td>{formatDate(booking.createdAt)}</td>
+                          <td>{booking.serviceName || booking.serviceId}</td>
+                          <td>
+                            {[booking.customerName, booking.customerPhone, booking.customerEmail]
+                              .filter(Boolean)
+                              .join(' • ') || '—'}
+                          </td>
+                          <td>{booking.quantity}</td>
+                          <td>
+                            <span className={`bookings-page__status bookings-page__status--${booking.status}`}>
+                              {statusLabel(booking.status)}
+                            </span>
+                          </td>
+                          <td>{booking.notes ?? '—'}</td>
+                          <td>
+                            <div className="bookings-page__actions">
+                              {(STATUS_ACTIONS[booking.status] ?? []).map(action => (
+                                <button
+                                  key={action.nextStatus}
+                                  className="btn btn-secondary"
+                                  type="button"
+                                  disabled={updatingBookingId === booking.id}
+                                  onClick={() => void handleStatusUpdate(booking.id, action.nextStatus)}
+                                >
+                                  {action.label}
+                                </button>
+                              ))}
+                              {!ACTIONABLE_STATUS.includes(booking.status as (typeof ACTIONABLE_STATUS)[number]) && (
+                                <span className="form__hint">No actions</span>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <div className="bookings-page__pagination">
+                  <button className="btn btn-secondary" type="button" disabled={pageNumber <= 1} onClick={handlePreviousPage}>
+                    Previous
+                  </button>
+                  <button className="btn btn-secondary" type="button" disabled={!hasNextPage} onClick={handleNextPage}>
+                    Next
+                  </button>
+                </div>
+              </>
             ) : (
-              <p className="form__hint">No bookings yet.</p>
+              <div className="stack gap-2">
+                <p className="form__hint">No bookings yet.</p>
+                <p className="form__hint">
+                  Set up your booking widget and integration to start receiving appointments.
+                </p>
+                <Link to="/docs/integration-quickstart" className="btn btn-secondary" style={{ width: 'fit-content' }}>
+                  Open integration guide
+                </Link>
+              </div>
             )}
           </>
         )}


### PR DESCRIPTION
### Motivation
- Turn the Bookings page from a passive report into an operations tool by enabling per-row status transitions (Confirm/Reschedule/Cancel/Complete) so staff can manage appointments inline. 
- Support larger stores and avoid missing older records by replacing the hard 100-record snapshot with cursor-based pagination. 
- Make bookings more readable and actionable by resolving `serviceId` to human-friendly service names and improving empty/error states with a CTA, retry, and diagnostics ID. 

### Description
- Rewrote `web/src/pages/Bookings.tsx` to add per-row action buttons that call Firestore `updateDoc` to change booking `status` and optimistically update the UI. 
- Added status, service, and date-range filters plus a customer search field and an explicit `Apply filters` control that queries Firestore with filters applied. 
- Replaced the previous `onSnapshot` + `limit(100)` approach with cursor-based pagination using `getDocs`, `startAfter`, a cursor stack, and `PAGE_SIZE` of 25 with Next/Previous controls. 
- Implemented service name resolution by loading `services` and `integrationServices` collections and mapping `serviceId` -> readable `serviceName`, and added `Bookings.css` for status badge colors, action layout, and pagination styling. 
- Improved UX for empty and error states by adding a setup CTA linking to the integration docs, a retry button, and a generated diagnostics ID shown on failures. 

### Testing
- Attempted a TypeScript build with `npm run build`, which failed in this environment due to missing type definition files for `vite/client` and `vitest/globals` before installing dependencies. 
- Attempted dependency installation with `npm ci`, which failed due to npm registry access returning `403 Forbidden`, preventing full build and runtime verification. 
- No automated unit or integration tests were executed against the modified page in this environment due to the dependency/install limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09163466c8322949cdf7639842e4e)