### PR TITLE
Add workspace switcher and membership-aware UI to Shell

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -238,6 +238,12 @@ body.shell--menu-open {
   color: #0f172a;
 }
 
+.shell__workspace-switch-hint {
+  margin: 0;
+  font-size: 12px;
+  color: #64748b;
+}
+
 .shell__nav-link {
   display: flex;
   align-items: center;
@@ -288,6 +294,43 @@ body.shell--menu-open {
   gap: 12px;
   flex-wrap: wrap;
   justify-content: flex-end;
+}
+
+.shell__store-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+}
+
+.shell__store-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #475569;
+}
+
+.shell__store-select {
+  min-width: 150px;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: #ffffff;
+  color: #0f172a;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.shell__store-select[data-readonly] {
+  border-style: dashed;
+}
+
+.shell__store-link-hint {
+  margin: 0;
+  font-size: 12px;
+  color: #475569;
 }
 
 .shell__resume-banner {

--- a/web/src/layout/Shell.test.tsx
+++ b/web/src/layout/Shell.test.tsx
@@ -12,6 +12,7 @@ const mockUseStoreBilling = vi.fn()
 const mockUseActiveStore = vi.fn()
 const mockUseWorkspaceIdentity = vi.fn()
 const mockUseMemberships = vi.fn()
+const mockSetActiveStoreId = vi.fn()
 
 vi.mock('../hooks/useAuthUser', () => ({
   useAuthUser: () => mockUseAuthUser(),
@@ -67,9 +68,15 @@ describe('Shell', () => {
     mockUseActiveStore.mockReset()
     mockUseWorkspaceIdentity.mockReset()
     mockUseMemberships.mockReset()
+    mockSetActiveStoreId.mockReset()
 
     mockUseAuthUser.mockReturnValue({ uid: 'user-123', email: 'owner@example.com' })
-    mockUseActiveStore.mockReturnValue({ storeId: 'store-123', isLoading: false, error: null })
+    mockUseActiveStore.mockReturnValue({
+      storeId: 'store-123',
+      isLoading: false,
+      error: null,
+      setActiveStoreId: mockSetActiveStoreId,
+    })
     mockUseWorkspaceIdentity.mockReturnValue({ name: 'Demo Store', loading: false })
     mockUseMemberships.mockReturnValue({ memberships: [], loading: false, error: null })
     mockUseConnectivityStatus.mockReturnValue({
@@ -97,6 +104,70 @@ describe('Shell', () => {
     renderShell()
 
     expect(screen.getByText('Standard')).toBeInTheDocument()
+    expect(
+      screen.getByText(/to link more stores, ask each workspace owner to add/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/workspace switch appears when this account is linked to 2\+ workspaces/i),
+    ).toBeInTheDocument()
+  })
+
+  it('switches workspaces when the account has multiple memberships', async () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [
+        { id: 'member-1', uid: 'user-123', storeId: 'store-123', role: 'owner' },
+        { id: 'member-2', uid: 'user-123', storeId: 'store-456', role: 'staff' },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    renderShell()
+    const user = userEvent.setup()
+
+    await user.selectOptions(screen.getByLabelText(/select workspace/i), 'store-456')
+
+    expect(mockSetActiveStoreId).toHaveBeenCalledWith('store-456')
+    expect(
+      screen.queryByText(/to link more stores, ask each workspace owner to add/i),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/workspace switch appears when this account is linked to 2\+ workspaces/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows only connected workspaces for the signed-in user', () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [
+        { id: 'member-1', uid: 'user-123', storeId: 'store-123', role: 'staff' },
+        { id: 'member-2', uid: 'other-user', storeId: 'store-456', role: 'owner' },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    renderShell()
+
+    expect(screen.queryByLabelText(/select workspace/i)).not.toBeInTheDocument()
+    expect(screen.getByText('Standard')).toBeInTheDocument()
+  })
+
+  it('explains why switcher is hidden when multiple rows map to one store id', () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [
+        { id: 'member-1', uid: 'user-123', storeId: 'same-store', role: 'owner' },
+        { id: 'member-2', uid: 'user-123', storeId: 'same-store', role: 'staff' },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    renderShell()
+
+    expect(screen.queryByLabelText(/select workspace/i)).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/multiple team rows, but they all point to the same workspace id/i),
+    ).toBeInTheDocument()
   })
 
   it('shows a billing reminder when payment is past due', () => {

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -78,7 +78,7 @@ function buildBannerMessage(queueStatus: ReturnType<typeof useConnectivityStatus
 }
 
 export default function Shell({ children }: { children: React.ReactNode }) {
-  const { storeId } = useActiveStore()
+  const { storeId, setActiveStoreId } = useActiveStore()
   const { memberships, loading: membershipsLoading } = useMemberships()
   const user = useAuthUser()
   const { isPwaApp } = usePwaContext()
@@ -343,6 +343,37 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
   const workspaceStatus = billing?.planKey ?? 'Workspace ready'
   const workspaceLabel = workspaceName || workspaceStatus
+  const connectedMembershipRows = useMemo(
+    () =>
+      memberships.filter(membership => {
+        const normalizedStoreId =
+          typeof membership.storeId === 'string' ? membership.storeId.trim() : ''
+        return Boolean(normalizedStoreId) && membership.uid === user?.uid
+      }),
+    [memberships, user?.uid],
+  )
+  const selectableMemberships = useMemo(() => {
+    const byStore = new Map<string, (typeof memberships)[number]>()
+
+    connectedMembershipRows.forEach(membership => {
+      const normalizedStoreId =
+        typeof membership.storeId === 'string' ? membership.storeId.trim() : ''
+      if (!normalizedStoreId) return
+
+      const existing = byStore.get(normalizedStoreId)
+      if (!existing) {
+        byStore.set(normalizedStoreId, membership)
+        return
+      }
+
+      // If duplicate rows exist for the same store, prefer owner visibility.
+      if (existing.role !== 'owner' && membership.role === 'owner') {
+        byStore.set(normalizedStoreId, membership)
+      }
+    })
+
+    return Array.from(byStore.values())
+  }, [connectedMembershipRows])
 
   const navSection = (
     <div className="shell__nav-group">
@@ -358,6 +389,13 @@ export default function Shell({ children }: { children: React.ReactNode }) {
             : workspaceLabel}
         </span>
       </div>
+      {selectableMemberships.length <= 1 && (
+        <p className="shell__workspace-switch-hint">
+          {connectedMembershipRows.length > 1
+            ? 'We found multiple team rows, but they all point to the same workspace ID. Add this account to a different store ID to enable switching.'
+            : 'Workspace switch appears when this account is linked to 2+ workspaces.'}
+        </p>
+      )}
 
       <nav
         className="shell__nav"
@@ -403,13 +441,38 @@ export default function Shell({ children }: { children: React.ReactNode }) {
         aria-live="polite"
       >
         <span className="shell__store-label">Workspace</span>
-        <span
-          className="shell__store-select"
-          data-readonly
-        >
-          {workspaceStatus}
-        </span>
+        {selectableMemberships.length > 1 ? (
+          <select
+            className="shell__store-select"
+            value={storeId ?? ''}
+            onChange={event => setActiveStoreId(event.target.value)}
+            aria-label="Select workspace"
+          >
+            {selectableMemberships.map(membership => (
+              <option
+                key={membership.id}
+                value={membership.storeId ?? ''}
+              >
+                {membership.storeId}
+                {membership.role === 'owner' ? ' (Owner)' : ''}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span
+            className="shell__store-select"
+            data-readonly
+          >
+            {workspaceStatus}
+          </span>
+        )}
       </div>
+      {selectableMemberships.length <= 1 && (
+        <p className="shell__store-link-hint">
+          To link more stores, ask each workspace owner to add{' '}
+          <strong>{userEmail}</strong> as staff or owner in Team Members.
+        </p>
+      )}
 
       {banner && (
         <div

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -470,7 +470,10 @@ export default function Shell({ children }: { children: React.ReactNode }) {
       {selectableMemberships.length <= 1 && (
         <p className="shell__store-link-hint">
           To link more stores, ask each workspace owner to add{' '}
-          <strong>{userEmail}</strong> as staff or owner in Team Members.
+          <strong>{userEmail}</strong> as staff or owner in Team Members. Each
+          row must use that store&apos;s own <code>storeId</code> (not{' '}
+          <code>{storeId ?? 'your current store id'}</code>) and this account&apos;s UID{' '}
+          <code>{user?.uid ?? 'unknown'}</code>.
         </p>
       )}
 


### PR DESCRIPTION
### Motivation

- Enable switching between workspaces when a signed-in account is linked to multiple store memberships.  
- Provide clear hints when switching is unavailable, including when multiple membership rows map to the same store id or when the account has only one connected workspace.

### Description

- Add styles in `web/src/layout/Shell.css` for the workspace/store switcher and hint text, including `.shell__store-switcher`, `.shell__store-select`, and `.shell__workspace-switch-hint`.  
- Compute `connectedMembershipRows` and `selectableMemberships` in `web/src/layout/Shell.tsx` to filter and dedupe membership rows by `storeId`, preferring rows with `role === 'owner'`.  
- Render a `select` when more than one `selectableMemberships` entry exists and call `setActiveStoreId` (from `useActiveStore`) on change, otherwise render a read-only store label and contextual hint messages.  
- Update `web/src/layout/Shell.test.tsx` to mock `setActiveStoreId` and add tests covering rendering of hints, switching workspaces, visibility for only connected workspaces, and the duplicate-rows explanation.

### Testing

- Ran unit tests with `vitest` (project `test` script); updated `Shell` tests in `Shell.test.tsx` executed and passed.  
- Verified the new test cases for switching behavior, hint visibility, and duplicate-row messaging all succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0de636c908322a0cf56717e7d2d78)