### PR TITLE
Fix workspace switch crash and add team-member delete action in Account roster

### DIFF
--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -343,6 +343,10 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
   const workspaceStatus = billing?.planKey ?? 'Workspace ready'
   const workspaceLabel = workspaceName || workspaceStatus
+  const connectedMembershipRows = useMemo(
+    () => memberships.filter(membership => membership.uid === user?.uid),
+    [memberships, user?.uid],
+  )
   const selectableMemberships = useMemo(() => {
     const byStore = new Map<string, (typeof memberships)[number]>()
 

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -1651,6 +1651,32 @@ export default function AccountOverview({
     }
   }
 
+  async function handleDeleteMember(member: RosterMember) {
+    if (!storeId || !isOwner) return
+    if (member.role === 'owner') {
+      publish({ message: 'Owner access cannot be removed here.', tone: 'error' })
+      return
+    }
+
+    setPendingActionId(member.id)
+    try {
+      await deleteDoc(doc(db, 'teamMembers', member.id))
+      setRoster(current => current.filter(entry => entry.id !== member.id))
+      publish({
+        message: `Deleted ${member.email ?? 'team member'} from your workspace.`,
+        tone: 'success',
+      })
+    } catch (error) {
+      console.warn('[account] Failed to delete team member', error)
+      publish({
+        message: 'Unable to delete this team member. Please try again.',
+        tone: 'error',
+      })
+    } finally {
+      setPendingActionId(null)
+    }
+  }
+
   return (
     <div className="account-overview">
       <Heading>{isPromotionsView ? 'Public page' : 'Account overview'}</Heading>
@@ -3040,12 +3066,13 @@ export default function AccountOverview({
               <th scope="col">Status</th>
               <th scope="col">Invited by</th>
               <th scope="col">Updated</th>
+              {isOwner && <th scope="col">Actions</th>}
             </tr>
           </thead>
           <tbody>
             {roster.length === 0 && !rosterLoading ? (
               <tr className="account-overview__roster-empty">
-                <td colSpan={5}>No team members found.</td>
+                <td colSpan={isOwner ? 6 : 5}>No team members found.</td>
               </tr>
             ) : (
               roster.map(member => (
@@ -3067,6 +3094,22 @@ export default function AccountOverview({
                   </td>
                   <td>{formatValue(member.invitedBy)}</td>
                   <td>{formatTimestamp(member.updatedAt ?? member.createdAt)}</td>
+                  {isOwner && (
+                    <td>
+                      {member.role !== 'owner' ? (
+                        <button
+                          type="button"
+                          className="button button--ghost button--small"
+                          onClick={() => handleDeleteMember(member)}
+                          disabled={pendingActionId === member.id}
+                        >
+                          Delete
+                        </button>
+                      ) : (
+                        <span className="account-overview__hint">—</span>
+                      )}
+                    </td>
+                  )}
                 </tr>
               ))
             )}


### PR DESCRIPTION
### Motivation

- Prevent a runtime crash in the workspace switch hint caused by referencing an undefined `connectedMembershipRows` value.  
- Give workspace owners the ability to remove non-owner team members directly from the Account > Team roster UI.

### Description

- Define `connectedMembershipRows` in `web/src/layout/Shell.tsx` with a `useMemo` that filters memberships for the current user to avoid the undefined reference.  
- Add `handleDeleteMember` to `web/src/pages/AccountOverview.tsx` which deletes a `teamMembers` Firestore document, updates local `roster` state, and publishes success/error toasts.  
- Add an `Actions` column to the team roster table that is shown only to owners, render a `Delete` button for non-owner members, and prevent deleting owner rows from this view.  
- Adjust the empty-state table `colSpan` so the number of columns matches the conditional `Actions` column.

### Testing

- Ran `npm --prefix web run lint`, which failed due to a missing local ESLint dependency (`@eslint/js`) in this environment.  
- Ran `npm --prefix web run build`, which failed due to missing type definitions (`vite/client` and `vitest/globals`) in this environment.  
- No automated unit tests were executed as part of this change in this environment due to dependency/type resolution failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e102b9244c8322aa8ed88a9bf6080f)