### PR TITLE
Improve booking management UX and organize integrations settings

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -12,6 +12,7 @@ import Sell from './pages/Sell'
 import CloseDay from './pages/CloseDay'
 import Customers from './pages/Customers'
 import Bookings from './pages/Bookings'
+import BookingEditor from './pages/BookingEditor'
 import Logi from './pages/Logi'
 import Onboarding from './pages/Onboarding'
 import AccountOverview from './pages/AccountOverview'
@@ -73,6 +74,8 @@ const router = createBrowserRouter([
           { path: 'sell', element: <Sell /> },
           { path: 'customers', element: <Customers /> },
           { path: 'bookings', element: <Bookings /> },
+          { path: 'bookings/new', element: <BookingEditor /> },
+          { path: 'bookings/:bookingId', element: <BookingEditor /> },
           { path: 'data-transfer', element: <DataTransfer /> },
           { path: 'bulk-messaging', element: <BulkMessaging /> },
           { path: 'logi', element: <Logi /> },

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -346,6 +346,7 @@ type AccountTab = 'workspace' | 'integrations' | 'promotions' | 'operations'
 type OperationsTab = 'billing' | 'team' | 'data-controls'
 type PublicPageTab = 'overview' | 'promo' | 'gallery' | 'website-sync'
 type PromoGalleryTab = 'upload' | 'view'
+type IntegrationTab = 'overview' | 'keys' | 'booking' | 'webhooks' | 'tests'
 
 export default function AccountOverview({
   headingLevel = 'h1',
@@ -396,6 +397,7 @@ export default function AccountOverview({
   const [isEditingProfile, setIsEditingProfile] = useState(false)
   const [activeTab, setActiveTab] = useState<AccountTab>('workspace')
   const [operationsTab, setOperationsTab] = useState<OperationsTab>('billing')
+  const [integrationTab, setIntegrationTab] = useState<IntegrationTab>('overview')
 
   const [isSavingPromo, setIsSavingPromo] = useState(false)
   const [isConnectingTikTok, setIsConnectingTikTok] = useState(false)
@@ -2029,6 +2031,46 @@ export default function AccountOverview({
 
           <div className="account-overview__website-sync" role="status" aria-live="polite">
             <p className="account-overview__website-sync-title">Choose your integration tutorial.</p>
+            <div className="account-overview__tabs" aria-label="Integration sections">
+              <button
+                type="button"
+                className={`account-overview__tab ${integrationTab === 'overview' ? 'is-active' : ''}`}
+                onClick={() => setIntegrationTab('overview')}
+              >
+                Overview
+              </button>
+              <button
+                type="button"
+                className={`account-overview__tab ${integrationTab === 'keys' ? 'is-active' : ''}`}
+                onClick={() => setIntegrationTab('keys')}
+              >
+                API tokens
+              </button>
+              <button
+                type="button"
+                className={`account-overview__tab ${integrationTab === 'booking' ? 'is-active' : ''}`}
+                onClick={() => setIntegrationTab('booking')}
+              >
+                Booking sync
+              </button>
+              <button
+                type="button"
+                className={`account-overview__tab ${integrationTab === 'webhooks' ? 'is-active' : ''}`}
+                onClick={() => setIntegrationTab('webhooks')}
+              >
+                Webhooks
+              </button>
+              <button
+                type="button"
+                className={`account-overview__tab ${integrationTab === 'tests' ? 'is-active' : ''}`}
+                onClick={() => setIntegrationTab('tests')}
+              >
+                Tests
+              </button>
+            </div>
+
+            {(integrationTab === 'overview' || integrationTab === 'booking') && (
+              <>
             <p className="account-overview__hint">
               Booking ingestion mapping can be managed in
               {' '}
@@ -2073,6 +2115,9 @@ export default function AccountOverview({
               <code>{storeId}</code>
               . You can find it in <strong>Account overview → Workspace details</strong>.
             </p>
+              </>
+            )}
+            {(integrationTab === 'overview' || integrationTab === 'keys') && (
             <div className="account-overview__website-sync-actions">
               <button
                 type="button"
@@ -2090,7 +2135,8 @@ export default function AccountOverview({
                 Test Sedifex endpoint
               </button>
             </div>
-            {isOwner && (
+            )}
+            {isOwner && (integrationTab === 'overview' || integrationTab === 'keys') && (
               <div className="account-overview__website-sync-test">
                 <label>
                   <span>New integration key name</span>
@@ -2111,7 +2157,7 @@ export default function AccountOverview({
                 </button>
               </div>
             )}
-            {isOwner && latestIntegrationToken && (
+            {isOwner && latestIntegrationToken && (integrationTab === 'overview' || integrationTab === 'keys') && (
               <div className="account-overview__integration-token-notice" role="status" aria-live="polite">
                 <p>
                   <strong>This is your integration key.</strong>
@@ -2122,7 +2168,7 @@ export default function AccountOverview({
                 <code className="account-overview__integration-token-value">{latestIntegrationToken}</code>
               </div>
             )}
-            {isOwner && (
+            {isOwner && (integrationTab === 'overview' || integrationTab === 'keys') && (
               <div className="account-overview__website-sync-keys">
                 <p className="account-overview__hint">Active integration keys</p>
                 {integrationKeysLoading ? (
@@ -2167,7 +2213,7 @@ export default function AccountOverview({
                 )}
               </div>
             )}
-            {isOwner && (
+            {isOwner && (integrationTab === 'overview' || integrationTab === 'webhooks') && (
               <div className="account-overview__website-sync-keys">
                 <p className="account-overview__hint">Sedifex booking webhooks</p>
                 <p className="account-overview__hint">
@@ -2238,6 +2284,7 @@ export default function AccountOverview({
                 )}
               </div>
             )}
+            {(integrationTab === 'overview' || integrationTab === 'tests') && (
             <div className="account-overview__website-sync-test">
               <label>
                 <span>Test your endpoint</span>
@@ -2257,6 +2304,7 @@ export default function AccountOverview({
                 {isTestingEndpoint ? 'Testing…' : 'Test endpoint'}
               </button>
             </div>
+            )}
             {endpointTestStatus && <p className="account-overview__hint">{endpointTestStatus}</p>}
           </div>
 

--- a/web/src/pages/BookingEditor.css
+++ b/web/src/pages/BookingEditor.css
@@ -1,0 +1,25 @@
+.booking-editor-page__card {
+  display: grid;
+  gap: 1rem;
+}
+
+.booking-editor-page__form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.booking-editor-page__form label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.booking-editor-page__notes {
+  grid-column: 1 / -1;
+}
+
+.booking-editor-page__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/web/src/pages/BookingEditor.tsx
+++ b/web/src/pages/BookingEditor.tsx
@@ -1,0 +1,226 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Timestamp, doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import './BookingEditor.css'
+
+type BookingFormState = {
+  fullName: string
+  phone: string
+  email: string
+  serviceName: string
+  serviceId: string
+  bookingDate: string
+  bookingTime: string
+  preferredBranch: string
+  preferredContactMethod: string
+  status: string
+  quantity: string
+  notes: string
+  depositAmount: string
+  paymentMethod: string
+}
+
+const DEFAULT_FORM: BookingFormState = {
+  fullName: '',
+  phone: '',
+  email: '',
+  serviceName: '',
+  serviceId: '',
+  bookingDate: '',
+  bookingTime: '',
+  preferredBranch: '',
+  preferredContactMethod: '',
+  status: 'confirmed',
+  quantity: '1',
+  notes: '',
+  depositAmount: '',
+  paymentMethod: '',
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+export default function BookingEditor() {
+  const { storeId } = useActiveStore()
+  const { bookingId = 'new' } = useParams()
+  const navigate = useNavigate()
+  const isCreateMode = bookingId === 'new'
+  const [form, setForm] = useState<BookingFormState>(DEFAULT_FORM)
+  const [loading, setLoading] = useState(!isCreateMode)
+  const [saving, setSaving] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!storeId || isCreateMode) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    async function loadBooking() {
+      setLoading(true)
+      setErrorMessage(null)
+      try {
+        const bookingRef = doc(db, 'stores', storeId, 'integrationBookings', bookingId)
+        const snap = await getDoc(bookingRef)
+        if (!snap.exists()) {
+          if (!cancelled) {
+            setErrorMessage('Booking not found.')
+          }
+          return
+        }
+        const data = snap.data() as Record<string, unknown>
+        if (cancelled) return
+        setForm({
+          fullName: stringValue(data.fullName || data.name || data.customerName),
+          phone: stringValue(data.phone || data.customerPhone),
+          email: stringValue(data.email || data.customerEmail),
+          serviceName: stringValue(data.serviceName || data.internalServiceName),
+          serviceId: stringValue(data.serviceId),
+          bookingDate: stringValue(data.bookingDate || data.date),
+          bookingTime: stringValue(data.bookingTime || data.time),
+          preferredBranch: stringValue(data.preferredBranch || data.branchName),
+          preferredContactMethod: stringValue(data.preferredContactMethod || data.contactMethod),
+          status: stringValue(data.status) || 'confirmed',
+          quantity: String(typeof data.quantity === 'number' ? data.quantity : 1),
+          notes: stringValue(data.notes),
+          depositAmount: stringValue(data.depositAmount),
+          paymentMethod: stringValue(data.paymentMethod),
+        })
+      } catch (error) {
+        console.error('[booking-editor] Failed to load booking', error)
+        if (!cancelled) {
+          setErrorMessage('Unable to load this booking. Please retry.')
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void loadBooking()
+    return () => {
+      cancelled = true
+    }
+  }, [bookingId, isCreateMode, storeId])
+
+  const quantityValue = useMemo(() => {
+    const parsed = Number.parseInt(form.quantity, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1
+  }, [form.quantity])
+
+  async function handleSave() {
+    if (!storeId) {
+      setErrorMessage('Select a workspace before editing bookings.')
+      return
+    }
+    if (!form.fullName.trim()) {
+      setErrorMessage('Customer name is required.')
+      return
+    }
+
+    setSaving(true)
+    setErrorMessage(null)
+    const targetId = isCreateMode ? doc(db, 'stores', storeId, 'integrationBookings').id : bookingId
+
+    try {
+      await setDoc(
+        doc(db, 'stores', storeId, 'integrationBookings', targetId),
+        {
+          name: form.fullName.trim(),
+          fullName: form.fullName.trim(),
+          phone: form.phone.trim(),
+          email: form.email.trim(),
+          serviceName: form.serviceName.trim(),
+          serviceId: form.serviceId.trim(),
+          date: form.bookingDate,
+          bookingDate: form.bookingDate,
+          time: form.bookingTime,
+          bookingTime: form.bookingTime,
+          preferredBranch: form.preferredBranch.trim(),
+          preferredContactMethod: form.preferredContactMethod.trim(),
+          status: form.status.trim() || 'confirmed',
+          quantity: quantityValue,
+          notes: form.notes.trim(),
+          depositAmount: form.depositAmount.trim(),
+          paymentMethod: form.paymentMethod.trim(),
+          customer: {
+            name: form.fullName.trim(),
+            phone: form.phone.trim(),
+            email: form.email.trim(),
+          },
+          source: isCreateMode ? 'manual' : 'manual-edit',
+          syncStatus: 'pending',
+          syncRequestedAt: Timestamp.now(),
+          updatedAt: serverTimestamp(),
+          createdAt: isCreateMode ? serverTimestamp() : undefined,
+        },
+        { merge: true },
+      )
+
+      navigate('/bookings')
+    } catch (error) {
+      console.error('[booking-editor] Failed to save booking', error)
+      setErrorMessage('Unable to save booking right now.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <main className="page booking-editor-page">
+      <section className="card booking-editor-page__card stack gap-3">
+        <header className="stack gap-1">
+          <p className="form__hint">
+            <Link to="/bookings">← Back to bookings</Link>
+          </p>
+          <h1>{isCreateMode ? 'Add booking' : 'Edit booking'}</h1>
+          <p className="form__hint">Save changes to update this booking and queue sync back to your sheet.</p>
+        </header>
+
+        {loading && <p className="form__hint">Loading booking…</p>}
+        {errorMessage && <p className="form__error">{errorMessage}</p>}
+
+        {!loading && (
+          <form
+            className="booking-editor-page__form"
+            onSubmit={event => {
+              event.preventDefault()
+              void handleSave()
+            }}
+          >
+            <label><span>Customer name</span><input value={form.fullName} onChange={event => setForm(prev => ({ ...prev, fullName: event.target.value }))} required /></label>
+            <label><span>Phone</span><input value={form.phone} onChange={event => setForm(prev => ({ ...prev, phone: event.target.value }))} /></label>
+            <label><span>Email</span><input type="email" value={form.email} onChange={event => setForm(prev => ({ ...prev, email: event.target.value }))} /></label>
+            <label><span>Service name</span><input value={form.serviceName} onChange={event => setForm(prev => ({ ...prev, serviceName: event.target.value }))} /></label>
+            <label><span>Service ID</span><input value={form.serviceId} onChange={event => setForm(prev => ({ ...prev, serviceId: event.target.value }))} /></label>
+            <label><span>Booking date</span><input type="date" value={form.bookingDate} onChange={event => setForm(prev => ({ ...prev, bookingDate: event.target.value }))} /></label>
+            <label><span>Booking time</span><input type="time" value={form.bookingTime} onChange={event => setForm(prev => ({ ...prev, bookingTime: event.target.value }))} /></label>
+            <label><span>Preferred branch</span><input value={form.preferredBranch} onChange={event => setForm(prev => ({ ...prev, preferredBranch: event.target.value }))} /></label>
+            <label><span>Preferred contact method</span><input value={form.preferredContactMethod} onChange={event => setForm(prev => ({ ...prev, preferredContactMethod: event.target.value }))} /></label>
+            <label>
+              <span>Status</span>
+              <select value={form.status} onChange={event => setForm(prev => ({ ...prev, status: event.target.value }))}>
+                <option value="confirmed">Confirmed</option>
+                <option value="rescheduled">Rescheduled</option>
+                <option value="completed">Completed</option>
+                <option value="cancelled">Cancelled</option>
+              </select>
+            </label>
+            <label><span>Quantity</span><input type="number" min={1} value={form.quantity} onChange={event => setForm(prev => ({ ...prev, quantity: event.target.value }))} /></label>
+            <label><span>Deposit amount</span><input value={form.depositAmount} onChange={event => setForm(prev => ({ ...prev, depositAmount: event.target.value }))} /></label>
+            <label><span>Payment method</span><input value={form.paymentMethod} onChange={event => setForm(prev => ({ ...prev, paymentMethod: event.target.value }))} /></label>
+            <label className="booking-editor-page__notes"><span>Notes</span><textarea value={form.notes} onChange={event => setForm(prev => ({ ...prev, notes: event.target.value }))} rows={4} /></label>
+
+            <div className="booking-editor-page__actions">
+              <button type="submit" className="button button--primary" disabled={saving}>
+                {saving ? 'Saving…' : 'Save and sync'}
+              </button>
+            </div>
+          </form>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/web/src/pages/BookingMappingSettings.css
+++ b/web/src/pages/BookingMappingSettings.css
@@ -12,6 +12,20 @@
   margin: 0.25rem 0;
 }
 
+.booking-mapping-settings__intro {
+  border: 1px solid var(--border-color, #dbeafe);
+  background: #f8fbff;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+}
+
+.booking-mapping-settings__intro-list {
+  margin: 0.45rem 0 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
 .booking-mapping-settings__crumbs {
   margin: 0;
   font-size: 0.86rem;

--- a/web/src/pages/BookingMappingSettings.tsx
+++ b/web/src/pages/BookingMappingSettings.tsx
@@ -292,9 +292,16 @@ export default function BookingMappingSettings() {
         <header className="booking-mapping-settings__header">
           <p className="booking-mapping-settings__crumbs">Settings → Integrations → Booking Mapping</p>
           <h1 id="booking-mapping-title">Booking mapping</h1>
-          <p className="form__hint">
-            Configure alias lookups and sheet column headers used by booking ingestion.
-          </p>
+          <div className="booking-mapping-settings__intro">
+            <p className="form__hint">
+              Configure alias lookups and sheet column headers used by booking ingestion.
+            </p>
+            <ul className="booking-mapping-settings__intro-list">
+              <li>Back to Integrations to review API key, booking, and webhook setup.</li>
+              <li>Add custom aliases that should map to each canonical field (up to {MAX_ALIASES_PER_FIELD} aliases per field).</li>
+              <li>Set output labels for each booking sheet column used during sync.</li>
+            </ul>
+          </div>
           <p className="form__hint">
             <Link to="/account">Back to Integrations</Link>
           </p>
@@ -318,7 +325,7 @@ export default function BookingMappingSettings() {
             <section className="booking-mapping-settings__section" aria-labelledby="booking-aliases-heading">
               <h2 id="booking-aliases-heading">Field aliases</h2>
               <p className="form__hint">
-                Add custom aliases that should map to each canonical field (up to {MAX_ALIASES_PER_FIELD} aliases per field).
+                Add custom aliases that should map incoming payload keys to each canonical field.
               </p>
 
               <div className="booking-mapping-settings__alias-grid">
@@ -389,7 +396,7 @@ export default function BookingMappingSettings() {
 
             <section className="booking-mapping-settings__section" aria-labelledby="sheet-headers-heading">
               <h2 id="sheet-headers-heading">Sheet headers</h2>
-              <p className="form__hint">Set output labels for each booking sheet column.</p>
+              <p className="form__hint">Set output labels for each booking sheet column used for sheet sync output.</p>
 
               <div className="booking-mapping-settings__header-grid">
                 {SHEET_HEADER_KEYS.map(key => (

--- a/web/src/pages/Bookings.css
+++ b/web/src/pages/Bookings.css
@@ -1,3 +1,11 @@
+.bookings-page__header-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .bookings-page__filters {
   display: grid;
   gap: 12px;

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -55,7 +55,6 @@ const PAGE_SIZE = 25
 const STATUS_ALL = 'all'
 const SERVICE_ALL = 'all'
 
-const ACTIONABLE_STATUS = ['confirmed', 'rescheduled'] as const
 const STATUS_ACTIONS: Record<string, Array<{ label: string; nextStatus: string }>> = {
   confirmed: [
     { label: 'Reschedule', nextStatus: 'rescheduled' },
@@ -141,7 +140,6 @@ export default function Bookings() {
   const [hasNextPage, setHasNextPage] = useState(false)
   const [pageNumber, setPageNumber] = useState(1)
   const [updatingBookingId, setUpdatingBookingId] = useState<string | null>(null)
-  const [selectedBookingId, setSelectedBookingId] = useState<string | null>(null)
 
   const hydrateBooking = useCallback((docSnap: QueryDocumentSnapshot<DocumentData>, serviceMap: Map<string, string>) => {
     const data = docSnap.data() as Record<string, unknown>
@@ -367,10 +365,30 @@ export default function Bookings() {
         await deleteDoc(doc(db, 'stores', storeId, 'integrationBookings', bookingId))
 
         setBookings(previous => previous.filter(booking => booking.id !== bookingId))
-        setSelectedBookingId(previous => (previous === bookingId ? null : previous))
       } catch (error) {
         console.error('[bookings] Failed to delete booking', error)
         setErrorMessage('Delete failed. Please retry.')
+      } finally {
+        setUpdatingBookingId(null)
+      }
+    },
+    [storeId],
+  )
+
+  const handleSyncBooking = useCallback(
+    async (bookingId: string) => {
+      if (!storeId) return
+      setUpdatingBookingId(bookingId)
+      setErrorMessage(null)
+      try {
+        await updateDoc(doc(db, 'stores', storeId, 'integrationBookings', bookingId), {
+          syncRequestedAt: Timestamp.now(),
+          syncStatus: 'pending',
+          updatedAt: Timestamp.now(),
+        })
+      } catch (error) {
+        console.error('[bookings] Failed to request booking sync', error)
+        setErrorMessage('Unable to queue this booking for sheet sync. Please retry.')
       } finally {
         setUpdatingBookingId(null)
       }
@@ -388,20 +406,18 @@ export default function Bookings() {
     })
   }, [bookings, searchTerm])
 
-  const confirmedCount = useMemo(
-    () => bookings.filter(booking => booking.status === 'confirmed').length,
-    [bookings],
-  )
-  const selectedBooking = useMemo(
-    () => bookings.find(booking => booking.id === selectedBookingId) ?? null,
-    [bookings, selectedBookingId],
-  )
+  const confirmedCount = useMemo(() => bookings.filter(booking => booking.status === 'confirmed').length, [bookings])
 
   return (
     <main className="page bookings-page">
       <section className="card stack gap-4">
         <header className="stack gap-1">
-          <h1>Bookings</h1>
+          <div className="bookings-page__header-row">
+            <h1>Bookings</h1>
+            <Link to="/bookings/new" className="btn btn-secondary">
+              Add booking
+            </Link>
+          </div>
           <p className="form__hint">
             Website bookings appear here. New booking contact details are automatically mapped into Customers when they include a phone or email.
           </p>
@@ -486,9 +502,7 @@ export default function Bookings() {
                       {filteredBookings.map(booking => (
                         <tr
                           key={booking.id}
-                          className={selectedBookingId === booking.id ? 'bookings-page__row bookings-page__row--selected' : 'bookings-page__row'}
-                          onClick={() => setSelectedBookingId(current => (current === booking.id ? null : booking.id))}
-                          style={{ cursor: 'pointer' }}
+                          className="bookings-page__row"
                         >
                           <td>{formatDate(booking.createdAt)}</td>
                           <td>{booking.serviceName || booking.serviceId}</td>
@@ -517,6 +531,17 @@ export default function Bookings() {
                                   {action.label}
                                 </button>
                               ))}
+                              <Link to={`/bookings/${booking.id}`} className="btn btn-secondary">
+                                Edit
+                              </Link>
+                              <button
+                                className="btn btn-secondary"
+                                type="button"
+                                disabled={updatingBookingId === booking.id}
+                                onClick={() => void handleSyncBooking(booking.id)}
+                              >
+                                Sync to sheet
+                              </button>
                               <button
                                 className="btn btn-secondary"
                                 type="button"
@@ -525,9 +550,9 @@ export default function Bookings() {
                               >
                                 Delete
                               </button>
-                              {!ACTIONABLE_STATUS.includes(booking.status as (typeof ACTIONABLE_STATUS)[number]) && (
-                                <span className="form__hint">No status actions</span>
-                              )}
+                              <Link to={`/bookings/${booking.id}`} className="btn btn-secondary">
+                                Open
+                              </Link>
                             </div>
                           </td>
                         </tr>
@@ -535,33 +560,6 @@ export default function Bookings() {
                     </tbody>
                   </table>
                 </div>
-                <section className="bookings-page__details card stack gap-2">
-                  <h3>Booking details</h3>
-                  {selectedBooking ? (
-                    <dl className="bookings-page__details-grid">
-                      <div><dt>Name</dt><dd>{selectedBooking.bookingName ?? selectedBooking.customerName ?? '—'}</dd></div>
-                      <div><dt>Phone</dt><dd>{selectedBooking.bookingPhone ?? selectedBooking.customerPhone ?? '—'}</dd></div>
-                      <div><dt>Service ID</dt><dd>{selectedBooking.serviceId}</dd></div>
-                      <div><dt>Date</dt><dd>{selectedBooking.bookingDate ?? '—'}</dd></div>
-                      <div><dt>Service name</dt><dd>{selectedBooking.serviceName || '—'}</dd></div>
-                      <div><dt>Time</dt><dd>{selectedBooking.bookingTime ?? '—'}</dd></div>
-                      <div><dt>Preferred Branch</dt><dd>{selectedBooking.preferredBranch ?? '—'}</dd></div>
-                      <div><dt>Session Type / Duration</dt><dd>{selectedBooking.sessionType ?? '—'}</dd></div>
-                      <div><dt>Therapist Preference</dt><dd>{selectedBooking.therapistPreference ?? '—'}</dd></div>
-                      <div><dt>Preferred Contact Method</dt><dd>{selectedBooking.preferredContactMethod ?? '—'}</dd></div>
-                      <div><dt>Deposit Amount</dt><dd>{selectedBooking.depositAmount ?? '—'}</dd></div>
-                      <div><dt>Payment Method</dt><dd>{selectedBooking.paymentMethod ?? '—'}</dd></div>
-                      <div><dt>Email</dt><dd>{selectedBooking.bookingEmail ?? selectedBooking.customerEmail ?? '—'}</dd></div>
-                      <div><dt>Payment Screenshot URL</dt><dd>{selectedBooking.paymentScreenshotUrl ?? '—'}</dd></div>
-                      <div><dt>Notes / Special requests</dt><dd>{selectedBooking.notes ?? '—'}</dd></div>
-                      <div><dt>Payment screenshot ready</dt><dd>{selectedBooking.paymentScreenshotReady === null ? '—' : selectedBooking.paymentScreenshotReady ? 'Yes' : 'No'}</dd></div>
-                      <div><dt>No-refund policy accepted</dt><dd>{selectedBooking.noRefundAccepted === null ? '—' : selectedBooking.noRefundAccepted ? 'Yes' : 'No'}</dd></div>
-                    </dl>
-                  ) : (
-                    <p className="form__hint">Click a booking row to view full details.</p>
-                  )}
-                  <p className="form__hint">Note: Payments are non-refundable after confirmation.</p>
-                </section>
                 <div className="bookings-page__pagination">
                   <button className="btn btn-secondary" type="button" disabled={pageNumber <= 1} onClick={handlePreviousPage}>
                     Previous


### PR DESCRIPTION
### Motivation

- Make it possible to edit bookings (including rescheduled ones) and to manually add bookings so staff can correct or create appointments and push changes back to the sheet.
- Replace confusing inline-expanded booking details with a full-screen editor so users have a focused editing surface.
- Provide an explicit manual sync control so booking edits/creates can be queued to sync back to the sheet.
- Improve the Integrations area and Booking Mapping guidance so API keys, booking sync, webhooks and tests are easier to find and configure.

### Description

- Added a full-screen booking editor page and routes (`/bookings/new` and `/bookings/:bookingId`) that create/edit booking documents and set `syncStatus: 'pending'` and `syncRequestedAt` when saving to queue sheet syncs (`web/src/pages/BookingEditor.tsx`, `web/src/pages/BookingEditor.css`, `web/src/main.tsx`).
- Updated the bookings list UI to include an `Add booking` button, row-level `Edit` and `Open` links, and a `Sync to sheet` action that sets sync metadata on the Firestore document via a new `handleSyncBooking` helper (`web/src/pages/Bookings.tsx`, `web/src/pages/Bookings.css`).
- Implemented queuing behavior when saving manual/edited bookings by writing `syncStatus`, `syncRequestedAt`, `source`, and timestamps so backend sync workers can pick them up unchanged (`BookingEditor` save logic and `handleSyncBooking`).
- Reorganized the Integrations area in the Account Overview into sub-tabs (Overview, API tokens, Booking sync, Webhooks, Tests) and conditioned controls per tab to declutter the UI (`web/src/pages/AccountOverview.tsx`).
- Clarified the Booking Mapping settings header and added an intro panel with actionable guidance and small styling improvements (`web/src/pages/BookingMappingSettings.tsx`, `web/src/pages/BookingMappingSettings.css`).

### Testing

- Ran the test command `npm run -s test -- --runInBand`, which failed in this environment because `vitest` is not installed (`sh: 1: vitest: not found`).
- Attempted a build via `npm run -s build`, which failed in this environment due to missing type definitions (`Cannot find type definition file for 'vite/client'` and `Cannot find type definition file for 'vitest/globals'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1dbc922f08322b49b2c79f011c2ff)