### PR TITLE
Enable scrolling for left navigation sidebar

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -207,6 +207,9 @@ body.shell--menu-open {
   position: sticky;
   top: 92px;
   align-self: start;
+  max-height: calc(100dvh - 108px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 14px;
   border-radius: 16px;
   border: 1px solid #e2e8f0;


### PR DESCRIPTION
### Motivation
- The left navigation can exceed the viewport height which makes some items unreachable when the main content scrolls, so the sidebar needs its own constrained scrolling.

### Description
- Add `max-height: calc(100dvh - 108px)`, `overflow-y: auto`, and `overscroll-behavior: contain` to `.shell__sidebar` in `web/src/layout/Shell.css` to limit its viewport height and enable contained vertical scrolling.

### Testing
- Ran `npm --prefix web run lint`, which failed in this environment due to a missing dependency (`@eslint/js`), and the failure is unrelated to the CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10c738fdc8322a022fc92f4501a02)