### PR TITLE
Darken QR-page headline and add 'Powered by Sedifex' footer

### DIFF
--- a/web/src/pages/PublicCustomerIntake.css
+++ b/web/src/pages/PublicCustomerIntake.css
@@ -37,6 +37,11 @@
   font-size: clamp(1.5rem, 4vw, 2rem);
 }
 
+.public-customer-intake--qr .public-customer-intake__headline {
+  color: #0f172a;
+  font-weight: 800;
+}
+
 .public-customer-intake p {
   margin: 0;
   color: #334155;
@@ -120,6 +125,14 @@
 .public-customer-intake__fallback {
   font-size: 0.8rem;
   color: #64748b;
+}
+
+.public-customer-intake__powered-by {
+  margin-top: 0.35rem;
+  text-align: center;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #0f172a;
 }
 
 .public-customer-intake--a5 .public-customer-intake__card {

--- a/web/src/pages/PublicCustomerIntake.tsx
+++ b/web/src/pages/PublicCustomerIntake.tsx
@@ -190,7 +190,7 @@ export default function PublicCustomerIntake() {
         <section className="public-customer-intake__card" style={{ borderColor: `${profile.accentColor}33` }}>
           {profile.logoUrl ? <img src={profile.logoUrl} alt={`${title} logo`} className="public-customer-intake__logo" /> : null}
           <p className="public-customer-intake__kicker" style={{ color: profile.accentColor }}>Customer Invite</p>
-          <h1>{profile.headline}</h1>
+          <h1 className="public-customer-intake__headline">{profile.headline}</h1>
           <p>{profile.storeName ? `You are joining ${profile.storeName}.` : 'You are joining our customer list.'}</p>
           <p>{profile.cta}</p>
           <p className="public-customer-intake__fallback">
@@ -215,6 +215,7 @@ export default function PublicCustomerIntake() {
               Print / Save PDF
             </button>
           </div>
+          <p className="public-customer-intake__powered-by">Powered by Sedifex</p>
         </section>
       </main>
     )


### PR DESCRIPTION
### Motivation
- Improve readability of the customer QR print/display page headline and add clear branding on printed/exported QR pages.

### Description
- Introduced a `public-customer-intake__headline` class and updated `web/src/pages/PublicCustomerIntake.tsx` to use it, added CSS rules in `web/src/pages/PublicCustomerIntake.css` to darken and bold the headline in QR mode, and appended a `Powered by Sedifex` footer with styling for the QR view.

### Testing
- Executed `cd web && npm run -s lint`, which failed in this environment because the ESLint config imports `@eslint/js` that is not installed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37725a6408322a625195ae1029f96)