### PR TITLE
Booking ingestion: normalize attributes, alias mapping, sheet sync, and tests

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -37,7 +37,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkMessage = exports.emitBookingWebhooks = exports.emitProductWebhooks = exports.enrichProductDataAfterSave = exports.syncPublicProducts = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.v1IntegrationBookings = exports.v1IntegrationAvailability = exports.v1IntegrationPromo = exports.integrationPromo = exports.v1IntegrationProducts = exports.integrationProducts = exports.v1Products = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.revokeWebhookEndpoint = exports.upsertWebhookEndpoint = exports.listWebhookEndpoints = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.acceptStoreMasterInvite = exports.createStoreMasterInviteLink = exports.manageStaffAccount = exports.generateSocialPost = exports.generateAiAdvice = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
-exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = void 0;
+exports.__testing = exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = void 0;
 // functions/src/index.ts
 const functions = __importStar(require("firebase-functions/v1"));
 const crypto = __importStar(require("crypto"));
@@ -2916,6 +2916,166 @@ function toPlainObject(value) {
     }
     return value;
 }
+const BOOKING_ATTRIBUTE_MAX_KEYS = 40;
+const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500;
+const DEFAULT_BOOKING_ALIASES = {
+    customerName: ['name', 'fullName', 'customerName', 'clientName'],
+    customerPhone: ['phone', 'customerPhone', 'phoneNumber', 'mobile', 'whatsapp'],
+    customerEmail: ['email', 'customerEmail', 'emailAddress'],
+    serviceName: ['serviceName', 'productName', 'service_note_name', 'internalServiceName'],
+    bookingDate: ['date', 'bookingDate'],
+    bookingTime: ['time', 'bookingTime'],
+    preferredBranch: ['preferredBranch', 'branch', 'branchName'],
+    preferredContactMethod: ['preferredContactMethod', 'contactMethod'],
+    depositAmount: ['depositAmount', 'depositPaid', 'amountPaid'],
+    paymentMethod: ['paymentMethod'],
+};
+const DEFAULT_BOOKING_SHEET_HEADERS = {
+    customerName: 'Customer Name',
+    customerPhone: 'Customer Phone',
+    customerEmail: 'Customer Email',
+    serviceName: 'Service',
+    bookingDate: 'Booking Date',
+    bookingTime: 'Booking Time',
+    preferredBranch: 'Preferred Branch',
+    preferredContactMethod: 'Preferred Contact Method',
+    paymentMethod: 'Payment Method',
+    depositAmount: 'Deposit Amount',
+    status: 'Status',
+    quantity: 'Quantity',
+};
+function normalizeBookingAliasList(value) {
+    if (!Array.isArray(value))
+        return [];
+    return value
+        .map(item => (typeof item === 'string' ? item.trim() : ''))
+        .filter(item => item.length > 0)
+        .slice(0, 40);
+}
+function normalizeBookingHeaderMap(value) {
+    const objectValue = toPlainObject(value);
+    const normalized = {};
+    for (const [key, header] of Object.entries(objectValue)) {
+        if (typeof header !== 'string')
+            continue;
+        const normalizedHeader = header.trim().slice(0, 120);
+        if (!normalizedHeader)
+            continue;
+        normalized[key.trim()] = normalizedHeader;
+    }
+    return normalized;
+}
+async function loadBookingIngestionConfig(storeId) {
+    const storeSnap = await firestore_1.defaultDb.collection('stores').doc(storeId).get();
+    const storeData = (storeSnap.data() ?? {});
+    const integrationConfig = toPlainObject(storeData.integrationBookingConfig);
+    const fieldAliases = toPlainObject(integrationConfig.fieldAliases);
+    const aliases = {
+        customerName: [...DEFAULT_BOOKING_ALIASES.customerName, ...normalizeBookingAliasList(fieldAliases.customerName)],
+        customerPhone: [...DEFAULT_BOOKING_ALIASES.customerPhone, ...normalizeBookingAliasList(fieldAliases.customerPhone)],
+        customerEmail: [...DEFAULT_BOOKING_ALIASES.customerEmail, ...normalizeBookingAliasList(fieldAliases.customerEmail)],
+        serviceName: [...DEFAULT_BOOKING_ALIASES.serviceName, ...normalizeBookingAliasList(fieldAliases.serviceName)],
+        bookingDate: [...DEFAULT_BOOKING_ALIASES.bookingDate, ...normalizeBookingAliasList(fieldAliases.bookingDate)],
+        bookingTime: [...DEFAULT_BOOKING_ALIASES.bookingTime, ...normalizeBookingAliasList(fieldAliases.bookingTime)],
+        preferredBranch: [...DEFAULT_BOOKING_ALIASES.preferredBranch, ...normalizeBookingAliasList(fieldAliases.preferredBranch)],
+        preferredContactMethod: [
+            ...DEFAULT_BOOKING_ALIASES.preferredContactMethod,
+            ...normalizeBookingAliasList(fieldAliases.preferredContactMethod),
+        ],
+        depositAmount: [...DEFAULT_BOOKING_ALIASES.depositAmount, ...normalizeBookingAliasList(fieldAliases.depositAmount)],
+        paymentMethod: [...DEFAULT_BOOKING_ALIASES.paymentMethod, ...normalizeBookingAliasList(fieldAliases.paymentMethod)],
+    };
+    return {
+        mappingVersion: toTrimmedStringOrNull(integrationConfig.mappingVersion) ?? 'v1',
+        aliases,
+        sheetHeaders: {
+            ...DEFAULT_BOOKING_SHEET_HEADERS,
+            ...normalizeBookingHeaderMap(integrationConfig.sheetHeaders),
+        },
+    };
+}
+function canonicalizeBookingKey(key) {
+    return key.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+function buildBookingValueLookup(source) {
+    const lookup = new Map();
+    for (const [key, value] of Object.entries(source)) {
+        const normalized = canonicalizeBookingKey(key);
+        if (!normalized || lookup.has(normalized))
+            continue;
+        lookup.set(normalized, value);
+    }
+    return lookup;
+}
+function pickBookingValueFromAliases(options) {
+    for (const alias of options.aliases) {
+        const normalizedAlias = canonicalizeBookingKey(alias);
+        if (!normalizedAlias)
+            continue;
+        for (const lookup of options.lookups) {
+            if (lookup.has(normalizedAlias)) {
+                return lookup.get(normalizedAlias);
+            }
+        }
+    }
+    return null;
+}
+function sanitizeBookingAttributes(raw) {
+    const sanitized = {};
+    const truncatedKeys = [];
+    const droppedKeys = [];
+    const rawEntries = Object.entries(raw);
+    const keptEntries = rawEntries.slice(0, BOOKING_ATTRIBUTE_MAX_KEYS);
+    for (const [key, value] of keptEntries) {
+        const normalizedKey = key.trim().slice(0, 80);
+        if (!normalizedKey) {
+            droppedKeys.push(key);
+            continue;
+        }
+        if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+            sanitized[normalizedKey] = value;
+            continue;
+        }
+        if (typeof value === 'string') {
+            const nextValue = value.trim().slice(0, BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH);
+            if (nextValue.length < value.trim().length)
+                truncatedKeys.push(normalizedKey);
+            sanitized[normalizedKey] = nextValue;
+            continue;
+        }
+        if (Array.isArray(value)) {
+            if (value.length > 20)
+                truncatedKeys.push(normalizedKey);
+            sanitized[normalizedKey] = value.slice(0, 20);
+            continue;
+        }
+        if (value && typeof value === 'object') {
+            const stringified = JSON.stringify(value);
+            const nextValue = stringified.slice(0, BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH);
+            if (nextValue.length < stringified.length)
+                truncatedKeys.push(normalizedKey);
+            sanitized[normalizedKey] = nextValue;
+            continue;
+        }
+        const fallback = String(value);
+        const nextValue = fallback.slice(0, BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH);
+        if (nextValue.length < fallback.length)
+            truncatedKeys.push(normalizedKey);
+        sanitized[normalizedKey] = nextValue;
+    }
+    if (rawEntries.length > BOOKING_ATTRIBUTE_MAX_KEYS) {
+        droppedKeys.push(...rawEntries.slice(BOOKING_ATTRIBUTE_MAX_KEYS).map(([key]) => key));
+    }
+    return {
+        attributes: sanitized,
+        meta: {
+            totalReceived: rawEntries.length,
+            totalStored: Object.keys(sanitized).length,
+            truncatedKeys,
+            droppedKeys,
+        },
+    };
+}
 function mapAvailabilitySlotDoc(docSnap) {
     const data = docSnap.data();
     const storeId = toTrimmedStringOrNull(data.storeId);
@@ -2962,6 +3122,15 @@ function mapIntegrationBookingDoc(docSnap) {
         : 'confirmed';
     const customer = toPlainObject(data.customer);
     const quantityRaw = toFiniteNumber(data.quantity, 1);
+    const attributesMetaRaw = toPlainObject(data.attributesMeta);
+    const sheetSyncRaw = toPlainObject(data.sheetSync);
+    const sheetColumnsRaw = toPlainObject(sheetSyncRaw.columns);
+    const sheetColumns = {};
+    for (const [header, value] of Object.entries(sheetColumnsRaw)) {
+        if (value === null || typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value))) {
+            sheetColumns[header] = value;
+        }
+    }
     return {
         id: docSnap.id,
         storeId,
@@ -2975,6 +3144,37 @@ function mapIntegrationBookingDoc(docSnap) {
         },
         quantity: Math.max(1, Math.floor(quantityRaw)),
         notes: toTrimmedStringOrNull(data.notes),
+        importantFields: {
+            serviceName: toTrimmedStringOrNull(data.serviceName),
+            bookingDate: toTrimmedStringOrNull(data.date),
+            bookingTime: toTrimmedStringOrNull(data.time),
+            preferredBranch: toTrimmedStringOrNull(data.preferredBranch),
+            preferredContactMethod: toTrimmedStringOrNull(data.preferredContactMethod),
+            paymentMethod: toTrimmedStringOrNull(data.paymentMethod),
+            depositAmount: typeof data.depositAmount === 'number' && Number.isFinite(data.depositAmount)
+                ? data.depositAmount
+                : toTrimmedStringOrNull(data.depositAmount),
+        },
+        sheetSync: {
+            mappingVersion: toTrimmedStringOrNull(sheetSyncRaw.mappingVersion) ?? 'v1',
+            columns: sheetColumns,
+        },
+        attributesMeta: {
+            totalReceived: Math.max(0, Math.floor(toFiniteNumber(attributesMetaRaw.totalReceived, 0))),
+            totalStored: Math.max(0, Math.floor(toFiniteNumber(attributesMetaRaw.totalStored, 0))),
+            truncatedKeys: Array.isArray(attributesMetaRaw.truncatedKeys)
+                ? attributesMetaRaw.truncatedKeys
+                    .map(key => (typeof key === 'string' ? key.trim() : ''))
+                    .filter(Boolean)
+                    .slice(0, 100)
+                : [],
+            droppedKeys: Array.isArray(attributesMetaRaw.droppedKeys)
+                ? attributesMetaRaw.droppedKeys
+                    .map(key => (typeof key === 'string' ? key.trim() : ''))
+                    .filter(Boolean)
+                    .slice(0, 100)
+                : [],
+        },
         attributes: toPlainObject(data.attributes),
         createdAt: normalizeTimestampIso(data.createdAt),
         updatedAt: normalizeTimestampIso(data.updatedAt),
@@ -3764,6 +3964,7 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         return;
     }
     const payload = toPlainObject(req.body);
