### PR TITLE
Bookings page: add explanatory intro and styles

### DIFF
--- a/web/src/pages/Bookings.css
+++ b/web/src/pages/Bookings.css
@@ -6,6 +6,13 @@
   flex-wrap: wrap;
 }
 
+.bookings-page__intro {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: #1f2937;
+}
+
 .bookings-page__filters {
   display: grid;
   gap: 12px;

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -392,15 +392,15 @@ export default function Bookings() {
     <main className="page bookings-page">
       <section className="card stack gap-4">
         <header className="stack gap-1">
-          <div className="bookings-page__header-row">
-            <h1>Bookings</h1>
-            <Link to="/bookings/new" className="btn btn-secondary">
-              Add booking
-            </Link>
-          </div>
-          <p className="form__hint">
-            Website bookings appear here. New bookings and booking updates are synced automatically, and booking contact details are mapped into Customers when they include a phone or email.
+          <h1>Bookings</h1>
+          <p className="bookings-page__intro">
+            Every website booking appears here in real time, including new appointments, reschedules, and cancellations, so your calendar always reflects the latest client
+            activity without manual updates. When a booking includes a phone number or email, we automatically map those contact details into Customers to reduce duplicate
+            entries, preserve complete client history, and make it easier for your team to confirm visits, send reminders, and deliver faster support.
           </p>
+          <Link to="/bookings/new" className="btn btn-secondary">
+            Add booking
+          </Link>
         </header>
 
         <div className="bookings-page__filters">


### PR DESCRIPTION
### Motivation
- Provide clearer onboarding text on the Bookings page to explain real-time syncing and automatic contact mapping so users understand behavior and benefits without digging into settings.
- Introduce a dedicated intro element to enable consistent styling and spacing for the header area.

### Description
- Replaced the short `form__hint` paragraph with a multi-line explanatory paragraph and moved the `Add booking` button below the new intro in `Bookings.tsx` to improve header layout and readability.
- Added `.bookings-page__intro` styles in `Bookings.css` to control spacing, font size, line height, and text color for the new intro copy.
- Removed the older `.bookings-page__header-row` wrapper markup around the title/button to simplify the header structure; no booking logic was modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e292717378832290d7967a6be5d5e2)