### PR TITLE
Add canonical booking fields (branch/event/stay/paymentAmount) and mapping support

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -188,6 +188,53 @@ Query parameters:
   - Existing customer records are matched by `storeId + phone` first, then `storeId + email`.
   - New customer records are tagged with `source: "integrationBooking"` for later segmentation.
 
+#### Booking canonical field map (for website developers)
+
+To prevent sync mismatches between different form builders, use these canonical keys in booking payloads and/or map your website labels to them in **Settings → Integrations → Booking Mapping**.
+
+| Canonical key | Purpose | Common website aliases |
+|---|---|---|
+| `customerName` | Booker full name | `name`, `fullName`, `clientName` |
+| `customerPhone` | Booker phone | `phone`, `phoneNumber`, `mobile`, `whatsapp` |
+| `customerEmail` | Booker email | `email`, `emailAddress` |
+| `serviceName` | Product/service selected | `productName`, `service_note_name` |
+| `bookingDate` | Booking date | `date` |
+| `bookingTime` | Booking time | `time` |
+| `branchLocationId` | Internal branch/store location id | `branchId`, `locationId`, `storeBranchId` |
+| `branchLocationName` | Human-readable branch name | `branchName`, `storeBranch`, `locationName` |
+| `eventLocation` | Where event takes place | `eventVenue`, `venue`, `eventAddress` |
+| `customerStayLocation` | Where customer is staying | `stayLocation`, `hotelLocation`, `guestLocation` |
+| `paymentMethod` | How customer pays | `payment_method`, `paymentType` |
+| `paymentAmount` | Amount charged/paid | `amount`, `total`, `price` |
+
+**Legacy compatibility:** `preferredBranch` and `depositAmount` are still supported, but new implementations should prefer `branchLocationId`/`branchLocationName` and `paymentAmount`.
+
+#### Example request body (recommended shape)
+
+```json
+{
+  "serviceId": "svc_event_001",
+  "slotId": "slot_2026_08_01_10_00",
+  "customer": {
+    "name": "Ada Mensah",
+    "phone": "+233201234567",
+    "email": "ada@example.com"
+  },
+  "quantity": 2,
+  "notes": "Need projector setup",
+  "paymentMethod": "bank_transfer",
+  "paymentAmount": 250,
+  "branchLocationId": "branch_accra_airport",
+  "branchLocationName": "Airport Branch",
+  "eventLocation": "National Theatre, Accra",
+  "customerStayLocation": "Labadi Beach Hotel",
+  "attributes": {
+    "source": "wordpress_booking_form",
+    "campaign": "summer_launch"
+  }
+}
+```
+
 ## 4) Deduplication and caching
 
 - Deduplicate by product `id` (and optionally `updatedAt` when merging data sources).

--- a/docs/integration-quickstart.md
+++ b/docs/integration-quickstart.md
@@ -226,6 +226,7 @@ Booking/registration note:
 - Build booking forms on each website using store-defined fields.
 - Put vertical-specific data (e.g., school/travel extras) inside `attributes` in the booking payload.
 - Keep API keys server-side; submit booking requests from your website backend only.
+- For a developer-ready canonical booking field dictionary (including `branchLocationId`, `eventLocation`, `customerStayLocation`, and `paymentAmount`) plus a full request example, see `docs/integration-api-guide.md` under **POST /v1IntegrationBookings**.
 
 ### Common 404 fix (important)
 

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -2925,8 +2925,13 @@ const DEFAULT_BOOKING_ALIASES = {
     serviceName: ['serviceName', 'productName', 'service_note_name', 'internalServiceName'],
     bookingDate: ['date', 'bookingDate'],
     bookingTime: ['time', 'bookingTime'],
+    branchLocationId: ['branchLocationId', 'branchId', 'locationId', 'storeBranchId'],
+    branchLocationName: ['branchLocationName', 'branchName', 'storeBranch', 'locationName', 'branch'],
+    eventLocation: ['eventLocation', 'eventVenue', 'venue', 'eventAddress'],
+    customerStayLocation: ['customerStayLocation', 'stayLocation', 'hotelLocation', 'guestLocation'],
     preferredBranch: ['preferredBranch', 'branch', 'branchName'],
     preferredContactMethod: ['preferredContactMethod', 'contactMethod'],
+    paymentAmount: ['paymentAmount', 'amount', 'total', 'price'],
     depositAmount: ['depositAmount', 'depositPaid', 'amountPaid'],
     paymentMethod: ['paymentMethod'],
 };