+    const bookingConfig = await loadBookingIngestionConfig(authContext.storeId);
     const serviceId = await resolveIntegrationBookingServiceId({
         storeId: authContext.storeId,
         payload,
@@ -3778,7 +3979,12 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
     const slotId = toTrimmedStringOrNull(payload.slotId) ??
         toTrimmedStringOrNull(payload.slotID) ??
         toTrimmedStringOrNull(payload.slot_id);
-    const payloadAttributes = toPlainObject(payload.attributes);
+    const sanitizedAttributesResult = sanitizeBookingAttributes(toPlainObject(payload.attributes));
+    const payloadAttributes = sanitizedAttributesResult.attributes;
+    const payloadLookup = buildBookingValueLookup(payload);
+    const attributesLookup = buildBookingValueLookup(payloadAttributes);
+    const customer = toPlainObject(payload.customer);
+    const customerLookup = buildBookingValueLookup(customer);
     const pickBookingString = (...values) => {
         for (const value of values) {
             const normalized = toTrimmedStringOrNull(value);
@@ -3812,24 +4018,53 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         }
         return null;
     };
-    const bookingDate = pickBookingString(payload.date, payload.bookingDate, payloadAttributes.date, payloadAttributes.bookingDate);
-    const bookingTime = pickBookingString(payload.time, payload.bookingTime, payloadAttributes.time, payloadAttributes.bookingTime);
-    const preferredBranch = pickBookingString(payload.preferredBranch, payload.branch, payload.branchName, payloadAttributes.preferredBranch, payloadAttributes.branch, payloadAttributes.branchName);
+    const bookingDate = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.bookingDate,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.date, payload.bookingDate, payloadAttributes.date, payloadAttributes.bookingDate);
+    const bookingTime = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.bookingTime,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.time, payload.bookingTime, payloadAttributes.time, payloadAttributes.bookingTime);
+    const preferredBranch = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.preferredBranch,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.preferredBranch, payload.branch, payload.branchName, payloadAttributes.preferredBranch, payloadAttributes.branch, payloadAttributes.branchName);
     const sessionType = pickBookingString(payload.sessionType, payload.duration, payload.sessionDuration, payloadAttributes.sessionType, payloadAttributes.duration, payloadAttributes.sessionDuration);
     const therapistPreference = pickBookingString(payload.therapistPreference, payload.preferredTherapist, payloadAttributes.therapistPreference, payloadAttributes.preferredTherapist);
