### PR TITLE
Add Booking Mapping settings UI for integrationBookingConfig

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -30,6 +30,7 @@ import DataTransfer from './pages/DataTransfer'
 import PromoLandingPage from './pages/PromoLandingPage'
 import PublicPageSettings from './pages/PublicPageSettings'
 import SocialMediaPage from './pages/SocialMediaPage'
+import BookingMappingSettings from './pages/BookingMappingSettings'
 
 // ✅ NEW: public receipt page used by QR/share
 import ReceiptView from './pages/ReceiptView'
@@ -93,6 +94,7 @@ const router = createBrowserRouter([
           { path: 'social-media', element: <SocialMediaPage /> },
           { path: 'merchant-feed', element: <Navigate to="/social-media" replace /> },
           { path: 'support', element: <Support /> },
+          { path: 'settings/integrations/booking-mapping', element: <BookingMappingSettings /> },
         ],
       },
 

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -2030,6 +2030,11 @@ export default function AccountOverview({
           <div className="account-overview__website-sync" role="status" aria-live="polite">
             <p className="account-overview__website-sync-title">Choose your integration tutorial.</p>
             <p className="account-overview__hint">
+              Booking ingestion mapping can be managed in
+              {' '}
+              <Link to="/settings/integrations/booking-mapping">Settings → Integrations → Booking Mapping</Link>.
+            </p>
+            <p className="account-overview__hint">
               Sedifex supports both WordPress and Next.js storefronts.
               {' '}
               <a href="/docs/integration-quickstart" target="_blank" rel="noreferrer">

--- a/web/src/pages/BookingMappingSettings.css
+++ b/web/src/pages/BookingMappingSettings.css
@@ -1,0 +1,136 @@
+.booking-mapping-settings {
+  display: grid;
+  gap: 1rem;
+}
+
+.booking-mapping-settings__card {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.booking-mapping-settings__header h1 {
+  margin: 0.25rem 0;
+}
+
+.booking-mapping-settings__crumbs {
+  margin: 0;
+  font-size: 0.86rem;
+  color: var(--text-muted, #64748b);
+}
+
+.booking-mapping-settings__section {
+  border-top: 1px solid var(--border-color, #e2e8f0);
+  padding-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.booking-mapping-settings__section h2,
+.booking-mapping-settings__alias-card h3 {
+  margin: 0;
+}
+
+.booking-mapping-settings__alias-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.85rem;
+}
+
+.booking-mapping-settings__alias-card {
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 0.75rem;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.booking-mapping-settings__chips {
+  min-height: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.booking-mapping-settings__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  background: #f8fafc;
+}
+
+.booking-mapping-settings__chip button {
+  border: 0;
+  background: transparent;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  color: inherit;
+}
+
+.booking-mapping-settings__alias-input-row {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.booking-mapping-settings__alias-input-row input {
+  flex: 1;
+}
+
+.booking-mapping-settings__header-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.booking-mapping-settings__feedback {
+  border-radius: 0.625rem;
+  padding: 0.75rem 0.875rem;
+  margin: 0;
+}
+
+.booking-mapping-settings__feedback--error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+.booking-mapping-settings__feedback--success {
+  background: #f0fdf4;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+}
+
+.booking-mapping-settings__feedback--warning {
+  background: #fffbeb;
+  color: #92400e;
+  border: 1px solid #fcd34d;
+}
+
+.booking-mapping-settings__feedback ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.booking-mapping-settings__preview-table-wrapper {
+  overflow-x: auto;
+}
+
+.booking-mapping-settings__preview-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.booking-mapping-settings__preview-table th,
+.booking-mapping-settings__preview-table td {
+  text-align: left;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  padding: 0.55rem;
+}
+
+.booking-mapping-settings__actions {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/web/src/pages/BookingMappingSettings.tsx
+++ b/web/src/pages/BookingMappingSettings.tsx
@@ -1,0 +1,461 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { doc, getDoc, setDoc } from 'firebase/firestore'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import './BookingMappingSettings.css'
+
+const MAX_ALIASES_PER_FIELD = 40
+
+type CanonicalFieldKey =
+  | 'customerName'
+  | 'customerPhone'
+  | 'customerEmail'
+  | 'serviceName'
+  | 'bookingDate'
+  | 'bookingTime'
+  | 'preferredBranch'
+  | 'preferredContactMethod'
+  | 'depositAmount'
+  | 'paymentMethod'
+
+type SheetOnlyKey = 'status' | 'quantity'
+
+type SheetHeaderKey = CanonicalFieldKey | SheetOnlyKey
+
+const CANONICAL_FIELD_KEYS: CanonicalFieldKey[] = [
+  'customerName',
+  'customerPhone',
+  'customerEmail',
+  'serviceName',
+  'bookingDate',
+  'bookingTime',
+  'preferredBranch',
+  'preferredContactMethod',
+  'depositAmount',
+  'paymentMethod',
+]
+
+const SHEET_HEADER_KEYS: SheetHeaderKey[] = [...CANONICAL_FIELD_KEYS, 'status', 'quantity']
+
+const FIELD_LABELS: Record<SheetHeaderKey, string> = {
+  customerName: 'Customer name',
+  customerPhone: 'Customer phone',
+  customerEmail: 'Customer email',
+  serviceName: 'Service name',
+  bookingDate: 'Booking date',
+  bookingTime: 'Booking time',
+  preferredBranch: 'Preferred branch',
+  preferredContactMethod: 'Preferred contact method',
+  depositAmount: 'Deposit amount',
+  paymentMethod: 'Payment method',
+  status: 'Status',
+  quantity: 'Quantity',
+}
+
+const DEFAULT_SHEET_HEADERS: Record<SheetHeaderKey, string> = {
+  customerName: 'Customer Name',
+  customerPhone: 'Customer Phone',
+  customerEmail: 'Customer Email',
+  serviceName: 'Service',
+  bookingDate: 'Booking Date',
+  bookingTime: 'Booking Time',
+  preferredBranch: 'Preferred Branch',
+  preferredContactMethod: 'Preferred Contact Method',
+  depositAmount: 'Deposit Amount',
+  paymentMethod: 'Payment Method',
+  status: 'Status',
+  quantity: 'Quantity',
+}
+
+type AliasState = Record<CanonicalFieldKey, string[]>
+type HeaderState = Record<SheetHeaderKey, string>
+type AliasDraftState = Record<CanonicalFieldKey, string>
+
+function toTrimmedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function buildDefaultAliasState(): AliasState {
+  return CANONICAL_FIELD_KEYS.reduce((acc, key) => {
+    acc[key] = []
+    return acc
+  }, {} as AliasState)
+}
+
+function buildDefaultHeaderState(): HeaderState {
+  return SHEET_HEADER_KEYS.reduce((acc, key) => {
+    acc[key] = DEFAULT_SHEET_HEADERS[key]
+    return acc
+  }, {} as HeaderState)
+}
+
+function buildDefaultAliasDraftState(): AliasDraftState {
+  return CANONICAL_FIELD_KEYS.reduce((acc, key) => {
+    acc[key] = ''
+    return acc
+  }, {} as AliasDraftState)
+}
+
+function splitAliases(value: string): string[] {
+  return value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+export default function BookingMappingSettings() {
+  const { storeId, isLoading: storeLoading, error: storeError } = useActiveStore()
+  const [aliasesByField, setAliasesByField] = useState<AliasState>(buildDefaultAliasState)
+  const [aliasDraftByField, setAliasDraftByField] = useState<AliasDraftState>(buildDefaultAliasDraftState)
+  const [sheetHeaders, setSheetHeaders] = useState<HeaderState>(buildDefaultHeaderState)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [saveMessage, setSaveMessage] = useState<string | null>(null)
+
+  const duplicateHeaderGroups = useMemo(() => {
+    const headerToKeys = new Map<string, SheetHeaderKey[]>()
+
+    for (const key of SHEET_HEADER_KEYS) {
+      const normalizedHeader = sheetHeaders[key].trim().toLowerCase()
+      if (!normalizedHeader) continue
+      const existing = headerToKeys.get(normalizedHeader) ?? []
+      existing.push(key)
+      headerToKeys.set(normalizedHeader, existing)
+    }
+
+    return Array.from(headerToKeys.values()).filter(keys => keys.length > 1)
+  }, [sheetHeaders])
+
+  const hasHeaderValidationError = useMemo(
+    () => SHEET_HEADER_KEYS.some(key => !sheetHeaders[key].trim()),
+    [sheetHeaders],
+  )
+
+  useEffect(() => {
+    if (!storeId) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    async function loadConfig() {
+      setLoading(true)
+      setErrorMessage(null)
+      setSaveMessage(null)
+
+      try {
+        const storeSnap = await getDoc(doc(db, 'stores', storeId))
+        const storeData = (storeSnap.data() ?? {}) as Record<string, unknown>
+        const configRaw =
+          storeData.integrationBookingConfig && typeof storeData.integrationBookingConfig === 'object'
+            ? (storeData.integrationBookingConfig as Record<string, unknown>)
+            : {}
+
+        const aliasesRaw =
+          configRaw.fieldAliases && typeof configRaw.fieldAliases === 'object'
+            ? (configRaw.fieldAliases as Record<string, unknown>)
+            : {}
+
+        const nextAliases = buildDefaultAliasState()
+        for (const key of CANONICAL_FIELD_KEYS) {
+          const rawList = aliasesRaw[key]
+          if (!Array.isArray(rawList)) continue
+
+          const normalizedList = Array.from(
+            new Set(
+              rawList
+                .map(item => toTrimmedString(item))
+                .filter(Boolean),
+            ),
+          ).slice(0, MAX_ALIASES_PER_FIELD)
+
+          nextAliases[key] = normalizedList
+        }
+
+        const sheetHeadersRaw =
+          configRaw.sheetHeaders && typeof configRaw.sheetHeaders === 'object'
+            ? (configRaw.sheetHeaders as Record<string, unknown>)
+            : {}
+
+        const nextHeaders = buildDefaultHeaderState()
+        for (const key of SHEET_HEADER_KEYS) {
+          const providedHeader = toTrimmedString(sheetHeadersRaw[key])
+          if (providedHeader) {
+            nextHeaders[key] = providedHeader.slice(0, 120)
+          }
+        }
+
+        if (!cancelled) {
+          setAliasesByField(nextAliases)
+          setSheetHeaders(nextHeaders)
+        }
+      } catch (error) {
+        console.error('[booking-mapping] Failed to load integrationBookingConfig', error)
+        if (!cancelled) {
+          setErrorMessage('Unable to load booking mapping settings right now. Please try again.')
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    loadConfig().catch(error => {
+      console.error('[booking-mapping] Unexpected load failure', error)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [storeId])
+
+  const addAliases = useCallback((field: CanonicalFieldKey, rawInput: string) => {
+    const parsed = splitAliases(rawInput)
+    if (parsed.length === 0) return
+
+    setAliasesByField(previous => {
+      const existing = previous[field]
+      const normalizedExisting = new Set(existing.map(alias => alias.toLowerCase()))
+      const merged = [...existing]
+
+      for (const alias of parsed) {
+        if (merged.length >= MAX_ALIASES_PER_FIELD) break
+        const normalizedAlias = alias.toLowerCase()
+        if (normalizedExisting.has(normalizedAlias)) continue
+        merged.push(alias)
+        normalizedExisting.add(normalizedAlias)
+      }
+
+      return {
+        ...previous,
+        [field]: merged,
+      }
+    })
+  }, [])
+
+  const removeAlias = useCallback((field: CanonicalFieldKey, alias: string) => {
+    setAliasesByField(previous => ({
+      ...previous,
+      [field]: previous[field].filter(existing => existing !== alias),
+    }))
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    if (!storeId) {
+      setErrorMessage('Select a workspace before editing booking mapping settings.')
+      return
+    }
+
+    if (hasHeaderValidationError) {
+      setErrorMessage('Every sheet header must have a label before saving.')
+      return
+    }
+
+    if (CANONICAL_FIELD_KEYS.some(key => aliasesByField[key].length > MAX_ALIASES_PER_FIELD)) {
+      setErrorMessage(`Each field supports up to ${MAX_ALIASES_PER_FIELD} aliases.`)
+      return
+    }
+
+    setSaving(true)
+    setErrorMessage(null)
+    setSaveMessage(null)
+
+    try {
+      await setDoc(
+        doc(db, 'stores', storeId),
+        {
+          integrationBookingConfig: {
+            mappingVersion: 'v1',
+            fieldAliases: aliasesByField,
+            sheetHeaders,
+          },
+        },
+        { merge: true },
+      )
+
+      setSaveMessage('Booking mapping saved. New ingested bookings will use this config immediately.')
+    } catch (error) {
+      console.error('[booking-mapping] Failed to save integrationBookingConfig', error)
+      setErrorMessage('Unable to save booking mapping right now. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }, [aliasesByField, hasHeaderValidationError, sheetHeaders, storeId])
+
+  return (
+    <main className="page booking-mapping-settings">
+      <section className="card booking-mapping-settings__card" aria-labelledby="booking-mapping-title">
+        <header className="booking-mapping-settings__header">
+          <p className="booking-mapping-settings__crumbs">Settings → Integrations → Booking Mapping</p>
+          <h1 id="booking-mapping-title">Booking mapping</h1>
+          <p className="form__hint">
+            Configure alias lookups and sheet column headers used by booking ingestion.
+          </p>
+          <p className="form__hint">
+            <Link to="/account">Back to Integrations</Link>
+          </p>
+        </header>
+
+        {(storeError || errorMessage) && (
+          <p className="booking-mapping-settings__feedback booking-mapping-settings__feedback--error" role="alert">
+            {storeError ?? errorMessage}
+          </p>
+        )}
+        {saveMessage && (
+          <p className="booking-mapping-settings__feedback booking-mapping-settings__feedback--success" role="status">
+            {saveMessage}
+          </p>
+        )}
+
+        {(storeLoading || loading) && <p className="form__hint">Loading booking mapping settings…</p>}
+
+        {!storeLoading && !loading && storeId && (
+          <>
+            <section className="booking-mapping-settings__section" aria-labelledby="booking-aliases-heading">
+              <h2 id="booking-aliases-heading">Field aliases</h2>
+              <p className="form__hint">
+                Add custom aliases that should map to each canonical field (up to {MAX_ALIASES_PER_FIELD} aliases per field).
+              </p>
+
+              <div className="booking-mapping-settings__alias-grid">
+                {CANONICAL_FIELD_KEYS.map(field => (
+                  <article key={field} className="booking-mapping-settings__alias-card">
+                    <h3>{FIELD_LABELS[field]}</h3>
+                    <div className="booking-mapping-settings__chips" aria-live="polite">
+                      {aliasesByField[field].length === 0 ? (
+                        <span className="form__hint">No custom aliases yet.</span>
+                      ) : (
+                        aliasesByField[field].map(alias => (
+                          <span key={alias} className="booking-mapping-settings__chip">
+                            <code>{alias}</code>
+                            <button
+                              type="button"
+                              aria-label={`Remove ${alias} alias from ${FIELD_LABELS[field]}`}
+                              onClick={() => removeAlias(field, alias)}
+                            >
+                              ×
+                            </button>
+                          </span>
+                        ))
+                      )}
+                    </div>
+
+                    <label>
+                      <span>Add alias</span>
+                      <div className="booking-mapping-settings__alias-input-row">
+                        <input
+                          type="text"
+                          value={aliasDraftByField[field]}
+                          placeholder="example_field_name"
+                          onChange={event =>
+                            setAliasDraftByField(previous => ({
+                              ...previous,
+                              [field]: event.target.value,
+                            }))
+                          }
+                          onKeyDown={event => {
+                            if (event.key === 'Enter' || event.key === ',') {
+                              event.preventDefault()
+                              addAliases(field, aliasDraftByField[field])
+                              setAliasDraftByField(previous => ({ ...previous, [field]: '' }))
+                            }
+                          }}
+                        />
+                        <button
+                          type="button"
+                          className="button button--secondary"
+                          onClick={() => {
+                            addAliases(field, aliasDraftByField[field])
+                            setAliasDraftByField(previous => ({ ...previous, [field]: '' }))
+                          }}
+                          disabled={aliasesByField[field].length >= MAX_ALIASES_PER_FIELD}
+                        >
+                          Add
+                        </button>
+                      </div>
+                    </label>
+
+                    <p className="form__hint">
+                      {aliasesByField[field].length}/{MAX_ALIASES_PER_FIELD} aliases
+                    </p>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className="booking-mapping-settings__section" aria-labelledby="sheet-headers-heading">
+              <h2 id="sheet-headers-heading">Sheet headers</h2>
+              <p className="form__hint">Set output labels for each booking sheet column.</p>
+
+              <div className="booking-mapping-settings__header-grid">
+                {SHEET_HEADER_KEYS.map(key => (
+                  <label key={key}>
+                    <span>{FIELD_LABELS[key]}</span>
+                    <input
+                      type="text"
+                      value={sheetHeaders[key]}
+                      onChange={event =>
+                        setSheetHeaders(previous => ({
+                          ...previous,
+                          [key]: event.target.value,
+                        }))
+                      }
+                      maxLength={120}
+                      required
+                    />
+                  </label>
+                ))}
+              </div>
+
+              {duplicateHeaderGroups.length > 0 && (
+                <div className="booking-mapping-settings__feedback booking-mapping-settings__feedback--warning" role="status">
+                  <strong>Warning:</strong> some canonical fields share the same sheet header:
+                  <ul>
+                    {duplicateHeaderGroups.map(group => (
+                      <li key={group.join('-')}>{group.map(key => FIELD_LABELS[key]).join(', ')}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </section>
+
+            <section className="booking-mapping-settings__section" aria-labelledby="preview-heading">
+              <h2 id="preview-heading">Preview</h2>
+              <p className="form__hint">This is the column output that will be used when booking data is synced.</p>
+              <div className="booking-mapping-settings__preview-table-wrapper">
+                <table className="booking-mapping-settings__preview-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Canonical key</th>
+                      <th scope="col">Sheet column label</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {SHEET_HEADER_KEYS.map(key => (
+                      <tr key={key}>
+                        <td>
+                          <code>{key}</code>
+                        </td>
+                        <td>{sheetHeaders[key].trim() || '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <div className="booking-mapping-settings__actions">
+              <button type="button" className="button button--primary" onClick={handleSave} disabled={saving}>
+                {saving ? 'Saving…' : 'Save booking mapping'}
+              </button>
+            </div>
+          </>
+        )}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a UI for configuring booking ingestion mappings that the backend already reads from `stores/{storeId}.integrationBookingConfig`, enabling non-dev changes to take effect immediately. 
- Expose the canonical booking keys and sheet headers so store owners can control alias lookups and final sheet column labels from the app.

### Description
- Added a new authenticated page `web/src/pages/BookingMappingSettings.tsx` and stylesheet `web/src/pages/BookingMappingSettings.css` implementing sections: Field aliases, Sheet headers, Preview and Save. 
- Persist and load config to/from Firestore at `stores/{storeId}.integrationBookingConfig` with payload fields `mappingVersion`, `fieldAliases`, and `sheetHeaders` using a merge write via `setDoc`.
- Enforced client-side validations including `max aliases` per field (`40`), `no empty header labels` (blocks save), and a warning when multiple canonical fields share the same sheet header; also added a preview table for the final sheet columns.
- Registered the page route at `settings/integrations/booking-mapping` in `web/src/main.tsx` and added a discoverability link from Account → Integrations in `web/src/pages/AccountOverview.tsx`.

### Testing
- Ran `npm run lint` in `web/` (failed in this environment due to missing local dependency `@eslint/js`).
- Ran `npm run build` in `web/` (failed due to missing type definition packages `vite/client` and `vitest/globals` in this environment).
- Attempted `npm ci` (failed with `403 Forbidden` when contacting npm registry in this environment), so full dependency install and CI build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e162639b20832197f6bbd4c3434eb3)