### PR TITLE
Fix missing fallback link on customer QR page

### DIFF
--- a/web/src/pages/PublicCustomerIntake.css
+++ b/web/src/pages/PublicCustomerIntake.css
@@ -117,9 +117,10 @@
 }
 
 .public-customer-intake__link {
+  display: block;
   word-break: break-all;
   font-size: 0.85rem;
-  color: #475569;
+  color: #334155;
 }
 
 .public-customer-intake__fallback {
@@ -153,7 +154,6 @@
     align-content: center;
   }
 
-  .public-customer-intake__link,
   .public-customer-intake .button {
     display: none;
   }

--- a/web/src/pages/PublicCustomerIntake.tsx
+++ b/web/src/pages/PublicCustomerIntake.tsx
@@ -50,6 +50,7 @@ export default function PublicCustomerIntake() {
     if (!inviteId || typeof window === 'undefined') return ''
     return `${window.location.origin}/join-customers/${encodeURIComponent(inviteId)}`
   }, [inviteId])
+  const fallbackLink = useMemo(() => profile.vanityPath || intakeUrl, [profile.vanityPath, intakeUrl])
 
   useEffect(() => {
     let active = true
@@ -205,7 +206,13 @@ export default function PublicCustomerIntake() {
           ) : (
             <div className="public-customer-intake__qr public-customer-intake__qr--empty">QR unavailable</div>
           )}
-          <p className="public-customer-intake__link">{profile.vanityPath || intakeUrl}</p>
+          {fallbackLink ? (
+            <a className="public-customer-intake__link" href={fallbackLink} target="_blank" rel="noreferrer">
+              {fallbackLink}
+            </a>
+          ) : (
+            <p className="public-customer-intake__link">Link unavailable. Please request a new invite link.</p>
+          )}
           <p className="public-customer-intake__fallback">If QR fails, type this link in your browser.</p>
           <div className="customers-page__form-actions">
             <button type="button" className="button button--ghost" onClick={() => setVariant(variant === 'a4' ? 'a5' : 'a4')}>


### PR DESCRIPTION
### Motivation
- The QR landing sheet showed the text "If QR fails, type this link in your browser." but did not render a usable link or provide a clear fallback when the URL is unavailable, which made printed sheets and users without a working scanner unable to reach the intake page.
- The change ensures the message is actionable both on-screen and in print by exposing the actual URL or a clear fallback message.

### Description
- Compute a `fallbackLink` via `useMemo` from `profile.vanityPath` or the generated `intakeUrl` and render it as an explicit `<a>` when present in `web/src/pages/PublicCustomerIntake.tsx`.
- Show a concise placeholder message when no fallback URL can be resolved so the sheet no longer displays an empty link area.
- Make the fallback link block-level and adjust its color in `web/src/pages/PublicCustomerIntake.css`, and remove it from the print-hide rule so the URL remains visible when printed.
- Files modified: `web/src/pages/PublicCustomerIntake.tsx` and `web/src/pages/PublicCustomerIntake.css`.

### Testing
- Ran the application build with `npm --prefix web run build`, which failed in this environment due to missing TypeScript type definitions for `vite/client` and `vitest/globals`, so the build could not be validated here.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37ec80c9883229b4291b173b0ad5b)