-    const preferredContactMethod = pickBookingString(payload.preferredContactMethod, payload.contactMethod, payloadAttributes.preferredContactMethod, payloadAttributes.contactMethod);
-    const depositAmount = pickBookingAmount(payload.depositAmount, payload.depositPaid, payload.amountPaid, payloadAttributes.depositAmount, payloadAttributes.depositPaid, payloadAttributes.amountPaid);
-    const paymentMethod = pickBookingString(payload.paymentMethod, payloadAttributes.paymentMethod);
+    const preferredContactMethod = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.preferredContactMethod,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.preferredContactMethod, payload.contactMethod, payloadAttributes.preferredContactMethod, payloadAttributes.contactMethod);
+    const depositAmount = pickBookingAmount(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.depositAmount,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.depositAmount, payload.depositPaid, payload.amountPaid, payloadAttributes.depositAmount, payloadAttributes.depositPaid, payloadAttributes.amountPaid);
+    const paymentMethod = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.paymentMethod,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.paymentMethod, payloadAttributes.paymentMethod);
     const paymentScreenshotUrl = pickBookingString(payload.paymentScreenshotUrl, payload.screenshotUrl, payloadAttributes.paymentScreenshotUrl, payloadAttributes.screenshotUrl);
     const paymentScreenshotReady = pickBookingBoolean(payload.paymentScreenshotReady, payloadAttributes.paymentScreenshotReady);
     const noRefundAccepted = pickBookingBoolean(payload.noRefundAccepted, payload.agreeNoRefundPolicy, payloadAttributes.noRefundAccepted, payloadAttributes.agreeNoRefundPolicy);
-    const serviceName = pickBookingString(payload.serviceName, payload.productName, payload.service_note_name, payload.internalServiceName, payloadAttributes.serviceName, payloadAttributes.productName, payloadAttributes.service_note_name, payloadAttributes.internalServiceName);
+    const serviceName = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.serviceName,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.serviceName, payload.productName, payload.service_note_name, payload.internalServiceName, payloadAttributes.serviceName, payloadAttributes.productName, payloadAttributes.service_note_name, payloadAttributes.internalServiceName);
     const quantityRaw = toFiniteNumber(payload.quantity, 1);
     const quantity = Math.max(1, Math.floor(quantityRaw));
