### PR TITLE
Consolidate social share actions into single copy flow and include image link

### DIFF
--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -19,7 +19,6 @@ type ProductOption = {
 }
 
 type RegenerateTarget = 'all' | 'caption' | 'hashtags'
-type CopyTarget = 'caption' | 'hashtags' | 'full'
 type ContentTone = 'standard' | 'playful' | 'professional'
 type ContentLength = 'short' | 'medium' | 'long'
 type LaunchPlatformTarget = 'instagram' | 'tiktok'
@@ -461,67 +460,29 @@ export default function SocialMediaPage() {
     }
   }
 
-  async function handleCopy(target: CopyTarget) {
+  async function handleCopyPost() {
     if (!result) return
-    const fullText = [result.post.caption, contactCta, result.post.hashtags.join(' ')].filter(Boolean).join('\n\n')
-    const text = target === 'caption' ? result.post.caption : target === 'hashtags' ? result.post.hashtags.join(' ') : fullText
+    const imageLine = result.product.imageUrl ? `Image: ${result.product.imageUrl}` : null
+    const fullText = [result.post.caption, contactCta, result.post.hashtags.join(' '), imageLine].filter(Boolean).join('\n\n')
     try {
-      await navigator.clipboard.writeText(text)
-      publish({ tone: 'success', message: `${target === 'full' ? 'Post draft' : target} copied.` })
+      await navigator.clipboard.writeText(fullText)
+      publish({ tone: 'success', message: 'Post text and image link copied.' })
     } catch (_error) {
       publish({ tone: 'error', message: 'Clipboard not available in this browser.' })
     }
   }
 
-  async function handleImageDownload() {
-    const imageUrl = result?.product.imageUrl
-    if (!imageUrl) {
-      publish({ tone: 'error', message: 'No image available to download for this item yet.' })
-      return
-    }
-
-    const suggestedName = `social-image-${new Date().toISOString().slice(0, 10)}.jpg`
-
-    try {
-      const response = await fetch(imageUrl, { mode: 'cors' })
-      if (!response.ok) {
-        throw new Error(`Image download failed with status ${response.status}`)
-      }
-      const blob = await response.blob()
-      const blobUrl = URL.createObjectURL(blob)
-      const link = document.createElement('a')
-      link.href = blobUrl
-      link.download = suggestedName
-      document.body.appendChild(link)
-      link.click()
-      link.remove()
-      URL.revokeObjectURL(blobUrl)
-      publish({ tone: 'success', message: 'Image downloaded. Upload it in your social app next.' })
-      return
-    } catch (error) {
-      console.warn('[social-media] Blob image download failed, falling back to new tab', error)
-    }
-
-    const link = document.createElement('a')
-    link.href = imageUrl
-    link.target = '_blank'
-    link.rel = 'noopener noreferrer'
-    document.body.appendChild(link)
-    link.click()
-    link.remove()
-    publish({ tone: 'success', message: 'Opened image in a new tab. Long-press or right-click to save it.' })
-  }
-
   async function handleSendToPlatform(target: LaunchPlatformTarget) {
     if (!result) return
 
-    const fullText = [result.post.caption, contactCta, result.post.hashtags.join(' ')].filter(Boolean).join('\n\n')
+    const imageLine = result.product.imageUrl ? `Image: ${result.product.imageUrl}` : null
+    const fullText = [result.post.caption, contactCta, result.post.hashtags.join(' '), imageLine].filter(Boolean).join('\n\n')
 
     try {
       await navigator.clipboard.writeText(fullText)
       publish({
         tone: 'success',
-        message: `Draft copied. Paste it in ${target === 'instagram' ? 'Instagram' : 'TikTok'} after uploading the image.`,
+        message: `Draft copied with image link. Paste it in ${target === 'instagram' ? 'Instagram' : 'TikTok'}.`,
       })
     } catch (_error) {
       publish({
@@ -536,19 +497,22 @@ export default function SocialMediaPage() {
 
   function handleDownload() {
     if (!result) return
+    const imageLine = result.product.imageUrl ? `Image: ${result.product.imageUrl}` : ''
     const body = [
       `Platform: ${result.post.platform}`,
       `Product: ${result.product.name}`,
       '',
       'Manual upload steps:',
-      '1. Download image.',
-      `2. Upload image in the ${result.post.platform === 'instagram' ? 'Instagram' : 'TikTok'} app.`,
-      '3. Paste caption + hashtags.',
+      '1. Open the original image link.',
+      '2. Hold (mobile) or right-click (desktop) the picture to save it.',
+      `3. Upload image in the ${result.post.platform === 'instagram' ? 'Instagram' : 'TikTok'} app.`,
+      '4. Paste caption + hashtags + image link.',
       '',
       'Draft content:',
       result.post.caption,
       contactCta,
       result.post.hashtags.join(' '),
+      imageLine,
       result.post.disclaimer ? `Disclaimer: ${result.post.disclaimer}` : '',
     ]
       .filter(Boolean)
@@ -681,7 +645,12 @@ export default function SocialMediaPage() {
             <p style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{contactCta}</p>
             <p style={{ margin: 0, color: 'var(--muted, #555)' }}>{result.post.hashtags.join(' ')}</p>
             {result.post.disclaimer ? <p style={{ margin: 0 }}><strong>Disclaimer:</strong> {result.post.disclaimer}</p> : null}
-            <p style={{ margin: 0 }}><strong>Selected image:</strong> {result.product.imageUrl ? 'Ready to download and upload manually.' : 'No image URL on this item yet.'}</p>
+            <p style={{ margin: 0 }}>
+              <strong>Selected image:</strong>{' '}
+              {result.product.imageUrl
+                ? 'Use Open original image, then hold/right-click the picture to save when needed.'
+                : 'No image URL on this item yet.'}
+            </p>
             {result.product.imageUrl ? (
               <p style={{ margin: 0, fontSize: 13 }}>
                 <strong>Image URL:</strong>{' '}
@@ -690,7 +659,9 @@ export default function SocialMediaPage() {
                 </a>
               </p>
             ) : null}
-            <p style={{ margin: 0, fontSize: 13, opacity: 0.8 }}>Step 1: Download image. Step 2: Use Send to Instagram/TikTok (or open app manually). Step 3: Paste caption + hashtags.</p>
+            <p style={{ margin: 0, fontSize: 13, opacity: 0.8 }}>
+              Step 1: Open original image and hold/right-click the picture to save. Step 2: Use Send to Instagram/TikTok (or open app manually). Step 3: Paste caption + hashtags + image link.
+            </p>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
               <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('instagram')}>
                 Send to Instagram
@@ -698,10 +669,7 @@ export default function SocialMediaPage() {
               <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('tiktok')}>
                 Send to TikTok
               </button>
-              <button type="button" className="button secondary" onClick={() => void handleCopy('caption')}>Copy caption</button>
-              <button type="button" className="button secondary" onClick={() => void handleCopy('hashtags')}>Copy hashtags</button>
-              <button type="button" className="button secondary" onClick={() => void handleCopy('full')}>Copy full draft</button>
-              <button type="button" className="button secondary" onClick={handleImageDownload} disabled={!result.product.imageUrl}>Download image</button>
+              <button type="button" className="button secondary" onClick={() => void handleCopyPost()}>Copy text + image link</button>
               <button type="button" className="button secondary" onClick={handleDownload}>Download .txt</button>
             </div>
           </div>

--- a/web/src/pages/__tests__/SocialMediaPage.test.tsx
+++ b/web/src/pages/__tests__/SocialMediaPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import SocialMediaPage from '../SocialMediaPage'
 
@@ -147,15 +147,18 @@ describe('SocialMediaPage manual flow', () => {
     expect(await screen.findByText('Call now: +15551234567 • Email: hello@example.com')).toBeInTheDocument()
   })
 
-  it('disables download image button when image URL is missing', async () => {
+  it('shows only one copy button for full content and no download image button', async () => {
     const user = userEvent.setup()
     render(<SocialMediaPage />)
 
     await user.click(screen.getByRole('button', { name: /generate social post/i }))
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /download image/i })).toBeDisabled()
-    })
+    await screen.findByText('Try our Zobo Mix today')
+    expect(screen.getByRole('button', { name: /copy text \+ image link/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /copy caption/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /copy hashtags/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /copy full draft/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /download image/i })).not.toBeInTheDocument()
   })
 
   it('normalizes mixed draft text so only caption and hashtags are shown', async () => {
@@ -191,12 +194,32 @@ describe('SocialMediaPage manual flow', () => {
     expect(screen.getByText('#AntiPimples #ClearSkin')).toBeInTheDocument()
     expect(screen.queryByText(/^Caption:/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/^Hashtags:/i)).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /download image/i })).toBeEnabled()
+    expect(screen.getByText(/open original image, then hold\/right-click the picture to save/i)).toBeInTheDocument()
   })
 
-  it('opens instagram when send button is used', async () => {
+  it('copies text and image link before opening instagram', async () => {
     const user = userEvent.setup()
     const clipboardSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValueOnce()
+    mockRequestSocialPost.mockResolvedValueOnce({
+      storeId: 'store-1',
+      productId: 'product-1',
+      product: {
+        id: 'product-1',
+        name: 'Zobo Mix',
+        category: 'Drinks',
+        description: 'Fresh and ready',
+        price: 15,
+        imageUrl: 'https://example.com/image.jpg',
+        itemType: 'product',
+      },
+      post: {
+        platform: 'instagram',
+        caption: 'Try our Zobo Mix today',
+        cta: 'Order now!',
+        hashtags: ['#zobo', '#ghana'],
+        disclaimer: null,
+      },
+    })
     render(<SocialMediaPage />)
 
     await user.click(screen.getByRole('button', { name: /generate social post/i }))
@@ -204,5 +227,39 @@ describe('SocialMediaPage manual flow', () => {
 
     expect(openSpy).toHaveBeenCalledWith('https://www.instagram.com/', '_blank', 'noopener,noreferrer')
     expect(clipboardSpy).toHaveBeenCalledWith(expect.stringContaining('Try our Zobo Mix today'))
+    expect(clipboardSpy).toHaveBeenCalledWith(expect.stringContaining('Image: https://example.com/image.jpg'))
+  })
+
+  it('copy text + image link button copies everything in one action', async () => {
+    const user = userEvent.setup()
+    const clipboardSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValueOnce()
+    mockRequestSocialPost.mockResolvedValueOnce({
+      storeId: 'store-1',
+      productId: 'product-1',
+      product: {
+        id: 'product-1',
+        name: 'Zobo Mix',
+        category: 'Drinks',
+        description: 'Fresh and ready',
+        price: 15,
+        imageUrl: 'https://example.com/image.jpg',
+        itemType: 'product',
+      },
+      post: {
+        platform: 'instagram',
+        caption: 'Try our Zobo Mix today',
+        cta: 'Order now!',
+        hashtags: ['#zobo', '#ghana'],
+        disclaimer: null,
+      },
+    })
+    render(<SocialMediaPage />)
+
+    await user.click(screen.getByRole('button', { name: /generate social post/i }))
+    await user.click(await screen.findByRole('button', { name: /copy text \+ image link/i }))
+
+    expect(clipboardSpy).toHaveBeenCalledWith(expect.stringContaining('Try our Zobo Mix today'))
+    expect(clipboardSpy).toHaveBeenCalledWith(expect.stringContaining('#zobo #ghana'))
+    expect(clipboardSpy).toHaveBeenCalledWith(expect.stringContaining('Image: https://example.com/image.jpg'))
   })
 })


### PR DESCRIPTION
### Motivation
- Simplify the Social media UI to a single, unambiguous copy action so users can copy everything needed in one step.
- Remove the fragile image download flow and instead instruct users to open the original image and hold/right-click to save, while ensuring shares include the image link.
- Ensure sharing to Instagram/TikTok copies caption + contact CTA + hashtags + image URL to the clipboard before opening the platform.

### Description
- Removed per-target copy buttons and the `handleImageDownload` flow and replaced them with a single `handleCopyPost` that copies caption, contact CTA, hashtags, and the product image URL.
- Updated `handleSendToPlatform` so clipboard content includes the image link and the success message reflects that it copied the image URL as well.
- Changed on-screen guidance and the downloadable `.txt` instructions to tell users to `Open original image` and `hold (mobile) or right-click (desktop)` the picture to save it.
- Updated the test file `web/src/pages/__tests__/SocialMediaPage.test.tsx` to assert only one copy button exists, the download-image button is gone, the send-to-platform flow copies the image link, and the single copy action contains caption, hashtags, and the image URL.

### Testing
- Updated unit tests in `web/src/pages/__tests__/SocialMediaPage.test.tsx` to cover the new single-copy behavior and send-to-platform clipboard content; the test file was modified but not executed successfully in this environment.
- Attempted to run `cd web && npm test -- src/pages/__tests__/SocialMediaPage.test.tsx` which failed with `vitest: not found` in the environment.
- Attempted `cd web && npm install` to install dev dependencies but it failed due to registry access returning `403 Forbidden`, so automated tests could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1421ef1788321b1f1726ffdffb872)