@@ -2937,8 +2942,13 @@ const DEFAULT_BOOKING_SHEET_HEADERS = {
     serviceName: 'Service',
     bookingDate: 'Booking Date',
     bookingTime: 'Booking Time',
+    branchLocationId: 'Branch Location ID',
+    branchLocationName: 'Branch Location Name',
+    eventLocation: 'Event Location',
+    customerStayLocation: 'Customer Stay Location',
     preferredBranch: 'Preferred Branch',
     preferredContactMethod: 'Preferred Contact Method',
+    paymentAmount: 'Payment Amount',
     paymentMethod: 'Payment Method',
     depositAmount: 'Deposit Amount',
     status: 'Status',
@@ -2977,11 +2987,25 @@ async function loadBookingIngestionConfig(storeId) {
         serviceName: [...DEFAULT_BOOKING_ALIASES.serviceName, ...normalizeBookingAliasList(fieldAliases.serviceName)],
         bookingDate: [...DEFAULT_BOOKING_ALIASES.bookingDate, ...normalizeBookingAliasList(fieldAliases.bookingDate)],
         bookingTime: [...DEFAULT_BOOKING_ALIASES.bookingTime, ...normalizeBookingAliasList(fieldAliases.bookingTime)],
+        branchLocationId: [
+            ...DEFAULT_BOOKING_ALIASES.branchLocationId,
+            ...normalizeBookingAliasList(fieldAliases.branchLocationId),
+        ],
+        branchLocationName: [
+            ...DEFAULT_BOOKING_ALIASES.branchLocationName,
+            ...normalizeBookingAliasList(fieldAliases.branchLocationName),
+        ],
+        eventLocation: [...DEFAULT_BOOKING_ALIASES.eventLocation, ...normalizeBookingAliasList(fieldAliases.eventLocation)],
+        customerStayLocation: [
+            ...DEFAULT_BOOKING_ALIASES.customerStayLocation,
+            ...normalizeBookingAliasList(fieldAliases.customerStayLocation),
+        ],
         preferredBranch: [...DEFAULT_BOOKING_ALIASES.preferredBranch, ...normalizeBookingAliasList(fieldAliases.preferredBranch)],
         preferredContactMethod: [
             ...DEFAULT_BOOKING_ALIASES.preferredContactMethod,
             ...normalizeBookingAliasList(fieldAliases.preferredContactMethod),
         ],
+        paymentAmount: [...DEFAULT_BOOKING_ALIASES.paymentAmount, ...normalizeBookingAliasList(fieldAliases.paymentAmount)],
         depositAmount: [...DEFAULT_BOOKING_ALIASES.depositAmount, ...normalizeBookingAliasList(fieldAliases.depositAmount)],
         paymentMethod: [...DEFAULT_BOOKING_ALIASES.paymentMethod, ...normalizeBookingAliasList(fieldAliases.paymentMethod)],
     };
@@ -3148,9 +3172,16 @@ function mapIntegrationBookingDoc(docSnap) {
             serviceName: toTrimmedStringOrNull(data.serviceName),
             bookingDate: toTrimmedStringOrNull(data.date),
             bookingTime: toTrimmedStringOrNull(data.time),
+            branchLocationId: toTrimmedStringOrNull(data.branchLocationId),
+            branchLocationName: toTrimmedStringOrNull(data.branchLocationName),
+            eventLocation: toTrimmedStringOrNull(data.eventLocation),
+            customerStayLocation: toTrimmedStringOrNull(data.customerStayLocation),
             preferredBranch: toTrimmedStringOrNull(data.preferredBranch),
             preferredContactMethod: toTrimmedStringOrNull(data.preferredContactMethod),
             paymentMethod: toTrimmedStringOrNull(data.paymentMethod),
+            paymentAmount: typeof data.paymentAmount === 'number' && Number.isFinite(data.paymentAmount)
+                ? data.paymentAmount
+                : toTrimmedStringOrNull(data.paymentAmount),
             depositAmount: typeof data.depositAmount === 'number' && Number.isFinite(data.depositAmount)
                 ? data.depositAmount
                 : toTrimmedStringOrNull(data.depositAmount),
@@ -4026,6 +4057,22 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         aliases: bookingConfig.aliases.bookingTime,
         lookups: [payloadLookup, attributesLookup],
     }), payload.time, payload.bookingTime, payloadAttributes.time, payloadAttributes.bookingTime);
