### PR TITLE
Fix integration API keys callable timestamp serialization

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -1942,6 +1942,10 @@ exports.listIntegrationApiKeys = functions.https.onCall(async (_data, context) =
         const keys = snapshot.docs
             .map(docSnap => {
             const data = docSnap.data();
+            const lastUsedAt = data.lastUsedAt instanceof firestore_1.admin.firestore.Timestamp ? data.lastUsedAt.toMillis() : null;
+            const createdAt = data.createdAt instanceof firestore_1.admin.firestore.Timestamp ? data.createdAt.toMillis() : null;
+            const updatedAt = data.updatedAt instanceof firestore_1.admin.firestore.Timestamp ? data.updatedAt.toMillis() : null;
+            const revokedAt = data.revokedAt instanceof firestore_1.admin.firestore.Timestamp ? data.revokedAt.toMillis() : null;
             return {
                 id: docSnap.id,
                 name: typeof data.name === 'string' ? data.name : 'Unnamed key',
@@ -1949,15 +1953,15 @@ exports.listIntegrationApiKeys = functions.https.onCall(async (_data, context) =
                 keyPreview: typeof data.keyPreview === 'string' && data.keyPreview.trim()
                     ? data.keyPreview
                     : '••••••••',
-                lastUsedAt: data.lastUsedAt instanceof firestore_1.admin.firestore.Timestamp ? data.lastUsedAt : null,
-                createdAt: data.createdAt instanceof firestore_1.admin.firestore.Timestamp ? data.createdAt : null,
-                updatedAt: data.updatedAt instanceof firestore_1.admin.firestore.Timestamp ? data.updatedAt : null,
-                revokedAt: data.revokedAt instanceof firestore_1.admin.firestore.Timestamp ? data.revokedAt : null,
+                lastUsedAt,
+                createdAt,
+                updatedAt,
+                revokedAt,
             };
         })
             .sort((a, b) => {
-            const aMillis = a.createdAt?.toMillis() ?? 0;
-            const bMillis = b.createdAt?.toMillis() ?? 0;
+            const aMillis = a.createdAt ?? 0;
+            const bMillis = b.createdAt ?? 0;
             return bMillis - aMillis;
         })
             .slice(0, 50);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2613,6 +2613,14 @@ export const listIntegrationApiKeys = functions.https.onCall(
       const keys = snapshot.docs
         .map(docSnap => {
           const data = docSnap.data() as Record<string, unknown>
+          const lastUsedAt =
+            data.lastUsedAt instanceof admin.firestore.Timestamp ? data.lastUsedAt.toMillis() : null
+          const createdAt =
+            data.createdAt instanceof admin.firestore.Timestamp ? data.createdAt.toMillis() : null
+          const updatedAt =
+            data.updatedAt instanceof admin.firestore.Timestamp ? data.updatedAt.toMillis() : null
+          const revokedAt =
+            data.revokedAt instanceof admin.firestore.Timestamp ? data.revokedAt.toMillis() : null
           return {
             id: docSnap.id,
             name: typeof data.name === 'string' ? data.name : 'Unnamed key',
@@ -2621,15 +2629,15 @@ export const listIntegrationApiKeys = functions.https.onCall(
               typeof data.keyPreview === 'string' && data.keyPreview.trim()
                 ? data.keyPreview
                 : '••••••••',
-            lastUsedAt: data.lastUsedAt instanceof admin.firestore.Timestamp ? data.lastUsedAt : null,
-            createdAt: data.createdAt instanceof admin.firestore.Timestamp ? data.createdAt : null,
-            updatedAt: data.updatedAt instanceof admin.firestore.Timestamp ? data.updatedAt : null,
-            revokedAt: data.revokedAt instanceof admin.firestore.Timestamp ? data.revokedAt : null,
+            lastUsedAt,
+            createdAt,
+            updatedAt,
+            revokedAt,
           }
         })
         .sort((a, b) => {
-          const aMillis = a.createdAt?.toMillis() ?? 0
-          const bMillis = b.createdAt?.toMillis() ?? 0
+          const aMillis = a.createdAt ?? 0
+          const bMillis = b.createdAt ?? 0
           return bMillis - aMillis
         })
         .slice(0, 50)

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -187,6 +187,14 @@ function isTimestamp(value: unknown): value is Timestamp {
   )
 }
 
+function toTimestamp(value: unknown): Timestamp | null {
+  if (isTimestamp(value)) return value
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Timestamp.fromMillis(value)
+  }
+  return null
+}
+
 function mapStoreSnapshot(
   snapshot:
     | DocumentSnapshot<DocumentData>
@@ -708,10 +716,10 @@ export default function AccountOverview({
               typeof item.keyPreview === 'string' && item.keyPreview.trim()
                 ? item.keyPreview
                 : '••••••••',
-            createdAt: isTimestamp(item.createdAt) ? item.createdAt : null,
-            updatedAt: isTimestamp(item.updatedAt) ? item.updatedAt : null,
-            revokedAt: isTimestamp(item.revokedAt) ? item.revokedAt : null,
-            lastUsedAt: isTimestamp(item.lastUsedAt) ? item.lastUsedAt : null,
+            createdAt: toTimestamp(item.createdAt),
+            updatedAt: toTimestamp(item.updatedAt),
+            revokedAt: toTimestamp(item.revokedAt),
+            lastUsedAt: toTimestamp(item.lastUsedAt),
           }))
         : []
       setIntegrationApiKeys(keys.filter(key => key.id))


### PR DESCRIPTION
### Motivation
- Clients were seeing `FirebaseError: internal` when calling `listIntegrationApiKeys`, which was traced to returned Firestore `Timestamp` objects that do not serialize cleanly from the callable payload. 
- The change ensures the callable returns plain numeric milliseconds and the UI accepts both numeric and `Timestamp` values to avoid runtime failures.

### Description
- In `functions/src/index.ts` convert `createdAt`, `updatedAt`, `revokedAt`, and `lastUsedAt` to millisecond numbers before returning them from the `listIntegrationApiKeys` callable and sort by those numeric values. 
- The compiled output in `functions/lib/index.js` was updated to match the same serialization behavior. 
- In `web/src/pages/AccountOverview.tsx` add a `toTimestamp` helper that accepts either a Firebase `Timestamp` or a numeric millisecond value and use it when mapping the callable response so the UI works with the new payload format.

### Testing
- Ran `npm run -s build` in `functions/` and it completed successfully. 
- Attempted `npm run -s test -- AccountOverview` in `web/`, but it failed in this environment because `vitest` is not installed. 
- Attempted `npm run -s build` in `web/`, but it failed in this environment due to missing type definitions (`vite/client`, `vitest/globals`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bfef4ddc832296c01eda743a1d0d)