-    const customer = toPlainObject(payload.customer);
-    const customerName = toTrimmedStringOrNull(customer.name);
-    const customerPhone = toTrimmedStringOrNull(customer.phone);
-    const customerEmail = toTrimmedStringOrNull(customer.email);
+    const customerName = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.customerName,
+        lookups: [customerLookup, payloadLookup, attributesLookup],
+    }));
+    const customerPhone = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.customerPhone,
+        lookups: [customerLookup, payloadLookup, attributesLookup],
+    }));
+    const customerEmail = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.customerEmail,
+        lookups: [customerLookup, payloadLookup, attributesLookup],
+    }));
     if (!customerName && !customerPhone && !customerEmail) {
         res.status(400).json({ error: 'missing-customer-identity' });
         return;
@@ -3840,6 +4075,37 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         .collection('integrationBookings')
         .doc();
     const now = firestore_1.admin.firestore.FieldValue.serverTimestamp();
+    const importantFields = {
+        serviceName,
+        bookingDate,
+        bookingTime,
+        preferredBranch,
+        preferredContactMethod,
+        paymentMethod,
+        depositAmount,
+    };
+    const sheetColumns = {};
+    const sheetValueByCanonicalKey = {
+        customerName,
+        customerPhone,
+        customerEmail,
+        serviceName,
+        bookingDate,
+        bookingTime,
+        preferredBranch,
+        preferredContactMethod,
+        paymentMethod,
+        depositAmount: typeof depositAmount === 'number' && Number.isFinite(depositAmount) ? depositAmount : depositAmount ?? null,
+        status: 'confirmed',
+        quantity,
+    };
+    for (const [canonicalKey, header] of Object.entries(bookingConfig.sheetHeaders)) {
+        if (!header)
+            continue;
+        if (!Object.prototype.hasOwnProperty.call(sheetValueByCanonicalKey, canonicalKey))
+            continue;
+        sheetColumns[header] = sheetValueByCanonicalKey[canonicalKey] ?? null;
+    }
     const bookingData = {
         storeId: authContext.storeId,
         serviceId,
@@ -3853,21 +4119,26 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         name: customerName,
         phone: customerPhone,
         email: customerEmail,
-        serviceName,
-        date: bookingDate,
-        time: bookingTime,
-        preferredBranch,
+        serviceName: importantFields.serviceName,
+        date: importantFields.bookingDate,
+        time: importantFields.bookingTime,
+        preferredBranch: importantFields.preferredBranch,
         sessionType,
         therapistPreference,
-        preferredContactMethod,
-        depositAmount,
-        paymentMethod,
+        preferredContactMethod: importantFields.preferredContactMethod,
+        depositAmount: importantFields.depositAmount,
+        paymentMethod: importantFields.paymentMethod,
         paymentScreenshotUrl,
         paymentScreenshotReady,
         noRefundAccepted,
         quantity,
         notes: toTrimmedStringOrNull(payload.notes),
         attributes: payloadAttributes,
+        attributesMeta: sanitizedAttributesResult.meta,
+        sheetSync: {
+            mappingVersion: bookingConfig.mappingVersion,
+            columns: sheetColumns,
+        },
         source: 'website',
         createdAt: now,
         updatedAt: now,
@@ -5999,3 +6270,9 @@ exports.handlePaystackWebhook = functions.https.onRequest(async (req, res) => {
         res.status(500).send('error');
     }
 });
+exports.__testing = {
+    canonicalizeBookingKey,
+    buildBookingValueLookup,
+    pickBookingValueFromAliases,
+    sanitizeBookingAttributes,
+};

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,6 +7,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "rimraf lib && tsc",
+    "test": "node test/bookingNormalization.test.js",
     "clean": "rimraf lib",
     "serve": "firebase emulators:start --only functions",
     "deploy": "firebase deploy --only functions --project sedifex-web --force",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3778,6 +3778,201 @@ function toPlainObject(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>
 }
 
+const BOOKING_ATTRIBUTE_MAX_KEYS = 40
+const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500
+
+type BookingFieldAliasConfig = {
+  customerName: string[]
+  customerPhone: string[]
+  customerEmail: string[]
+  serviceName: string[]
+  bookingDate: string[]
+  bookingTime: string[]
+  preferredBranch: string[]
+  preferredContactMethod: string[]
+  depositAmount: string[]
+  paymentMethod: string[]
+}
+
+type BookingIngestionConfig = {
+  mappingVersion: string
+  aliases: BookingFieldAliasConfig
+  sheetHeaders: Record<string, string>
+}
+
+type SanitizedBookingAttributesResult = {
+  attributes: Record<string, unknown>
+  meta: {
+    totalReceived: number
+    totalStored: number
+    truncatedKeys: string[]
+    droppedKeys: string[]
+  }
+}
+
+const DEFAULT_BOOKING_ALIASES: BookingFieldAliasConfig = {
+  customerName: ['name', 'fullName', 'customerName', 'clientName'],
+  customerPhone: ['phone', 'customerPhone', 'phoneNumber', 'mobile', 'whatsapp'],
+  customerEmail: ['email', 'customerEmail', 'emailAddress'],
+  serviceName: ['serviceName', 'productName', 'service_note_name', 'internalServiceName'],
+  bookingDate: ['date', 'bookingDate'],
+  bookingTime: ['time', 'bookingTime'],
+  preferredBranch: ['preferredBranch', 'branch', 'branchName'],
+  preferredContactMethod: ['preferredContactMethod', 'contactMethod'],
+  depositAmount: ['depositAmount', 'depositPaid', 'amountPaid'],
+  paymentMethod: ['paymentMethod'],
+}
+
+const DEFAULT_BOOKING_SHEET_HEADERS: Record<string, string> = {
+  customerName: 'Customer Name',
+  customerPhone: 'Customer Phone',
+  customerEmail: 'Customer Email',
+  serviceName: 'Service',
+  bookingDate: 'Booking Date',
+  bookingTime: 'Booking Time',
+  preferredBranch: 'Preferred Branch',
+  preferredContactMethod: 'Preferred Contact Method',
+  paymentMethod: 'Payment Method',
+  depositAmount: 'Deposit Amount',
+  status: 'Status',
+  quantity: 'Quantity',
+}
+
+function normalizeBookingAliasList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map(item => (typeof item === 'string' ? item.trim() : ''))
+    .filter(item => item.length > 0)
+    .slice(0, 40)
+}
+
+function normalizeBookingHeaderMap(value: unknown): Record<string, string> {
+  const objectValue = toPlainObject(value)
+  const normalized: Record<string, string> = {}
+  for (const [key, header] of Object.entries(objectValue)) {
+    if (typeof header !== 'string') continue
+    const normalizedHeader = header.trim().slice(0, 120)
+    if (!normalizedHeader) continue
+    normalized[key.trim()] = normalizedHeader
+  }
+  return normalized
+}
+
+async function loadBookingIngestionConfig(storeId: string): Promise<BookingIngestionConfig> {
+  const storeSnap = await db.collection('stores').doc(storeId).get()
+  const storeData = (storeSnap.data() ?? {}) as Record<string, unknown>
+  const integrationConfig = toPlainObject(storeData.integrationBookingConfig)
+  const fieldAliases = toPlainObject(integrationConfig.fieldAliases)
+
+  const aliases: BookingFieldAliasConfig = {
+    customerName: [...DEFAULT_BOOKING_ALIASES.customerName, ...normalizeBookingAliasList(fieldAliases.customerName)],
+    customerPhone: [...DEFAULT_BOOKING_ALIASES.customerPhone, ...normalizeBookingAliasList(fieldAliases.customerPhone)],
+    customerEmail: [...DEFAULT_BOOKING_ALIASES.customerEmail, ...normalizeBookingAliasList(fieldAliases.customerEmail)],
+    serviceName: [...DEFAULT_BOOKING_ALIASES.serviceName, ...normalizeBookingAliasList(fieldAliases.serviceName)],
+    bookingDate: [...DEFAULT_BOOKING_ALIASES.bookingDate, ...normalizeBookingAliasList(fieldAliases.bookingDate)],
+    bookingTime: [...DEFAULT_BOOKING_ALIASES.bookingTime, ...normalizeBookingAliasList(fieldAliases.bookingTime)],
+    preferredBranch: [...DEFAULT_BOOKING_ALIASES.preferredBranch, ...normalizeBookingAliasList(fieldAliases.preferredBranch)],
+    preferredContactMethod: [
+      ...DEFAULT_BOOKING_ALIASES.preferredContactMethod,
+      ...normalizeBookingAliasList(fieldAliases.preferredContactMethod),
+    ],
+    depositAmount: [...DEFAULT_BOOKING_ALIASES.depositAmount, ...normalizeBookingAliasList(fieldAliases.depositAmount)],
+    paymentMethod: [...DEFAULT_BOOKING_ALIASES.paymentMethod, ...normalizeBookingAliasList(fieldAliases.paymentMethod)],
+  }
+
+  return {
+    mappingVersion: toTrimmedStringOrNull(integrationConfig.mappingVersion) ?? 'v1',
+    aliases,
+    sheetHeaders: {
+      ...DEFAULT_BOOKING_SHEET_HEADERS,
+      ...normalizeBookingHeaderMap(integrationConfig.sheetHeaders),
+    },
+  }
+}
+
+function canonicalizeBookingKey(key: string): string {
+  return key.trim().toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function buildBookingValueLookup(source: Record<string, unknown>): Map<string, unknown> {
+  const lookup = new Map<string, unknown>()
+  for (const [key, value] of Object.entries(source)) {
+    const normalized = canonicalizeBookingKey(key)
+    if (!normalized || lookup.has(normalized)) continue
+    lookup.set(normalized, value)
+  }
+  return lookup
+}
+
+function pickBookingValueFromAliases(options: {
+  aliases: string[]
+  lookups: Array<Map<string, unknown>>
+}): unknown {
+  for (const alias of options.aliases) {
+    const normalizedAlias = canonicalizeBookingKey(alias)
+    if (!normalizedAlias) continue
+    for (const lookup of options.lookups) {
+      if (lookup.has(normalizedAlias)) {
+        return lookup.get(normalizedAlias)
+      }
+    }
+  }
+  return null
+}
+
+function sanitizeBookingAttributes(raw: Record<string, unknown>): SanitizedBookingAttributesResult {
+  const sanitized: Record<string, unknown> = {}
+  const truncatedKeys: string[] = []
+  const droppedKeys: string[] = []
+  const rawEntries = Object.entries(raw)
+  const keptEntries = rawEntries.slice(0, BOOKING_ATTRIBUTE_MAX_KEYS)
+  for (const [key, value] of keptEntries) {
+    const normalizedKey = key.trim().slice(0, 80)
+    if (!normalizedKey) {
+      droppedKeys.push(key)
+      continue
+    }
+    if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+      sanitized[normalizedKey] = value
+      continue
+    }
+    if (typeof value === 'string') {
+      const nextValue = value.trim().slice(0, BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH)
+      if (nextValue.length < value.trim().length) truncatedKeys.push(normalizedKey)
+      sanitized[normalizedKey] = nextValue
+      continue
+    }
+    if (Array.isArray(value)) {
+      if (value.length > 20) truncatedKeys.push(normalizedKey)
+      sanitized[normalizedKey] = value.slice(0, 20)
+      continue
+    }
+    if (value && typeof value === 'object') {
+      const stringified = JSON.stringify(value)
+      const nextValue = stringified.slice(0, BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH)
+      if (nextValue.length < stringified.length) truncatedKeys.push(normalizedKey)
+      sanitized[normalizedKey] = nextValue
+      continue
+    }
+    const fallback = String(value)
+    const nextValue = fallback.slice(0, BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH)
+    if (nextValue.length < fallback.length) truncatedKeys.push(normalizedKey)
+    sanitized[normalizedKey] = nextValue
+  }
+  if (rawEntries.length > BOOKING_ATTRIBUTE_MAX_KEYS) {
+    droppedKeys.push(...rawEntries.slice(BOOKING_ATTRIBUTE_MAX_KEYS).map(([key]) => key))
+  }
+  return {
+    attributes: sanitized,
+    meta: {
+      totalReceived: rawEntries.length,
+      totalStored: Object.keys(sanitized).length,
+      truncatedKeys,
+      droppedKeys,
+    },
+  }
+}
+
 type IntegrationAvailabilitySlot = {
   id: string
   storeId: string
@@ -3843,6 +4038,25 @@ type IntegrationBookingRecord = {
   }
   quantity: number
   notes: string | null
+  importantFields: {
+    serviceName: string | null
+    bookingDate: string | null
+    bookingTime: string | null
+    preferredBranch: string | null
+    preferredContactMethod: string | null
+    paymentMethod: string | null
+    depositAmount: string | number | null
+  }
+  sheetSync: {
+    mappingVersion: string
+    columns: Record<string, string | number | null>
+  }
+  attributesMeta: {
+    totalReceived: number
+    totalStored: number
+    truncatedKeys: string[]
+    droppedKeys: string[]
+  }
   attributes: Record<string, unknown>
   createdAt: string | null
   updatedAt: string | null
@@ -3865,6 +4079,15 @@ function mapIntegrationBookingDoc(
 
   const customer = toPlainObject(data.customer)
   const quantityRaw = toFiniteNumber(data.quantity, 1)
+  const attributesMetaRaw = toPlainObject(data.attributesMeta)
+  const sheetSyncRaw = toPlainObject(data.sheetSync)
+  const sheetColumnsRaw = toPlainObject(sheetSyncRaw.columns)
+  const sheetColumns: Record<string, string | number | null> = {}
+  for (const [header, value] of Object.entries(sheetColumnsRaw)) {
+    if (value === null || typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value))) {
+      sheetColumns[header] = value
+    }
+  }
   return {
     id: docSnap.id,
     storeId,
@@ -3878,6 +4101,38 @@ function mapIntegrationBookingDoc(
     },
     quantity: Math.max(1, Math.floor(quantityRaw)),
     notes: toTrimmedStringOrNull(data.notes),
+    importantFields: {
+      serviceName: toTrimmedStringOrNull(data.serviceName),
+      bookingDate: toTrimmedStringOrNull(data.date),
+      bookingTime: toTrimmedStringOrNull(data.time),
+      preferredBranch: toTrimmedStringOrNull(data.preferredBranch),
+      preferredContactMethod: toTrimmedStringOrNull(data.preferredContactMethod),
+      paymentMethod: toTrimmedStringOrNull(data.paymentMethod),
+      depositAmount:
+        typeof data.depositAmount === 'number' && Number.isFinite(data.depositAmount)
+          ? data.depositAmount
+          : toTrimmedStringOrNull(data.depositAmount),
+    },
+    sheetSync: {
+      mappingVersion: toTrimmedStringOrNull(sheetSyncRaw.mappingVersion) ?? 'v1',
+      columns: sheetColumns,
+    },
+    attributesMeta: {
+      totalReceived: Math.max(0, Math.floor(toFiniteNumber(attributesMetaRaw.totalReceived, 0))),
+      totalStored: Math.max(0, Math.floor(toFiniteNumber(attributesMetaRaw.totalStored, 0))),
+      truncatedKeys: Array.isArray(attributesMetaRaw.truncatedKeys)
+        ? attributesMetaRaw.truncatedKeys
+            .map(key => (typeof key === 'string' ? key.trim() : ''))
+            .filter(Boolean)
+            .slice(0, 100)
+        : [],
+      droppedKeys: Array.isArray(attributesMetaRaw.droppedKeys)
+        ? attributesMetaRaw.droppedKeys
+            .map(key => (typeof key === 'string' ? key.trim() : ''))
+            .filter(Boolean)
+            .slice(0, 100)
+        : [],
+    },
     attributes: toPlainObject(data.attributes),
     createdAt: normalizeTimestampIso(data.createdAt),
     updatedAt: normalizeTimestampIso(data.updatedAt),
@@ -4746,6 +5001,7 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
   }
 
   const payload = toPlainObject(req.body)