+    const branchLocationId = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.branchLocationId,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.branchLocationId, payload.branchId, payload.locationId, payloadAttributes.branchLocationId, payloadAttributes.branchId, payloadAttributes.locationId);
+    const branchLocationName = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.branchLocationName,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.branchLocationName, payload.branchName, payload.branch, payloadAttributes.branchLocationName, payloadAttributes.branchName, payloadAttributes.branch);
+    const eventLocation = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.eventLocation,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.eventLocation, payload.eventVenue, payload.venue, payloadAttributes.eventLocation, payloadAttributes.eventVenue, payloadAttributes.venue);
+    const customerStayLocation = pickBookingString(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.customerStayLocation,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.customerStayLocation, payload.stayLocation, payload.hotelLocation, payloadAttributes.customerStayLocation, payloadAttributes.stayLocation, payloadAttributes.hotelLocation);
     const preferredBranch = pickBookingString(pickBookingValueFromAliases({
         aliases: bookingConfig.aliases.preferredBranch,
         lookups: [payloadLookup, attributesLookup],
@@ -4040,6 +4087,10 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         aliases: bookingConfig.aliases.depositAmount,
         lookups: [payloadLookup, attributesLookup],
     }), payload.depositAmount, payload.depositPaid, payload.amountPaid, payloadAttributes.depositAmount, payloadAttributes.depositPaid, payloadAttributes.amountPaid);
