### PR TITLE
Improve Terms and Privacy page margins for desktop & mobile

### DIFF
--- a/web/src/pages/legal/LegalPage.css
+++ b/web/src/pages/legal/LegalPage.css
@@ -1,0 +1,16 @@
+.legal-page {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: clamp(2.25rem, 5vw, 3.5rem) clamp(1rem, 4vw, 2.5rem);
+}
+
+.legal-page__content {
+  width: min(100%, 76ch);
+}
+
+@media (max-width: 640px) {
+  .legal-page {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+}

--- a/web/src/pages/legal/PrivacyPage.tsx
+++ b/web/src/pages/legal/PrivacyPage.tsx
@@ -1,3 +1,5 @@
+import './LegalPage.css'
+
 export default function PrivacyPage() {
   const today = new Date().toLocaleDateString(undefined, {
     year: "numeric",
@@ -6,7 +8,8 @@ export default function PrivacyPage() {
   });
 
   return (
-    <main className="prose prose-slate mx-auto max-w-3xl px-4 py-12">
+    <main className="legal-page">
+      <article className="legal-page__content prose prose-slate mx-auto max-w-3xl px-4 py-12">
       <p className="text-sm font-semibold uppercase tracking-wide text-violet-600">
         Legal
       </p>
@@ -208,6 +211,7 @@ export default function PrivacyPage() {
           </li>
         </ul>
       </section>
+      </article>
     </main>
   );
 }

--- a/web/src/pages/legal/TermsPage.tsx
+++ b/web/src/pages/legal/TermsPage.tsx
@@ -1,3 +1,5 @@
+import './LegalPage.css'
+
 export default function TermsPage() {
   const today = new Date().toLocaleDateString(undefined, {
     year: 'numeric',
@@ -6,7 +8,8 @@ export default function TermsPage() {
   })
 
   return (
-    <main className="prose prose-slate mx-auto max-w-3xl px-4 py-12">
+    <main className="legal-page">
+      <article className="legal-page__content prose prose-slate mx-auto max-w-3xl px-4 py-12">
       <p className="text-sm font-semibold uppercase tracking-wide text-violet-600">Legal</p>
 
       <h1 className="mb-2 text-3xl font-bold text-slate-900">Terms of Service</h1>
@@ -120,6 +123,7 @@ export default function TermsPage() {
           </li>
         </ul>
       </section>
+      </article>
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Ensure legal pages render with consistent, comfortable side margins and readable line-length on both computer and phone screens.

### Description
- Add a shared layout stylesheet `web/src/pages/legal/LegalPage.css` and wrap `TermsPage` and `PrivacyPage` content in `.legal-page` / `.legal-page__content` containers so spacing is controlled without changing the existing typography or legal text.

### Testing
- Ran a build attempt with `npm --prefix web run build`, which failed in this environment due to missing TypeScript type definitions for `vite/client` and `vitest/globals` (unrelated to the layout changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e1771cf88322a07b62628684f4dc)