+  const bookingConfig = await loadBookingIngestionConfig(authContext.storeId)
   const serviceId = await resolveIntegrationBookingServiceId({
     storeId: authContext.storeId,
     payload,
@@ -4763,7 +5019,12 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     toTrimmedStringOrNull(payload.slotId) ??
     toTrimmedStringOrNull(payload.slotID) ??
     toTrimmedStringOrNull(payload.slot_id)
-  const payloadAttributes = toPlainObject(payload.attributes)
+  const sanitizedAttributesResult = sanitizeBookingAttributes(toPlainObject(payload.attributes))
+  const payloadAttributes = sanitizedAttributesResult.attributes
+  const payloadLookup = buildBookingValueLookup(payload)
+  const attributesLookup = buildBookingValueLookup(payloadAttributes)
+  const customer = toPlainObject(payload.customer)
+  const customerLookup = buildBookingValueLookup(customer)
   const pickBookingString = (...values: unknown[]) => {
     for (const value of values) {
       const normalized = toTrimmedStringOrNull(value)
@@ -4791,9 +5052,31 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     }
     return null
   }
-  const bookingDate = pickBookingString(payload.date, payload.bookingDate, payloadAttributes.date, payloadAttributes.bookingDate)
-  const bookingTime = pickBookingString(payload.time, payload.bookingTime, payloadAttributes.time, payloadAttributes.bookingTime)
+  const bookingDate = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.bookingDate,
+      lookups: [payloadLookup, attributesLookup],
+    }),
+    payload.date,
+    payload.bookingDate,
+    payloadAttributes.date,
+    payloadAttributes.bookingDate,
+  )
+  const bookingTime = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.bookingTime,
+      lookups: [payloadLookup, attributesLookup],
+    }),
+    payload.time,
+    payload.bookingTime,
+    payloadAttributes.time,
+    payloadAttributes.bookingTime,
+  )
   const preferredBranch = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.preferredBranch,
