### PR TITLE
Add workspace switcher to Shell and filter memberships to signed-in user

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -290,6 +290,43 @@ body.shell--menu-open {
   justify-content: flex-end;
 }
 
+.shell__store-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+}
+
+.shell__store-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #475569;
+}
+
+.shell__store-select {
+  min-width: 150px;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: #ffffff;
+  color: #0f172a;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.shell__store-select[data-readonly] {
+  border-style: dashed;
+}
+
+.shell__store-link-hint {
+  margin: 0;
+  font-size: 12px;
+  color: #475569;
+}
+
 .shell__resume-banner {
   display: inline-flex;
   align-items: center;

--- a/web/src/layout/Shell.test.tsx
+++ b/web/src/layout/Shell.test.tsx
@@ -12,6 +12,7 @@ const mockUseStoreBilling = vi.fn()
 const mockUseActiveStore = vi.fn()
 const mockUseWorkspaceIdentity = vi.fn()
 const mockUseMemberships = vi.fn()
+const mockSetActiveStoreId = vi.fn()
 
 vi.mock('../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
@@ -67,9 +68,15 @@ describe('Shell', () => {
     mockUseActiveStore.mockReset()
     mockUseWorkspaceIdentity.mockReset()
     mockUseMemberships.mockReset()
+    mockSetActiveStoreId.mockReset()
 
     mockUseAuthUser.mockReturnValue({ uid: 'user-123', email: 'owner@example.com' })
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
+    mockUseActiveStore.mockReturnValue({
+      storeId: 'store-123',
+      isLoading: false,
+      error: null,
+      setActiveStoreId: mockSetActiveStoreId,
+    })
     mockUseWorkspaceIdentity.mockReturnValue({ name: 'Demo Store', loading: false })
     mockUseMemberships.mockReturnValue({ memberships: [], loading: false, error: null })
     mockUseConnectivityStatus.mockReturnValue({
@@ -96,6 +103,46 @@ describe('Shell', () => {
   it('renders the workspace status', () => {
     renderShell()
 
+    expect(screen.getByText('Standard')).toBeInTheDocument()
+    expect(
+      screen.getByText(/to link more stores, ask each workspace owner to add/i),
+    ).toBeInTheDocument()
+  })
+
+  it('switches workspaces when the account has multiple memberships', async () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [
+        { id: 'member-1', uid: 'user-123', storeId: 'store-123', role: 'owner' },
+        { id: 'member-2', uid: 'user-123', storeId: 'store-456', role: 'staff' },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    renderShell()
+    const user = userEvent.setup()
+
+    await user.selectOptions(screen.getByLabelText(/select workspace/i), 'store-456')
+
+    expect(mockSetActiveStoreId).toHaveBeenCalledWith('store-456')
+    expect(
+      screen.queryByText(/to link more stores, ask each workspace owner to add/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows only connected workspaces for the signed-in user', () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [
+        { id: 'member-1', uid: 'user-123', storeId: 'store-123', role: 'staff' },
+        { id: 'member-2', uid: 'other-user', storeId: 'store-456', role: 'owner' },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    renderShell()
+
+    expect(screen.queryByLabelText(/select workspace/i)).not.toBeInTheDocument()
     expect(screen.getByText('Standard')).toBeInTheDocument()
   })
 

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -78,7 +78,7 @@ function buildBannerMessage(queueStatus: ReturnType<typeof useConnectivityStatus
 }
 
 export default function Shell({ children }: { children: React.ReactNode }) {
-  const { storeId } = useActiveStore()
+  const { storeId, setActiveStoreId } = useActiveStore()
   const { memberships, loading: membershipsLoading } = useMemberships()
   const user = useAuthUser()
   const { isPwaApp } = usePwaContext()
@@ -343,6 +343,31 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
   const workspaceStatus = billing?.planKey ?? 'Workspace ready'
   const workspaceLabel = workspaceName || workspaceStatus
+  const selectableMemberships = useMemo(() => {
+    const byStore = new Map<string, (typeof memberships)[number]>()
+
+    memberships.forEach(membership => {
+      const normalizedStoreId =
+        typeof membership.storeId === 'string' ? membership.storeId.trim() : ''
+
+      // A workspace qualifies only when it has a valid storeId and belongs to
+      // the currently signed-in user identity.
+      if (!normalizedStoreId || membership.uid !== user?.uid) return
+
+      const existing = byStore.get(normalizedStoreId)
+      if (!existing) {
+        byStore.set(normalizedStoreId, membership)
+        return
+      }
+
+      // If duplicate rows exist for the same store, prefer owner visibility.
+      if (existing.role !== 'owner' && membership.role === 'owner') {
+        byStore.set(normalizedStoreId, membership)
+      }
+    })
+
+    return Array.from(byStore.values())
+  }, [memberships, user?.uid])
 
   const navSection = (
     <div className="shell__nav-group">
@@ -403,13 +428,38 @@ export default function Shell({ children }: { children: React.ReactNode }) {
         aria-live="polite"
       >
         <span className="shell__store-label">Workspace</span>
-        <span
-          className="shell__store-select"
-          data-readonly
-        >
-          {workspaceStatus}
-        </span>
+        {selectableMemberships.length > 1 ? (
+          <select
+            className="shell__store-select"
+            value={storeId ?? ''}
+            onChange={event => setActiveStoreId(event.target.value)}
+            aria-label="Select workspace"
+          >
+            {selectableMemberships.map(membership => (
+              <option
+                key={membership.id}
+                value={membership.storeId ?? ''}
+              >
+                {membership.storeId}
+                {membership.role === 'owner' ? ' (Owner)' : ''}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span
+            className="shell__store-select"
+            data-readonly
+          >
+            {workspaceStatus}
+          </span>
+        )}
       </div>
+      {selectableMemberships.length <= 1 && (
+        <p className="shell__store-link-hint">
+          To link more stores, ask each workspace owner to add{' '}
+          <strong>{userEmail}</strong> as staff or owner in Team Members.
+        </p>
+      )}
 
       {banner && (
         <div


### PR DESCRIPTION
### Motivation

- Expose a workspace switcher in the shell header so users with multiple memberships can change the active workspace.  
- Ensure the workspace chooser only shows stores that belong to the signed-in user and prefer owner entries when duplicates exist.  

### Description

- Added UI and styles for a store switcher with new CSS classes: `.shell__store-switcher`, `.shell__store-label`, `.shell__store-select`, and `.shell__store-link-hint`.  
- Updated `Shell` to read `setActiveStoreId` from `useActiveStore` and render a `<select>` when multiple selectable memberships exist, calling `setActiveStoreId` on change.  
- Introduced `selectableMemberships` (memoized) to filter `memberships` to entries with a valid `storeId` that match the signed-in user's `uid` and to prefer `owner` role for duplicate store rows.  
- When only one (or zero) selectable membership exists the store name is shown as read-only and a hint is displayed explaining how to link additional stores.  
- Tests updated in `web/src/layout/Shell.test.tsx` to mock `setActiveStoreId`, cover workspace switching, and verify only connected workspaces are shown to the signed-in user.  

### Testing

- Ran the `Shell` unit test suite in `web/src/layout/Shell.test.tsx` (Vitest with `@testing-library/react`) which includes `renders the workspace status`, `switches workspaces when the account has multiple memberships`, and `shows only connected workspaces for the signed-in user`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0de636c908322a0cf56717e7d2d78)