### PR TITLE
Differentiate billing vs internal errors on blocked-workspace screen

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -116,6 +116,13 @@ export default function App() {
       </main>
     )
   } else if (storeAccessStatus === 'failed' && !isPublicRoute && !isAccountRoute) {
+    const normalizedStoreAccessError = storeAccessError?.toLowerCase() ?? ''
+    const hasBillingRelatedError =
+      normalizedStoreAccessError.includes('bill') ||
+      normalizedStoreAccessError.includes('payment') ||
+      normalizedStoreAccessError.includes('subscription') ||
+      normalizedStoreAccessError.includes('plan')
+
     content = (
       <main className="app" style={appStyle}>
         <div className="app__card">
@@ -124,9 +131,15 @@ export default function App() {
             {storeAccessError ??
               'Your Sedifex workspace is unavailable. Please upgrade your plan or contact support to restore access.'}
           </p>
-          <p className="form__hint">
-            Billing issues can block workspace access. Update your subscription to restore it.
-          </p>
+          {hasBillingRelatedError ? (
+            <p className="form__hint">
+              Billing issues can block workspace access. Update your subscription to restore it.
+            </p>
+          ) : (
+            <p className="form__hint">
+              This looks like an internal workspace setup issue. Please contact support to restore access.
+            </p>
+          )}
           <div className="flex gap-3 mt-4">
             <Link className="button button--primary" to="/account">
               Go to billing


### PR DESCRIPTION
### Motivation
- Prevent showing billing-recovery guidance to customers when the workspace failure is an internal/setup error so paid clients are not misled.

### Description
- Add `normalizedStoreAccessError` and simple keyword checks for `bill`, `payment`, `subscription`, and `plan` to detect billing-related failures. 
- Conditionally render the existing billing guidance only when the error appears billing-related, otherwise render a support-focused internal-issue message. 
- Change implemented in `web/src/App.tsx` near the blocked-workspace rendering logic.

### Testing
- Ran the project lint with `npm --prefix web run lint`, which failed in this environment because `@eslint/js` is missing and ESLint could not load `web/eslint.config.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bbe6f6b88321a2ae84a40d2924c1)