### PR TITLE
Resolve booking service ID from env or product name with sensible fallback

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -69,7 +69,7 @@ const INTEGRATION_CONTRACT_VERSION = (0, params_1.defineString)('INTEGRATION_CON
     default: '2026-04-13',
 });
 const SEDIFEX_INTEGRATION_API_KEY = (0, params_1.defineString)('SEDIFEX_INTEGRATION_API_KEY', { default: '' });
-const BOOKING_DEFAULT_SERVICE_ID = (0, params_1.defineString)('BOOKING_DEFAULT_SERVICE_ID', { default: '' });
+const BOOKING_DEFAULT_SERVICE_ID_ENV_KEY = 'BOOKING_DEFAULT_SERVICE_ID';
 /** ============================================================================
  *  HELPERS
  * ==========================================================================*/
@@ -83,6 +83,9 @@ function getOpenAiConfig() {
         openAiConfigWarned = true;
     }
     return { apiKey, model };
+}
+function getBookingDefaultServiceId() {
+    return process.env[BOOKING_DEFAULT_SERVICE_ID_ENV_KEY]?.trim() || '';
 }
 function getIntegrationMasterApiKey() {
     const apiKey = SEDIFEX_INTEGRATION_API_KEY.value()?.trim() ||
@@ -3506,10 +3509,26 @@ async function resolveIntegrationBookingServiceId(options) {
                 return slotServiceId;
         }
     }
-    const defaultServiceId = BOOKING_DEFAULT_SERVICE_ID.value()?.trim() || '';
+    const defaultServiceId = getBookingDefaultServiceId();
     if (defaultServiceId)
         return defaultServiceId;
-    return null;
+    const serviceNameFallback = toTrimmedStringOrNull(payload.productName) ??
+        toTrimmedStringOrNull(payload.product_name) ??
+        toTrimmedStringOrNull(payload.serviceName) ??
+        toTrimmedStringOrNull(payload.service_name) ??
+        toTrimmedStringOrNull(payload.name) ??
+        toTrimmedStringOrNull(payload.title);
+    if (serviceNameFallback) {
+        const normalized = serviceNameFallback
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .slice(0, 60);
+        if (normalized) {
+            return `name:${normalized}`;
+        }
+    }
+    return 'unspecified-service';
 }
 exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);
@@ -3590,7 +3609,7 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
     if (!serviceId) {
         res.status(400).json({
             error: 'service-not-resolved',
-            message: 'Service could not be resolved. Configure BOOKING_DEFAULT_SERVICE_ID or provide serviceId.',
+            message: 'Service could not be resolved. Configure BOOKING_DEFAULT_SERVICE_ID, provide serviceId, or include product/service name.',
         });
         return;
     }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -164,7 +164,7 @@ const INTEGRATION_CONTRACT_VERSION = defineString('INTEGRATION_CONTRACT_VERSION'
   default: '2026-04-13',
 })
 const SEDIFEX_INTEGRATION_API_KEY = defineString('SEDIFEX_INTEGRATION_API_KEY', { default: '' })
-const BOOKING_DEFAULT_SERVICE_ID = defineString('BOOKING_DEFAULT_SERVICE_ID', { default: '' })
+const BOOKING_DEFAULT_SERVICE_ID_ENV_KEY = 'BOOKING_DEFAULT_SERVICE_ID'
 /** ============================================================================
  *  HELPERS
  * ==========================================================================*/
@@ -184,6 +184,10 @@ function getOpenAiConfig() {
   }
 
   return { apiKey, model }
+}
+
+function getBookingDefaultServiceId() {
+  return process.env[BOOKING_DEFAULT_SERVICE_ID_ENV_KEY]?.trim() || ''
 }
 
 function getIntegrationMasterApiKey(): string {
@@ -4417,10 +4421,28 @@ async function resolveIntegrationBookingServiceId(options: {
     }
   }
 
-  const defaultServiceId = BOOKING_DEFAULT_SERVICE_ID.value()?.trim() || ''
+  const defaultServiceId = getBookingDefaultServiceId()
   if (defaultServiceId) return defaultServiceId
 
-  return null
+  const serviceNameFallback =
+    toTrimmedStringOrNull(payload.productName) ??
+    toTrimmedStringOrNull(payload.product_name) ??
+    toTrimmedStringOrNull(payload.serviceName) ??
+    toTrimmedStringOrNull(payload.service_name) ??
+    toTrimmedStringOrNull(payload.name) ??
+    toTrimmedStringOrNull(payload.title)
+  if (serviceNameFallback) {
+    const normalized = serviceNameFallback
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60)
+    if (normalized) {
+      return `name:${normalized}`
+    }
+  }
+
+  return 'unspecified-service'
 }
 
 export const v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
@@ -4506,7 +4528,8 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
   if (!serviceId) {
     res.status(400).json({
       error: 'service-not-resolved',
-      message: 'Service could not be resolved. Configure BOOKING_DEFAULT_SERVICE_ID or provide serviceId.',
+      message:
+        'Service could not be resolved. Configure BOOKING_DEFAULT_SERVICE_ID, provide serviceId, or include product/service name.',
     })
     return
   }


### PR DESCRIPTION
### Motivation
- Improve resolution of a booking `serviceId` for integration bookings when explicit IDs or slots are not provided.
- Allow configuring a default service via environment variable key `BOOKING_DEFAULT_SERVICE_ID` rather than only Firebase params.
- Provide a deterministic fallback derived from product/service name to avoid failing integrations that omit a service identifier.

### Description
- Added helper `getBookingDefaultServiceId()` and replaced direct use of the Firebase param with reading `process.env[BOOKING_DEFAULT_SERVICE_ID]` in `functions/src/index.ts` and the compiled `functions/lib/index.js`.
- Extended `resolveIntegrationBookingServiceId` to derive a normalized `name:<slug>` fallback from `productName`, `product_name`, `serviceName`, `service_name`, `name`, or `title` when no explicit service or slot mapping is found.
- When no other resolution succeeds, return the literal `'unspecified-service'` instead of `null` to provide a consistent value.
- Updated the integration error message to instruct callers to configure the env var, provide a `serviceId`, or include a product/service name.

### Testing
- No automated tests were added or run as part of this change; please run existing CI to validate integration and unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d23490448322bbb60e68285c25ce)