### PR TITLE
Normalize integration API key callable timestamps to millis

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2582,6 +2582,20 @@ function isFirestoreMissingIndexError(error: unknown) {
   return false
 }
 
+function toMillisOrNull(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'object' && value !== null) {
+    const toMillis = (value as { toMillis?: unknown }).toMillis
+    if (typeof toMillis === 'function') {
+      const millis = toMillis.call(value)
+      return typeof millis === 'number' && Number.isFinite(millis) ? millis : null
+    }
+  }
+  return null
+}
+
 export const listIntegrationApiKeys = functions.https.onCall(
   async (_data: unknown, context: functions.https.CallableContext) => {
     let uid: string | null = null
@@ -2613,14 +2627,10 @@ export const listIntegrationApiKeys = functions.https.onCall(
       const keys = snapshot.docs
         .map(docSnap => {
           const data = docSnap.data() as Record<string, unknown>
-          const lastUsedAt =
-            data.lastUsedAt instanceof admin.firestore.Timestamp ? data.lastUsedAt.toMillis() : null
-          const createdAt =
-            data.createdAt instanceof admin.firestore.Timestamp ? data.createdAt.toMillis() : null
-          const updatedAt =
-            data.updatedAt instanceof admin.firestore.Timestamp ? data.updatedAt.toMillis() : null
-          const revokedAt =
-            data.revokedAt instanceof admin.firestore.Timestamp ? data.revokedAt.toMillis() : null
+          const lastUsedAt = toMillisOrNull(data.lastUsedAt)
+          const createdAt = toMillisOrNull(data.createdAt)
+          const updatedAt = toMillisOrNull(data.updatedAt)
+          const revokedAt = toMillisOrNull(data.revokedAt)
           return {
             id: docSnap.id,
             name: typeof data.name === 'string' ? data.name : 'Unnamed key',
@@ -2635,11 +2645,7 @@ export const listIntegrationApiKeys = functions.https.onCall(
             revokedAt,
           }
         })
-        .sort((a, b) => {
-          const aMillis = a.createdAt ?? 0
-          const bMillis = b.createdAt ?? 0
-          return bMillis - aMillis
-        })
+        .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
         .slice(0, 50)
 
       return { storeId, keys }

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -189,7 +189,7 @@ function isTimestamp(value: unknown): value is Timestamp {
 
 function toTimestamp(value: unknown): Timestamp | null {
   if (isTimestamp(value)) return value
-  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
     return Timestamp.fromMillis(value)
   }
   return null


### PR DESCRIPTION
### Motivation
- Callable responses containing Firestore `Timestamp` objects can fail to serialize for callable clients and surface as opaque `FirebaseError: internal`, so integration API key timestamps should be returned as plain numbers (milliseconds) or `null` to be callable-safe. 
- Sorting of integration keys should operate on numeric millisecond values to avoid relying on Timestamp comparison semantics. 
- The UI mapping helper should accept either a Firebase `Timestamp` or a millisecond number so rendering remains stable after changing the backend payload.

### Description
- Added `toMillisOrNull(value: unknown): number | null` in `functions/src/index.ts` which returns a finite millisecond number for numeric inputs or objects exposing a `toMillis()` method (e.g., Firestore `Timestamp`), otherwise `null`.
- Updated `listIntegrationApiKeys` in `functions/src/index.ts` to normalize `lastUsedAt`, `createdAt`, `updatedAt`, and `revokedAt` to plain millisecond numbers (or `null`) using `toMillisOrNull` and to sort keys by numeric `createdAt` with `(b.createdAt ?? 0) - (a.createdAt ?? 0)`.
- Relaxed `toTimestamp` in `web/src/pages/AccountOverview.tsx` to accept any finite millisecond number (removed the `> 0` check) so the frontend can convert millisecond values back into `Timestamp` instances for UI use.

### Testing
- Built the Functions package with `npm --prefix functions run build`, which completed successfully.
- Attempted to run the web unit tests with `npm --prefix web run test -- src/pages/__tests__/AccountOverview.test.tsx`, but the run failed in this environment because the `vitest` executable is not available (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4cc4e57208322a919a5622e52982f)