+      lookups: [payloadLookup, attributesLookup],
+    }),
     payload.preferredBranch,
     payload.branch,
     payload.branchName,
@@ -4816,12 +5099,20 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     payloadAttributes.preferredTherapist,
   )
   const preferredContactMethod = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.preferredContactMethod,
+      lookups: [payloadLookup, attributesLookup],
+    }),
     payload.preferredContactMethod,
     payload.contactMethod,
     payloadAttributes.preferredContactMethod,
     payloadAttributes.contactMethod,
   )
   const depositAmount = pickBookingAmount(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.depositAmount,
+      lookups: [payloadLookup, attributesLookup],
+    }),
     payload.depositAmount,
     payload.depositPaid,
     payload.amountPaid,
@@ -4829,7 +5120,14 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     payloadAttributes.depositPaid,
     payloadAttributes.amountPaid,
   )
-  const paymentMethod = pickBookingString(payload.paymentMethod, payloadAttributes.paymentMethod)
+  const paymentMethod = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.paymentMethod,
+      lookups: [payloadLookup, attributesLookup],
+    }),
+    payload.paymentMethod,
+    payloadAttributes.paymentMethod,
+  )
   const paymentScreenshotUrl = pickBookingString(
     payload.paymentScreenshotUrl,
     payload.screenshotUrl,
@@ -4844,6 +5142,10 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     payloadAttributes.agreeNoRefundPolicy,
   )
   const serviceName = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.serviceName,
