### PR TITLE
Add public customer invite links with branding, validation, and rate limiting

### DIFF
--- a/web/api/public-customer-intake.ts
+++ b/web/api/public-customer-intake.ts
@@ -1,5 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { FieldValue } from 'firebase-admin/firestore'
+import { createHash } from 'node:crypto'
+import { FieldValue, Timestamp } from 'firebase-admin/firestore'
 import { db } from './_firebase-admin.js'
 
 type StoreRecord = {
@@ -8,11 +9,23 @@ type StoreRecord = {
   companyName?: unknown
   name?: unknown
   customerIntakeTagline?: unknown
+  customerIntakeHeadline?: unknown
+  customerIntakeCta?: unknown
+  customerIntakeAccentColor?: unknown
+  customerIntakeLogoUrl?: unknown
+  customerIntakeInviteId?: unknown
+  customerIntakeInviteStatus?: unknown
+  customerIntakeVanityPath?: unknown
 }
 
 function sanitizeString(value: unknown, max = 200): string {
   if (typeof value !== 'string') return ''
   return value.trim().slice(0, max)
+}
+
+function normalizeColorInput(value: unknown): string {
+  const color = sanitizeString(value, 12)
+  return /^#[0-9a-fA-F]{6}$/.test(color) ? color : '#4f46e5'
 }
 
 function getStoreName(raw: StoreRecord | undefined): string | null {
@@ -25,56 +38,286 @@ function getStoreName(raw: StoreRecord | undefined): string | null {
   return null
 }
 
+function normalizePhone(input: string): string {
+  const trimmed = input.trim()
+  if (!trimmed) return ''
+  const digits = trimmed.replace(/\D/g, '')
+  if (!digits) return ''
+
+  if (trimmed.startsWith('+')) return `+${digits}`
+  if (trimmed.startsWith('00')) return `+${digits.replace(/^00/, '')}`
+  if (trimmed.startsWith('0')) return `+233${digits.replace(/^0/, '')}`
+  return `+${digits}`
+}
+
+function normalizeEmail(input: string): string {
+  return input.trim().toLowerCase()
+}
+
+function isValidEmail(value: string): boolean {
+  if (!value) return true
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+}
+
+function isValidPhone(value: string): boolean {
+  if (!value) return true
+  const digits = value.replace(/\D/g, '')
+  return digits.length >= 8 && digits.length <= 15
+}
+
+function hashValue(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24)
+}
+
+function resolveClientIp(req: VercelRequest): string {
+  const forwarded = req.headers['x-forwarded-for']
+  if (typeof forwarded === 'string') {
+    const [first] = forwarded.split(',')
+    const trimmed = first?.trim()
+    if (trimmed) return trimmed
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0] ?? 'unknown'
+  }
+  return req.socket.remoteAddress || 'unknown'
+}
+
+async function resolveStoreByInvite(firestore: ReturnType<typeof db>, inviteId: string) {
+  const snapshot = await firestore
+    .collection('stores')
+    .where('customerIntakeInviteId', '==', inviteId)
+    .limit(1)
+    .get()
+
+  if (snapshot.empty) return null
+  const storeDoc = snapshot.docs[0]
+  const data = (storeDoc.data() ?? {}) as StoreRecord
+  const status = sanitizeString(data.customerIntakeInviteStatus, 20) || 'active'
+  if (status !== 'active') return null
+
+  return {
+    storeId: storeDoc.id,
+    data,
+  }
+}
+
+async function enforceRateLimit(params: {
+  firestore: ReturnType<typeof db>
+  inviteId: string
+  ipHash: string
+}) {
+  const { firestore, inviteId, ipHash } = params
+  const now = Date.now()
+  const tenMinuteBucket = Math.floor(now / (10 * 60_000))
+  const hourBucket = Math.floor(now / (60 * 60_000))
+
+  const perIpRef = firestore
+    .collection('publicIntakeRateLimits')
+    .doc(`ip_${inviteId}_${ipHash}_${String(tenMinuteBucket)}`)
+  const perInviteRef = firestore
+    .collection('publicIntakeRateLimits')
+    .doc(`invite_${inviteId}_${String(hourBucket)}`)
+
+  await firestore.runTransaction(async tx => {
+    const [perIpSnap, perInviteSnap] = await Promise.all([tx.get(perIpRef), tx.get(perInviteRef)])
+
+    const ipCount = Number(perIpSnap.data()?.count ?? 0)
+    const inviteCount = Number(perInviteSnap.data()?.count ?? 0)
+
+    if (ipCount >= 6) {
+      throw new Error('too-many-per-ip')
+    }
+    if (inviteCount >= 80) {
+      throw new Error('too-many-per-invite')
+    }
+
+    tx.set(
+      perIpRef,
+      {
+        inviteId,
+        ipHash,
+        bucket: tenMinuteBucket,
+        count: ipCount + 1,
+        updatedAt: FieldValue.serverTimestamp(),
+        expiresAt: Timestamp.fromMillis(now + 2 * 60 * 60_000),
+      },
+      { merge: true },
+    )
+
+    tx.set(
+      perInviteRef,
+      {
+        inviteId,
+        bucket: hourBucket,
+        count: inviteCount + 1,
+        updatedAt: FieldValue.serverTimestamp(),
+        expiresAt: Timestamp.fromMillis(now + 6 * 60 * 60_000),
+      },
+      { merge: true },
+    )
+  })
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const firestore = db()
   if (req.method === 'GET') {
-    const storeId = sanitizeString(req.query.storeId, 100)
-    if (!storeId) return res.status(400).json({ error: 'Missing storeId.' })
+    const inviteId = sanitizeString(req.query.inviteId, 120)
+    if (!inviteId) return res.status(400).json({ error: 'Missing inviteId.' })
 
-    const snapshot = await firestore.collection('stores').doc(storeId).get()
-    if (!snapshot.exists) return res.status(404).json({ error: 'Store not found.' })
-    const raw = snapshot.data() as StoreRecord | undefined
+    const resolved = await resolveStoreByInvite(firestore, inviteId)
+    if (!resolved) return res.status(404).json({ error: 'Invite link not found or inactive.' })
 
+    const raw = resolved.data
     return res.status(200).json({
       storeName: getStoreName(raw),
-      tagline: sanitizeString(raw?.customerIntakeTagline, 180) || 'Share your details so we can serve you better.',
+      tagline: sanitizeString(raw.customerIntakeTagline, 180) || 'Share your details so we can serve you better.',
+      headline: sanitizeString(raw.customerIntakeHeadline, 180) || 'Hello, kindly scan to join our customer list.',
+      cta: sanitizeString(raw.customerIntakeCta, 180) || 'Join now for updates and priority support.',
+      accentColor: normalizeColorInput(raw.customerIntakeAccentColor),
+      logoUrl: sanitizeString(raw.customerIntakeLogoUrl, 300) || null,
+      vanityPath: sanitizeString(raw.customerIntakeVanityPath, 120) || '',
     })
   }
 
   if (req.method === 'POST') {
     const body = (req.body ?? {}) as Record<string, unknown>
-    const storeId = sanitizeString(body.storeId, 100)
+    const inviteId = sanitizeString(body.inviteId, 120)
     const name = sanitizeString(body.name, 120)
-    const phone = sanitizeString(body.phone, 40)
-    const email = sanitizeString(body.email, 120).toLowerCase()
+    const phone = normalizePhone(sanitizeString(body.phone, 40))
+    const email = normalizeEmail(sanitizeString(body.email, 120))
     const notes = sanitizeString(body.notes, 500)
-    const source = 'public-intake-link'
+    const consent = body.consent === true
+    const consentSource = sanitizeString(body.consentSource, 120) || 'public-customer-intake'
+    const submittedFrom = sanitizeString(body.submittedFrom, 40) || 'link'
+    const utmSource = sanitizeString(body.utmSource, 80) || null
+    const websiteTrap = sanitizeString(body.website, 160)
+    const formStartedAt = Number(body.formStartedAt)
 
-    if (!storeId) return res.status(400).json({ error: 'Missing storeId.' })
+    if (!inviteId) return res.status(400).json({ error: 'Missing inviteId.' })
     if (!name) return res.status(400).json({ error: 'Name is required.' })
     if (!phone && !email) {
       return res.status(400).json({ error: 'Provide at least a phone number or email.' })
     }
+    if (!consent) {
+      return res.status(400).json({ error: 'Consent is required before submission.' })
+    }
+    if (websiteTrap) {
+      return res.status(400).json({ error: 'Submission blocked.' })
+    }
+    if (!Number.isFinite(formStartedAt) || Date.now() - formStartedAt < 1500) {
+      return res.status(400).json({ error: 'Please take a moment before submitting.' })
+    }
+    if (!isValidPhone(phone)) {
+      return res.status(400).json({ error: 'Phone number format is invalid.' })
+    }
+    if (!isValidEmail(email)) {
+      return res.status(400).json({ error: 'Email format is invalid.' })
+    }
 
-    const storeSnapshot = await firestore.collection('stores').doc(storeId).get()
-    if (!storeSnapshot.exists) {
+    const resolved = await resolveStoreByInvite(firestore, inviteId)
+    if (!resolved) {
       return res.status(404).json({ error: 'This link is no longer valid.' })
     }
 
-    await firestore.collection('customers').add({
-      storeId,
+    const clientIp = resolveClientIp(req)
+    const ipHash = hashValue(clientIp)
+    try {
+      await enforceRateLimit({ firestore, inviteId, ipHash })
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('too-many')) {
+        return res.status(429).json({ error: 'Too many submissions. Please try again later.' })
+      }
+      throw error
+    }
+
+    const source = 'public-intake-link'
+    const emailKey = email || null
+    const phoneKey = phone ? phone.replace(/\D/g, '') : null
+
+    const existingByEmailSnap = emailKey
+      ? await firestore
+          .collection('customers')
+          .where('storeId', '==', resolved.storeId)
+          .where('email', '==', emailKey)
+          .limit(1)
+          .get()
+      : null
+
+    const existingByPhoneSnap = !existingByEmailSnap?.empty && phone
+      ? null
+      : phone
+      ? await firestore
+          .collection('customers')
+          .where('storeId', '==', resolved.storeId)
+          .where('phone', '==', phone)
+          .limit(1)
+          .get()
+      : null
+
+    const existingDoc =
+      existingByEmailSnap && !existingByEmailSnap.empty
+        ? existingByEmailSnap.docs[0]
+        : existingByPhoneSnap && !existingByPhoneSnap.empty
+        ? existingByPhoneSnap.docs[0]
+        : null
+
+    const intakePayload = {
+      storeId: resolved.storeId,
       name,
       displayName: name,
       phone: phone || null,
+      phoneKey,
       email: email || null,
+      emailKey,
       notes: notes || null,
       source,
+      submittedFrom,
+      inviteId,
+      utmSource,
       tags: ['Public Invite'],
-      createdAt: FieldValue.serverTimestamp(),
+      consent: {
+        granted: true,
+        timestamp: FieldValue.serverTimestamp(),
+        source: consentSource,
+      },
+      lastSubmissionAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),
-    })
+      metadata: {
+        inviteId,
+        submittedFrom,
+        utmSource,
+        ipHash,
+      },
+    }
 
-    return res.status(200).json({ ok: true })
+    if (existingDoc) {
+      const existingData = existingDoc.data() as { tags?: unknown; notes?: unknown }
+      const existingTags = Array.isArray(existingData.tags)
+        ? existingData.tags.filter(tag => typeof tag === 'string')
+        : []
+      const mergedTags = Array.from(new Set([...existingTags, 'Public Invite']))
+      const existingNotes = typeof existingData.notes === 'string' ? existingData.notes.trim() : ''
+      const mergedNotes = notes ? Array.from(new Set([existingNotes, notes].filter(Boolean))).join(' | ') : existingNotes
+
+      await existingDoc.ref.set(
+        {
+          ...intakePayload,
+          tags: mergedTags,
+          notes: mergedNotes || null,
+        },
+        { merge: true },
+      )
+    } else {
+      await firestore.collection('customers').add({
+        ...intakePayload,
+        createdAt: FieldValue.serverTimestamp(),
+      })
+    }
+
+    return res.status(200).json({
+      ok: true,
+      whatsappLink: phone ? `https://wa.me/${phone.replace(/^\+/, '')}` : null,
+    })
   }
 
   return res.status(405).json({ error: 'Method not allowed.' })

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -57,8 +57,8 @@ const router = createBrowserRouter([
   { path: '/:slug', element: <PromoLandingPage /> },
   { path: '/customer-display', element: <CustomerDisplay /> },
   { path: '/display', element: <CustomerDisplay /> },
-  { path: '/join-customers/:storeId', element: <PublicCustomerIntake /> },
-  { path: '/join-customers/:storeId/:mode', element: <PublicCustomerIntake /> },
+  { path: '/join-customers/:inviteId', element: <PublicCustomerIntake /> },
+  { path: '/join-customers/:inviteId/:mode', element: <PublicCustomerIntake /> },
 
   {
     path: '/',

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -4,6 +4,7 @@ import {
   collection,
   deleteDoc,
   doc,
+  getDoc,
   onSnapshot,
   orderBy,
   query,
@@ -326,6 +327,19 @@ function buildPhoneKey(value: string | null | undefined): string {
   return normalizePhoneNumber(value).replace(/\D/g, '')
 }
 
+function createInviteId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID().replace(/-/g, '').slice(0, 24)
+  }
+  return Math.random().toString(36).slice(2, 14) + Math.random().toString(36).slice(2, 14)
+}
+
+function normalizeColorInput(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return '#4f46e5'
+  return /^#[0-9a-fA-F]{6}$/.test(trimmed) ? trimmed : '#4f46e5'
+}
+
 export default function Customers() {
   const { storeId: activeStoreId } = useActiveStore()
   const navigate = useNavigate()
@@ -357,10 +371,18 @@ export default function Customers() {
   const [messageBody, setMessageBody] = useState('')
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<CustomerTab>('view')
+  const [inviteId, setInviteId] = useState<string | null>(null)
+  const [inviteStatus, setInviteStatus] = useState<'active' | 'revoked'>('active')
+  const [inviteHeadline, setInviteHeadline] = useState('Hello, kindly scan to join our customer list.')
+  const [inviteTagline, setInviteTagline] = useState('Share your details so we can serve you better.')
+  const [inviteCta, setInviteCta] = useState('Join now for updates and priority support.')
+  const [inviteAccentColor, setInviteAccentColor] = useState('#4f46e5')
+  const [inviteLogoUrl, setInviteLogoUrl] = useState('')
+  const [savingInviteSettings, setSavingInviteSettings] = useState(false)
   const intakeLink = useMemo(() => {
-    if (!activeStoreId || typeof window === 'undefined') return null
-    return `${window.location.origin}/join-customers/${encodeURIComponent(activeStoreId)}`
-  }, [activeStoreId])
+    if (!inviteId || typeof window === 'undefined') return null
+    return `${window.location.origin}/join-customers/${encodeURIComponent(inviteId)}`
+  }, [inviteId])
   const intakeQrLink = useMemo(() => {
     if (!intakeLink) return null
     return `${intakeLink}/qr`
@@ -373,6 +395,55 @@ export default function Customers() {
       }
     }
   }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadInviteSettings() {
+      if (!activeStoreId) {
+        setInviteId(null)
+        setInviteStatus('active')
+        return
+      }
+      try {
+        const snapshot = await getDoc(doc(db, 'stores', activeStoreId))
+        const data = snapshot.data() as Record<string, unknown> | undefined
+        if (cancelled) return
+        setInviteId(
+          typeof data?.customerIntakeInviteId === 'string' && data.customerIntakeInviteId.trim()
+            ? data.customerIntakeInviteId.trim()
+            : null,
+        )
+        setInviteStatus(data?.customerIntakeInviteStatus === 'revoked' ? 'revoked' : 'active')
+        setInviteHeadline(
+          typeof data?.customerIntakeHeadline === 'string' && data.customerIntakeHeadline.trim()
+            ? data.customerIntakeHeadline.trim()
+            : 'Hello, kindly scan to join our customer list.',
+        )
+        setInviteTagline(
+          typeof data?.customerIntakeTagline === 'string' && data.customerIntakeTagline.trim()
+            ? data.customerIntakeTagline.trim()
+            : 'Share your details so we can serve you better.',
+        )
+        setInviteCta(
+          typeof data?.customerIntakeCta === 'string' && data.customerIntakeCta.trim()
+            ? data.customerIntakeCta.trim()
+            : 'Join now for updates and priority support.',
+        )
+        setInviteAccentColor(
+          normalizeColorInput(typeof data?.customerIntakeAccentColor === 'string' ? data.customerIntakeAccentColor : ''),
+        )
+        setInviteLogoUrl(
+          typeof data?.customerIntakeLogoUrl === 'string' ? data.customerIntakeLogoUrl.trim() : '',
+        )
+      } catch (loadError) {
+        console.error('[customers] Failed to load invite settings', loadError)
+      }
+    }
+    void loadInviteSettings()
+    return () => {
+      cancelled = true
+    }
+  }, [activeStoreId])
 
   function showSuccess(message: string) {
     setSuccess(message)
@@ -1159,7 +1230,13 @@ export default function Customers() {
   }
 
   async function copyInviteLink(target: 'form' | 'qr') {
-    const value = target === 'qr' ? intakeQrLink : intakeLink
+    const activeInviteId = await ensureInviteId()
+    if (!activeInviteId) return
+    const baseLink =
+      typeof window !== 'undefined'
+        ? `${window.location.origin}/join-customers/${encodeURIComponent(activeInviteId)}`
+        : null
+    const value = target === 'qr' ? (baseLink ? `${baseLink}/qr` : null) : baseLink
     if (!value) {
       setError('No store selected yet. Please refresh and try again.')
       return
@@ -1172,6 +1249,117 @@ export default function Customers() {
     } catch (copyError) {
       console.error('[customers] Failed to copy invite link', copyError)
       setError('Could not copy link. Please copy it manually from the field.')
+    }
+  }
+
+  async function ensureInviteId() {
+    if (!activeStoreId) {
+      setError('No active store selected.')
+      return null
+    }
+    if (inviteId && inviteStatus === 'active') {
+      return inviteId
+    }
+    const nextInviteId = createInviteId()
+    setSavingInviteSettings(true)
+    try {
+      await updateDoc(doc(db, 'stores', activeStoreId), {
+        customerIntakeInviteId: nextInviteId,
+        customerIntakeInviteStatus: 'active',
+        customerIntakeHeadline: inviteHeadline.trim(),
+        customerIntakeTagline: inviteTagline.trim(),
+        customerIntakeCta: inviteCta.trim(),
+        customerIntakeAccentColor: normalizeColorInput(inviteAccentColor),
+        customerIntakeLogoUrl: inviteLogoUrl.trim() || null,
+        customerIntakeUpdatedAt: serverTimestamp(),
+      })
+      setInviteId(nextInviteId)
+      setInviteStatus('active')
+      showSuccess('Public invite link is ready.')
+      return nextInviteId
+    } catch (inviteError) {
+      console.error('[customers] Failed to initialize invite id', inviteError)
+      setError('Could not create invite link right now.')
+      return null
+    } finally {
+      setSavingInviteSettings(false)
+    }
+  }
+
+  async function rotateInviteId() {
+    if (!activeStoreId) {
+      setError('No active store selected.')
+      return
+    }
+    const confirmed = window.confirm(
+      'Rotate invite URL? Printed QR posters with the current link will stop working immediately.',
+    )
+    if (!confirmed) {
+      return
+    }
+    const nextInviteId = createInviteId()
+    setSavingInviteSettings(true)
+    setError(null)
+    try {
+      await updateDoc(doc(db, 'stores', activeStoreId), {
+        customerIntakeInviteId: nextInviteId,
+        customerIntakeInviteStatus: 'active',
+        customerIntakeUpdatedAt: serverTimestamp(),
+      })
+      setInviteId(nextInviteId)
+      setInviteStatus('active')
+      showSuccess('Invite link rotated. Previous URL is now disabled.')
+    } catch (rotateError) {
+      console.error('[customers] Failed to rotate invite id', rotateError)
+      setError('Could not rotate invite link.')
+    } finally {
+      setSavingInviteSettings(false)
+    }
+  }
+
+  async function toggleInviteStatus(nextStatus: 'active' | 'revoked') {
+    if (!activeStoreId) {
+      setError('No active store selected.')
+      return
+    }
+    setSavingInviteSettings(true)
+    try {
+      await updateDoc(doc(db, 'stores', activeStoreId), {
+        customerIntakeInviteStatus: nextStatus,
+        customerIntakeUpdatedAt: serverTimestamp(),
+      })
+      setInviteStatus(nextStatus)
+      showSuccess(nextStatus === 'active' ? 'Invite link activated.' : 'Invite link revoked.')
+    } catch (statusError) {
+      console.error('[customers] Failed to update invite status', statusError)
+      setError('Could not update invite status.')
+    } finally {
+      setSavingInviteSettings(false)
+    }
+  }
+
+  async function saveInviteBranding() {
+    if (!activeStoreId) {
+      setError('No active store selected.')
+      return
+    }
+    setSavingInviteSettings(true)
+    setError(null)
+    try {
+      await updateDoc(doc(db, 'stores', activeStoreId), {
+        customerIntakeHeadline: inviteHeadline.trim() || 'Hello, kindly scan to join our customer list.',
+        customerIntakeTagline: inviteTagline.trim() || 'Share your details so we can serve you better.',
+        customerIntakeCta: inviteCta.trim() || 'Join now for updates and priority support.',
+        customerIntakeAccentColor: normalizeColorInput(inviteAccentColor),
+        customerIntakeLogoUrl: inviteLogoUrl.trim() || null,
+        customerIntakeUpdatedAt: serverTimestamp(),
+      })
+      showSuccess('Invite branding saved.')
+    } catch (brandingError) {
+      console.error('[customers] Failed to save invite branding', brandingError)
+      setError('Could not save invite branding settings.')
+    } finally {
+      setSavingInviteSettings(false)
     }
   }
 
@@ -1267,7 +1455,7 @@ export default function Customers() {
                 type="button"
                 className="button button--primary"
                 onClick={() => copyInviteLink('form')}
-                disabled={!intakeLink}
+                disabled={savingInviteSettings}
               >
                 Copy form link
               </button>
@@ -1275,9 +1463,25 @@ export default function Customers() {
                 type="button"
                 className="button button--outline"
                 onClick={() => copyInviteLink('qr')}
-                disabled={!intakeQrLink}
+                disabled={savingInviteSettings}
               >
                 Copy QR link
+              </button>
+              <button
+                type="button"
+                className="button button--outline"
+                onClick={rotateInviteId}
+                disabled={!activeStoreId || savingInviteSettings}
+              >
+                Rotate invite URL
+              </button>
+              <button
+                type="button"
+                className="button button--ghost"
+                onClick={() => toggleInviteStatus(inviteStatus === 'active' ? 'revoked' : 'active')}
+                disabled={!inviteId || savingInviteSettings}
+              >
+                {inviteStatus === 'active' ? 'Revoke link' : 'Reactivate link'}
               </button>
               <a
                 className={`button button--ghost${!intakeQrLink ? ' button--disabled' : ''}`}
@@ -1291,6 +1495,76 @@ export default function Customers() {
               >
                 Open QR page
               </a>
+            </div>
+
+            <p className="card__subtitle">
+              Invite status: <strong>{inviteStatus === 'active' ? 'Active' : 'Revoked'}</strong>
+            </p>
+            <p className="card__subtitle">
+              QR links do not expire automatically. They remain valid until you manually rotate or revoke them.
+            </p>
+
+            <div className="customers-page__form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="customer-invite-headline">QR poster headline</label>
+                <input
+                  id="customer-invite-headline"
+                  value={inviteHeadline}
+                  onChange={event => setInviteHeadline(event.target.value)}
+                  placeholder="Hello, kindly scan to join our customer list."
+                />
+              </div>
+              <div className="field">
+                <label className="field__label" htmlFor="customer-invite-cta">CTA sentence</label>
+                <input
+                  id="customer-invite-cta"
+                  value={inviteCta}
+                  onChange={event => setInviteCta(event.target.value)}
+                  placeholder="Join now for updates and priority support."
+                />
+              </div>
+            </div>
+
+            <div className="field">
+              <label className="field__label" htmlFor="customer-invite-tagline">Public form tagline</label>
+              <input
+                id="customer-invite-tagline"
+                value={inviteTagline}
+                onChange={event => setInviteTagline(event.target.value)}
+                placeholder="Share your details so we can serve you better."
+              />
+            </div>
+
+            <div className="customers-page__form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="customer-invite-logo-url">Logo URL</label>
+                <input
+                  id="customer-invite-logo-url"
+                  value={inviteLogoUrl}
+                  onChange={event => setInviteLogoUrl(event.target.value)}
+                  placeholder="https://example.com/logo.png"
+                />
+              </div>
+              <div className="field">
+                <label className="field__label" htmlFor="customer-invite-accent">Accent color (#RRGGBB)</label>
+                <input
+                  id="customer-invite-accent"
+                  value={inviteAccentColor}
+                  onChange={event => setInviteAccentColor(event.target.value)}
+                  placeholder="#4f46e5"
+                />
+              </div>
+            </div>
+
+            <div className="customers-page__form-actions">
+              <button
+                type="button"
+                className="button button--primary"
+                onClick={saveInviteBranding}
+                disabled={!activeStoreId || savingInviteSettings}
+              >
+                Save branding settings
+              </button>
             </div>
 
             {error && <p className="customers-page__message customers-page__message--error">{error}</p>}

--- a/web/src/pages/PublicCustomerIntake.css
+++ b/web/src/pages/PublicCustomerIntake.css
@@ -17,6 +17,12 @@
   gap: 0.9rem;
 }
 
+.public-customer-intake__logo {
+  width: min(120px, 40%);
+  height: auto;
+  object-fit: contain;
+}
+
 .public-customer-intake__kicker {
   margin: 0;
   font-size: 0.8rem;
@@ -65,6 +71,27 @@
   color: #b91c1c;
 }
 
+.public-customer-intake__consent {
+  display: flex !important;
+  align-items: flex-start;
+  gap: 0.55rem;
+  font-weight: 500 !important;
+}
+
+.public-customer-intake__consent input {
+  width: 1.1rem !important;
+  height: 1.1rem;
+  margin-top: 0.12rem;
+}
+
+.public-customer-intake__bot-trap {
+  position: absolute !important;
+  left: -9999px !important;
+  width: 1px !important;
+  height: 1px !important;
+  opacity: 0 !important;
+}
+
 .public-customer-intake__qr {
   width: min(360px, 100%);
   margin-inline: auto;
@@ -88,6 +115,15 @@
   word-break: break-all;
   font-size: 0.85rem;
   color: #475569;
+}
+
+.public-customer-intake__fallback {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.public-customer-intake--a5 .public-customer-intake__card {
+  width: min(520px, 100%);
 }
 
 @media print {

--- a/web/src/pages/PublicCustomerIntake.tsx
+++ b/web/src/pages/PublicCustomerIntake.tsx
@@ -7,13 +7,31 @@ import './PublicCustomerIntake.css'
 type IntakeProfile = {
   storeName: string | null
   tagline: string
+  headline: string
+  cta: string
+  accentColor: string
+  logoUrl: string | null
+  vanityPath: string
 }
 
 type SubmissionState = 'idle' | 'submitting' | 'success' | 'error'
 
+function normalizeAccentColor(input: string | null | undefined): string {
+  if (!input) return '#4f46e5'
+  return /^#[0-9a-fA-F]{6}$/.test(input) ? input : '#4f46e5'
+}
+
 export default function PublicCustomerIntake() {
-  const { storeId = '', mode } = useParams<{ storeId: string; mode?: string }>()
-  const [profile, setProfile] = useState<IntakeProfile>({ storeName: null, tagline: 'Join our customer list.' })
+  const { inviteId = '', mode } = useParams<{ inviteId: string; mode?: string }>()
+  const [profile, setProfile] = useState<IntakeProfile>({
+    storeName: null,
+    tagline: 'Join our customer list.',
+    headline: 'Hello, kindly scan to join our customer list.',
+    cta: 'Join now for updates and priority support.',
+    accentColor: '#4f46e5',
+    logoUrl: null,
+    vanityPath: '',
+  })
   const [loadingProfile, setLoadingProfile] = useState(true)
   const [submissionState, setSubmissionState] = useState<SubmissionState>('idle')
   const [message, setMessage] = useState<string | null>(null)
@@ -21,35 +39,52 @@ export default function PublicCustomerIntake() {
   const [phone, setPhone] = useState('')
   const [email, setEmail] = useState('')
   const [notes, setNotes] = useState('')
+  const [consentChecked, setConsentChecked] = useState(false)
   const [qrSvg, setQrSvg] = useState('')
+  const [variant, setVariant] = useState<'a4' | 'a5'>('a4')
+  const [formStartedAt] = useState(() => Date.now())
+  const [websiteTrap, setWebsiteTrap] = useState('')
 
   const isQrMode = mode === 'qr'
   const intakeUrl = useMemo(() => {
-    if (!storeId || typeof window === 'undefined') return ''
-    return `${window.location.origin}/join-customers/${encodeURIComponent(storeId)}`
-  }, [storeId])
+    if (!inviteId || typeof window === 'undefined') return ''
+    return `${window.location.origin}/join-customers/${encodeURIComponent(inviteId)}`
+  }, [inviteId])
 
   useEffect(() => {
     let active = true
 
     async function loadProfile() {
-      if (!storeId) {
+      if (!inviteId) {
         setLoadingProfile(false)
-        setMessage('Invalid store link.')
+        setMessage('Invalid customer invite link.')
         return
       }
 
       try {
-        const response = await fetch(`/api/public-customer-intake?storeId=${encodeURIComponent(storeId)}`)
+        const response = await fetch(`/api/public-customer-intake?inviteId=${encodeURIComponent(inviteId)}`)
         const payload = (await response.json()) as {
           storeName?: string | null
           tagline?: string | null
+          headline?: string | null
+          cta?: string | null
+          accentColor?: string | null
+          logoUrl?: string | null
+          vanityPath?: string | null
           error?: string
         }
         if (!active) return
 
         if (!response.ok) {
-          setProfile({ storeName: null, tagline: 'Join our customer list.' })
+          setProfile({
+            storeName: null,
+            tagline: 'Join our customer list.',
+            headline: 'Hello, kindly scan to join our customer list.',
+            cta: 'Join now for updates and priority support.',
+            accentColor: '#4f46e5',
+            logoUrl: null,
+            vanityPath: '',
+          })
           setMessage(payload.error ?? 'This customer link is unavailable.')
           return
         }
@@ -57,6 +92,11 @@ export default function PublicCustomerIntake() {
         setProfile({
           storeName: payload.storeName?.trim() || null,
           tagline: payload.tagline?.trim() || 'Join our customer list.',
+          headline: payload.headline?.trim() || 'Hello, kindly scan to join our customer list.',
+          cta: payload.cta?.trim() || 'Join now for updates and priority support.',
+          accentColor: normalizeAccentColor(payload.accentColor),
+          logoUrl: payload.logoUrl?.trim() || null,
+          vanityPath: payload.vanityPath?.trim() || '',
         })
       } catch (error) {
         if (!active) return
@@ -71,7 +111,7 @@ export default function PublicCustomerIntake() {
     return () => {
       active = false
     }
-  }, [storeId])
+  }, [inviteId])
 
   useEffect(() => {
     if (!isQrMode || !intakeUrl) return
@@ -89,7 +129,13 @@ export default function PublicCustomerIntake() {
 
   async function submit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (!storeId) return
+    if (!inviteId) return
+
+    if (!consentChecked) {
+      setSubmissionState('error')
+      setMessage('Please agree to be contacted before submitting.')
+      return
+    }
 
     setSubmissionState('submitting')
     setMessage(null)
@@ -99,15 +145,22 @@ export default function PublicCustomerIntake() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          storeId,
+          inviteId,
           name,
           phone,
           email,
           notes,
+          consent: true,
+          consentSource: 'public-customer-intake',
+          submittedFrom: 'link',
+          formStartedAt,
+          website: websiteTrap,
+          utmSource:
+            typeof window !== 'undefined' ? new URL(window.location.href).searchParams.get('utm_source') : null,
         }),
       })
 
-      const payload = (await response.json()) as { ok?: boolean; error?: string }
+      const payload = (await response.json()) as { ok?: boolean; error?: string; whatsappLink?: string | null }
       if (!response.ok || !payload.ok) {
         setSubmissionState('error')
         setMessage(payload.error ?? 'Could not submit details. Please try again.')
@@ -115,11 +168,13 @@ export default function PublicCustomerIntake() {
       }
 
       setSubmissionState('success')
-      setMessage('Thanks! Your details have been saved.')
+      setMessage(payload.whatsappLink ? 'Saved. You can now close this page or continue on WhatsApp.' : 'Saved. You can now close this page.')
       setName('')
       setPhone('')
       setEmail('')
       setNotes('')
+      setConsentChecked(false)
+      setWebsiteTrap('')
     } catch (error) {
       console.error('[public-customer-intake] Failed to submit profile', error)
       setSubmissionState('error')
@@ -131,12 +186,16 @@ export default function PublicCustomerIntake() {
 
   if (isQrMode) {
     return (
-      <main className="public-customer-intake public-customer-intake--qr">
-        <section className="public-customer-intake__card">
-          <p className="public-customer-intake__kicker">Customer Invite</p>
-          <h1>Hello, kindly scan to join our customer list.</h1>
+      <main className={`public-customer-intake public-customer-intake--qr public-customer-intake--${variant}`}>
+        <section className="public-customer-intake__card" style={{ borderColor: `${profile.accentColor}33` }}>
+          {profile.logoUrl ? <img src={profile.logoUrl} alt={`${title} logo`} className="public-customer-intake__logo" /> : null}
+          <p className="public-customer-intake__kicker" style={{ color: profile.accentColor }}>Customer Invite</p>
+          <h1>{profile.headline}</h1>
           <p>{profile.storeName ? `You are joining ${profile.storeName}.` : 'You are joining our customer list.'}</p>
-          <p>After scanning, submit your details and download or print this card if needed.</p>
+          <p>{profile.cta}</p>
+          <p className="public-customer-intake__fallback">
+            This QR code stays active unless the business rotates or revokes the invite link.
+          </p>
           {qrSvg ? (
             <div
               className="public-customer-intake__qr"
@@ -146,10 +205,16 @@ export default function PublicCustomerIntake() {
           ) : (
             <div className="public-customer-intake__qr public-customer-intake__qr--empty">QR unavailable</div>
           )}
-          <p className="public-customer-intake__link">{intakeUrl}</p>
-          <button type="button" className="button button--primary" onClick={() => window.print()}>
-            Print poster
-          </button>
+          <p className="public-customer-intake__link">{profile.vanityPath || intakeUrl}</p>
+          <p className="public-customer-intake__fallback">If QR fails, type this link in your browser.</p>
+          <div className="customers-page__form-actions">
+            <button type="button" className="button button--ghost" onClick={() => setVariant(variant === 'a4' ? 'a5' : 'a4')}>
+              Switch to {variant === 'a4' ? 'A5' : 'A4'}
+            </button>
+            <button type="button" className="button button--primary" onClick={() => window.print()}>
+              Print / Save PDF
+            </button>
+          </div>
         </section>
       </main>
     )
@@ -157,8 +222,9 @@ export default function PublicCustomerIntake() {
 
   return (
     <main className="public-customer-intake">
-      <section className="public-customer-intake__card">
-        <p className="public-customer-intake__kicker">{title}</p>
+      <section className="public-customer-intake__card" style={{ borderColor: `${profile.accentColor}33` }}>
+        {profile.logoUrl ? <img src={profile.logoUrl} alt={`${title} logo`} className="public-customer-intake__logo" /> : null}
+        <p className="public-customer-intake__kicker" style={{ color: profile.accentColor }}>{title}</p>
         <h1>Join our customer list</h1>
         <p>{profile.tagline}</p>
 
@@ -203,6 +269,24 @@ export default function PublicCustomerIntake() {
               placeholder="Any note you want us to know"
             />
           </label>
+          <label className="public-customer-intake__consent">
+            <input
+              type="checkbox"
+              checked={consentChecked}
+              onChange={event => setConsentChecked(event.target.checked)}
+              required
+            />
+            I agree to be contacted by this business about products, services, and updates.
+          </label>
+          <input
+            className="public-customer-intake__bot-trap"
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+            value={websiteTrap}
+            onChange={event => setWebsiteTrap(event.target.value)}
+            placeholder="website"
+          />
           <button
             type="submit"
             className="button button--primary"


### PR DESCRIPTION
### Motivation
- Provide a public, shareable customer intake flow reachable via invite IDs/QR codes with configurable branding and text.
- Protect the public intake endpoint from abuse and spam with validation, honeypot, and rate limits.
- Allow stores to rotate/revoke invite links and persist invite metadata on the `stores` record.

### Description
- Reworked API at `web/api/public-customer-intake.ts` to accept `inviteId` instead of `storeId`, resolve stores by `customerIntakeInviteId`, require consent, validate email/phone, apply a honeypot `website` trap, and reject too-fast submissions based on `formStartedAt`.
- Implemented rate limiting with Firestore transactional counters (`publicIntakeRateLimits`) enforcing per-IP (10-minute) and per-invite (hour) buckets and hashed client IPs via `sha256`.
- De-duplicated customer records by matching existing customers by `email` or `phone`, merging tags/notes when appropriate, and returning a `whatsappLink` when a phone is present.
- Extended store branding fields and controls: `customerIntakeHeadline`, `customerIntakeCta`, `customerIntakeAccentColor`, `customerIntakeLogoUrl`, `customerIntakeInviteId`, `customerIntakeInviteStatus`, and `customerIntakeVanityPath` are read and written from the UI.
- Client-side changes include renaming routes and params from `storeId` to `inviteId`, added `PublicCustomerIntake` UI to show branding and QR poster variants, and enhanced `Customers` admin page with invite creation, rotation, revocation, and branding controls plus helper functions `createInviteId` and `normalizeColorInput`.
- Styling updates added logo, consent checkbox, honeypot input, and print-friendly poster variants in `PublicCustomerIntake.css`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3729713b483228c1c38cab4304cf5)