### PR TITLE
Bulk email: Google Sheets template & Apps Script queueing + in-app composer

### DIFF
--- a/docs/bulk-email-google-sheets-guide.md
+++ b/docs/bulk-email-google-sheets-guide.md
@@ -16,7 +16,55 @@ Use this guide when each store should own its Google Sheet and Apps Script deplo
 5. In Sedifex, open **Account → Integrations → Bulk Email (Google Sheets)**.
 6. Paste Web App URL + shared token, then verify connection.
 
-## Apps Script sample (starter)
+## Sheet template (what the store should create)
+Create one tab with this exact name:
+- **Tab name:** `Recipients` *(change this in script if you use another name)*
+
+Use row 1 as headers:
+
+| Column | Header | What to put there |
+|---|---|---|
+| A | `email` | Customer email address (required) |
+| B | `name` | Customer name (optional) |
+| C | `status` | Leave blank. Script writes `SENT`, `SKIPPED`, or `ERROR`. |
+| D | `last_sent_at` | Leave blank. Script writes timestamp after send. |
+| E | `notes` | Optional internal notes. |
+
+### Sample rows
+| email | name | status | last_sent_at | notes |
+|---|---|---|---|---|
+| ama@example.com | Ama |  |  | VIP |
+| kojo@example.com | Kojo |  |  | Follow up in May |
+
+### Queue tab (for daily-limit overflow)
+Add another tab for queued retries:
+- **Tab name:** `EmailQueue` *(change in script if needed)*
+
+| Column | Header | Purpose |
+|---|---|---|
+| A | `queued_at` | When message was queued |
+| B | `email` | Recipient email |
+| C | `name` | Recipient name (optional) |
+| D | `subject` | Email subject |
+| E | `html` | Email HTML body |
+| F | `from_name` | Sender display name |
+| G | `status` | `QUEUED`, `SENT`, or `ERROR` |
+| H | `last_attempt_at` | Last retry time |
+| I | `error` | Last error message |
+
+## Where the topic and message go
+- **Topic (email subject):** set in Sedifex campaign **Subject** field. It is sent as `payload.subject`.
+- **Message (email body):** set in Sedifex campaign **Message** editor. It is sent as `payload.html`.
+- The sheet is mainly for recipients (`email`, optional `name`) and delivery tracking (`status`, `last_sent_at`).
+- In the script, these are used here:
+  - `subject: payload.subject || 'Update from your store'`
+  - `htmlBody: payload.html || ''`
+
+If you want to type subject/body in Google Sheets instead, add columns like `subject` and `message_html`, then replace `payload.subject` and `payload.html` with those cell values.
+
+## Apps Script sample (starter, with CHANGE ME markers)
+> Paste this into **Extensions → Apps Script**. If needed, change the values under `CONFIG` to match your own sheet/tab/columns.
+
 ```javascript
 function doPost(e) {
   const payload = JSON.parse(e.postData.contents || '{}')
@@ -27,27 +75,199 @@ function doPost(e) {
       .setMimeType(ContentService.MimeType.JSON)
   }
 
-  const recipients = Array.isArray(payload.recipients) ? payload.recipients : []
+  // CHANGE ME: update these if your tab name or column layout is different.
+  const CONFIG = {
+    sheetTabName: 'Recipients', // CHANGE ME
+    queueTabName: 'EmailQueue', // CHANGE ME
+    headers: {
+      email: 'email',           // CHANGE ME
+      name: 'name',             // CHANGE ME
+      status: 'status',         // CHANGE ME
+      lastSentAt: 'last_sent_at' // CHANGE ME
+    }
+  }
+
+  const recipientsFromPayload = Array.isArray(payload.recipients) ? payload.recipients : []
+  const ss = SpreadsheetApp.getActiveSpreadsheet()
+  const sheet = ss.getSheetByName(CONFIG.sheetTabName)
+
+  if (!sheet) {
+    return ContentService.createTextOutput(JSON.stringify({
+      ok: false,
+      error: `sheet tab not found: ${CONFIG.sheetTabName}`,
+    })).setMimeType(ContentService.MimeType.JSON)
+  }
+
+  const values = sheet.getDataRange().getValues()
+  if (!values.length) {
+    return ContentService.createTextOutput(JSON.stringify({ ok: false, error: 'sheet is empty' }))
+      .setMimeType(ContentService.MimeType.JSON)
+  }
+
+  const headers = values[0].map((h) => (h || '').toString().trim().toLowerCase())
+  const emailCol = headers.indexOf(CONFIG.headers.email.toLowerCase())
+  const nameCol = headers.indexOf(CONFIG.headers.name.toLowerCase())
+  const statusCol = headers.indexOf(CONFIG.headers.status.toLowerCase())
+  const lastSentAtCol = headers.indexOf(CONFIG.headers.lastSentAt.toLowerCase())
+
+  if (emailCol < 0) {
+    return ContentService.createTextOutput(JSON.stringify({
+      ok: false,
+      error: `missing required header: ${CONFIG.headers.email}`,
+    })).setMimeType(ContentService.MimeType.JSON)
+  }
+
+  let attempted = 0
   let sent = 0
+  const errors = []
 
-  recipients.forEach((row) => {
-    const email = (row?.email || '').toString().trim()
-    if (!email) return
+  // Priority: use Sedifex payload recipients if provided; otherwise fall back to sheet rows.
+  const sheetRows = values.slice(1).map((row, i) => ({
+    rowIndex: i + 2,
+    email: (row[emailCol] || '').toString().trim(),
+    name: nameCol >= 0 ? (row[nameCol] || '').toString().trim() : '',
+  }))
 
-    MailApp.sendEmail({
-      to: email,
-      subject: payload.subject || 'Update from your store',
-      htmlBody: payload.html || '',
-      name: payload.fromName || 'Sedifex Campaign',
-    })
-    sent += 1
+  const recipients = recipientsFromPayload.length
+    ? recipientsFromPayload.map((r) => ({
+        rowIndex: null,
+        email: (r?.email || '').toString().trim(),
+        name: (r?.name || '').toString().trim(),
+      }))
+    : sheetRows
+
+  recipients.forEach((recipient) => {
+    const email = recipient.email
+    if (!email) {
+      if (recipient.rowIndex && statusCol >= 0) {
+        sheet.getRange(recipient.rowIndex, statusCol + 1).setValue('SKIPPED')
+      }
+      return
+    }
+
+    attempted += 1
+
+    try {
+      MailApp.sendEmail({
+        to: email,
+        subject: payload.subject || 'Update from your store',
+        htmlBody: payload.html || '',
+        name: payload.fromName || 'Sedifex Campaign',
+      })
+      sent += 1
+
+      if (recipient.rowIndex && statusCol >= 0) {
+        sheet.getRange(recipient.rowIndex, statusCol + 1).setValue('SENT')
+      }
+      if (recipient.rowIndex && lastSentAtCol >= 0) {
+        sheet.getRange(recipient.rowIndex, lastSentAtCol + 1).setValue(new Date())
+      }
+    } catch (err) {
+      const message = String(err)
+      errors.push({ email, message })
+
+      // Queue when daily send limit/quota is reached.
+      if (isDailyLimitError(message)) {
+        enqueueEmail(ss, CONFIG.queueTabName, {
+          email,
+          name: recipient.name || '',
+          subject: payload.subject || 'Update from your store',
+          html: payload.html || '',
+          fromName: payload.fromName || 'Sedifex Campaign',
+          error: message,
+        })
+      }
+
+      if (recipient.rowIndex && statusCol >= 0) {
+        sheet
+          .getRange(recipient.rowIndex, statusCol + 1)
+          .setValue(isDailyLimitError(message) ? 'QUEUED' : 'ERROR')
+      }
+    }
   })
 
   return ContentService.createTextOutput(JSON.stringify({
     ok: true,
-    attempted: recipients.length,
+    attempted,
     sent,
+    failed: attempted - sent,
+    queuedForRetry: errors.filter((e) => isDailyLimitError(e.message)).length,
+    errors,
   })).setMimeType(ContentService.MimeType.JSON)
+}
+
+function isDailyLimitError(message) {
+  const text = (message || '').toLowerCase()
+  return text.includes('limit exceeded') || text.includes('quota')
+}
+
+function getOrCreateQueueSheet(ss, queueTabName) {
+  const sheet = ss.getSheetByName(queueTabName) || ss.insertSheet(queueTabName)
+  if (sheet.getLastRow() === 0) {
+    sheet.appendRow([
+      'queued_at',
+      'email',
+      'name',
+      'subject',
+      'html',
+      'from_name',
+      'status',
+      'last_attempt_at',
+      'error',
+    ])
+  }
+  return sheet
+}
+
+function enqueueEmail(ss, queueTabName, item) {
+  const queueSheet = getOrCreateQueueSheet(ss, queueTabName)
+  queueSheet.appendRow([
+    new Date(),
+    item.email || '',
+    item.name || '',
+    item.subject || '',
+    item.html || '',
+    item.fromName || '',
+    'QUEUED',
+    '',
+    item.error || '',
+  ])
+}
+
+/**
+ * Optional: run this with a time-based trigger every 15-60 minutes.
+ * It retries queued emails after daily limits reset.
+ */
+function processEmailQueue() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet()
+  const queueSheet = getOrCreateQueueSheet(ss, 'EmailQueue') // CHANGE ME if renamed
+  const values = queueSheet.getDataRange().getValues()
+  if (values.length <= 1) return
+
+  const data = values.slice(1)
+  data.forEach((row, idx) => {
+    const rowNumber = idx + 2
+    const status = (row[6] || '').toString().trim().toUpperCase()
+    if (status !== 'QUEUED') return
+
+    const email = (row[1] || '').toString().trim()
+    if (!email) return
+
+    try {
+      MailApp.sendEmail({
+        to: email,
+        subject: (row[3] || '').toString(),
+        htmlBody: (row[4] || '').toString(),
+        name: (row[5] || 'Sedifex Campaign').toString(),
+      })
+      queueSheet.getRange(rowNumber, 7).setValue('SENT') // status
+      queueSheet.getRange(rowNumber, 8).setValue(new Date()) // last_attempt_at
+      queueSheet.getRange(rowNumber, 9).setValue('') // error
+    } catch (err) {
+      queueSheet.getRange(rowNumber, 8).setValue(new Date())
+      queueSheet.getRange(rowNumber, 9).setValue(String(err))
+    }
+  })
 }
 ```
 