+      lookups: [payloadLookup, attributesLookup],
+    }),
     payload.serviceName,
     payload.productName,
     payload.service_note_name,
@@ -4855,10 +5157,24 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
   )
   const quantityRaw = toFiniteNumber(payload.quantity, 1)
   const quantity = Math.max(1, Math.floor(quantityRaw))
-  const customer = toPlainObject(payload.customer)
-  const customerName = toTrimmedStringOrNull(customer.name)
-  const customerPhone = toTrimmedStringOrNull(customer.phone)
-  const customerEmail = toTrimmedStringOrNull(customer.email)
+  const customerName = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.customerName,
+      lookups: [customerLookup, payloadLookup, attributesLookup],
+    }),
+  )
+  const customerPhone = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.customerPhone,
+      lookups: [customerLookup, payloadLookup, attributesLookup],
+    }),
+  )
+  const customerEmail = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.customerEmail,
+      lookups: [customerLookup, payloadLookup, attributesLookup],
+    }),
+  )
   if (!customerName && !customerPhone && !customerEmail) {
     res.status(400).json({ error: 'missing-customer-identity' })
     return
@@ -4870,6 +5186,35 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     .collection('integrationBookings')
     .doc()
   const now = admin.firestore.FieldValue.serverTimestamp()
+  const importantFields = {
+    serviceName,
+    bookingDate,
+    bookingTime,
+    preferredBranch,
+    preferredContactMethod,
+    paymentMethod,
+    depositAmount,
+  }
+  const sheetColumns: Record<string, string | number | null> = {}
+  const sheetValueByCanonicalKey: Record<string, string | number | null> = {
+    customerName,
+    customerPhone,
+    customerEmail,
+    serviceName,
+    bookingDate,
+    bookingTime,
+    preferredBranch,
+    preferredContactMethod,
+    paymentMethod,
+    depositAmount: typeof depositAmount === 'number' && Number.isFinite(depositAmount) ? depositAmount : depositAmount ?? null,
+    status: 'confirmed',
+    quantity,
+  }
+  for (const [canonicalKey, header] of Object.entries(bookingConfig.sheetHeaders)) {
+    if (!header) continue
+    if (!Object.prototype.hasOwnProperty.call(sheetValueByCanonicalKey, canonicalKey)) continue
+    sheetColumns[header] = sheetValueByCanonicalKey[canonicalKey] ?? null
+  }
   const bookingData = {
     storeId: authContext.storeId,
     serviceId,
@@ -4883,21 +5228,26 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     name: customerName,
     phone: customerPhone,
     email: customerEmail,
-    serviceName,
-    date: bookingDate,
-    time: bookingTime,
-    preferredBranch,
+    serviceName: importantFields.serviceName,
+    date: importantFields.bookingDate,
+    time: importantFields.bookingTime,
+    preferredBranch: importantFields.preferredBranch,
     sessionType,
     therapistPreference,
-    preferredContactMethod,
-    depositAmount,
-    paymentMethod,
+    preferredContactMethod: importantFields.preferredContactMethod,
+    depositAmount: importantFields.depositAmount,
+    paymentMethod: importantFields.paymentMethod,
     paymentScreenshotUrl,
     paymentScreenshotReady,
     noRefundAccepted,
     quantity,
     notes: toTrimmedStringOrNull(payload.notes),
     attributes: payloadAttributes,
+    attributesMeta: sanitizedAttributesResult.meta,
+    sheetSync: {
+      mappingVersion: bookingConfig.mappingVersion,
+      columns: sheetColumns,
+    },
     source: 'website',
     createdAt: now,
     updatedAt: now,
@@ -7500,3 +7850,10 @@ export const handlePaystackWebhook = functions.https.onRequest(async (req, res) 
     res.status(500).send('error')
   }
 })
