### PR TITLE
Fix Firebase Functions deploy filter to ignore internal exports

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Build and list functions to deploy
         run: |
           npm --prefix functions run build
-          FUNCTIONS_LIST=$(node -e "const fn = require('./functions/lib/index.js'); process.stdout.write(Object.keys(fn).join(','));")
+          FUNCTIONS_LIST=$(node -e "const exportsMap = require('./functions/lib/index.js'); const deployable = Object.keys(exportsMap).filter((name) => !name.startsWith('__')); process.stdout.write(deployable.join(','));")
           if [ -z "$FUNCTIONS_LIST" ]; then
-            echo "No exported functions found in functions/lib/index.js"
+            echo "No deployable function exports found in functions/lib/index.js"
             exit 1
           fi
           echo "FUNCTIONS_ONLY=$(printf '%s' "$FUNCTIONS_LIST" | sed 's/[^,]*/functions:&/g')" >> "$GITHUB_ENV"


### PR DESCRIPTION
### Motivation
- Deploys were failing with `Error: No function matches the filter: default:__testing` because the workflow enumerated every export from `functions/lib/index.js`, including internal helpers like `__testing`.
- The deploy step must only include actual function exports to avoid `firebase deploy --only` filters that reference non-functions.

### Description
- Change the export discovery in `.github/workflows/deploy-functions.yml` to build `FUNCTIONS_LIST` from `Object.keys(exportsMap).filter((name) => !name.startsWith('__'))` so names prefixed with `__` are excluded.
- Update the empty-list failure message to `No deployable function exports found in functions/lib/index.js` to match the new filtering behavior.
- The only modified file is `.github/workflows/deploy-functions.yml` and the workflow still writes `FUNCTIONS_ONLY` as `functions:<name>` entries for deployment.

### Testing
- Ran `npm --prefix functions run build` and the build completed successfully.
- Ran the updated node export-list check and verified `__testing` is excluded from the discovered exports.
- Generated and inspected the `FUNCTIONS_ONLY` string (formatted as `functions:<name>,...`) and confirmed it is produced correctly for deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e233b116888322a630d68c5c93a3b8)