### PR TITLE
Retry social post generation once after confirming AI backend reachability

### DIFF
--- a/web/src/api/socialPost.ts
+++ b/web/src/api/socialPost.ts
@@ -1,4 +1,5 @@
 import { httpsCallable } from 'firebase/functions'
+import { FirebaseError } from 'firebase/app'
 import { functions } from '../firebase'
 import { requestAiAdvisor } from './aiAdvisor'
 
@@ -142,5 +143,23 @@ export async function requestSocialPost(payload: GenerateSocialPostPayload): Pro
     return (response.data ?? {}) as GenerateSocialPostResponse
   } catch (_error) {
     return requestSocialPostFallback(payload)
+  }
+}
+
+export async function confirmSocialBackendReachable(): Promise<boolean> {
+  const callable = httpsCallable(functions, 'generateSocialPost')
+
+  try {
+    await callable({ platform: 'instagram', product: { name: '' } })
+    return true
+  } catch (error) {
+    if (error instanceof FirebaseError) {
+      const code = typeof error.code === 'string' ? error.code.trim() : ''
+      if (code === 'functions/unavailable' || code === 'functions/not-found') {
+        return false
+      }
+    }
+
+    return true
   }
 }

--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -5,7 +5,12 @@ import { db } from '../firebase'
 import PageSection from '../layout/PageSection'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useToast } from '../components/ToastProvider'
-import { requestSocialPost, type GenerateSocialPostResponse, type SocialPlatform } from '../api/socialPost'
+import {
+  confirmSocialBackendReachable,
+  requestSocialPost,
+  type GenerateSocialPostResponse,
+  type SocialPlatform,
+} from '../api/socialPost'
 import type { Product } from '../types/product'
 
 type ProductOption = {
@@ -446,21 +451,22 @@ export default function SocialMediaPage() {
     if (!storeId || !selectedProduct) return
     setLoading(true)
     setInlineError(null)
-    try {
-      const response = await requestSocialPost({
-        storeId,
-        platform,
-        productId: selectedProduct.id,
-        product: {
-          id: selectedProduct.id,
-          name: selectedProduct.name,
-          category: selectedProduct.category,
-          description: selectedProduct.description,
-          price: selectedProduct.price,
-          imageUrl: selectedProduct.imageUrl,
-          itemType: selectedProduct.itemType,
-        },
-      })
+    const requestPayload = {
+      storeId,
+      platform,
+      productId: selectedProduct.id,
+      product: {
+        id: selectedProduct.id,
+        name: selectedProduct.name,
+        category: selectedProduct.category,
+        description: selectedProduct.description,
+        price: selectedProduct.price,
+        imageUrl: selectedProduct.imageUrl,
+        itemType: selectedProduct.itemType,
+      },
+    }
+
+    const mergeGeneratedResult = (response: GenerateSocialPostResponse) => {
       const styledPost = applyPresets(response.post)
       const styledResponse: GenerateSocialPostResponse = {
         ...response,
@@ -483,9 +489,36 @@ export default function SocialMediaPage() {
 
       setResult(merged)
       persistHistory(merged)
+      return merged
+    }
+
+    try {
+      const response = await requestSocialPost(requestPayload)
+      mergeGeneratedResult(response)
       publish({ tone: 'success', message: 'Social post draft generated. Review before publishing.' })
     } catch (error) {
       console.error('[social-media] Failed to generate social post', error)
+      const backendReachable = await confirmSocialBackendReachable()
+
+      if (backendReachable) {
+        try {
+          publish({ tone: 'warning', message: 'AI backend is reachable. Retrying generation once…' })
+          const retryResponse = await requestSocialPost(requestPayload)
+          mergeGeneratedResult(retryResponse)
+          publish({ tone: 'success', message: 'Social post draft generated after retry.' })
+          return
+        } catch (retryError) {
+          console.error('[social-media] Retry failed after backend reachability check', retryError)
+          const retryMessage = getCallableErrorMessage(retryError)
+          publish({ tone: 'error', message: retryMessage || 'Retry failed. Please try again shortly.' })
+          setInlineError(
+            retryMessage ||
+              'Generation failed after retry. Confirm Firebase Functions configuration and try again in a moment.',
+          )
+          return
+        }
+      }
+
       const serverMessage = getCallableErrorMessage(error)
       publish({
         tone: 'error',
@@ -495,7 +528,7 @@ export default function SocialMediaPage() {
       })
       setInlineError(
         serverMessage ||
-          'Generation failed. Confirm the AI backend (Firebase Functions) is deployed and reachable, then retry.',
+          'Generation failed. Firebase Functions AI backend appears unreachable. Deploy/verify backend, then retry.',
       )
     } finally {
       setLoading(false)


### PR DESCRIPTION
### Motivation
- Improve robustness when generating social posts by distinguishing between a missing/unavailable AI backend and other failures.
- Provide a safer automatic retry when the backend is reachable to recover from transient errors.
- Surface clearer inline/toast messaging to guide users when Firebase Functions are not deployed or when retries fail.

### Description
- Added `confirmSocialBackendReachable()` in `web/src/api/socialPost.ts` which probes the `generateSocialPost` callable and treats `functions/unavailable` and `functions/not-found` as unreachable.
- Refactored `handleGenerate` in `web/src/pages/SocialMediaPage.tsx` to build a single `requestPayload`, centralize merge/persist logic into a helper, and call the new reachability check after an initial failure.
- If the backend is reachable, the page retries `requestSocialPost` once and updates UI to show retry/success messages; otherwise it surfaces a clearer unreachable-backend message.
- Updated imports in `SocialMediaPage` to use the new helper and adjusted inline error text to mention Firebase Functions reachability.

### Testing
- Ran `npm --prefix web run test -- SocialMediaPage --runInBand` which failed because `vitest` is not available in the execution environment (test run did not complete).
- Ran `npm --prefix web run build` which failed due to missing type definitions caused by dependencies not being installed (build did not complete).
- Attempted `npm --prefix web ci` to install dependencies but it failed with HTTP 403 from the npm registry in this environment, preventing full install and local test/build verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60af90c2c8322b8f8fd23d4a7fbca)