### PR TITLE
Improve integration API key callable error diagnostics

### DIFF
--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -726,6 +726,8 @@ export default function AccountOverview({
     } catch (error) {
       console.error('[account] Failed to load integration API keys', error)
       const callableError = error as FirebaseError | null
+      const errorCode = typeof callableError?.code === 'string' ? callableError.code : ''
+      const errorMessage = typeof callableError?.message === 'string' ? callableError.message : ''
       const detailsRaw =
         callableError && 'details' in callableError
           ? (callableError as FirebaseError & { details?: unknown }).details
@@ -737,15 +739,22 @@ export default function AccountOverview({
             ? detailsRaw
             : ''
       console.error('[account] listIntegrationApiKeys diagnostics', {
-        code: callableError?.code ?? null,
-        message: callableError?.message ?? null,
+        code: errorCode || null,
+        message: errorMessage || null,
         details: detailsRaw ?? null,
       })
-      const detail =
-        callableError && typeof callableError.code === 'string' && callableError.code
-          ? ` (${callableError.code}${callableError.message ? `: ${callableError.message}` : ''}${detailText ? ` | details: ${detailText}` : ''})`
+      const internalHint =
+        errorCode === 'functions/internal' && !detailText
+          ? ' Check Cloud Functions logs for listIntegrationApiKeys and verify VITE_FB_FUNCTIONS_REGION points to the deployed region.'
           : ''
-      publish({ message: `Unable to load integration API keys.${detail}`, tone: 'error' })
+      const detail =
+        errorCode
+          ? ` (${errorCode}${errorMessage ? `: ${errorMessage}` : ''}${detailText ? ` | details: ${detailText}` : ''})`
+          : ''
+      publish({
+        message: `Unable to load integration API keys.${detail}${internalHint}`,
+        tone: 'error',
+      })
       setIntegrationApiKeys([])
     } finally {
       setIntegrationKeysLoading(false)


### PR DESCRIPTION
### Motivation
- Make errors from the `listIntegrationApiKeys` callable more actionable for owners and easier to log by normalizing the callable error code/message before use. 
- Surface a targeted hint for the `functions/internal` failure case when no details are present so operators can quickly check Cloud Functions logs and region configuration.

### Description
- In `web/src/pages/AccountOverview.tsx` (inside `refreshIntegrationApiKeys`) extract `errorCode` and `errorMessage` from the callable error to produce stable diagnostic values. 
- Replace direct use of the raw error object in diagnostic logs with the normalized `errorCode`/`errorMessage`, and keep the original `details` content for inspection. 
- Add an `internalHint` when `errorCode === 'functions/internal'` and there are no details, and append that hint to the user-facing toast message while preserving the existing fallback behavior (`setIntegrationApiKeys([])`).

### Testing
- Ran `npm --prefix web run lint`, which failed in this environment due to a missing dev dependency (`@eslint/js`) required by the ESLint config, so linting could not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c8f6e40483228f883e6b5d7189a0)