### PR TITLE
Add CLI flags and documentation for public catalog backfill

### DIFF
--- a/docs/public-catalog-backfill.md
+++ b/docs/public-catalog-backfill.md
@@ -1,0 +1,60 @@
+# Public catalog backfill (`publicProducts` / `publicServices`)
+
+Use this when older `products` documents were created before the `syncPublicProducts` trigger existed (or before `itemType` routing was added), and you need to populate:
+
+- `publicProducts`
+- `publicServices`
+
+## Prerequisites
+
+- Firebase Admin credentials available in your shell (`GOOGLE_APPLICATION_CREDENTIALS`), or run in an environment where `firebase-admin` can authenticate.
+- Install functions dependencies:
+
+```bash
+cd functions
+npm ci
+```
+
+## Run backfill
+
+From repo root:
+
+```bash
+npm --prefix functions run backfill-public-catalog
+```
+
+The script will:
+
+1. Read docs from `products`.
+2. Write each record into:
+   - `publicServices` when `itemType === "service"`
+   - `publicProducts` for all other item types (`product`, `made_to_order`, missing/unknown)
+3. Remove the same doc id from the opposite collection.
+4. Backfill missing `publishedAt` values in both public collections.
+
+## Run for one store only
+
+You can scope by `storeId` in two equivalent ways:
+
+```bash
+npm --prefix functions run backfill-public-catalog -- --store-id=YOUR_STORE_ID
+```
+
+or:
+
+```bash
+node functions/scripts/backfillPublicProducts.js YOUR_STORE_ID
+```
+
+## Verify after backfill
+
+Quick counts in Firestore console:
+
+- `products` for a store
+- `publicProducts` for same store
+- `publicServices` for same store
+
+Then verify a few sample product IDs:
+
+- A `service` item should only exist in `publicServices/<productId>`.
+- A non-service item should only exist in `publicProducts/<productId>`.

--- a/functions/scripts/backfillPublicProducts.js
+++ b/functions/scripts/backfillPublicProducts.js
@@ -9,6 +9,44 @@ if (!admin.apps.length) {
 
 const db = admin.firestore()
 
+function parseCliArgs(argv) {
+  const options = {
+    storeId: null,
+    showHelp: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (!token) continue
+    if (token === '--help' || token === '-h') {
+      options.showHelp = true
+      continue
+    }
+    if (token === '--store-id') {
+      options.storeId = argv[index + 1] ?? null
+      index += 1
+      continue
+    }
+    if (token.startsWith('--store-id=')) {
+      options.storeId = token.slice('--store-id='.length)
+      continue
+    }
+    if (!token.startsWith('--') && !options.storeId) {
+      // Backward-compatible positional form: node backfillPublicProducts.js <storeId>
+      options.storeId = token
+    }
+  }
+
+  return options
+}
+
+function printHelp() {
+  console.log('Usage: node scripts/backfillPublicProducts.js [--store-id=<storeId>]')
+  console.log('')
+  console.log('Backfills products into publicProducts/publicServices based on itemType.')
+  console.log('If --store-id is omitted, the script processes all products.')
+}
+
 function toTrimmedStringOrNull(value) {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
@@ -148,7 +186,13 @@ function resolvePublishedAtValue(data) {
 }
 
 async function run() {
-  const targetStoreId = toTrimmedStringOrNull(process.argv[2])
+  const args = parseCliArgs(process.argv.slice(2))
+  if (args.showHelp) {
+    printHelp()
+    return
+  }
+
+  const targetStoreId = toTrimmedStringOrNull(args.storeId)
   let query = db.collection('products')
 
   if (targetStoreId) {


### PR DESCRIPTION
### Motivation

- Provide a clear, supported way to backfill legacy `products` documents into the public catalog collections `publicProducts` / `publicServices`.
- Allow scoping the backfill to a single store and expose usage/help to make ad-hoc runs safer and easier.

### Description

- Added CLI parsing to `functions/scripts/backfillPublicProducts.js` with support for `--store-id`, `--store-id=<id>`, positional `storeId` (backwards-compatible), and `--help` via `parseCliArgs` and `printHelp`.
- The script behavior and routing remain unchanged: docs with `itemType === 'service'` are written to `publicServices` and other items to `publicProducts`, and the opposite collection entry is deleted.
- Added `docs/public-catalog-backfill.md` with prerequisites, run commands, store-scoped usage examples, and verification steps.

### Testing

- Ran `node functions/scripts/backfillPublicProducts.js --help` and it printed usage text (success).
- Ran `node --check functions/scripts/backfillPublicProducts.js` to verify syntax (success).
- Ran `npm --prefix functions run build` to compile the functions sources (success).
- Ran `npm --prefix functions test` after building and the test suite executed successfully (`bookingNormalization` tests passed); note that running tests before building produced a `MODULE_NOT_FOUND` error due to missing compiled `lib` files but that was resolved by the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5defef6588322b6c70e827801f604)