+    const paymentAmount = pickBookingAmount(pickBookingValueFromAliases({
+        aliases: bookingConfig.aliases.paymentAmount,
+        lookups: [payloadLookup, attributesLookup],
+    }), payload.paymentAmount, payload.amount, payload.total, payload.price, payloadAttributes.paymentAmount, payloadAttributes.amount, payloadAttributes.total, payloadAttributes.price);
     const paymentMethod = pickBookingString(pickBookingValueFromAliases({
         aliases: bookingConfig.aliases.paymentMethod,
         lookups: [payloadLookup, attributesLookup],
@@ -4079,9 +4130,14 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         serviceName,
         bookingDate,
         bookingTime,
+        branchLocationId,
+        branchLocationName,
+        eventLocation,
+        customerStayLocation,
         preferredBranch,
         preferredContactMethod,
         paymentMethod,
+        paymentAmount,
         depositAmount,
     };
     const sheetColumns = {};
@@ -4092,9 +4148,14 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         serviceName,
         bookingDate,
         bookingTime,
+        branchLocationId,
+        branchLocationName,
+        eventLocation,
+        customerStayLocation,
         preferredBranch,
         preferredContactMethod,
         paymentMethod,
+        paymentAmount: typeof paymentAmount === 'number' && Number.isFinite(paymentAmount) ? paymentAmount : paymentAmount ?? null,
         depositAmount: typeof depositAmount === 'number' && Number.isFinite(depositAmount) ? depositAmount : depositAmount ?? null,
         status: 'confirmed',
         quantity,
@@ -4122,12 +4183,17 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         serviceName: importantFields.serviceName,
         date: importantFields.bookingDate,
         time: importantFields.bookingTime,
+        branchLocationId: importantFields.branchLocationId,
+        branchLocationName: importantFields.branchLocationName,
+        eventLocation: importantFields.eventLocation,
+        customerStayLocation: importantFields.customerStayLocation,
         preferredBranch: importantFields.preferredBranch,
         sessionType,
         therapistPreference,
         preferredContactMethod: importantFields.preferredContactMethod,
         depositAmount: importantFields.depositAmount,
         paymentMethod: importantFields.paymentMethod,
+        paymentAmount: importantFields.paymentAmount,
         paymentScreenshotUrl,
         paymentScreenshotReady,
         noRefundAccepted,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3788,8 +3788,13 @@ type BookingFieldAliasConfig = {
   serviceName: string[]
   bookingDate: string[]
   bookingTime: string[]
+  branchLocationId: string[]
+  branchLocationName: string[]
+  eventLocation: string[]
+  customerStayLocation: string[]
   preferredBranch: string[]
   preferredContactMethod: string[]
+  paymentAmount: string[]
   depositAmount: string[]
   paymentMethod: string[]
 }
@@ -3817,8 +3822,13 @@ const DEFAULT_BOOKING_ALIASES: BookingFieldAliasConfig = {
   serviceName: ['serviceName', 'productName', 'service_note_name', 'internalServiceName'],
   bookingDate: ['date', 'bookingDate'],
   bookingTime: ['time', 'bookingTime'],
+  branchLocationId: ['branchLocationId', 'branchId', 'locationId', 'storeBranchId'],
+  branchLocationName: ['branchLocationName', 'branchName', 'storeBranch', 'locationName', 'branch'],
+  eventLocation: ['eventLocation', 'eventVenue', 'venue', 'eventAddress'],
+  customerStayLocation: ['customerStayLocation', 'stayLocation', 'hotelLocation', 'guestLocation'],
   preferredBranch: ['preferredBranch', 'branch', 'branchName'],
   preferredContactMethod: ['preferredContactMethod', 'contactMethod'],
+  paymentAmount: ['paymentAmount', 'amount', 'total', 'price'],
   depositAmount: ['depositAmount', 'depositPaid', 'amountPaid'],
   paymentMethod: ['paymentMethod'],
 }
@@ -3830,8 +3840,13 @@ const DEFAULT_BOOKING_SHEET_HEADERS: Record<string, string> = {
   serviceName: 'Service',
   bookingDate: 'Booking Date',
   bookingTime: 'Booking Time',
+  branchLocationId: 'Branch Location ID',
+  branchLocationName: 'Branch Location Name',
+  eventLocation: 'Event Location',
+  customerStayLocation: 'Customer Stay Location',
   preferredBranch: 'Preferred Branch',
   preferredContactMethod: 'Preferred Contact Method',
+  paymentAmount: 'Payment Amount',
   paymentMethod: 'Payment Method',
   depositAmount: 'Deposit Amount',
   status: 'Status',
@@ -3871,11 +3886,25 @@ async function loadBookingIngestionConfig(storeId: string): Promise<BookingInges
     serviceName: [...DEFAULT_BOOKING_ALIASES.serviceName, ...normalizeBookingAliasList(fieldAliases.serviceName)],
     bookingDate: [...DEFAULT_BOOKING_ALIASES.bookingDate, ...normalizeBookingAliasList(fieldAliases.bookingDate)],
     bookingTime: [...DEFAULT_BOOKING_ALIASES.bookingTime, ...normalizeBookingAliasList(fieldAliases.bookingTime)],
+    branchLocationId: [
+      ...DEFAULT_BOOKING_ALIASES.branchLocationId,
+      ...normalizeBookingAliasList(fieldAliases.branchLocationId),
+    ],
+    branchLocationName: [
+      ...DEFAULT_BOOKING_ALIASES.branchLocationName,
+      ...normalizeBookingAliasList(fieldAliases.branchLocationName),
+    ],
+    eventLocation: [...DEFAULT_BOOKING_ALIASES.eventLocation, ...normalizeBookingAliasList(fieldAliases.eventLocation)],
+    customerStayLocation: [
+      ...DEFAULT_BOOKING_ALIASES.customerStayLocation,
+      ...normalizeBookingAliasList(fieldAliases.customerStayLocation),
+    ],
     preferredBranch: [...DEFAULT_BOOKING_ALIASES.preferredBranch, ...normalizeBookingAliasList(fieldAliases.preferredBranch)],
     preferredContactMethod: [
       ...DEFAULT_BOOKING_ALIASES.preferredContactMethod,
       ...normalizeBookingAliasList(fieldAliases.preferredContactMethod),
     ],
+    paymentAmount: [...DEFAULT_BOOKING_ALIASES.paymentAmount, ...normalizeBookingAliasList(fieldAliases.paymentAmount)],
     depositAmount: [...DEFAULT_BOOKING_ALIASES.depositAmount, ...normalizeBookingAliasList(fieldAliases.depositAmount)],
     paymentMethod: [...DEFAULT_BOOKING_ALIASES.paymentMethod, ...normalizeBookingAliasList(fieldAliases.paymentMethod)],
   }
@@ -4042,9 +4071,14 @@ type IntegrationBookingRecord = {
     serviceName: string | null
     bookingDate: string | null
     bookingTime: string | null
+    branchLocationId: string | null
+    branchLocationName: string | null
+    eventLocation: string | null
+    customerStayLocation: string | null
     preferredBranch: string | null
     preferredContactMethod: string | null
     paymentMethod: string | null
+    paymentAmount: string | number | null
     depositAmount: string | number | null
   }
   sheetSync: {
@@ -4105,9 +4139,17 @@ function mapIntegrationBookingDoc(
       serviceName: toTrimmedStringOrNull(data.serviceName),
       bookingDate: toTrimmedStringOrNull(data.date),
       bookingTime: toTrimmedStringOrNull(data.time),
+      branchLocationId: toTrimmedStringOrNull(data.branchLocationId),
+      branchLocationName: toTrimmedStringOrNull(data.branchLocationName),
+      eventLocation: toTrimmedStringOrNull(data.eventLocation),
+      customerStayLocation: toTrimmedStringOrNull(data.customerStayLocation),
       preferredBranch: toTrimmedStringOrNull(data.preferredBranch),
       preferredContactMethod: toTrimmedStringOrNull(data.preferredContactMethod),
       paymentMethod: toTrimmedStringOrNull(data.paymentMethod),
+      paymentAmount:
+        typeof data.paymentAmount === 'number' && Number.isFinite(data.paymentAmount)
+          ? data.paymentAmount
+          : toTrimmedStringOrNull(data.paymentAmount),
       depositAmount:
         typeof data.depositAmount === 'number' && Number.isFinite(data.depositAmount)
           ? data.depositAmount
@@ -5072,6 +5114,54 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     payloadAttributes.time,
     payloadAttributes.bookingTime,
   )
+  const branchLocationId = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.branchLocationId,
+      lookups: [payloadLookup, attributesLookup],
+    }),
+    payload.branchLocationId,
+    payload.branchId,
+    payload.locationId,
+    payloadAttributes.branchLocationId,
+    payloadAttributes.branchId,
+    payloadAttributes.locationId,
+  )
+  const branchLocationName = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.branchLocationName,
+      lookups: [payloadLookup, attributesLookup],
+    }),
+    payload.branchLocationName,
+    payload.branchName,
+    payload.branch,
+    payloadAttributes.branchLocationName,
+    payloadAttributes.branchName,
+    payloadAttributes.branch,
+  )
+  const eventLocation = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.eventLocation,
+      lookups: [payloadLookup, attributesLookup],
+    }),
+    payload.eventLocation,
+    payload.eventVenue,
+    payload.venue,
+    payloadAttributes.eventLocation,
+    payloadAttributes.eventVenue,
+    payloadAttributes.venue,
+  )
+  const customerStayLocation = pickBookingString(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.customerStayLocation,
+      lookups: [payloadLookup, attributesLookup],
+    }),
+    payload.customerStayLocation,
+    payload.stayLocation,
+    payload.hotelLocation,
+    payloadAttributes.customerStayLocation,
+    payloadAttributes.stayLocation,
+    payloadAttributes.hotelLocation,
+  )
   const preferredBranch = pickBookingString(
     pickBookingValueFromAliases({
       aliases: bookingConfig.aliases.preferredBranch,
@@ -5119,6 +5209,20 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     payloadAttributes.depositAmount,
     payloadAttributes.depositPaid,
     payloadAttributes.amountPaid,
+  )
+  const paymentAmount = pickBookingAmount(
+    pickBookingValueFromAliases({
+      aliases: bookingConfig.aliases.paymentAmount,
+      lookups: [payloadLookup, attributesLookup],
+    }),
+    payload.paymentAmount,
+    payload.amount,
+    payload.total,
+    payload.price,
+    payloadAttributes.paymentAmount,
+    payloadAttributes.amount,
+    payloadAttributes.total,
+    payloadAttributes.price,
   )
   const paymentMethod = pickBookingString(
     pickBookingValueFromAliases({
@@ -5190,9 +5294,14 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     serviceName,
     bookingDate,
     bookingTime,
+    branchLocationId,
+    branchLocationName,
+    eventLocation,
+    customerStayLocation,
     preferredBranch,
     preferredContactMethod,
     paymentMethod,
+    paymentAmount,
     depositAmount,
   }
   const sheetColumns: Record<string, string | number | null> = {}
@@ -5203,9 +5312,14 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     serviceName,
     bookingDate,
     bookingTime,
+    branchLocationId,
+    branchLocationName,
+    eventLocation,
+    customerStayLocation,
     preferredBranch,
     preferredContactMethod,
     paymentMethod,
+    paymentAmount: typeof paymentAmount === 'number' && Number.isFinite(paymentAmount) ? paymentAmount : paymentAmount ?? null,
     depositAmount: typeof depositAmount === 'number' && Number.isFinite(depositAmount) ? depositAmount : depositAmount ?? null,
     status: 'confirmed',
     quantity,
@@ -5231,12 +5345,17 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     serviceName: importantFields.serviceName,
     date: importantFields.bookingDate,
     time: importantFields.bookingTime,
+    branchLocationId: importantFields.branchLocationId,
+    branchLocationName: importantFields.branchLocationName,
+    eventLocation: importantFields.eventLocation,
+    customerStayLocation: importantFields.customerStayLocation,
     preferredBranch: importantFields.preferredBranch,
     sessionType,
     therapistPreference,
     preferredContactMethod: importantFields.preferredContactMethod,
     depositAmount: importantFields.depositAmount,
     paymentMethod: importantFields.paymentMethod,
+    paymentAmount: importantFields.paymentAmount,
     paymentScreenshotUrl,
     paymentScreenshotReady,
     noRefundAccepted,

--- a/web/src/pages/BookingMappingSettings.tsx
+++ b/web/src/pages/BookingMappingSettings.tsx
@@ -14,8 +14,13 @@ type CanonicalFieldKey =
   | 'serviceName'
   | 'bookingDate'
   | 'bookingTime'
+  | 'branchLocationId'
+  | 'branchLocationName'
+  | 'eventLocation'
+  | 'customerStayLocation'
   | 'preferredBranch'
   | 'preferredContactMethod'
+  | 'paymentAmount'
   | 'depositAmount'
   | 'paymentMethod'
 
@@ -30,8 +35,13 @@ const CANONICAL_FIELD_KEYS: CanonicalFieldKey[] = [
   'serviceName',
   'bookingDate',
   'bookingTime',
+  'branchLocationId',
+  'branchLocationName',
+  'eventLocation',
+  'customerStayLocation',
   'preferredBranch',
   'preferredContactMethod',
+  'paymentAmount',
   'depositAmount',
   'paymentMethod',
 ]
@@ -45,8 +55,13 @@ const FIELD_LABELS: Record<SheetHeaderKey, string> = {
   serviceName: 'Service name',
   bookingDate: 'Booking date',
   bookingTime: 'Booking time',
+  branchLocationId: 'Branch location id',
+  branchLocationName: 'Branch location name',
+  eventLocation: 'Event location',
+  customerStayLocation: 'Customer stay location',
   preferredBranch: 'Preferred branch',
   preferredContactMethod: 'Preferred contact method',
+  paymentAmount: 'Payment amount',
   depositAmount: 'Deposit amount',
   paymentMethod: 'Payment method',
   status: 'Status',
@@ -60,8 +75,13 @@ const DEFAULT_SHEET_HEADERS: Record<SheetHeaderKey, string> = {
   serviceName: 'Service',
   bookingDate: 'Booking Date',
   bookingTime: 'Booking Time',
+  branchLocationId: 'Branch Location ID',
+  branchLocationName: 'Branch Location Name',
+  eventLocation: 'Event Location',
+  customerStayLocation: 'Customer Stay Location',
   preferredBranch: 'Preferred Branch',
   preferredContactMethod: 'Preferred Contact Method',
+  paymentAmount: 'Payment Amount',
   depositAmount: 'Deposit Amount',
   paymentMethod: 'Payment Method',
   status: 'Status',

--- a/web/src/pages/docs/IntegrationQuickstartPage.tsx
+++ b/web/src/pages/docs/IntegrationQuickstartPage.tsx
@@ -38,6 +38,27 @@ export default function IntegrationQuickstartPage() {
       </section>
 
       <section>
+        <h2>Booking field standardization (recommended)</h2>
+        <p>
+          To avoid sync errors across WordPress forms, page builders, and custom sites, map all incoming booking payloads
+          to canonical Sedifex field keys before sending them.
+        </p>
+        <ul>
+          <li><code>branchLocationId</code>: internal branch selector id (for multi-branch stores).</li>
+          <li><code>branchLocationName</code>: branch label shown to users (for reporting and sheet output).</li>
+          <li><code>eventLocation</code>: where an event takes place.</li>
+          <li><code>customerStayLocation</code>: where the customer is currently staying.</li>
+          <li><code>paymentMethod</code>: payment channel used (cash/card/transfer/etc.).</li>
+          <li><code>paymentAmount</code>: amount paid or to charge for the booking.</li>
+        </ul>
+        <p>
+          You can configure aliases for these keys in <strong>Settings → Integrations → Booking Mapping</strong>, so
+          labels like <code>venue</code>, <code>event_venue</code>, or <code>hotelLocation</code> still resolve to the
+          same canonical values.
+        </p>
+      </section>
+
+      <section>
         <h2>Next.js cache guidance</h2>
         <ul>
           <li><strong>30–120s</strong> revalidate window for frequent stock/price/promo/gallery changes.</li>


### PR DESCRIPTION
### Motivation

- Standardize incoming booking payloads to avoid mapping drift between different website form builders and the backend booking ingestion pipeline.
- Support multi-branch and event-based bookings and capture payment amounts for improved reporting, sheet output, and integrations.

### Description

- Add new canonical booking keys `branchLocationId`, `branchLocationName`, `eventLocation`, `customerStayLocation`, and `paymentAmount` across the codebase and docs, including example payloads in `docs/integration-api-guide.md` and guidance in `docs/integration-quickstart.md` and the web docs page. 
- Extend booking alias and header configs in the functions implementation (`functions/src/index.ts` and compiled `functions/lib/index.js`) to include default aliases and `DEFAULT_BOOKING_SHEET_HEADERS` for the new keys, and include them when loading `integrationBookingConfig` for a store. 
- Update request parsing and normalization in the `v1IntegrationBookings` handler to pick values for the new fields (including `pickBookingAmount`/`pickBookingString` lookups), add them to `importantFields`, `sheetSync` columns, and persisted `bookingData`. 
- Update the web admin mapping UI in `web/src/pages/BookingMappingSettings.tsx` to surface the new canonical keys and default labels so stores can configure aliases and sheet headers. 

### Testing

- Ran TypeScript build with `yarn build` to ensure the functions and web app compile successfully and it completed without errors. 
- Executed unit tests with `yarn test` and the test suite passed. 
- Ran linter (`yarn lint`) and fixed issues so the code passes linting checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22dcadf188322a4422bd4b271b54d)