### PR TITLE
Add in-app multi-branch team member assignment form

### DIFF
--- a/web/src/pages/StaffManagement.tsx
+++ b/web/src/pages/StaffManagement.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import {
+  addDoc,
   collection,
   type DocumentData,
   getDocs,
@@ -7,6 +8,7 @@ import {
   orderBy,
   query,
   type QueryDocumentSnapshot,
+  serverTimestamp,
   where,
 } from 'firebase/firestore'
 import { useToast } from '../components/ToastProvider'
@@ -109,6 +111,11 @@ export default function StaffManagement({ headingLevel = 'h1' }: StaffManagement
   const [inviteRole, setInviteRole] = useState<Membership['role']>('staff')
   const [invitePassword, setInvitePassword] = useState('')
   const [inviting, setInviting] = useState(false)
+  const [assignmentUid, setAssignmentUid] = useState('')
+  const [assignmentEmail, setAssignmentEmail] = useState('')
+  const [assignmentStoreId, setAssignmentStoreId] = useState('')
+  const [assignmentRole, setAssignmentRole] = useState<Membership['role']>('staff')
+  const [assigning, setAssigning] = useState(false)
 
   const activeMembership = useMemo(() => {
     if (!storeId) return null
@@ -225,6 +232,51 @@ export default function StaffManagement({ headingLevel = 'h1' }: StaffManagement
       publish({ message, tone: 'error' })
     } finally {
       setInviting(false)
+    }
+  }
+
+  async function handleAssignmentSave(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!isOwner || assigning) {
+      return
+    }
+
+    const uid = assignmentUid.trim()
+    const email = assignmentEmail.trim().toLowerCase()
+    const targetStoreId = assignmentStoreId.trim()
+
+    if (!uid || !email || !targetStoreId) {
+      const message = 'UID, email, and branch store ID are required.'
+      setError(message)
+      publish({ message, tone: 'error' })
+      return
+    }
+
+    setAssigning(true)
+    setError(null)
+    try {
+      await addDoc(collection(db, 'teamMembers'), {
+        uid,
+        email,
+        storeId: targetStoreId,
+        role: assignmentRole,
+        status: 'active',
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      })
+      publish({ message: 'Branch access saved.', tone: 'success' })
+      setAssignmentUid('')
+      setAssignmentEmail('')
+      setAssignmentStoreId('')
+      setAssignmentRole('staff')
+      setRefreshToken(token => token + 1)
+    } catch (err) {
+      console.warn('[staff] Failed to save branch access assignment', err)
+      const message = err instanceof Error ? err.message : 'Could not save branch access.'
+      setError(message)
+      publish({ message, tone: 'error' })
+    } finally {
+      setAssigning(false)
     }
   }
 
@@ -394,6 +446,76 @@ export default function StaffManagement({ headingLevel = 'h1' }: StaffManagement
             Only workspace owners can save staff members.
           </p>
         )}
+      </section>
+
+      <section className="card staff-card" aria-labelledby="branch-assignment">
+        <div className="staff-card__header">
+          <div>
+            <p className="staff-card__eyebrow">Multi-branch access</p>
+            <h2 id="branch-assignment">Assign existing user to a branch</h2>
+            <p className="staff-card__hint">
+              Creates a team member row in Firestore so one user can access multiple branch store IDs.
+            </p>
+          </div>
+        </div>
+
+        <form className="staff-card__form" onSubmit={handleAssignmentSave}>
+          <label>
+            <span>User UID</span>
+            <input
+              type="text"
+              required
+              value={assignmentUid}
+              onChange={event => setAssignmentUid(event.target.value)}
+              placeholder="Firebase Auth UID"
+              disabled={!isOwner || assigning}
+            />
+          </label>
+
+          <label>
+            <span>Email</span>
+            <input
+              type="email"
+              required
+              value={assignmentEmail}
+              onChange={event => setAssignmentEmail(event.target.value)}
+              placeholder="user@example.com"
+              disabled={!isOwner || assigning}
+            />
+          </label>
+
+          <label>
+            <span>Branch Store ID</span>
+            <input
+              type="text"
+              required
+              value={assignmentStoreId}
+              onChange={event => setAssignmentStoreId(event.target.value)}
+              placeholder="store-branch-001"
+              disabled={!isOwner || assigning}
+            />
+          </label>
+
+          <label>
+            <span>Role</span>
+            <select
+              value={assignmentRole}
+              onChange={event => setAssignmentRole(event.target.value as Membership['role'])}
+              disabled={!isOwner || assigning}
+            >
+              <option value="owner">Owner</option>
+              <option value="staff">Staff</option>
+            </select>
+          </label>
+
+          <button
+            type="submit"
+            className="button button--primary"
+            disabled={!isOwner || assigning}
+          >
+            {assigning ? 'Saving…' : 'Save branch access'}
+          </button>
+        </form>
       </section>
 
       <section className="card staff-card" aria-labelledby="staff-list">


### PR DESCRIPTION
### Motivation
- Allow workspace owners to assign an existing Firebase user to additional branch store IDs from inside the app instead of editing Firestore Console manually.

### Description
- Add Firestore helpers `addDoc` and `serverTimestamp` and new component state for assignment inputs (`assignmentUid`, `assignmentEmail`, `assignmentStoreId`, `assignmentRole`, `assigning`).
- Implement `handleAssignmentSave` which validates inputs, creates a new `teamMembers` document with `uid`, `email`, `storeId`, `role`, `status`, and timestamps, and refreshes the roster on success.
- Add a new owner-only UI section and form in `StaffManagement` at `web/src/pages/StaffManagement.tsx` to capture UID, email, branch store ID, and role and submit via `handleAssignmentSave`.
- Preserve existing invite/reset/deactivate flows and gate the assignment flow to owners only.

### Testing
- Ran `npm run lint` in `web` which failed due to missing local dependency `@eslint/js` in this environment.
- Ran a unit test command (`npm run test -- src/pages/__tests__/AccountOverview.test.tsx`) which failed because the `vitest` binary is not available in this environment.
- No other automated tests were executed successfully in this environment; manual verification of code formatting and a commit were performed locally (`web/src/pages/StaffManagement.tsx` updated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1016f4bb08322a551023d01b24c6e)