+
+export const __testing = {
+  canonicalizeBookingKey,
+  buildBookingValueLookup,
+  pickBookingValueFromAliases,
+  sanitizeBookingAttributes,
+}

--- a/functions/test/bookingNormalization.test.js
+++ b/functions/test/bookingNormalization.test.js
@@ -1,0 +1,95 @@
+const assert = require('assert')
+const Module = require('module')
+
+let currentDefaultDb = {
+  collection: () => ({
+    doc: () => ({
+      get: async () => ({ data: () => ({}) }),
+    }),
+  }),
+}
+
+const originalLoad = Module._load
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'firebase-admin') {
+    const firestore = () => currentDefaultDb
+    firestore.FieldValue = {
+      serverTimestamp: () => ({ __mockServerTimestamp: true }),
+      increment: value => ({ __mockIncrement: value }),
+    }
+    firestore.Timestamp = {
+      fromDate: value => value,
+    }
+
+    return {
+      initializeApp: () => ({ name: 'mock-app' }),
+      app: () => ({ name: 'mock-app' }),
+      apps: [{ name: 'mock-app' }],
+      firestore,
+      auth: () => ({
+        getUser: async () => null,
+        setCustomUserClaims: async () => {},
+      }),
+    }
+  }
+
+  if (request === 'firebase-admin/firestore') {
+    return {
+      getFirestore: () => currentDefaultDb,
+    }
+  }
+
+  return originalLoad(request, parent, isMain)
+}
+
+function loadFunctionsModule() {
+  delete require.cache[require.resolve('../lib/index.js')]
+  return require('../lib/index.js')
+}
+
+function runCanonicalKeyTests(testing) {
+  assert.strictEqual(testing.canonicalizeBookingKey(' Customer_Name '), 'customername')
+  assert.strictEqual(testing.canonicalizeBookingKey('customer-name'), 'customername')
+}
+
+function runLookupTests(testing) {
+  const lookup = testing.buildBookingValueLookup({
+    Customer_Name: 'Ama',
+    customerPhone: '+233123',
+  })
+
+  const name = testing.pickBookingValueFromAliases({
+    aliases: ['customerName'],
+    lookups: [lookup],
+  })
+  assert.strictEqual(name, 'Ama')
+}
+
+function runSanitizeTests(testing) {
+  const raw = {
+    short: 'ok',
+    long: 'x'.repeat(800),
+    list: new Array(50).fill('a'),
+  }
+  const result = testing.sanitizeBookingAttributes(raw)
+
+  assert.strictEqual(typeof result.attributes.short, 'string')
+  assert.strictEqual(result.attributes.long.length, 500)
+  assert.strictEqual(result.attributes.list.length, 20)
+  assert.ok(result.meta.truncatedKeys.includes('long'))
+  assert.ok(result.meta.truncatedKeys.includes('list'))
+  assert.strictEqual(result.meta.totalReceived, 3)
+  assert.strictEqual(result.meta.totalStored, 3)
+}
+
+function run() {
+  const module = loadFunctionsModule()
+  assert.ok(module.__testing, 'Expected __testing exports')
+
+  runCanonicalKeyTests(module.__testing)
+  runLookupTests(module.__testing)
+  runSanitizeTests(module.__testing)
+}
+
+run()
+console.log('bookingNormalization tests passed')


### PR DESCRIPTION
### Motivation
- Normalize and sanitize free-form booking payloads to improve reliability when ingesting bookings from external integrations and websites.  
- Provide flexible alias mapping and configurable sheet header mapping so stores can supply different field names without breaking ingestion.  
- Capture metadata about stored attributes and make helper functions testable for easier validation and debugging.

### Description
- Added booking ingestion utilities including `canonicalizeBookingKey`, `buildBookingValueLookup`, `pickBookingValueFromAliases`, `sanitizeBookingAttributes`, `normalizeBookingAliasList`, `normalizeBookingHeaderMap`, and `loadBookingIngestionConfig` to parse aliases, sanitize attributes, and build sheet column mappings.  
- Integrated the new normalization logic into the `v1IntegrationBookings` flow to sanitize `attributes`, select important fields via alias lookups, populate `attributesMeta` and `sheetSync` in stored booking documents, and ensure consistent `importantFields`.  
- Extended `mapIntegrationBookingDoc` to return `importantFields`, `sheetSync`, and `attributesMeta`, and exported internal helpers under `__testing` for unit testing.  
- Added a test harness `functions/test/bookingNormalization.test.js` and a `test` script in `functions/package.json` to run the normalization tests.

### Testing
- Ran the new booking normalization unit tests with `node functions/test/bookingNormalization.test.js` (invoked via `npm --prefix functions test`) and the tests passed.  
- No other automated test changes were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1490f38088321b9911260461af74c)