### PR TITLE
Simplify Bookings actions and auto-queue sync on updates

### DIFF
--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -327,6 +327,8 @@ export default function Bookings() {
       try {
         await updateDoc(doc(db, 'stores', storeId, 'integrationBookings', bookingId), {
           status: nextStatus,
+          syncStatus: 'pending',
+          syncRequestedAt: Timestamp.now(),
           updatedAt: Timestamp.now(),
         })
 
@@ -349,8 +351,6 @@ export default function Bookings() {
     },
     [storeId],
   )
-
-
 
   const handleDeleteBooking = useCallback(
     async (bookingId: string) => {
@@ -375,26 +375,6 @@ export default function Bookings() {
     [storeId],
   )
 
-  const handleSyncBooking = useCallback(
-    async (bookingId: string) => {
-      if (!storeId) return
-      setUpdatingBookingId(bookingId)
-      setErrorMessage(null)
-      try {
-        await updateDoc(doc(db, 'stores', storeId, 'integrationBookings', bookingId), {
-          syncRequestedAt: Timestamp.now(),
-          syncStatus: 'pending',
-          updatedAt: Timestamp.now(),
-        })
-      } catch (error) {
-        console.error('[bookings] Failed to request booking sync', error)
-        setErrorMessage('Unable to queue this booking for sheet sync. Please retry.')
-      } finally {
-        setUpdatingBookingId(null)
-      }
-    },
-    [storeId],
-  )
 
   const filteredBookings = useMemo(() => {
     const queryText = searchTerm.trim().toLowerCase()
@@ -419,7 +399,7 @@ export default function Bookings() {
             </Link>
           </div>
           <p className="form__hint">
-            Website bookings appear here. New booking contact details are automatically mapped into Customers when they include a phone or email.
+            Website bookings appear here. New bookings and booking updates are synced automatically, and booking contact details are mapped into Customers when they include a phone or email.
           </p>
         </header>
 
@@ -538,21 +518,10 @@ export default function Bookings() {
                                 className="btn btn-secondary"
                                 type="button"
                                 disabled={updatingBookingId === booking.id}
-                                onClick={() => void handleSyncBooking(booking.id)}
-                              >
-                                Sync to sheet
-                              </button>
-                              <button
-                                className="btn btn-secondary"
-                                type="button"
-                                disabled={updatingBookingId === booking.id}
                                 onClick={() => void handleDeleteBooking(booking.id)}
                               >
                                 Delete
                               </button>
-                              <Link to={`/bookings/${booking.id}`} className="btn btn-secondary">
-                                Open
-                              </Link>
                             </div>
                           </td>
                         </tr>


### PR DESCRIPTION
### Motivation
- Remove the manual per-row "Sync to sheet" control because it may confuse non-technical users. 
- Ensure any client-side booking changes are reliably synced without requiring users to press a separate button. 
- Simplify row actions by removing a duplicate navigation action and keeping a single `Edit` path for details.

### Description
- Removed the `Sync to sheet` button and its handler from `web/src/pages/Bookings.tsx` so sync is no longer exposed as a manual action. 
- Removed the duplicate `Open` link and kept the `Edit` `Link` as the single booking-detail navigation action in `web/src/pages/Bookings.tsx`. 
- Updated `handleStatusUpdate` in `web/src/pages/Bookings.tsx` to write `syncStatus: 'pending'` and `syncRequestedAt: Timestamp.now()` when changing a booking status so updates are automatically queued for sheet sync. 
- Updated the page helper copy to explain that new bookings and booking updates are synced automatically in `web/src/pages/Bookings.tsx`.

### Testing
- Ran the lint script via `npm --prefix web run lint`, which failed in this environment due to a missing dependency (`@eslint/js`), so ESLint did not complete successfully. 
- No other automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28edf36ac83228bc88aaf1d62695b)