### PR TITLE
Fix active workspace synchronization across all pages

### DIFF
--- a/web/src/hooks/useActiveStore.test.tsx
+++ b/web/src/hooks/useActiveStore.test.tsx
@@ -188,4 +188,32 @@ describe('useActiveStore', () => {
 
     expect(window.localStorage.getItem(storageKey)).toBe('store-b')
   })
+
+  it('syncs store selection across multiple hook instances', async () => {
+    mockUseMemberships.mockImplementation(storeId =>
+      storeId === undefined
+        ? { memberships: [], loading: true, error: null }
+        : {
+            memberships: [createMembership('store-a'), createMembership('store-b')],
+            loading: false,
+            error: null,
+          },
+    )
+
+    const first = renderHook(() => useActiveStore())
+    const second = renderHook(() => useActiveStore())
+
+    await waitFor(() => {
+      expect(first.result.current.isLoading).toBe(false)
+      expect(second.result.current.isLoading).toBe(false)
+    })
+
+    act(() => {
+      first.result.current.setActiveStoreId('store-b')
+    })
+
+    await waitFor(() => {
+      expect(second.result.current.storeId).toBe('store-b')
+    })
+  })
 })

--- a/web/src/hooks/useActiveStore.ts
+++ b/web/src/hooks/useActiveStore.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useMemberships } from './useMemberships'
 import { useAuthUser } from './useAuthUser'
-import { persistActiveStoreIdForUser, readActiveStoreId } from '../utils/activeStoreStorage'
+import {
+  ACTIVE_STORE_UPDATED_EVENT,
+  persistActiveStoreIdForUser,
+  readActiveStoreId,
+} from '../utils/activeStoreStorage'
 
 interface ActiveStoreState {
   storeId: string | null
@@ -27,6 +31,46 @@ export function useActiveStore(): ActiveStoreState {
 
   useEffect(() => {
     setSelectedStoreId(readActiveStoreId(user?.uid))
+  }, [user?.uid])
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !user?.uid) {
+      return
+    }
+
+    const syncFromStorage = () => {
+      const persistedStoreId = readActiveStoreId(user.uid)
+      setSelectedStoreId(previous => (previous === persistedStoreId ? previous : persistedStoreId))
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.storageArea !== window.localStorage) {
+        return
+      }
+
+      if (event.key && !event.key.endsWith(user.uid)) {
+        return
+      }
+
+      syncFromStorage()
+    }
+
+    const handleActiveStoreUpdated = (event: Event) => {
+      const detail = (event as CustomEvent<{ uid?: string; storeId?: string }>).detail
+      if (detail?.uid !== user.uid) {
+        return
+      }
+
+      syncFromStorage()
+    }
+
+    window.addEventListener('storage', handleStorage)
+    window.addEventListener(ACTIVE_STORE_UPDATED_EVENT, handleActiveStoreUpdated)
+
+    return () => {
+      window.removeEventListener('storage', handleStorage)
+      window.removeEventListener(ACTIVE_STORE_UPDATED_EVENT, handleActiveStoreUpdated)
+    }
   }, [user?.uid])
 
   useEffect(() => {

--- a/web/src/utils/activeStoreStorage.ts
+++ b/web/src/utils/activeStoreStorage.ts
@@ -1,5 +1,11 @@
 const ACTIVE_STORE_STORAGE_PREFIX = 'activeStoreId:'
 const LEGACY_ACTIVE_STORE_STORAGE_KEY = 'activeStoreId'
+export const ACTIVE_STORE_UPDATED_EVENT = 'sedifex:active-store-updated'
+
+type ActiveStoreUpdatedDetail = {
+  uid: string
+  storeId: string
+}
 
 function hasWindow(): boolean {
   return typeof window !== 'undefined'
@@ -23,6 +29,18 @@ function normalizeStoreId(storeId: string | null | undefined): string | null {
 
 export function getActiveStoreStorageKey(uid: string): string {
   return `${ACTIVE_STORE_STORAGE_PREFIX}${uid}`
+}
+
+function dispatchActiveStoreUpdated(detail: ActiveStoreUpdatedDetail) {
+  if (!hasWindow()) {
+    return
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<ActiveStoreUpdatedDetail>(ACTIVE_STORE_UPDATED_EVENT, {
+      detail,
+    }),
+  )
 }
 
 export function readActiveStoreId(uid: string | null | undefined): string | null {
@@ -49,6 +67,7 @@ export function persistActiveStoreIdForUser(uid: string | null | undefined, stor
   try {
     window.localStorage.setItem(getActiveStoreStorageKey(normalizedUid), normalizedStoreId)
     window.localStorage.removeItem(LEGACY_ACTIVE_STORE_STORAGE_KEY)
+    dispatchActiveStoreUpdated({ uid: normalizedUid, storeId: normalizedStoreId })
   } catch {
     /* noop */
   }


### PR DESCRIPTION
### Motivation
- Ensure that when a user switches or adds a workspace the change is immediately reflected across all pages and hook instances (the dashboard and other pages were not always switching to the newly selected workspace).

### Description
- Exported a global event constant `ACTIVE_STORE_UPDATED_EVENT` and added `dispatchActiveStoreUpdated` in `web/src/utils/activeStoreStorage.ts`, and dispatch it whenever `persistActiveStoreIdForUser` writes the active store to `localStorage`.
- Updated `useActiveStore` in `web/src/hooks/useActiveStore.ts` to subscribe to both the browser `storage` event and the new custom `sedifex:active-store-updated` event and re-read persisted state so all hook instances in the same tab stay synchronized.
- Added a regression test in `web/src/hooks/useActiveStore.test.tsx` that renders two `useActiveStore` instances and verifies a workspace change in one instance updates the other.

### Testing
- Added the unit test `useActiveStore` that asserts cross-instance sync (test added to `web/src/hooks/useActiveStore.test.tsx`).
- Attempted to run `npm --prefix web test -- useActiveStore.test.tsx`, but the environment failed to run tests because `vitest` was not available (`vitest: not found`).
- Attempted `npm --prefix web install` to install dependencies but the environment yielded a `403 Forbidden` from the npm registry, so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13ba8f3708321aa8b5396033f7db4)