### PR TITLE
Allow booking API saves when serviceId is missing

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -3509,7 +3509,23 @@ async function resolveIntegrationBookingServiceId(options) {
     const defaultServiceId = BOOKING_DEFAULT_SERVICE_ID.value()?.trim() || '';
     if (defaultServiceId)
         return defaultServiceId;
-    return null;
+    const serviceNameFallback = toTrimmedStringOrNull(payload.productName) ??
+        toTrimmedStringOrNull(payload.product_name) ??
+        toTrimmedStringOrNull(payload.serviceName) ??
+        toTrimmedStringOrNull(payload.service_name) ??
+        toTrimmedStringOrNull(payload.name) ??
+        toTrimmedStringOrNull(payload.title);
+    if (serviceNameFallback) {
+        const normalized = serviceNameFallback
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .slice(0, 60);
+        if (normalized) {
+            return `name:${normalized}`;
+        }
+    }
+    return 'unspecified-service';
 }
 exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);
@@ -3590,7 +3606,7 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
     if (!serviceId) {
         res.status(400).json({
             error: 'service-not-resolved',
-            message: 'Service could not be resolved. Configure BOOKING_DEFAULT_SERVICE_ID or provide serviceId.',
+            message: 'Service could not be resolved. Configure BOOKING_DEFAULT_SERVICE_ID, provide serviceId, or include product/service name.',
         });
         return;
     }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4420,7 +4420,25 @@ async function resolveIntegrationBookingServiceId(options: {
   const defaultServiceId = BOOKING_DEFAULT_SERVICE_ID.value()?.trim() || ''
   if (defaultServiceId) return defaultServiceId
 
-  return null
+  const serviceNameFallback =
+    toTrimmedStringOrNull(payload.productName) ??
+    toTrimmedStringOrNull(payload.product_name) ??
+    toTrimmedStringOrNull(payload.serviceName) ??
+    toTrimmedStringOrNull(payload.service_name) ??
+    toTrimmedStringOrNull(payload.name) ??
+    toTrimmedStringOrNull(payload.title)
+  if (serviceNameFallback) {
+    const normalized = serviceNameFallback
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60)
+    if (normalized) {
+      return `name:${normalized}`
+    }
+  }
+
+  return 'unspecified-service'
 }
 
 export const v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
@@ -4506,7 +4524,8 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
   if (!serviceId) {
     res.status(400).json({
       error: 'service-not-resolved',
-      message: 'Service could not be resolved. Configure BOOKING_DEFAULT_SERVICE_ID or provide serviceId.',
+      message:
+        'Service could not be resolved. Configure BOOKING_DEFAULT_SERVICE_ID, provide serviceId, or include product/service name.',
     })
     return
   }


### PR DESCRIPTION
### Motivation
- Ensure the integration booking endpoint can create bookings even when an explicit `serviceId` is not provided by accepting a product/service name as fallback.
- Prevent API failures from blocking booking creation when only a name-like field is available from website integrations.

### Description
- Updated `resolveIntegrationBookingServiceId` in `functions/src/index.ts` to fall back to payload name fields (`productName`, `product_name`, `serviceName`, `service_name`, `name`, `title`) when `serviceId` is not present or resolvable.
- Normalizes a found name to a slug and returns a synthetic service id in the form `name:<slug>` for stable downstream use.
- Added a final fallback value `unspecified-service` so booking creation can proceed even when no service id or name is available.
- Updated the API error message for unresolved service to mention that product/service name will be accepted as a fallback, and rebuilt `functions/lib/index.js` to match the TypeScript changes.

### Testing
- Ran `npm --prefix functions run build` and the TypeScript build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d23490448322bbb60e68285c25ce)