### PR TITLE
Improve docs text contrast and fix code block rendering in DocsPageLayout

### DIFF
--- a/web/src/components/docs/DocsPageLayout.css
+++ b/web/src/components/docs/DocsPageLayout.css
@@ -44,15 +44,29 @@
   margin: 0 0 8px;
 }
 
+.docs-page__content section,
+.docs-page__content h2,
+.docs-page__content h3,
+.docs-page__content p,
+.docs-page__content li,
+.docs-page__content strong {
+  color: #0f172a;
+}
+
 .docs-page__content p,
 .docs-page__content li {
   line-height: 1.6;
 }
 
-.docs-page__content code {
+.docs-page__content a {
+  color: #1d4ed8;
+}
+
+.docs-page__content :not(pre) > code {
   background: #e2e8f0;
   padding: 2px 6px;
   border-radius: 6px;
+  color: #0f172a;
 }
 
 .docs-page__content pre {
@@ -61,4 +75,12 @@
   border-radius: 10px;
   background: #0f172a;
   color: #e2e8f0;
+}
+
+.docs-page__content pre > code {
+  display: block;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  border-radius: 0;
 }


### PR DESCRIPTION
### Motivation
- Documentation content and code samples were rendering with poor contrast or masked by inline `code` styling, making pages hard to read. 
- The goal is to ensure all docs using `DocsPageLayout` display readable headings, paragraphs, lists, links, and code samples.

### Description
- Added explicit high-contrast color rules for docs content elements (`section`, `h2`, `h3`, `p`, `li`, `strong`) to ensure readable body text. 
- Added a readable link color for docs content via `.docs-page__content a { color: #1d4ed8; }`. 
- Scoped inline code styling to non-pre contexts with `.docs-page__content :not(pre) > code` so inline snippets keep the gray background but do not affect fenced/multiline blocks. 
- Reset `pre > code` to transparent background and `color: inherit` so fenced code blocks render correctly instead of appearing as masked bars.

### Testing
- Ran `git status` to verify the file change is present and inspected the updated file `web/src/components/docs/DocsPageLayout.css` successfully. 
- Attempted `npm --prefix web run build` which failed due to missing type definitions for `vite/client` and `vitest/globals` in this environment. 
- Attempted `npm --prefix web ci` which failed with `403 Forbidden` from the npm registry, preventing dependency install and a full build verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50ca7310c8322963fb43d123ed6ab)