### PR TITLE
Add npm script aliases for backfilling public products/services catalog

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -106,6 +106,28 @@ Query parameters:
 
 `publicProducts` and `publicServices` are convenience buckets derived from `itemType` so storefronts can render physical products and services in separate sections without extra client-side sorting.
 
+### `GET /integrationPublicCatalog?storeId=<storeId>` or `?slug=<promoSlug>` (public, no API key)
+
+- Use this endpoint when external/public sites cannot securely store integration API keys.
+- The response also includes `products`, `publicProducts`, and `publicServices`.
+- `publicProducts` = non-service items; `publicServices` = service items.
+- If precomputed public collections are empty, Sedifex falls back to reading from `products` for the store.
+
+```json
+{
+  "storeId": "store_123",
+  "products": [],
+  "publicProducts": [],
+  "publicServices": []
+}
+```
+
+#### Which endpoint should other websites use?
+
+1. **Server-to-server (recommended):** `GET /v1IntegrationProducts?storeId=<storeId>` with `x-api-key`.
+2. **Public website without secret storage:** `GET /integrationPublicCatalog?slug=<promoSlug>` (or `storeId`).
+3. In both cases, render from `publicProducts` and `publicServices` directly.
+
 ### `GET /v1IntegrationPromo?storeId=<storeId>` (authenticated) or `?slug=<promoSlug>` (public)
 
 ```json

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,9 @@
     "serve": "firebase emulators:start --only functions",
     "deploy": "firebase deploy --only functions --project sedifex-web --force",
     "force-update-owner-email": "node scripts/forceUpdateOwnerEmailByUid.js",
-    "backfill-public-products": "node scripts/backfillPublicProducts.js"
+    "backfill-public-products": "node scripts/backfillPublicProducts.js",
+    "backfill-public-services": "node scripts/backfillPublicProducts.js",
+    "backfill-public-catalog": "node scripts/backfillPublicProducts.js"
   },
   "dependencies": {
     "firebase-admin": "^13.6.0",


### PR DESCRIPTION
### Motivation
- Provide clearer, explicit npm script names to run the existing public catalog backfill for products and services without changing the backfill logic.

### Description
- Added `backfill-public-services` and `backfill-public-catalog` aliases in `functions/package.json` that point to the existing `scripts/backfillPublicProducts.js` and retained `backfill-public-products`.

### Testing
- Validated `functions/package.json` parses successfully with `node -e "JSON.parse(require('fs').readFileSync('functions/package.json','utf8'))"`, which completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e550bf7e888321882acd17d6c171d8)