### PR TITLE
Add public customer intake link flow with printable QR poster

### DIFF
--- a/web/api/public-customer-intake.ts
+++ b/web/api/public-customer-intake.ts
@@ -1,0 +1,81 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { FieldValue } from 'firebase-admin/firestore'
+import { db } from './_firebase-admin.js'
+
+type StoreRecord = {
+  storeName?: unknown
+  businessName?: unknown
+  companyName?: unknown
+  name?: unknown
+  customerIntakeTagline?: unknown
+}
+
+function sanitizeString(value: unknown, max = 200): string {
+  if (typeof value !== 'string') return ''
+  return value.trim().slice(0, max)
+}
+
+function getStoreName(raw: StoreRecord | undefined): string | null {
+  if (!raw) return null
+  const candidates = [raw.storeName, raw.businessName, raw.companyName, raw.name]
+  for (const candidate of candidates) {
+    const value = sanitizeString(candidate, 80)
+    if (value) return value
+  }
+  return null
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const firestore = db()
+  if (req.method === 'GET') {
+    const storeId = sanitizeString(req.query.storeId, 100)
+    if (!storeId) return res.status(400).json({ error: 'Missing storeId.' })
+
+    const snapshot = await firestore.collection('stores').doc(storeId).get()
+    if (!snapshot.exists) return res.status(404).json({ error: 'Store not found.' })
+    const raw = snapshot.data() as StoreRecord | undefined
+
+    return res.status(200).json({
+      storeName: getStoreName(raw),
+      tagline: sanitizeString(raw?.customerIntakeTagline, 180) || 'Share your details so we can serve you better.',
+    })
+  }
+
+  if (req.method === 'POST') {
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const storeId = sanitizeString(body.storeId, 100)
+    const name = sanitizeString(body.name, 120)
+    const phone = sanitizeString(body.phone, 40)
+    const email = sanitizeString(body.email, 120).toLowerCase()
+    const notes = sanitizeString(body.notes, 500)
+    const source = 'public-intake-link'
+
+    if (!storeId) return res.status(400).json({ error: 'Missing storeId.' })
+    if (!name) return res.status(400).json({ error: 'Name is required.' })
+    if (!phone && !email) {
+      return res.status(400).json({ error: 'Provide at least a phone number or email.' })
+    }
+
+    const storeSnapshot = await firestore.collection('stores').doc(storeId).get()
+    if (!storeSnapshot.exists) {
+      return res.status(404).json({ error: 'This link is no longer valid.' })
+    }
+
+    await firestore.collection('customers').add({
+      storeId,
+      name,
+      displayName: name,
+      phone: phone || null,
+      email: email || null,
+      notes: notes || null,
+      source,
+      tags: ['Public Invite'],
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    })
+
+    return res.status(200).json({ ok: true })
+  }
+
+  return res.status(405).json({ error: 'Method not allowed.' })
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -37,6 +37,7 @@ import BookingMappingSettings from './pages/BookingMappingSettings'
 // ✅ NEW: public receipt page used by QR/share
 import ReceiptView from './pages/ReceiptView'
 import CustomerDisplay from './pages/CustomerDisplay'
+import PublicCustomerIntake from './pages/PublicCustomerIntake'
 
 import PrivacyPage from './pages/legal/PrivacyPage'
 import CookiesPage from './pages/legal/CookiesPage'
@@ -56,6 +57,8 @@ const router = createBrowserRouter([
   { path: '/:slug', element: <PromoLandingPage /> },
   { path: '/customer-display', element: <CustomerDisplay /> },
   { path: '/display', element: <CustomerDisplay /> },
+  { path: '/join-customers/:storeId', element: <PublicCustomerIntake /> },
+  { path: '/join-customers/:storeId/:mode', element: <PublicCustomerIntake /> },
 
   {
     path: '/',

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -71,7 +71,7 @@ type CachedSaleRecord = {
 } & Record<string, unknown>
 
 type MessageChannel = 'whatsapp' | 'telegram' | 'email'
-type CustomerTab = 'view' | 'add'
+type CustomerTab = 'view' | 'add' | 'invite'
 
 const RECENT_VISIT_DAYS = 90
 const HIGH_VALUE_THRESHOLD = 1000
@@ -357,6 +357,14 @@ export default function Customers() {
   const [messageBody, setMessageBody] = useState('')
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<CustomerTab>('view')
+  const intakeLink = useMemo(() => {
+    if (!activeStoreId || typeof window === 'undefined') return null
+    return `${window.location.origin}/join-customers/${encodeURIComponent(activeStoreId)}`
+  }, [activeStoreId])
+  const intakeQrLink = useMemo(() => {
+    if (!intakeLink) return null
+    return `${intakeLink}/qr`
+  }, [intakeLink])
   useEffect(() => {
     return () => {
       if (messageTimeoutRef.current) {
@@ -1150,6 +1158,23 @@ export default function Customers() {
     setSelectedCustomerId(customer.id)
   }
 
+  async function copyInviteLink(target: 'form' | 'qr') {
+    const value = target === 'qr' ? intakeQrLink : intakeLink
+    if (!value) {
+      setError('No store selected yet. Please refresh and try again.')
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(value)
+      showSuccess(target === 'qr' ? 'QR page link copied.' : 'Customer intake link copied.')
+      setError(null)
+    } catch (copyError) {
+      console.error('[customers] Failed to copy invite link', copyError)
+      setError('Could not copy link. Please copy it manually from the field.')
+    }
+  }
+
   const isFormDisabled = busy || isImporting
 
   const totalShown = filteredCustomers.length
@@ -1197,7 +1222,83 @@ export default function Customers() {
           >
             Add new customer
           </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'invite'}
+            className={`button button--small ${activeTab === 'invite' ? 'button--primary' : 'button--ghost'}`}
+            onClick={() => setActiveTab('invite')}
+          >
+            Invite link & QR
+          </button>
         </div>
+
+        {activeTab === 'invite' ? (
+          <section className="card" aria-label="Customer invite link">
+            <div className="customers-page__section-header">
+              <h3 className="card__title">Public customer intake</h3>
+              <p className="card__subtitle">
+                Share this public link so customers can submit their details directly into your customer list.
+              </p>
+            </div>
+
+            <div className="field">
+              <label className="field__label" htmlFor="customer-intake-link">Public form link</label>
+              <input
+                id="customer-intake-link"
+                readOnly
+                value={intakeLink ?? ''}
+                placeholder="Select an active store to generate the link"
+              />
+            </div>
+
+            <div className="field">
+              <label className="field__label" htmlFor="customer-intake-qr-link">Printable QR page</label>
+              <input
+                id="customer-intake-qr-link"
+                readOnly
+                value={intakeQrLink ?? ''}
+                placeholder="Select an active store to generate the QR page"
+              />
+            </div>
+
+            <div className="customers-page__form-actions">
+              <button
+                type="button"
+                className="button button--primary"
+                onClick={() => copyInviteLink('form')}
+                disabled={!intakeLink}
+              >
+                Copy form link
+              </button>
+              <button
+                type="button"
+                className="button button--outline"
+                onClick={() => copyInviteLink('qr')}
+                disabled={!intakeQrLink}
+              >
+                Copy QR link
+              </button>
+              <a
+                className={`button button--ghost${!intakeQrLink ? ' button--disabled' : ''}`}
+                href={intakeQrLink ?? '#'}
+                target="_blank"
+                rel="noreferrer"
+                aria-disabled={!intakeQrLink}
+                onClick={event => {
+                  if (!intakeQrLink) event.preventDefault()
+                }}
+              >
+                Open QR page
+              </a>
+            </div>
+
+            {error && <p className="customers-page__message customers-page__message--error">{error}</p>}
+            {success && !error ? (
+              <p className="customers-page__message customers-page__message--success" role="status">{success}</p>
+            ) : null}
+          </section>
+        ) : null}
 
         {activeTab === 'add' ? (
           <section className="card" aria-label="Add a customer">

--- a/web/src/pages/PublicCustomerIntake.css
+++ b/web/src/pages/PublicCustomerIntake.css
@@ -1,0 +1,111 @@
+.public-customer-intake {
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: radial-gradient(circle at top, #f5f7ff 0%, #eef2ff 45%, #f8fafc 100%);
+}
+
+.public-customer-intake__card {
+  width: min(680px, 100%);
+  background: #ffffff;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 24px 50px -32px rgba(15, 23, 42, 0.35);
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.public-customer-intake__kicker {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4f46e5;
+}
+
+.public-customer-intake h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2rem);
+}
+
+.public-customer-intake p {
+  margin: 0;
+  color: #334155;
+}
+
+.public-customer-intake__form {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.public-customer-intake__form label {
+  display: grid;
+  gap: 0.35rem;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.public-customer-intake__form input,
+.public-customer-intake__form textarea {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.65rem;
+  padding: 0.7rem 0.8rem;
+  font: inherit;
+}
+
+.public-customer-intake__status {
+  font-weight: 600;
+}
+
+.public-customer-intake__status--error {
+  color: #b91c1c;
+}
+
+.public-customer-intake__qr {
+  width: min(360px, 100%);
+  margin-inline: auto;
+}
+
+.public-customer-intake__qr svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.public-customer-intake__qr--empty {
+  min-height: 220px;
+  display: grid;
+  place-items: center;
+  border: 1px dashed #94a3b8;
+  border-radius: 0.75rem;
+}
+
+.public-customer-intake__link {
+  word-break: break-all;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+@media print {
+  .public-customer-intake {
+    background: #fff;
+    padding: 0;
+  }
+
+  .public-customer-intake__card {
+    box-shadow: none;
+    border-color: #cbd5e1;
+    max-width: 100%;
+    min-height: 100vh;
+    align-content: center;
+  }
+
+  .public-customer-intake__link,
+  .public-customer-intake .button {
+    display: none;
+  }
+}

--- a/web/src/pages/PublicCustomerIntake.tsx
+++ b/web/src/pages/PublicCustomerIntake.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { BrowserQRCodeSvgWriter } from '@zxing/browser'
+import { EncodeHintType, QRCodeDecoderErrorCorrectionLevel } from '@zxing/library'
+import './PublicCustomerIntake.css'
+
+type IntakeProfile = {
+  storeName: string | null
+  tagline: string
+}
+
+type SubmissionState = 'idle' | 'submitting' | 'success' | 'error'
+
+export default function PublicCustomerIntake() {
+  const { storeId = '', mode } = useParams<{ storeId: string; mode?: string }>()
+  const [profile, setProfile] = useState<IntakeProfile>({ storeName: null, tagline: 'Join our customer list.' })
+  const [loadingProfile, setLoadingProfile] = useState(true)
+  const [submissionState, setSubmissionState] = useState<SubmissionState>('idle')
+  const [message, setMessage] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [email, setEmail] = useState('')
+  const [notes, setNotes] = useState('')
+  const [qrSvg, setQrSvg] = useState('')
+
+  const isQrMode = mode === 'qr'
+  const intakeUrl = useMemo(() => {
+    if (!storeId || typeof window === 'undefined') return ''
+    return `${window.location.origin}/join-customers/${encodeURIComponent(storeId)}`
+  }, [storeId])
+
+  useEffect(() => {
+    let active = true
+
+    async function loadProfile() {
+      if (!storeId) {
+        setLoadingProfile(false)
+        setMessage('Invalid store link.')
+        return
+      }
+
+      try {
+        const response = await fetch(`/api/public-customer-intake?storeId=${encodeURIComponent(storeId)}`)
+        const payload = (await response.json()) as {
+          storeName?: string | null
+          tagline?: string | null
+          error?: string
+        }
+        if (!active) return
+
+        if (!response.ok) {
+          setProfile({ storeName: null, tagline: 'Join our customer list.' })
+          setMessage(payload.error ?? 'This customer link is unavailable.')
+          return
+        }
+
+        setProfile({
+          storeName: payload.storeName?.trim() || null,
+          tagline: payload.tagline?.trim() || 'Join our customer list.',
+        })
+      } catch (error) {
+        if (!active) return
+        console.error('[public-customer-intake] Failed to load store profile', error)
+        setMessage('Unable to load this customer link right now.')
+      } finally {
+        if (active) setLoadingProfile(false)
+      }
+    }
+
+    void loadProfile()
+    return () => {
+      active = false
+    }
+  }, [storeId])
+
+  useEffect(() => {
+    if (!isQrMode || !intakeUrl) return
+    try {
+      const writer = new BrowserQRCodeSvgWriter()
+      const hints = new Map()
+      hints.set(EncodeHintType.ERROR_CORRECTION, QRCodeDecoderErrorCorrectionLevel.H)
+      const svg = writer.write(intakeUrl, 512, 512, hints).outerHTML
+      setQrSvg(svg)
+    } catch (error) {
+      console.error('[public-customer-intake] Failed to render QR code', error)
+      setQrSvg('')
+    }
+  }, [isQrMode, intakeUrl])
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!storeId) return
+
+    setSubmissionState('submitting')
+    setMessage(null)
+
+    try {
+      const response = await fetch('/api/public-customer-intake', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          storeId,
+          name,
+          phone,
+          email,
+          notes,
+        }),
+      })
+
+      const payload = (await response.json()) as { ok?: boolean; error?: string }
+      if (!response.ok || !payload.ok) {
+        setSubmissionState('error')
+        setMessage(payload.error ?? 'Could not submit details. Please try again.')
+        return
+      }
+
+      setSubmissionState('success')
+      setMessage('Thanks! Your details have been saved.')
+      setName('')
+      setPhone('')
+      setEmail('')
+      setNotes('')
+    } catch (error) {
+      console.error('[public-customer-intake] Failed to submit profile', error)
+      setSubmissionState('error')
+      setMessage('Network error. Please try again.')
+    }
+  }
+
+  const title = profile.storeName || 'Sedifex'
+
+  if (isQrMode) {
+    return (
+      <main className="public-customer-intake public-customer-intake--qr">
+        <section className="public-customer-intake__card">
+          <p className="public-customer-intake__kicker">Customer Invite</p>
+          <h1>Hello, kindly scan to join our customer list.</h1>
+          <p>{profile.storeName ? `You are joining ${profile.storeName}.` : 'You are joining our customer list.'}</p>
+          <p>After scanning, submit your details and download or print this card if needed.</p>
+          {qrSvg ? (
+            <div
+              className="public-customer-intake__qr"
+              dangerouslySetInnerHTML={{ __html: qrSvg }}
+              aria-label="Customer intake QR code"
+            />
+          ) : (
+            <div className="public-customer-intake__qr public-customer-intake__qr--empty">QR unavailable</div>
+          )}
+          <p className="public-customer-intake__link">{intakeUrl}</p>
+          <button type="button" className="button button--primary" onClick={() => window.print()}>
+            Print poster
+          </button>
+        </section>
+      </main>
+    )
+  }
+
+  return (
+    <main className="public-customer-intake">
+      <section className="public-customer-intake__card">
+        <p className="public-customer-intake__kicker">{title}</p>
+        <h1>Join our customer list</h1>
+        <p>{profile.tagline}</p>
+
+        {loadingProfile ? <p className="public-customer-intake__status">Loading…</p> : null}
+
+        <form className="public-customer-intake__form" onSubmit={submit}>
+          <label>
+            Full name
+            <input
+              value={name}
+              onChange={event => setName(event.target.value)}
+              placeholder="Your full name"
+              required
+              autoComplete="name"
+            />
+          </label>
+          <label>
+            Phone
+            <input
+              value={phone}
+              onChange={event => setPhone(event.target.value)}
+              placeholder="e.g. 024 000 0000"
+              autoComplete="tel"
+            />
+          </label>
+          <label>
+            Email
+            <input
+              value={email}
+              onChange={event => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              type="email"
+              autoComplete="email"
+            />
+          </label>
+          <label>
+            Notes (optional)
+            <textarea
+              value={notes}
+              onChange={event => setNotes(event.target.value)}
+              rows={3}
+              placeholder="Any note you want us to know"
+            />
+          </label>
+          <button
+            type="submit"
+            className="button button--primary"
+            disabled={submissionState === 'submitting' || loadingProfile}
+          >
+            {submissionState === 'submitting' ? 'Submitting…' : 'Save my details'}
+          </button>
+        </form>
+
+        {message ? (
+          <p
+            className={`public-customer-intake__status ${
+              submissionState === 'error' ? 'public-customer-intake__status--error' : ''
+            }`}
+            role="status"
+          >
+            {message}
+          </p>
+        ) : null}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a way for staff to generate a public, shareable intake link and a printable QR poster so customers can self-submit contact details into the store `customers` collection. 

### Description
- Added a new `Invite link & QR` tab to the Customers UI that shows a public intake URL and a printable QR page URL and lets staff copy or open those links via `web/src/pages/Customers.tsx`.
- Implemented a public intake page component `PublicCustomerIntake` with two modes (`/join-customers/:storeId` for the form and `/join-customers/:storeId/qr` for the branded QR poster and print support) in `web/src/pages/PublicCustomerIntake.tsx` and styling in `web/src/pages/PublicCustomerIntake.css`.
- Added a backend endpoint `web/api/public-customer-intake.ts` that supports `GET` to return store branding/tagline metadata and `POST` to validate and write submitted customer records into Firestore using the Admin SDK (creates a `customers` document with `source: 'public-intake-link'`).
- Registered new public routes in the app router (`web/src/main.tsx`) for `/join-customers/:storeId` and `/join-customers/:storeId/:mode` so the intake pages are accessible without login.

### Testing
- Attempted build with `npm --prefix web run build`, which failed due to missing type definition files (`vite/client` and `vitest/globals`) in this environment.
- Attempted dependency install with `npm --prefix web install`, which failed with `403 Forbidden` from the npm registry in this environment preventing a full build and automated test run.
- No automated unit or integration tests were executed successfully in this environment because of the dependency / build failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36a39c6388322b850731506353228)