### PR TITLE
Add Delete action to Bookings page

### DIFF
--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   collection,
+  deleteDoc,
   doc,
   getDocs,
   limit,
@@ -351,6 +352,32 @@ export default function Bookings() {
     [storeId],
   )
 
+
+
+  const handleDeleteBooking = useCallback(
+    async (bookingId: string) => {
+      if (!storeId) return
+      const shouldDelete = window.confirm('Delete this booking? This cannot be undone.')
+      if (!shouldDelete) return
+
+      setUpdatingBookingId(bookingId)
+      setErrorMessage(null)
+
+      try {
+        await deleteDoc(doc(db, 'stores', storeId, 'integrationBookings', bookingId))
+
+        setBookings(previous => previous.filter(booking => booking.id !== bookingId))
+        setSelectedBookingId(previous => (previous === bookingId ? null : previous))
+      } catch (error) {
+        console.error('[bookings] Failed to delete booking', error)
+        setErrorMessage('Delete failed. Please retry.')
+      } finally {
+        setUpdatingBookingId(null)
+      }
+    },
+    [storeId],
+  )
+
   const filteredBookings = useMemo(() => {
     const queryText = searchTerm.trim().toLowerCase()
     if (!queryText) return bookings
@@ -490,8 +517,16 @@ export default function Bookings() {
                                   {action.label}
                                 </button>
                               ))}
+                              <button
+                                className="btn btn-secondary"
+                                type="button"
+                                disabled={updatingBookingId === booking.id}
+                                onClick={() => void handleDeleteBooking(booking.id)}
+                              >
+                                Delete
+                              </button>
                               {!ACTIONABLE_STATUS.includes(booking.status as (typeof ACTIONABLE_STATUS)[number]) && (
-                                <span className="form__hint">No actions</span>
+                                <span className="form__hint">No status actions</span>
                               )}
                             </div>
                           </td>


### PR DESCRIPTION
### Motivation
- Provide a way to remove mistaken bookings directly from the Bookings page so admins can clean up incorrect entries.

### Description
- Import `deleteDoc` from `firebase/firestore` and add a `handleDeleteBooking` `useCallback` that confirms with `window.confirm`, deletes the Firestore document at `stores/{storeId}/integrationBookings/{bookingId}`, updates local `bookings` state, clears `selectedBookingId` when necessary, and manages `updatingBookingId` and `errorMessage`.
- Add a `Delete` button to each booking row wired to `handleDeleteBooking` so bookings can be removed inline.
- Adjust the UI helper label from `No actions` to `No status actions` to clarify the distinction between status actions and the new delete action.
- Preserve existing error handling and diagnostics behaviors when delete fails.

### Testing
- Ran `npm run lint` in `/web` which failed in this environment due to a missing `@eslint/js` dependency.
- Ran `npm run build` in `/web` which failed due to missing type definitions (`vite/client` and `vitest/globals`) in this environment.
- Ran `npm ci` which was blocked by the environment registry policy returning HTTP 403, so dependencies could not be installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e136047d188321b1fcc6f934221b8b)