### PR TITLE
Add Firestore indexes for publicProducts name/store filtering

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -36,6 +36,23 @@
       ]
     },
     {
+      "collectionGroup": "publicProducts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "storeId", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "publicProducts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "storeId", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "sales",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
### Motivation
- Queries against the public catalog needed to filter and sort `publicProducts` by product `name` and `storeId`, but the index set was missing `name` so those queries were inefficient or failed.

### Description
- Added two composite Firestore indexes to `firestore.indexes.json` for the `publicProducts` collection: one on `storeId + name` and another on `storeId + name + updatedAt`.
- The `storeId + name` index enables efficient filtering by store and product name, while the `storeId + name + updatedAt` index supports name-based queries ordered by recency.
- Only `firestore.indexes.json` was modified to include these new index entries.

### Testing
- Parsed `firestore.indexes.json` with `node -e "JSON.parse(require('fs').readFileSync('firestore.indexes.json','utf8'))"` to validate the file remained valid JSON and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f047ac38832292a722d8f94dca14)