### PR TITLE
Split public catalog into product/service buckets and backfill routing

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -98,9 +98,13 @@ Query parameters:
       "imageAlt": "Item image",
       "updatedAt": "2026-04-13T00:00:00.000Z"
     }
-  ]
+  ],
+  "publicProducts": [],
+  "publicServices": []
 }
 ```
+
+`publicProducts` and `publicServices` are convenience buckets derived from `itemType` so storefronts can render physical products and services in separate sections without extra client-side sorting.
 
 ### `GET /v1IntegrationPromo?storeId=<storeId>` (authenticated) or `?slug=<promoSlug>` (public)
 

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -2970,6 +2970,18 @@ function toPlainObject(value) {
     }
     return value;
 }
+function splitCatalogItemsByType(items) {
+    const publicProducts = [];
+    const publicServices = [];
+    for (const item of items) {
+        if (item.itemType === 'service') {
+            publicServices.push(item);
+            continue;
+        }
+        publicProducts.push(item);
+    }
+    return { publicProducts, publicServices };
+}
 const BOOKING_ATTRIBUTE_MAX_KEYS = 40;
 const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500;
 const DEFAULT_BOOKING_ALIASES = {
@@ -3705,10 +3717,13 @@ exports.integrationProducts = functions.https.onRequest(async (req, res) => {
             storeCity: storeMeta?.storeCity ?? null,
         };
     });
+    const { publicProducts, publicServices } = splitCatalogItemsByType(enrichedProducts);
     res.status(200).json({
         storeId: scopeStoreId ?? null,
         scope: isAllStoresRead ? 'all-stores' : 'store',
         products: enrichedProducts,
+        publicProducts,
+        publicServices,
     });
 });
 exports.v1IntegrationProducts = functions.https.onRequest(async (req, res) => {
@@ -3808,10 +3823,13 @@ exports.v1IntegrationProducts = functions.https.onRequest(async (req, res) => {
             storeCity: storeMeta?.storeCity ?? null,
         };
     });
+    const { publicProducts, publicServices } = splitCatalogItemsByType(enrichedProducts);
     res.status(200).json({
         storeId: scopeStoreId ?? null,
         scope: isAllStoresRead ? 'all-stores' : 'store',
         products: enrichedProducts,
+        publicProducts,
+        publicServices,
     });
 });
 exports.integrationPromo = functions.https.onRequest(async (req, res) => {
@@ -4538,25 +4556,7 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
         return;
     }
     const { storeId } = storeContext;
-    let productsSnapshot;
-    try {
-        productsSnapshot = await firestore_1.defaultDb
-            .collection('products')
-            .where('storeId', '==', storeId)
-            .orderBy('updatedAt', 'desc')
-            .limit(200)
-            .get();
-    }
-    catch (error) {
-        const code = error?.code;
-        const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition';
-        if (!isMissingIndex) {
-            throw error;
-        }
-        productsSnapshot = await firestore_1.defaultDb.collection('products').where('storeId', '==', storeId).limit(200).get();
-    }
-    const products = productsSnapshot.docs
-        .map(docSnap => {
+    const mapCatalogDoc = (docSnap) => {
         const data = docSnap.data();
         const name = typeof data.name === 'string' ? data.name.trim() : '';
         if (!name)
@@ -4575,9 +4575,77 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
                     : 'product',
             updatedAt: normalizeTimestampIso(data.updatedAt),
         };
-    })
-        .filter(item => item !== null);
-    res.status(200).json({ storeId, products });
+    };
+    const loadCatalogCollection = async (collectionName) => {
+        let snapshot;
+        try {
+            snapshot = await firestore_1.defaultDb
+                .collection(collectionName)
+                .where('storeId', '==', storeId)
+                .orderBy('updatedAt', 'desc')
+                .limit(200)
+                .get();
+        }
+        catch (error) {
+            const code = error?.code;
+            const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition';
+            if (!isMissingIndex) {
+                throw error;
+            }
+            snapshot = await firestore_1.defaultDb.collection(collectionName).where('storeId', '==', storeId).limit(200).get();
+        }
+        return snapshot;
+    };
+    const [publicProductsSnapshot, publicServicesSnapshot] = await Promise.all([
+        loadCatalogCollection('publicProducts'),
+        loadCatalogCollection('publicServices'),
+    ]);
+    const publicCatalogDocs = [...publicProductsSnapshot.docs, ...publicServicesSnapshot.docs];
+    let products = publicCatalogDocs
+        .map(mapCatalogDoc)
+        .filter(item => item !== null)
+        .sort((a, b) => {
+        if (!a.updatedAt && !b.updatedAt)
+            return 0;
+        if (!a.updatedAt)
+            return 1;
+        if (!b.updatedAt)
+            return -1;
+        return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
+    });
+    if (!products.length) {
+        let productsSnapshot;
+        try {
+            productsSnapshot = await firestore_1.defaultDb
+                .collection('products')
+                .where('storeId', '==', storeId)
+                .orderBy('updatedAt', 'desc')
+                .limit(200)
+                .get();
+        }
+        catch (error) {
+            const code = error?.code;
+            const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition';
+            if (!isMissingIndex) {
+                throw error;
+            }
+            productsSnapshot = await firestore_1.defaultDb.collection('products').where('storeId', '==', storeId).limit(200).get();
+        }
+        products = productsSnapshot.docs
+            .map(mapCatalogDoc)
+            .filter(item => item !== null)
+            .sort((a, b) => {
+            if (!a.updatedAt && !b.updatedAt)
+                return 0;
+            if (!a.updatedAt)
+                return 1;
+            if (!b.updatedAt)
+                return -1;
+            return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
+        });
+    }
+    const { publicProducts, publicServices } = splitCatalogItemsByType(products);
+    res.status(200).json({ storeId, products, publicProducts, publicServices });
 });
 exports.integrationGoogleMerchantFeed = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);
@@ -5183,27 +5251,37 @@ function toPublicProductPayload(productId, source, existing, storeMeta) {
         updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
     };
 }
+function resolvePublicCatalogCollectionName(itemType) {
+    return itemType === 'service' ? 'publicServices' : 'publicProducts';
+}
 exports.syncPublicProducts = functions.firestore
     .document('products/{productId}')
     .onWrite(async (change, context) => {
     const productId = context.params.productId;
     const publicProductRef = firestore_1.defaultDb.collection('publicProducts').doc(productId);
+    const publicServiceRef = firestore_1.defaultDb.collection('publicServices').doc(productId);
     if (!change.after.exists) {
         await publicProductRef.delete().catch(() => undefined);
+        await publicServiceRef.delete().catch(() => undefined);
         return;
     }
     const sourceData = (change.after.data() ?? {});
-    const existingPublicProductSnap = await publicProductRef.get();
-    const existingData = existingPublicProductSnap.exists
-        ? existingPublicProductSnap.data()
+    const destinationCollectionName = resolvePublicCatalogCollectionName(sourceData.itemType);
+    const destinationRef = firestore_1.defaultDb.collection(destinationCollectionName).doc(productId);
+    const oppositeRef = destinationCollectionName === 'publicServices' ? publicProductRef : publicServiceRef;
+    const existingDestinationSnap = await destinationRef.get();
+    const existingData = existingDestinationSnap.exists
+        ? existingDestinationSnap.data()
         : null;
     const storeMeta = await resolveStorePublicMetaByStoreId(typeof sourceData.storeId === 'string' ? sourceData.storeId : '');
     const payload = toPublicProductPayload(productId, sourceData, existingData, storeMeta);
     if (!payload) {
         await publicProductRef.delete().catch(() => undefined);
+        await publicServiceRef.delete().catch(() => undefined);
         return;
     }
-    await publicProductRef.set(payload, { merge: true });
+    await destinationRef.set(payload, { merge: true });
+    await oppositeRef.delete().catch(() => undefined);
 });
 exports.enrichProductDataAfterSave = functions.firestore
     .document('products/{productId}')

--- a/functions/scripts/backfillPublicProducts.js
+++ b/functions/scripts/backfillPublicProducts.js
@@ -119,6 +119,10 @@ function toPublicProduct(productDoc, storeMetaByStoreId) {
   }
 }
 
+function resolvePublicCatalogCollectionName(itemType) {
+  return itemType === 'service' ? 'publicServices' : 'publicProducts'
+}
+
 function hasPublishedAt(value) {
   return (
     value instanceof admin.firestore.Timestamp ||
@@ -182,10 +186,16 @@ async function run() {
       continue
     }
 
-    const targetRef = db.collection('publicProducts').doc(productDoc.id)
+    const targetCollectionName = resolvePublicCatalogCollectionName(payload.itemType)
+    const targetRef = db.collection(targetCollectionName).doc(productDoc.id)
+    const oppositeRef =
+      targetCollectionName === 'publicServices'
+        ? db.collection('publicProducts').doc(productDoc.id)
+        : db.collection('publicServices').doc(productDoc.id)
     batch.set(targetRef, payload, { merge: true })
+    batch.delete(oppositeRef)
     upserts += 1
-    writes += 1
+    writes += 2
 
     if (writes >= 450) {
       await batch.commit()
@@ -202,46 +212,53 @@ async function run() {
     `[backfillPublicProducts] done. upserts=${upserts}, skipped=${skipped}, total=${productsSnapshot.size}`,
   )
 
-  let publicProductsQuery = db.collection('publicProducts')
-  if (targetStoreId) {
-    publicProductsQuery = publicProductsQuery.where('storeId', '==', targetStoreId)
-  }
-  const publicProductsSnapshot = await publicProductsQuery.get()
-  console.log(`[backfillPublicProducts] scanning ${publicProductsSnapshot.size} publicProducts docs for publishedAt`)
-
+  const publicCollections = ['publicProducts', 'publicServices']
   let publishedAtBackfills = 0
-  batch = db.batch()
-  writes = 0
 
-  for (const publicProductDoc of publicProductsSnapshot.docs) {
-    const data = publicProductDoc.data() || {}
-    if (hasPublishedAt(data.publishedAt)) {
-      continue
+  for (const collectionName of publicCollections) {
+    let publicQuery = db.collection(collectionName)
+    if (targetStoreId) {
+      publicQuery = publicQuery.where('storeId', '==', targetStoreId)
     }
-
-    batch.set(
-      publicProductDoc.ref,
-      {
-        publishedAt: resolvePublishedAtValue(data),
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-      },
-      { merge: true },
+    const publicSnapshot = await publicQuery.get()
+    console.log(
+      `[backfillPublicProducts] scanning ${publicSnapshot.size} ${collectionName} docs for publishedAt`,
     )
-    publishedAtBackfills += 1
-    writes += 1
 
-    if (writes >= 450) {
+    batch = db.batch()
+    writes = 0
+    for (const publicDoc of publicSnapshot.docs) {
+      const data = publicDoc.data() || {}
+      if (hasPublishedAt(data.publishedAt)) {
+        continue
+      }
+
+      batch.set(
+        publicDoc.ref,
+        {
+          publishedAt: resolvePublishedAtValue(data),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+      )
+      publishedAtBackfills += 1
+      writes += 1
+
+      if (writes >= 450) {
+        await batch.commit()
+        batch = db.batch()
+        writes = 0
+      }
+    }
+
+    if (writes > 0) {
       await batch.commit()
-      batch = db.batch()
-      writes = 0
     }
   }
 
-  if (writes > 0) {
-    await batch.commit()
-  }
-
-  console.log(`[backfillPublicProducts] publishedAt backfill complete. updated=${publishedAtBackfills}`)
+  console.log(
+    `[backfillPublicProducts] publishedAt backfill complete across publicProducts/publicServices. updated=${publishedAtBackfills}`,
+  )
 }
 
 run().catch(error => {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3853,6 +3853,21 @@ function toPlainObject(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>
 }
 
+function splitCatalogItemsByType<T extends { itemType: 'product' | 'service' | 'made_to_order' }>(
+  items: T[],
+): { publicProducts: T[]; publicServices: T[] } {
+  const publicProducts: T[] = []
+  const publicServices: T[] = []
+  for (const item of items) {
+    if (item.itemType === 'service') {
+      publicServices.push(item)
+      continue
+    }
+    publicProducts.push(item)
+  }
+  return { publicProducts, publicServices }
+}
+
 const BOOKING_ATTRIBUTE_MAX_KEYS = 40
 const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500
 
@@ -4756,11 +4771,14 @@ export const integrationProducts = functions.https.onRequest(async (req, res) =>
       storeCity: storeMeta?.storeCity ?? null,
     }
   })
+  const { publicProducts, publicServices } = splitCatalogItemsByType(enrichedProducts)
 
   res.status(200).json({
     storeId: scopeStoreId ?? null,
     scope: isAllStoresRead ? 'all-stores' : 'store',
     products: enrichedProducts,
+    publicProducts,
+    publicServices,
   })
 })
 
@@ -4864,11 +4882,14 @@ export const v1IntegrationProducts = functions.https.onRequest(async (req, res) 
       storeCity: storeMeta?.storeCity ?? null,
     }
   })
+  const { publicProducts, publicServices } = splitCatalogItemsByType(enrichedProducts)
 
   res.status(200).json({
     storeId: scopeStoreId ?? null,
     scope: isAllStoresRead ? 'all-stores' : 'store',
     products: enrichedProducts,
+    publicProducts,
+    publicServices,
   })
 })
 
@@ -5755,50 +5776,98 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
   }
   const { storeId } = storeContext
 
-  let productsSnapshot: admin.firestore.QuerySnapshot
-  try {
-    productsSnapshot = await db
-      .collection('products')
-      .where('storeId', '==', storeId)
-      .orderBy('updatedAt', 'desc')
-      .limit(200)
-      .get()
-  } catch (error) {
-    const code = (error as { code?: number | string } | null)?.code
-    const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition'
-    if (!isMissingIndex) {
-      throw error
-    }
+  const mapCatalogDoc = (docSnap: admin.firestore.QueryDocumentSnapshot) => {
+    const data = docSnap.data() as Record<string, unknown>
+    const name = typeof data.name === 'string' ? data.name.trim() : ''
+    if (!name) return null
 
-    productsSnapshot = await db.collection('products').where('storeId', '==', storeId).limit(200).get()
+    return {
+      id: docSnap.id,
+      name,
+      description:
+        typeof data.description === 'string' && data.description.trim() ? data.description.trim() : null,
+      category: typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
+      price: typeof data.price === 'number' ? data.price : null,
+      ...extractProductImageSet(data),
+      itemType:
+        data.itemType === 'service'
+          ? 'service'
+          : data.itemType === 'made_to_order'
+            ? 'made_to_order'
+            : 'product',
+      updatedAt: normalizeTimestampIso(data.updatedAt),
+    } as const
   }
 
-  const products = productsSnapshot.docs
-    .map(docSnap => {
-      const data = docSnap.data() as Record<string, unknown>
-      const name = typeof data.name === 'string' ? data.name.trim() : ''
-      if (!name) return null
-
-      return {
-        id: docSnap.id,
-        name,
-        description:
-          typeof data.description === 'string' && data.description.trim() ? data.description.trim() : null,
-        category: typeof data.category === 'string' && data.category.trim() ? data.category.trim() : null,
-        price: typeof data.price === 'number' ? data.price : null,
-        ...extractProductImageSet(data),
-        itemType:
-          data.itemType === 'service'
-            ? 'service'
-            : data.itemType === 'made_to_order'
-              ? 'made_to_order'
-              : 'product',
-        updatedAt: normalizeTimestampIso(data.updatedAt),
+  const loadCatalogCollection = async (collectionName: 'publicProducts' | 'publicServices') => {
+    let snapshot: admin.firestore.QuerySnapshot
+    try {
+      snapshot = await db
+        .collection(collectionName)
+        .where('storeId', '==', storeId)
+        .orderBy('updatedAt', 'desc')
+        .limit(200)
+        .get()
+    } catch (error) {
+      const code = (error as { code?: number | string } | null)?.code
+      const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition'
+      if (!isMissingIndex) {
+        throw error
       }
-    })
-    .filter(item => item !== null)
+      snapshot = await db.collection(collectionName).where('storeId', '==', storeId).limit(200).get()
+    }
+    return snapshot
+  }
 
-  res.status(200).json({ storeId, products })
+  const [publicProductsSnapshot, publicServicesSnapshot] = await Promise.all([
+    loadCatalogCollection('publicProducts'),
+    loadCatalogCollection('publicServices'),
+  ])
+
+  const publicCatalogDocs = [...publicProductsSnapshot.docs, ...publicServicesSnapshot.docs]
+  let products = publicCatalogDocs
+    .map(mapCatalogDoc)
+    .filter(item => item !== null)
+    .sort((a, b) => {
+      if (!a.updatedAt && !b.updatedAt) return 0
+      if (!a.updatedAt) return 1
+      if (!b.updatedAt) return -1
+      return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
+    })
+
+  if (!products.length) {
+    let productsSnapshot: admin.firestore.QuerySnapshot
+    try {
+      productsSnapshot = await db
+        .collection('products')
+        .where('storeId', '==', storeId)
+        .orderBy('updatedAt', 'desc')
+        .limit(200)
+        .get()
+    } catch (error) {
+      const code = (error as { code?: number | string } | null)?.code
+      const isMissingIndex = code === 9 || code === '9' || code === 'failed-precondition'
+      if (!isMissingIndex) {
+        throw error
+      }
+
+      productsSnapshot = await db.collection('products').where('storeId', '==', storeId).limit(200).get()
+    }
+
+    products = productsSnapshot.docs
+      .map(mapCatalogDoc)
+      .filter(item => item !== null)
+      .sort((a, b) => {
+        if (!a.updatedAt && !b.updatedAt) return 0
+        if (!a.updatedAt) return 1
+        if (!b.updatedAt) return -1
+        return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
+      })
+  }
+
+  const { publicProducts, publicServices } = splitCatalogItemsByType(products)
+
+  res.status(200).json({ storeId, products, publicProducts, publicServices })
 })
 
 export const integrationGoogleMerchantFeed = functions.https.onRequest(async (req, res) => {
@@ -6505,21 +6574,31 @@ function toPublicProductPayload(
   }
 }
 
+function resolvePublicCatalogCollectionName(itemType: unknown): 'publicProducts' | 'publicServices' {
+  return itemType === 'service' ? 'publicServices' : 'publicProducts'
+}
+
 export const syncPublicProducts = functions.firestore
   .document('products/{productId}')
   .onWrite(async (change, context) => {
     const productId = context.params.productId
     const publicProductRef = db.collection('publicProducts').doc(productId)
+    const publicServiceRef = db.collection('publicServices').doc(productId)
 
     if (!change.after.exists) {
       await publicProductRef.delete().catch(() => undefined)
+      await publicServiceRef.delete().catch(() => undefined)
       return
     }
 
     const sourceData = (change.after.data() ?? {}) as Record<string, unknown>
-    const existingPublicProductSnap = await publicProductRef.get()
-    const existingData = existingPublicProductSnap.exists
-      ? (existingPublicProductSnap.data() as Record<string, unknown>)
+    const destinationCollectionName = resolvePublicCatalogCollectionName(sourceData.itemType)
+    const destinationRef = db.collection(destinationCollectionName).doc(productId)
+    const oppositeRef = destinationCollectionName === 'publicServices' ? publicProductRef : publicServiceRef
+
+    const existingDestinationSnap = await destinationRef.get()
+    const existingData = existingDestinationSnap.exists
+      ? (existingDestinationSnap.data() as Record<string, unknown>)
       : null
 
     const storeMeta = await resolveStorePublicMetaByStoreId(
@@ -6528,10 +6607,12 @@ export const syncPublicProducts = functions.firestore
     const payload = toPublicProductPayload(productId, sourceData, existingData, storeMeta)
     if (!payload) {
       await publicProductRef.delete().catch(() => undefined)
+      await publicServiceRef.delete().catch(() => undefined)
       return
     }
 
-    await publicProductRef.set(payload, { merge: true })
+    await destinationRef.set(payload, { merge: true })
+    await oppositeRef.delete().catch(() => undefined)
   })
 
 export const enrichProductDataAfterSave = functions.firestore

--- a/shared/integrationTypes.ts
+++ b/shared/integrationTypes.ts
@@ -47,6 +47,8 @@ export interface IntegrationPromo {
 export interface IntegrationProductsResponse {
   storeId: string
   products: IntegrationProduct[]
+  publicProducts?: IntegrationProduct[]
+  publicServices?: IntegrationProduct[]
 }
 
 export interface IntegrationPromoResponse {


### PR DESCRIPTION
### Motivation
- Make it easy for storefronts to separate physical products and services by materializing separate public collections instead of forcing client-side sorting.
- Backfill legacy product records into the correct public buckets so existing public pages auto-sort when new items are added.
- Improve verified/integrated data pulls by returning pre-split `publicProducts`/`publicServices` buckets from integration endpoints.

### Description
- Route synced public catalog documents into two Firestore collections by `itemType`: `publicProducts` for non-service items and `publicServices` for services, and delete stale docs from the opposite collection when a type changes or a source is removed (changes in `functions/src/index.ts`).
- Update the public catalog endpoint `integrationPublicCatalog` to read from both `publicProducts` and `publicServices` first (with a fallback to `products`), and return `products`, `publicProducts`, and `publicServices` in the response payload so clients can consume ready-made buckets.
- Add the same convenience buckets to authenticated product endpoints (`integrationProducts` and `v1IntegrationProducts`) and extend shared types in `shared/integrationTypes.ts` and docs in `docs/integration-api-guide.md` to document `publicProducts`/`publicServices`.
- Update the backfill script `functions/scripts/backfillPublicProducts.js` to backfill old records into the correct collection, remove opposite stale docs, and run `publishedAt` backfills across both public collections; add helpers `splitCatalogItemsByType` and `resolvePublicCatalogCollectionName` and include the compiled artifact (`functions/lib/index.js`) to keep build output aligned.

### Testing
- Ran `npm --prefix functions run build` which completed successfully.
- Ran `npm --prefix functions test` and the `bookingNormalization` tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54b4186188321bc6a0b082abff8db)