@@ -69,4 +289,5 @@ function doPost(e) {
 ## Important notes
 - Keep customer records in Sedifex only (no duplicate manual entry).
 - Google sending quotas apply.
+- If quota is reached, script can queue unsent emails to `EmailQueue` and retry later with a time-based trigger.
 - Rotate shared tokens when ownership/staff changes.

--- a/web/src/pages/BulkEmail.tsx
+++ b/web/src/pages/BulkEmail.tsx
@@ -1,33 +1,345 @@
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { collection, limit, onSnapshot, orderBy, query, where } from 'firebase/firestore'
 import PageSection from '../layout/PageSection'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import { useWorkspaceIdentity } from '../hooks/useWorkspaceIdentity'
+
+type Customer = {
+  id: string
+  name?: string
+  displayName?: string
+  email?: string
+  updatedAt?: unknown
+  createdAt?: unknown
+}
+
+type SendResult = {
+  ok?: boolean
+  attempted?: number
+  sent?: number
+  failed?: number
+  queuedForRetry?: number
+  error?: string
+  [key: string]: unknown
+}
+
+function getCustomerName(customer: Pick<Customer, 'displayName' | 'name' | 'email'>) {
+  const displayName = customer.displayName?.trim()
+  if (displayName) return displayName
+  const name = customer.name?.trim()
+  if (name) return name
+  const email = customer.email?.trim()
+  if (email) return email
+  return 'Unknown customer'
+}
 
 export default function BulkEmail() {
+  const { storeId } = useActiveStore()
+  const { name: workspaceName } = useWorkspaceIdentity()
+  const [customers, setCustomers] = useState<Customer[]>([])
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [webAppUrl, setWebAppUrl] = useState('')
+  const [sharedToken, setSharedToken] = useState('')
+  const [fromName, setFromName] = useState(workspaceName || 'Sedifex Campaign')
+  const [subject, setSubject] = useState('')
+  const [html, setHtml] = useState('')
+  const [searchTerm, setSearchTerm] = useState('')
+  const [isSending, setIsSending] = useState(false)
+  const [sendStatus, setSendStatus] = useState<string>('')
+  const [sendError, setSendError] = useState<string>('')
+  const [sendResult, setSendResult] = useState<SendResult | null>(null)
+
+  useEffect(() => {
+    if (!workspaceName) return
+    setFromName(prev => (prev ? prev : workspaceName))
+  }, [workspaceName])
+
+  useEffect(() => {
+    if (!storeId) {
+      setCustomers([])
+      setSelectedIds(new Set())
+      return undefined
+    }
+
+    const customerQuery = query(
+      collection(db, 'customers'),
+      where('storeId', '==', storeId),
+      orderBy('updatedAt', 'desc'),
+      orderBy('createdAt', 'desc'),
+      limit(500),
+    )
+
+    const unsubscribe = onSnapshot(customerQuery, snapshot => {
+      const rows = snapshot.docs.map(docSnap => ({
+        id: docSnap.id,
+        ...(docSnap.data() as Omit<Customer, 'id'>),
+      }))
+      setCustomers(rows)
+    })
+
+    return () => unsubscribe()
+  }, [storeId])
+
+  const emailCustomers = useMemo(
+    () =>
+      customers.filter(customer => {
+        const email = customer.email?.trim()
+        return Boolean(email)
+      }),
+    [customers],
+  )
+
+  const filteredCustomers = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase()
+    if (!term) return emailCustomers
+    return emailCustomers.filter(customer => {
+      const text = `${getCustomerName(customer)} ${customer.email || ''}`.toLowerCase()
+      return text.includes(term)
+    })
+  }, [emailCustomers, searchTerm])
+
+  const selectedCustomers = useMemo(
+    () => emailCustomers.filter(customer => selectedIds.has(customer.id)),
+    [emailCustomers, selectedIds],
+  )
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const selectAllFiltered = () => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      filteredCustomers.forEach(customer => next.add(customer.id))
+      return next
+    })
+  }
+
+  const clearSelection = () => setSelectedIds(new Set())
+
+  const handleSend = async () => {
+    setSendStatus('')
+    setSendError('')
+    setSendResult(null)
+
+    if (!webAppUrl.trim()) {
+      setSendError('Enter your Google Apps Script Web App URL.')
+      return
+    }
+    if (!sharedToken.trim()) {
+      setSendError('Enter your shared token.')
+      return
+    }
+    if (!subject.trim()) {
+      setSendError('Enter an email subject.')
+      return
+    }
+    if (!html.trim()) {
+      setSendError('Enter an email message.')
+      return
+    }
+    if (!selectedCustomers.length) {
+      setSendError('Select at least one customer with an email address.')
+      return
+    }
+
+    setIsSending(true)
+
+    try {
+      const payload = {
+        token: sharedToken.trim(),
+        campaignId: `cmp_${Date.now()}`,
+        fromName: fromName.trim() || 'Sedifex Campaign',
+        subject: subject.trim(),
+        html: html.trim(),
+        recipients: selectedCustomers.map(customer => ({
+          id: customer.id,
+          name: getCustomerName(customer),
+          email: customer.email?.trim() || '',
+        })),
+      }
+
+      const response = await fetch(webAppUrl.trim(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+
+      const bodyText = await response.text()
+      let body: SendResult = {}
+      try {
+        body = JSON.parse(bodyText) as SendResult
+      } catch {
+        body = { ok: false, error: bodyText || 'invalid-json-response' }
+      }
+
+      if (!response.ok || body.ok === false) {
+        const errorMessage = typeof body.error === 'string' ? body.error : `send-failed (${response.status})`
+        setSendError(errorMessage)
+        setSendResult(body)
+        return
+      }
+
+      setSendResult(body)
+      setSendStatus('Campaign sent to Apps Script endpoint successfully.')
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : 'Unable to send campaign.')
+    } finally {
+      setIsSending(false)
+    }
+  }
+
   return (
     <PageSection
       title="Bulk email"
-      subtitle="Send campaigns from Sedifex while keeping customers in one place."
+      subtitle="Compose your campaign in Sedifex, select recipients, and send to your Google Apps Script endpoint."
     >
       <div className="card" style={{ display: 'grid', gap: 16 }}>
-        <h3 className="card__title">Single source of truth</h3>
-        <p>
-          Sedifex is your customer source of truth. Stores should manage customers in Sedifex only,
-          then Sedifex passes recipients to the connected Google Apps Script endpoint as JSON when
-          sending.
+        <h3 className="card__title">In-app email composer</h3>
+        <p style={{ margin: 0 }}>
+          This composer sends your campaign payload directly to your Google Apps Script Web App URL.
+          Your script handles delivery (and optional queue retries).
         </p>
-        <ul>
-          <li>No duplicate customer entry in Google Sheets.</li>
-          <li>Store-owned Google Sheet and Apps Script handle the send step.</li>
-          <li>Sedifex controls audience selection, campaign payload, and send logs.</li>
-        </ul>
+
+        <label className="field">
+          <span>Apps Script Web App URL</span>
+          <input
+            value={webAppUrl}
+            onChange={event => setWebAppUrl(event.target.value)}
+            placeholder="https://script.google.com/macros/s/.../exec"
+            autoComplete="off"
+          />
+        </label>
+
+        <label className="field">
+          <span>Shared token</span>
+          <input
+            value={sharedToken}
+            onChange={event => setSharedToken(event.target.value)}
+            placeholder="Same value as SEDIFEX_SHARED_TOKEN in Apps Script properties"
+            autoComplete="off"
+          />
+        </label>
+
+        <div style={{ display: 'grid', gap: 10, gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+          <label className="field">
+            <span>From name</span>
+            <input value={fromName} onChange={event => setFromName(event.target.value)} />
+          </label>
+          <label className="field">
+            <span>Subject</span>
+            <input
+              value={subject}
+              onChange={event => setSubject(event.target.value)}
+              placeholder="Weekend promo just for you"
+            />
+          </label>
+        </div>
+
+        <label className="field">
+          <span>Message (HTML allowed)</span>
+          <textarea
+            value={html}
+            onChange={event => setHtml(event.target.value)}
+            rows={8}
+            placeholder="<p>Hello {{name}}, enjoy 10% off this weekend.</p>"
+          />
+        </label>
+
+        <div
+          style={{
+            border: '1px solid var(--line, #d8deeb)',
+            borderRadius: 12,
+            padding: 12,
+            display: 'grid',
+            gap: 10,
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
+            <strong>Recipients</strong>
+            <span>
+              {selectedCustomers.length} selected / {emailCustomers.length} with email
+            </span>
+          </div>
+
+          <label className="field">
+            <span>Search customers</span>
+            <input
+              value={searchTerm}
+              onChange={event => setSearchTerm(event.target.value)}
+              placeholder="Search by name or email"
+            />
+          </label>
+
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button type="button" className="button button--ghost" onClick={selectAllFiltered}>
+              Select filtered
+            </button>
+            <button type="button" className="button button--ghost" onClick={clearSelection}>
+              Clear selection
+            </button>
+          </div>
+
+          <div style={{ maxHeight: 260, overflow: 'auto', border: '1px solid var(--line, #e3e8f5)', borderRadius: 10 }}>
+            {filteredCustomers.length ? (
+              filteredCustomers.map(customer => {
+                const isChecked = selectedIds.has(customer.id)
+                return (
+                  <label
+                    key={customer.id}
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'auto 1fr',
+                      gap: 10,
+                      padding: '10px 12px',
+                      borderBottom: '1px solid var(--line, #f0f3fa)',
+                      background: isChecked ? 'var(--panel-muted, #f6f8fd)' : 'transparent',
+                    }}
+                  >
+                    <input type="checkbox" checked={isChecked} onChange={() => toggleSelect(customer.id)} />
+                    <span>
+                      <strong>{getCustomerName(customer)}</strong>
+                      <br />
+                      <small>{customer.email}</small>
+                    </span>
+                  </label>
+                )
+              })
+            ) : (
+              <p style={{ margin: 0, padding: 12 }}>No customers with email match this search.</p>
+            )}
+          </div>
+        </div>
+
         <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-          <Link className="button button--primary" to="/customers">
+          <button type="button" className="button button--primary" onClick={handleSend} disabled={isSending}>
+            {isSending ? 'Sending…' : 'Send bulk email'}
+          </button>
+          <Link className="button button--ghost" to="/docs/bulk-email-google-sheets-guide">
+            Open setup guide
+          </Link>
+          <Link className="button button--ghost" to="/customers">
             Manage customers
           </Link>
-          <Link className="button button--ghost" to="/account">
-            Configure integrations
-          </Link>
         </div>
+
+        {sendStatus ? <p style={{ margin: 0, color: 'var(--success, #137333)' }}>{sendStatus}</p> : null}
+        {sendError ? <p style={{ margin: 0, color: 'var(--danger, #b3261e)' }}>{sendError}</p> : null}
+        {sendResult ? (
+          <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>
+            {JSON.stringify(sendResult, null, 2)}
+          </pre>
+        ) : null}
       </div>
     </PageSection>
   )


### PR DESCRIPTION
### Motivation
- Provide a clear Google Sheet template and a more robust Apps Script starter so stores can own delivery while Sedifex remains the source of truth.
- Handle Google MailApp daily/quota limits by queuing failed sends for later retries.
- Offer an in-app composer that selects recipients from Firestore and posts campaign payloads to the store-owned Apps Script endpoint.

### Description
- Expanded `docs/bulk-email-google-sheets-guide.md` with a `Recipients` sheet template, `EmailQueue` tab spec, and detailed sample rows and headers, and clarified payload fields like `payload.subject` and `payload.html`.
- Replaced the Apps Script starter with a full sample that includes a `CONFIG` section, reads recipients from either the Sedifex payload or sheet rows, writes `SENT`/`SKIPPED`/`ERROR`/`QUEUED` statuses and `last_sent_at`, detects daily/quota errors via `isDailyLimitError`, and appends queued items to a queue sheet using `enqueueEmail` and `getOrCreateQueueSheet`.
- Added `processEmailQueue` to retry queued messages (intended to be run by a time trigger) and updated the script response to return `attempted`, `sent`, `failed`, `queuedForRetry`, and `errors` details.
- Rewrote `web/src/pages/BulkEmail.tsx` to add a composer UI, Firestore-backed customer listing and filtering, multi-select controls, inputs for `webAppUrl` and `sharedToken`, validation, and a `handleSend` routine that posts the JSON payload to the Apps Script endpoint and surfaces the response.
- Introduced lightweight types for `Customer` and `SendResult`, and new imports/use of Firestore and workspace/store hooks (`db`, `useActiveStore`, `useWorkspaceIdentity`).

### Testing
- No unit tests were added or changed for this PR.
- Performed a local TypeScript build via `yarn build` to ensure compilation of the updated frontend and the new imports, and it completed successfully.
- Ran lint checks via `yarn lint` and fixed any minor issues; lint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e35d39bf7c8322a5e91f3a8d5124e0)