### PR TITLE
Normalize booking date/time for sheet sync

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -3100,6 +3100,57 @@ function sanitizeBookingAttributes(raw) {
         },
     };
 }
+function formatDateParts(year, month, day) {
+    return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+function normalizeBookingDateForSheet(value) {
+    if (!value)
+        return null;
+    const trimmed = value.trim();
+    if (!trimmed)
+        return null;
+    const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (isoMatch) {
+        const [, yearRaw, monthRaw, dayRaw] = isoMatch;
+        const year = Number(yearRaw);
+        const month = Number(monthRaw);
+        const day = Number(dayRaw);
+        const date = new Date(Date.UTC(year, month - 1, day));
+        if (date.getUTCFullYear() === year &&
+            date.getUTCMonth() + 1 === month &&
+            date.getUTCDate() === day) {
+            return formatDateParts(year, month, day);
+        }
+        return null;
+    }
+    const parsed = new Date(trimmed);
+    if (!Number.isFinite(parsed.getTime())) {
+        return null;
+    }
+    return formatDateParts(parsed.getFullYear(), parsed.getMonth() + 1, parsed.getDate());
+}
+function normalizeBookingTimeForSheet(value) {
+    if (!value)
+        return null;
+    const trimmed = value.trim();
+    if (!trimmed)
+        return null;
+    const twentyFourHourMatch = trimmed.match(/^([01]?\d|2[0-3]):([0-5]\d)(?::[0-5]\d)?$/);
+    if (twentyFourHourMatch) {
+        const [, hourRaw, minuteRaw] = twentyFourHourMatch;
+        return `${String(Number(hourRaw)).padStart(2, '0')}:${minuteRaw}`;
+    }
+    const meridiemMatch = trimmed.match(/^([1-9]|1[0-2])(?::([0-5]\d))?\s*([ap]m)$/i);
+    if (meridiemMatch) {
+        const [, hourRaw, minuteRaw, meridiemRaw] = meridiemMatch;
+        const hour = Number(hourRaw);
+        const minute = minuteRaw ?? '00';
+        const meridiem = meridiemRaw.toLowerCase();
+        const normalizedHour = meridiem === 'pm' ? (hour === 12 ? 12 : hour + 12) : hour === 12 ? 0 : hour;
+        return `${String(normalizedHour).padStart(2, '0')}:${minute}`;
+    }
+    return null;
+}
 function mapAvailabilitySlotDoc(docSnap) {
     const data = docSnap.data();
     const storeId = toTrimmedStringOrNull(data.storeId);
@@ -4049,14 +4100,16 @@ exports.v1IntegrationBookings = functions.https.onRequest(async (req, res) => {
         }
         return null;
     };
-    const bookingDate = pickBookingString(pickBookingValueFromAliases({
+    const bookingDateRaw = pickBookingString(pickBookingValueFromAliases({
         aliases: bookingConfig.aliases.bookingDate,
         lookups: [payloadLookup, attributesLookup],
     }), payload.date, payload.bookingDate, payloadAttributes.date, payloadAttributes.bookingDate);
-    const bookingTime = pickBookingString(pickBookingValueFromAliases({
+    const bookingTimeRaw = pickBookingString(pickBookingValueFromAliases({
         aliases: bookingConfig.aliases.bookingTime,
         lookups: [payloadLookup, attributesLookup],
     }), payload.time, payload.bookingTime, payloadAttributes.time, payloadAttributes.bookingTime);
+    const bookingDate = normalizeBookingDateForSheet(bookingDateRaw) ?? bookingDateRaw;
+    const bookingTime = normalizeBookingTimeForSheet(bookingTimeRaw) ?? bookingTimeRaw;
     const branchLocationId = pickBookingString(pickBookingValueFromAliases({
         aliases: bookingConfig.aliases.branchLocationId,
         lookups: [payloadLookup, attributesLookup],
@@ -6341,4 +6394,6 @@ exports.__testing = {
     buildBookingValueLookup,
     pickBookingValueFromAliases,
     sanitizeBookingAttributes,
+    normalizeBookingDateForSheet,
+    normalizeBookingTimeForSheet,
 };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4002,6 +4002,64 @@ function sanitizeBookingAttributes(raw: Record<string, unknown>): SanitizedBooki
   }
 }
 
+function formatDateParts(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+function normalizeBookingDateForSheet(value: string | null): string | null {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (isoMatch) {
+    const [, yearRaw, monthRaw, dayRaw] = isoMatch
+    const year = Number(yearRaw)
+    const month = Number(monthRaw)
+    const day = Number(dayRaw)
+    const date = new Date(Date.UTC(year, month - 1, day))
+    if (
+      date.getUTCFullYear() === year &&
+      date.getUTCMonth() + 1 === month &&
+      date.getUTCDate() === day
+    ) {
+      return formatDateParts(year, month, day)
+    }
+    return null
+  }
+
+  const parsed = new Date(trimmed)
+  if (!Number.isFinite(parsed.getTime())) {
+    return null
+  }
+
+  return formatDateParts(parsed.getFullYear(), parsed.getMonth() + 1, parsed.getDate())
+}
+
+function normalizeBookingTimeForSheet(value: string | null): string | null {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const twentyFourHourMatch = trimmed.match(/^([01]?\d|2[0-3]):([0-5]\d)(?::[0-5]\d)?$/)
+  if (twentyFourHourMatch) {
+    const [, hourRaw, minuteRaw] = twentyFourHourMatch
+    return `${String(Number(hourRaw)).padStart(2, '0')}:${minuteRaw}`
+  }
+
+  const meridiemMatch = trimmed.match(/^([1-9]|1[0-2])(?::([0-5]\d))?\s*([ap]m)$/i)
+  if (meridiemMatch) {
+    const [, hourRaw, minuteRaw, meridiemRaw] = meridiemMatch
+    const hour = Number(hourRaw)
+    const minute = minuteRaw ?? '00'
+    const meridiem = meridiemRaw.toLowerCase()
+    const normalizedHour = meridiem === 'pm' ? (hour === 12 ? 12 : hour + 12) : hour === 12 ? 0 : hour
+    return `${String(normalizedHour).padStart(2, '0')}:${minute}`
+  }
+
+  return null
+}
+
 type IntegrationAvailabilitySlot = {
   id: string
   storeId: string
@@ -5094,7 +5152,7 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     }
     return null
   }
-  const bookingDate = pickBookingString(
+  const bookingDateRaw = pickBookingString(
     pickBookingValueFromAliases({
       aliases: bookingConfig.aliases.bookingDate,
       lookups: [payloadLookup, attributesLookup],
@@ -5104,7 +5162,7 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     payloadAttributes.date,
     payloadAttributes.bookingDate,
   )
-  const bookingTime = pickBookingString(
+  const bookingTimeRaw = pickBookingString(
     pickBookingValueFromAliases({
       aliases: bookingConfig.aliases.bookingTime,
       lookups: [payloadLookup, attributesLookup],
@@ -5114,6 +5172,8 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
     payloadAttributes.time,
     payloadAttributes.bookingTime,
   )
+  const bookingDate = normalizeBookingDateForSheet(bookingDateRaw) ?? bookingDateRaw
+  const bookingTime = normalizeBookingTimeForSheet(bookingTimeRaw) ?? bookingTimeRaw
   const branchLocationId = pickBookingString(
     pickBookingValueFromAliases({
       aliases: bookingConfig.aliases.branchLocationId,
@@ -7975,4 +8035,6 @@ export const __testing = {
   buildBookingValueLookup,
   pickBookingValueFromAliases,
   sanitizeBookingAttributes,
+  normalizeBookingDateForSheet,
+  normalizeBookingTimeForSheet,
 }

--- a/functions/test/bookingNormalization.test.js
+++ b/functions/test/bookingNormalization.test.js
@@ -82,6 +82,21 @@ function runSanitizeTests(testing) {
   assert.strictEqual(result.meta.totalStored, 3)
 }
 
+function runDateFormattingTests(testing) {
+  assert.strictEqual(testing.normalizeBookingDateForSheet('2026-04-29'), '2026-04-29')
+  assert.strictEqual(testing.normalizeBookingDateForSheet('April 29, 2026'), '2026-04-29')
+  assert.strictEqual(testing.normalizeBookingDateForSheet(''), null)
+  assert.strictEqual(testing.normalizeBookingDateForSheet('2026-02-30'), null)
+}
+
+function runTimeFormattingTests(testing) {
+  assert.strictEqual(testing.normalizeBookingTimeForSheet('19:00'), '19:00')
+  assert.strictEqual(testing.normalizeBookingTimeForSheet('7pm'), '19:00')
+  assert.strictEqual(testing.normalizeBookingTimeForSheet('7:05 PM'), '19:05')
+  assert.strictEqual(testing.normalizeBookingTimeForSheet('12am'), '00:00')
+  assert.strictEqual(testing.normalizeBookingTimeForSheet(''), null)
+}
+
 function run() {
   const module = loadFunctionsModule()
   assert.ok(module.__testing, 'Expected __testing exports')
@@ -89,6 +104,8 @@ function run() {
   runCanonicalKeyTests(module.__testing)
   runLookupTests(module.__testing)
   runSanitizeTests(module.__testing)
+  runDateFormattingTests(module.__testing)
+  runTimeFormattingTests(module.__testing)
 }
 
 run()


### PR DESCRIPTION
### Motivation
- Ensure booking data written to Google Sheets uses a consistent, spreadsheet-friendly format of `YYYY-MM-DD` for dates and 24-hour `HH:mm` for times so sheet consumers don't need to handle AM/PM or locale variations.

### Description
- Add helpers `formatDateParts`, `normalizeBookingDateForSheet`, and `normalizeBookingTimeForSheet` to `functions/src/index.ts` to parse and normalize common date/time inputs to `YYYY-MM-DD` and `HH:mm` respectively. 
- Use the new helpers when ingesting bookings by computing `bookingDateRaw`/`bookingTimeRaw` and replacing them with normalized `bookingDate`/`bookingTime` before storing and including sheet sync columns. 
- Expose `normalizeBookingDateForSheet` and `normalizeBookingTimeForSheet` via the `__testing` export for unit verification. 
- Add unit tests in `functions/test/bookingNormalization.test.js` to cover ISO and natural-language dates and AM/PM time inputs (examples: `2026-04-29`, `April 29, 2026`, `7pm` -> `19:00`).

### Testing
- Ran TypeScript build with `npm --prefix functions run build` and it completed successfully. 
- Ran unit tests with `npm --prefix functions test` and the added tests passed (`bookingNormalization tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29f7038848322b202a994e05f3a54)