### PR TITLE
Add Email delivery integration UI and Bulk Email composer improvements

### DIFF
--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -76,6 +76,9 @@ type StoreProfile = {
   tiktokConnectedAt: Timestamp | null
   promoImageUrl: string | null
   promoImageAlt: string | null
+  bulkEmailWebAppUrl: string | null
+  bulkEmailSharedToken: string | null
+  bulkEmailFromName: string | null
 }
 
 type SubscriptionProfile = {
@@ -226,6 +229,10 @@ function mapStoreSnapshot(
   // ✅ Prefer stores.ownerEmail for billing; fallback to stores.email
   const ownerEmail =
     toNullableString((data as any).ownerEmail) ?? toNullableString(data.email)
+  const bulkEmailRaw =
+    data.bulkEmailIntegration && typeof data.bulkEmailIntegration === 'object'
+      ? (data.bulkEmailIntegration as Record<string, unknown>)
+      : {}
 
   return {
     name: toNullableString(data.name),
@@ -262,6 +269,9 @@ function mapStoreSnapshot(
     tiktokConnectedAt: isTimestamp((data as any).tiktokConnectedAt) ? (data as any).tiktokConnectedAt : null,
     promoImageUrl: toNullableString((data as any).promoImageUrl),
     promoImageAlt: toNullableString((data as any).promoImageAlt),
+    bulkEmailWebAppUrl: toNullableString(bulkEmailRaw.webAppUrl),
+    bulkEmailSharedToken: toNullableString(bulkEmailRaw.sharedToken),
+    bulkEmailFromName: toNullableString(bulkEmailRaw.fromName),
   }
 }
 
@@ -351,7 +361,7 @@ type AccountTab =
   | 'data-controls'
 type PublicPageTab = 'overview' | 'promo' | 'gallery' | 'website-sync'
 type PromoGalleryTab = 'upload' | 'view'
-type IntegrationTab = 'overview' | 'keys' | 'booking' | 'webhooks' | 'tests'
+type IntegrationTab = 'overview' | 'keys' | 'booking' | 'webhooks' | 'email' | 'tests'
 
 export default function AccountOverview({
   headingLevel = 'h1',
@@ -445,6 +455,10 @@ export default function AccountOverview({
   const [webhookSecret, setWebhookSecret] = useState('')
   const [isSavingWebhookEndpoint, setIsSavingWebhookEndpoint] = useState(false)
   const [actioningWebhookEndpointId, setActioningWebhookEndpointId] = useState<string | null>(null)
+  const [bulkEmailWebAppUrl, setBulkEmailWebAppUrl] = useState('')
+  const [bulkEmailSharedToken, setBulkEmailSharedToken] = useState('')
+  const [bulkEmailFromName, setBulkEmailFromName] = useState('')
+  const [isSavingBulkEmailIntegration, setIsSavingBulkEmailIntegration] = useState(false)
   const isPromotionsView = viewMode === 'promotions'
 
   const activeMembership = useMemo(() => {
@@ -457,6 +471,19 @@ export default function AccountOverview({
     () => roster.filter(member => member.status === 'pending'),
     [roster],
   )
+
+  useEffect(() => {
+    if (!profile) {
+      setBulkEmailWebAppUrl('')
+      setBulkEmailSharedToken('')
+      setBulkEmailFromName('')
+      return
+    }
+
+    setBulkEmailWebAppUrl(profile.bulkEmailWebAppUrl ?? '')
+    setBulkEmailSharedToken(profile.bulkEmailSharedToken ?? '')
+    setBulkEmailFromName(profile.bulkEmailFromName ?? profile.displayName ?? profile.name ?? '')
+  }, [profile])
 
   useEffect(() => {
     if (!isPromotionsView) return
@@ -1493,6 +1520,55 @@ export default function AccountOverview({
     }
   }
 
+  async function handleSaveBulkEmailIntegration() {
+    if (!storeId) {
+      publish({ message: 'No store selected for email integration.', tone: 'error' })
+      return
+    }
+    if (!bulkEmailWebAppUrl.trim()) {
+      publish({ message: 'Enter your Google Apps Script Web App URL.', tone: 'error' })
+      return
+    }
+    if (!bulkEmailSharedToken.trim()) {
+      publish({ message: 'Enter your email shared token.', tone: 'error' })
+      return
+    }
+
+    try {
+      setIsSavingBulkEmailIntegration(true)
+      await setDoc(
+        doc(db, 'stores', storeId),
+        {
+          bulkEmailIntegration: {
+            webAppUrl: bulkEmailWebAppUrl.trim(),
+            sharedToken: bulkEmailSharedToken.trim(),
+            fromName: bulkEmailFromName.trim(),
+            updatedAt: serverTimestamp(),
+          },
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true },
+      )
+
+      setProfile(current =>
+        current
+          ? {
+              ...current,
+              bulkEmailWebAppUrl: bulkEmailWebAppUrl.trim(),
+              bulkEmailSharedToken: bulkEmailSharedToken.trim(),
+              bulkEmailFromName: bulkEmailFromName.trim() || null,
+            }
+          : current,
+      )
+      publish({ message: 'Bulk email integration saved.', tone: 'success' })
+    } catch (error) {
+      console.error('[account] Failed to save bulk email integration', error)
+      publish({ message: 'Unable to save bulk email integration.', tone: 'error' })
+    } finally {
+      setIsSavingBulkEmailIntegration(false)
+    }
+  }
+
   async function handleConnectTikTok() {
     if (!storeId) {
       publish({ message: 'No store selected for TikTok connection.', tone: 'error' })
@@ -2082,6 +2158,13 @@ export default function AccountOverview({
               </button>
               <button
                 type="button"
+                className={`account-overview__tab ${integrationTab === 'email' ? 'is-active' : ''}`}
+                onClick={() => setIntegrationTab('email')}
+              >
+                Email delivery
+              </button>
+              <button
+                type="button"
                 className={`account-overview__tab ${integrationTab === 'tests' ? 'is-active' : ''}`}
                 onClick={() => setIntegrationTab('tests')}
               >
@@ -2302,6 +2385,52 @@ export default function AccountOverview({
                     ))}
                   </ul>
                 )}
+              </div>
+            )}
+            {(integrationTab === 'overview' || integrationTab === 'email') && (
+              <div className="account-overview__website-sync-keys">
+                <p className="account-overview__hint">Bulk email delivery integration</p>
+                <p className="account-overview__hint">
+                  Configure this once here. The <Link to="/bulk-email">Bulk Email</Link> page will use these values
+                  when sending campaigns.
+                </p>
+                <div className="account-overview__website-sync-test">
+                  <label>
+                    <span>Google Apps Script Web App URL</span>
+                    <input
+                      type="url"
+                      value={bulkEmailWebAppUrl}
+                      onChange={event => setBulkEmailWebAppUrl(event.target.value)}
+                      placeholder="https://script.google.com/macros/s/.../exec"
+                    />
+                  </label>
+                  <label>
+                    <span>Shared token</span>
+                    <input
+                      type="password"
+                      value={bulkEmailSharedToken}
+                      onChange={event => setBulkEmailSharedToken(event.target.value)}
+                      placeholder="Set the same token in your Apps Script"
+                    />
+                  </label>
+                  <label>
+                    <span>From name (optional)</span>
+                    <input
+                      type="text"
+                      value={bulkEmailFromName}
+                      onChange={event => setBulkEmailFromName(event.target.value)}
+                      placeholder="Sedifex Campaign"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    className="button button--secondary"
+                    onClick={handleSaveBulkEmailIntegration}
+                    disabled={isSavingBulkEmailIntegration}
+                  >
+                    {isSavingBulkEmailIntegration ? 'Saving…' : 'Save email integration'}
+                  </button>
+                </div>
               </div>
             )}
             {(integrationTab === 'overview' || integrationTab === 'tests') && (

--- a/web/src/pages/BulkEmail.tsx
+++ b/web/src/pages/BulkEmail.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { collection, limit, onSnapshot, orderBy, query, where } from 'firebase/firestore'
+import { collection, doc, getDoc, limit, onSnapshot, orderBy, query, where } from 'firebase/firestore'
 import PageSection from '../layout/PageSection'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
@@ -46,6 +46,8 @@ export default function BulkEmail() {
   const [subject, setSubject] = useState('')
   const [html, setHtml] = useState('')
   const [searchTerm, setSearchTerm] = useState('')
+  const [isLoadingIntegration, setIsLoadingIntegration] = useState(false)
+  const [integrationError, setIntegrationError] = useState<string>('')
   const [isSending, setIsSending] = useState(false)
   const [sendStatus, setSendStatus] = useState<string>('')
   const [sendError, setSendError] = useState<string>('')
@@ -55,6 +57,64 @@ export default function BulkEmail() {
     if (!workspaceName) return
     setFromName(prev => (prev ? prev : workspaceName))
   }, [workspaceName])
+
+  useEffect(() => {
+    if (!storeId) {
+      setWebAppUrl('')
+      setSharedToken('')
+      setFromName(workspaceName || 'Sedifex Campaign')
+      return
+    }
+
+    let cancelled = false
+
+    async function loadIntegrationSettings() {
+      setIsLoadingIntegration(true)
+      setIntegrationError('')
+      try {
+        const snapshot = await getDoc(doc(db, 'stores', storeId))
+        if (cancelled) return
+
+        if (!snapshot.exists()) {
+          setIntegrationError('Workspace not found. Open Account → Integrations to reconnect email settings.')
+          return
+        }
+
+        const data = snapshot.data() as Record<string, unknown>
+        const bulkEmailIntegration =
+          data.bulkEmailIntegration && typeof data.bulkEmailIntegration === 'object'
+            ? (data.bulkEmailIntegration as Record<string, unknown>)
+            : {}
+
+        const savedWebAppUrl =
+          typeof bulkEmailIntegration.webAppUrl === 'string' ? bulkEmailIntegration.webAppUrl.trim() : ''
+        const savedSharedToken =
+          typeof bulkEmailIntegration.sharedToken === 'string' ? bulkEmailIntegration.sharedToken.trim() : ''
+        const savedFromName =
+          typeof bulkEmailIntegration.fromName === 'string' ? bulkEmailIntegration.fromName.trim() : ''
+
+        setWebAppUrl(savedWebAppUrl)
+        setSharedToken(savedSharedToken)
+        setFromName(savedFromName || workspaceName || 'Sedifex Campaign')
+
+        if (!savedWebAppUrl || !savedSharedToken) {
+          setIntegrationError('Email integration is incomplete. Open Account → Integrations → Email delivery.')
+        }
+      } catch (error) {
+        if (cancelled) return
+        console.error('[bulk-email] Failed to load email integration settings', error)
+        setIntegrationError('Unable to load email integration settings. Open Account → Integrations.')
+      } finally {
+        if (!cancelled) setIsLoadingIntegration(false)
+      }
+    }
+
+    void loadIntegrationSettings()
+
+    return () => {
+      cancelled = true
+    }
+  }, [storeId, workspaceName])
 
   useEffect(() => {
     if (!storeId) {
@@ -133,11 +193,11 @@ export default function BulkEmail() {
     setSendResult(null)
 
     if (!webAppUrl.trim()) {
-      setSendError('Enter your Google Apps Script Web App URL.')
+      setSendError('Connect your Google Apps Script Web App URL in Account → Integrations → Email delivery.')
       return
     }
     if (!sharedToken.trim()) {
-      setSendError('Enter your shared token.')
+      setSendError('Set your shared token in Account → Integrations → Email delivery.')
       return
     }
     if (!subject.trim()) {
@@ -202,56 +262,128 @@ export default function BulkEmail() {
   return (
     <PageSection
       title="Bulk email"
-      subtitle="Set up your email integration and use Sedifex customer data as the audience source."
+      subtitle="Compose and send your campaign from here. Integration settings are now managed under Account → Integrations."
     >
       <div className="card" style={{ display: 'grid', gap: 16 }}>
         <h3 className="card__title">In-app email composer</h3>
         <p style={{ margin: 0 }}>
-          This composer sends your campaign payload directly to your Google Apps Script Web App URL.
-          Your script handles delivery (and optional queue retries).
+          Write your message here, choose recipients, then send directly to your configured Google Apps Script endpoint.
         </p>
-        <ul>
-          <li>No duplicate customer entry in Google Sheets.</li>
-          <li>Store-owned Google Sheet and Apps Script handle the send step.</li>
-          <li>Sedifex passes campaign payload to your configured Apps Script endpoint.</li>
-        </ul>
-        <p style={{ margin: 0 }}>
-          <strong>Why you do not see a message input here:</strong> this page is currently an
-          integration setup page. The in-app email composer is not available on this screen yet.
-        </p>
+
         <div
           style={{
             border: '1px solid var(--line, #d8deeb)',
             borderRadius: 12,
             padding: 14,
             background: 'var(--panel-muted, #f6f8fd)',
+            display: 'grid',
+            gap: 8,
           }}
         >
-          <h4 style={{ margin: '0 0 8px' }}>How to send right now</h4>
-          <ol style={{ margin: 0, paddingInlineStart: 20, display: 'grid', gap: 6 }}>
-            <li>Open <strong>Account → Integrations</strong> and connect your Google Apps Script URL + token.</li>
-            <li>Keep your customers updated in <strong>Customers</strong> inside Sedifex.</li>
-            <li>
-              Use your Apps Script flow to send with Sedifex payload fields:
-              <code> subject </code>
-              and
-              <code> html </code>
-              (see setup guide).
-            </li>
-          </ol>
+          <p style={{ margin: 0 }}>
+            <strong>Delivery setup:</strong> Account → Integrations → Email delivery.
+          </p>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <Link className="button button--ghost" to="/account">
+              Open integrations
+            </Link>
+            <Link className="button button--ghost" to="/docs/bulk-email-google-sheets-guide">
+              Open setup guide
+            </Link>
+          </div>
+          {isLoadingIntegration ? <p style={{ margin: 0 }}>Loading integration settings…</p> : null}
+          {integrationError ? <p style={{ margin: 0, color: 'var(--danger, #b3261e)' }}>{integrationError}</p> : null}
         </div>
+
+        <div style={{ display: 'grid', gap: 10 }}>
+          <label style={{ display: 'grid', gap: 6 }}>
+            <span>From name</span>
+            <input
+              type="text"
+              value={fromName}
+              onChange={event => setFromName(event.target.value)}
+              placeholder="Sedifex Campaign"
+            />
+          </label>
+          <label style={{ display: 'grid', gap: 6 }}>
+            <span>Email subject</span>
+            <input
+              type="text"
+              value={subject}
+              onChange={event => setSubject(event.target.value)}
+              placeholder="Big weekend offer for loyal customers"
+            />
+          </label>
+          <label style={{ display: 'grid', gap: 6 }}>
+            <span>Email content (HTML or plain text)</span>
+            <textarea
+              rows={8}
+              value={html}
+              onChange={event => setHtml(event.target.value)}
+              placeholder="<h1>Hi {{name}}</h1><p>Thanks for shopping with us...</p>"
+            />
+          </label>
+        </div>
+
+        <div style={{ display: 'grid', gap: 10 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <strong>Recipients</strong>
+            <span>
+              {selectedCustomers.length} selected / {emailCustomers.length} with email
+            </span>
+          </div>
+          <label style={{ display: 'grid', gap: 6 }}>
+            <span>Search customers</span>
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={event => setSearchTerm(event.target.value)}
+              placeholder="Search name or email"
+            />
+          </label>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button type="button" className="button button--secondary" onClick={selectAllFiltered}>
+              Select all filtered
+            </button>
+            <button type="button" className="button button--ghost" onClick={clearSelection}>
+              Clear selection
+            </button>
+          </div>
+          <div style={{ maxHeight: 260, overflow: 'auto', border: '1px solid var(--line, #d8deeb)', borderRadius: 10 }}>
+            {filteredCustomers.length === 0 ? (
+              <p style={{ margin: 0, padding: 12 }}>No customers with email match your search.</p>
+            ) : (
+              <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                {filteredCustomers.map(customer => {
+                  const isSelected = selectedIds.has(customer.id)
+                  return (
+                    <li key={customer.id} style={{ borderBottom: '1px solid var(--line, #d8deeb)', padding: '10px 12px' }}>
+                      <label style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleSelect(customer.id)}
+                        />
+                        <span>
+                          <strong>{getCustomerName(customer)}</strong>
+                          <br />
+                          <span>{customer.email?.trim() || 'No email'}</span>
+                        </span>
+                      </label>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+
         <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
           <button type="button" className="button button--primary" onClick={handleSend} disabled={isSending}>
             {isSending ? 'Sending…' : 'Send bulk email'}
           </button>
-          <Link className="button button--ghost" to="/docs/bulk-email-google-sheets-guide">
-            Open setup guide
-          </Link>
           <Link className="button button--ghost" to="/customers">
             Manage customers
-          </Link>
-          <Link className="button button--ghost" to="/docs/bulk-email-google-sheets-guide">
-            Open setup guide
           </Link>
         </div>
 


### PR DESCRIPTION
### Motivation

- Provide a persistent workspace-level configuration for third-party bulk email delivery so campaigns can be sent from the in-app composer without re-entering integration settings.
- Surface integration controls under Account → Integrations so workspace owners can manage Google Apps Script URL, shared token, and from name in one place.

### Description

- Extended the `StoreProfile` shape to include `bulkEmailWebAppUrl`, `bulkEmailSharedToken`, and `bulkEmailFromName` and mapped these from `stores` documents in `mapStoreSnapshot`.
- Added UI and state to `AccountOverview` for an `Email delivery` integration tab, including inputs and a `handleSaveBulkEmailIntegration` handler that writes `bulkEmailIntegration` into the `stores` document using `setDoc` with `serverTimestamp()`.
- Prefilled account integration state from the loaded store profile and added client-side validation and publish/toast feedback on save operations.
- Updated `BulkEmail` page to load saved integration settings via `getDoc` from `stores/{storeId}`, show integration loading/error states, and adjusted messaging and composer behavior to rely on Account → Integrations for setup.
- Improved the in-app composer UI with `From name`, `Subject`, `HTML` body inputs, recipient selection UI, and clearer validation messages referencing the integrations screen.

### Testing

- Ran a TypeScript build/typecheck (`yarn build` / `tsc`) locally and confirmed there are no type errors.
- Ran lint checks (`yarn lint`) locally and addressed reported issues where applicable.
- No automated unit tests were changed by this PR; runtime behavior was exercised manually in a local dev environment (compose, save integration, and send flows) during development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36751e8d0832292852015535403a0)