### PR TITLE
Add Send to Instagram/TikTok actions on Social media page

### DIFF
--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -22,6 +22,7 @@ type RegenerateTarget = 'all' | 'caption' | 'hashtags'
 type CopyTarget = 'caption' | 'hashtags' | 'full'
 type ContentTone = 'standard' | 'playful' | 'professional'
 type ContentLength = 'short' | 'medium' | 'long'
+type LaunchPlatformTarget = 'instagram' | 'tiktok'
 type SocialHistoryEntry = {
   id: string
   createdAtIso: string
@@ -511,6 +512,28 @@ export default function SocialMediaPage() {
     publish({ tone: 'success', message: 'Opened image in a new tab. Long-press or right-click to save it.' })
   }
 
+  async function handleSendToPlatform(target: LaunchPlatformTarget) {
+    if (!result) return
+
+    const fullText = [result.post.caption, contactCta, result.post.hashtags.join(' ')].filter(Boolean).join('\n\n')
+
+    try {
+      await navigator.clipboard.writeText(fullText)
+      publish({
+        tone: 'success',
+        message: `Draft copied. Paste it in ${target === 'instagram' ? 'Instagram' : 'TikTok'} after uploading the image.`,
+      })
+    } catch (_error) {
+      publish({
+        tone: 'error',
+        message: 'Could not copy draft automatically. You can still copy manually below.',
+      })
+    }
+
+    const destination = target === 'instagram' ? 'https://www.instagram.com/' : 'https://www.tiktok.com/upload?lang=en'
+    window.open(destination, '_blank', 'noopener,noreferrer')
+  }
+
   function handleDownload() {
     if (!result) return
     const body = [
@@ -667,8 +690,14 @@ export default function SocialMediaPage() {
                 </a>
               </p>
             ) : null}
-            <p style={{ margin: 0, fontSize: 13, opacity: 0.8 }}>Step 1: Download image. Step 2: Upload on Instagram/TikTok app. Step 3: Paste caption + hashtags.</p>
+            <p style={{ margin: 0, fontSize: 13, opacity: 0.8 }}>Step 1: Download image. Step 2: Use Send to Instagram/TikTok (or open app manually). Step 3: Paste caption + hashtags.</p>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('instagram')}>
+                Send to Instagram
+              </button>
+              <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('tiktok')}>
+                Send to TikTok
+              </button>
               <button type="button" className="button secondary" onClick={() => void handleCopy('caption')}>Copy caption</button>
               <button type="button" className="button secondary" onClick={() => void handleCopy('hashtags')}>Copy hashtags</button>
               <button type="button" className="button secondary" onClick={() => void handleCopy('full')}>Copy full draft</button>

--- a/web/src/pages/__tests__/SocialMediaPage.test.tsx
+++ b/web/src/pages/__tests__/SocialMediaPage.test.tsx
@@ -39,6 +39,8 @@ vi.mock('../../firebase', () => ({
 }))
 
 describe('SocialMediaPage manual flow', () => {
+  const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
   beforeEach(() => {
     mockUseActiveStore.mockReset()
     mockPublish.mockReset()
@@ -104,6 +106,7 @@ describe('SocialMediaPage manual flow', () => {
         disclaimer: null,
       },
     })
+    openSpy.mockClear()
   })
 
   it('renders phone contact details in the draft area without CTA label text', async () => {
@@ -189,5 +192,17 @@ describe('SocialMediaPage manual flow', () => {
     expect(screen.queryByText(/^Caption:/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/^Hashtags:/i)).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /download image/i })).toBeEnabled()
+  })
+
+  it('opens instagram when send button is used', async () => {
+    const user = userEvent.setup()
+    const clipboardSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValueOnce()
+    render(<SocialMediaPage />)
+
+    await user.click(screen.getByRole('button', { name: /generate social post/i }))
+    await user.click(await screen.findByRole('button', { name: /send to instagram/i }))
+
+    expect(openSpy).toHaveBeenCalledWith('https://www.instagram.com/', '_blank', 'noopener,noreferrer')
+    expect(clipboardSpy).toHaveBeenCalledWith(expect.stringContaining('Try our Zobo Mix today'))
   })
 })


### PR DESCRIPTION
### Motivation
- Provide a faster manual publishing flow from the Social media page by letting users copy the generated draft and open Instagram or TikTok directly.

### Description
- Add a `LaunchPlatformTarget` type and a `handleSendToPlatform` helper that copies the draft (caption + contact CTA + hashtags) to the clipboard and opens the chosen platform in a new tab.
- Add `Send to Instagram` and `Send to TikTok` action buttons to the generated-draft actions area and update the inline posting guidance text to reference the new send shortcuts.
- Update the UI to call `handleSendToPlatform` and keep existing `Copy`, `Download image`, and `Download .txt` flows intact.
- Add a unit test in `SocialMediaPage.test.tsx` that spies on `window.open` and `navigator.clipboard.writeText` to verify the Instagram send action behavior.

### Testing
- Attempted to run the test file with `npm --prefix web test -- SocialMediaPage.test.tsx`, but the run failed in this environment because `vitest` is not available on PATH (`sh: 1: vitest: not found`).
- The new test (`opens instagram when send button is used`) was added but not executed successfully in this environment due to the missing test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13fb72e348321a9867c9fd188eddd)