### PR TITLE
Show booking payment amount in UI and editor

### DIFF
--- a/web/src/pages/BookingEditor.tsx
+++ b/web/src/pages/BookingEditor.tsx
@@ -18,6 +18,7 @@ type BookingFormState = {
   status: string
   quantity: string
   notes: string
+  paymentAmount: string
   depositAmount: string
   paymentMethod: string
 }
@@ -35,12 +36,15 @@ const DEFAULT_FORM: BookingFormState = {
   status: 'confirmed',
   quantity: '1',
   notes: '',
+  paymentAmount: '',
   depositAmount: '',
   paymentMethod: '',
 }
 
 function stringValue(value: unknown): string {
-  return typeof value === 'string' ? value : ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return ''
 }
 
 export default function BookingEditor() {
@@ -87,7 +91,8 @@ export default function BookingEditor() {
           status: stringValue(data.status) || 'confirmed',
           quantity: String(typeof data.quantity === 'number' ? data.quantity : 1),
           notes: stringValue(data.notes),
-          depositAmount: stringValue(data.depositAmount),
+          paymentAmount: stringValue(data.paymentAmount || data.amount || data.total || data.price),
+          depositAmount: stringValue(data.depositAmount || data.depositPaid || data.amountPaid),
           paymentMethod: stringValue(data.paymentMethod),
         })
       } catch (error) {
@@ -143,6 +148,7 @@ export default function BookingEditor() {
           status: form.status.trim() || 'confirmed',
           quantity: quantityValue,
           notes: form.notes.trim(),
+          paymentAmount: form.paymentAmount.trim(),
           depositAmount: form.depositAmount.trim(),
           paymentMethod: form.paymentMethod.trim(),
           customer: {
@@ -209,6 +215,7 @@ export default function BookingEditor() {
               </select>
             </label>
             <label><span>Quantity</span><input type="number" min={1} value={form.quantity} onChange={event => setForm(prev => ({ ...prev, quantity: event.target.value }))} /></label>
+            <label><span>Payment amount</span><input value={form.paymentAmount} onChange={event => setForm(prev => ({ ...prev, paymentAmount: event.target.value }))} /></label>
             <label><span>Deposit amount</span><input value={form.depositAmount} onChange={event => setForm(prev => ({ ...prev, depositAmount: event.target.value }))} /></label>
             <label><span>Payment method</span><input value={form.paymentMethod} onChange={event => setForm(prev => ({ ...prev, paymentMethod: event.target.value }))} /></label>
             <label className="booking-editor-page__notes"><span>Notes</span><textarea value={form.notes} onChange={event => setForm(prev => ({ ...prev, notes: event.target.value }))} rows={4} /></label>

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -32,6 +32,7 @@ type BookingRecord = {
   sessionType: string | null
   therapistPreference: string | null
   preferredContactMethod: string | null
+  paymentAmount: string | null
   depositAmount: string | null
   paymentMethod: string | null
   paymentScreenshotUrl: string | null
@@ -161,6 +162,7 @@ export default function Bookings() {
     const preferredContactMethod = pickString(data, ['preferredContactMethod', 'contactMethod'])
     const paymentMethod = pickString(data, ['paymentMethod'])
     const paymentScreenshotUrl = pickString(data, ['paymentScreenshotUrl', 'screenshotUrl'])
+    const paymentAmount = pickAmount(data, ['paymentAmount', 'amount', 'total', 'price'])
     const depositAmount = pickAmount(data, ['depositAmount', 'depositPaid', 'amountPaid'])
     const bookingDate = pickString(data, ['date', 'bookingDate'])
     const bookingTime = pickString(data, ['time', 'bookingTime'])
@@ -183,6 +185,7 @@ export default function Bookings() {
       preferredContactMethod,
       paymentMethod,
       paymentScreenshotUrl,
+      paymentAmount,
       depositAmount,
       paymentScreenshotReady,
       noRefundAccepted,
@@ -474,6 +477,7 @@ export default function Bookings() {
                         <th>Customer</th>
                         <th>Qty</th>
                         <th>Status</th>
+                        <th>Amount</th>
                         <th>Notes</th>
                         <th>Actions</th>
                       </tr>
@@ -497,6 +501,7 @@ export default function Bookings() {
                               {statusLabel(booking.status)}
                             </span>
                           </td>
+                          <td>{booking.paymentAmount ?? booking.depositAmount ?? '—'}</td>
                           <td>{booking.notes ?? '—'}</td>
                           <td>
                             <div className="bookings-page__actions">


### PR DESCRIPTION
### Motivation
- Bookings created via the integration use the canonical `paymentAmount` field but the web UI and editor were surfacing only `depositAmount`, causing payment updates to appear not reflected.
- Staff need a way to see and edit the canonical payment value directly from the dashboard/editor.

### Description
- Updated `web/src/pages/Bookings.tsx` to hydrate and include `paymentAmount` (with legacy fallbacks `amount`, `total`, `price`) and added an `Amount` column that displays `paymentAmount` falling back to `depositAmount` when absent.
- Updated `web/src/pages/BookingEditor.tsx` to add `paymentAmount` to the form state, load `paymentAmount` (with legacy fallbacks) when editing, expose an input for `paymentAmount`, and save `paymentAmount` back to Firestore.
- Improved value normalization in `BookingEditor` via `stringValue` to render numeric Firestore values as strings in inputs so amounts stored as numbers display correctly in the form.

### Testing
- Ran `npm --prefix web run lint`, which failed in this environment due to a missing dev dependency (`@eslint/js`).
- Ran `npm --prefix web run build`, which failed in this environment due to missing type definition packages (`vite/client`, `vitest/globals`) so a full build/test could not be completed here.
- No unit tests were run in this environment; changes are limited to the web UI layer and should be validated in a local dev environment or CI with the full `node_modules` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2955836d483229fe8cc9874c23cac)