### PR TITLE
Add Bulk Email page and refactor Account Overview tabs into Billing/Team/Data

### DIFF
--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -17,8 +17,8 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/bookings', label: 'Bookings', roles: ['owner', 'staff'] },
   { to: '/social-media', label: 'Social media', roles: ['owner'] },
   { to: '/bulk-messaging', label: 'SMS', roles: ['owner'] },
+  { to: '/bulk-email', label: 'Bulk email', roles: ['owner'] },
   { to: '/finance', label: 'Invoice', parentTo: '/sell', roles: ['owner'] },
-  { to: '/data-transfer', label: 'Data', roles: ['owner'] },
   { to: '/public-page', label: 'Public page', roles: ['owner'] },
   { to: '/account', label: 'Account', roles: ['owner'] },
 ]

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,6 +17,7 @@ import Logi from './pages/Logi'
 import Onboarding from './pages/Onboarding'
 import AccountOverview from './pages/AccountOverview'
 import BulkMessaging from './pages/BulkMessaging'
+import BulkEmail from './pages/BulkEmail'
 import StaffManagement from './pages/StaffManagement'
 import { BillingVerifyPage } from './pages/BillingVerifyPage'
 import Support from './pages/Support'
@@ -78,6 +79,7 @@ const router = createBrowserRouter([
           { path: 'bookings/:bookingId', element: <BookingEditor /> },
           { path: 'data-transfer', element: <DataTransfer /> },
           { path: 'bulk-messaging', element: <BulkMessaging /> },
+          { path: 'bulk-email', element: <BulkEmail /> },
           { path: 'logi', element: <Logi /> },
 
           // Finance

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -342,8 +342,13 @@ type AccountOverviewProps = {
   viewMode?: 'full' | 'promotions'
 }
 
-type AccountTab = 'workspace' | 'integrations' | 'promotions' | 'operations'
-type OperationsTab = 'billing' | 'team' | 'data-controls'
+type AccountTab =
+  | 'workspace'
+  | 'integrations'
+  | 'promotions'
+  | 'billing'
+  | 'team'
+  | 'data-controls'
 type PublicPageTab = 'overview' | 'promo' | 'gallery' | 'website-sync'
 type PromoGalleryTab = 'upload' | 'view'
 type IntegrationTab = 'overview' | 'keys' | 'booking' | 'webhooks' | 'tests'
@@ -396,7 +401,6 @@ export default function AccountOverview({
   const [isSavingProfile, setIsSavingProfile] = useState(false)
   const [isEditingProfile, setIsEditingProfile] = useState(false)
   const [activeTab, setActiveTab] = useState<AccountTab>('workspace')
-  const [operationsTab, setOperationsTab] = useState<OperationsTab>('billing')
   const [integrationTab, setIntegrationTab] = useState<IntegrationTab>('overview')
 
   const [isSavingPromo, setIsSavingPromo] = useState(false)
@@ -1751,11 +1755,27 @@ export default function AccountOverview({
           </button>
           <button
             type="button"
-            className={`account-overview__tab ${activeTab === 'operations' ? 'is-active' : ''}`}
-            aria-pressed={activeTab === 'operations'}
-            onClick={() => setActiveTab('operations')}
+            className={`account-overview__tab ${activeTab === 'billing' ? 'is-active' : ''}`}
+            aria-pressed={activeTab === 'billing'}
+            onClick={() => setActiveTab('billing')}
           >
-            Billing & team
+            Billing
+          </button>
+          <button
+            type="button"
+            className={`account-overview__tab ${activeTab === 'team' ? 'is-active' : ''}`}
+            aria-pressed={activeTab === 'team'}
+            onClick={() => setActiveTab('team')}
+          >
+            Team
+          </button>
+          <button
+            type="button"
+            className={`account-overview__tab ${activeTab === 'data-controls' ? 'is-active' : ''}`}
+            aria-pressed={activeTab === 'data-controls'}
+            onClick={() => setActiveTab('data-controls')}
+          >
+            Data
           </button>
         </nav>
       )}
@@ -2884,35 +2904,7 @@ export default function AccountOverview({
         </section>
       )}
 
-      {!isPromotionsView && activeTab === 'operations' && (
-        <>
-      <nav className="account-overview__tabs" aria-label="Account operations sections">
-        <button
-          type="button"
-          className={`account-overview__tab ${operationsTab === 'billing' ? 'is-active' : ''}`}
-          aria-pressed={operationsTab === 'billing'}
-          onClick={() => setOperationsTab('billing')}
-        >
-          Billing
-        </button>
-        <button
-          type="button"
-          className={`account-overview__tab ${operationsTab === 'team' ? 'is-active' : ''}`}
-          aria-pressed={operationsTab === 'team'}
-          onClick={() => setOperationsTab('team')}
-        >
-          Team roster
-        </button>
-        <button
-          type="button"
-          className={`account-overview__tab ${operationsTab === 'data-controls' ? 'is-active' : ''}`}
-          aria-pressed={operationsTab === 'data-controls'}
-          onClick={() => setOperationsTab('data-controls')}
-        >
-          Data controls
-        </button>
-      </nav>
-      {operationsTab === 'billing' && (
+      {!isPromotionsView && activeTab === 'billing' && (
         <>
       {/* ✅ Billing summary: prefer profile.ownerEmail, fallback to auth email */}
       <AccountBillingSection
@@ -2973,10 +2965,10 @@ export default function AccountOverview({
         </>
       )}
 
-      {operationsTab === 'data-controls' && (
+      {!isPromotionsView && activeTab === 'data-controls' && (
       <section aria-labelledby="account-overview-deletion">
         <div className="account-overview__section-header">
-          <h2 id="account-overview-deletion">Data controls</h2>
+          <h2 id="account-overview-deletion">Delete account</h2>
           <p className="account-overview__subtitle">
             Delete your workspace data instantly when you no longer want to keep it.
           </p>
@@ -3039,7 +3031,7 @@ export default function AccountOverview({
       </section>
       )}
 
-      {operationsTab === 'team' && (
+      {!isPromotionsView && activeTab === 'team' && (
       <section aria-labelledby="account-overview-roster">
         <h2 id="account-overview-roster">Team roster</h2>
 
@@ -3169,8 +3161,6 @@ export default function AccountOverview({
           </tbody>
         </table>
       </section>
-      )}
-        </>
       )}
     </div>
   )

--- a/web/src/pages/BulkEmail.tsx
+++ b/web/src/pages/BulkEmail.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import PageSection from '../layout/PageSection'
+
+export default function BulkEmail() {
+  return (
+    <PageSection
+      title="Bulk email"
+      subtitle="Send campaigns from Sedifex while keeping customers in one place."
+    >
+      <div className="card" style={{ display: 'grid', gap: 16 }}>
+        <h3 className="card__title">Single source of truth</h3>
+        <p>
+          Sedifex is your customer source of truth. Stores should manage customers in Sedifex only,
+          then Sedifex passes recipients to the connected Google Apps Script endpoint as JSON when
+          sending.
+        </p>
+        <ul>
+          <li>No duplicate customer entry in Google Sheets.</li>
+          <li>Store-owned Google Sheet and Apps Script handle the send step.</li>
+          <li>Sedifex controls audience selection, campaign payload, and send logs.</li>
+        </ul>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          <Link className="button button--primary" to="/customers">
+            Manage customers
+          </Link>
+          <Link className="button button--ghost" to="/account">
+            Configure integrations
+          </Link>
+        </div>
+      </div>
+    </PageSection>
+  )
+}

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -123,7 +123,7 @@ afterAll(() => {
 describe('AccountOverview', () => {
   async function openOperationsTab() {
     await userEvent.click(
-      await screen.findByRole('button', { name: /billing & team/i }),
+      await screen.findByRole('button', { name: /^billing$/i }),
     )
   }
 


### PR DESCRIPTION
### Motivation

- Provide a dedicated UI for bulk email campaigns and expose it in the app navigation. 
- Simplify the Account overview by splitting the previous combined "operations" area into distinct `billing`, `team`, and `data-controls` sections for clearer UX. 
- Hide the `data-transfer` entry from the main navigation while keeping its route available.

### Description

- Added a new page component `BulkEmail` at `web/src/pages/BulkEmail.tsx` with links to manage customers and integrations. 
- Exposed the new route and import in `web/src/main.tsx` with `{ path: 'bulk-email', element: <BulkEmail /> }`. 
- Added the navigation item for `/bulk-email` in `web/src/config/navigation.ts` and removed the `/data-transfer` nav entry (route remains defined in `main.tsx`). 
- Refactored `AccountOverview` (`web/src/pages/AccountOverview.tsx`) by expanding `AccountTab` to include `billing`, `team`, and `data-controls`, removing the nested `operationsTab` state, updating tab buttons and conditional rendering to show billing, team roster, and data/delete sections at the top level, and updating the section heading from `Data controls` to `Delete account`.
- Updated tests in `web/src/pages/__tests__/AccountOverview.test.tsx` to reflect the tab label change (now selecting `Billing` instead of `Billing & team`).

### Testing

- Ran unit tests with `yarn test` and all tests completed successfully. 
- Verified updated `AccountOverview` unit tests (including the modified selector for the `Billing` tab) passed. 
- No UI integration or E2E tests were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34b2723f88321b50613e717177110)