### PR TITLE
Fix duplicate entries in public catalog sync output

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -2960,6 +2960,25 @@ function splitCatalogItemsByType(items) {
     }
     return { publicProducts, publicServices };
 }
+function dedupeCatalogItemsById(items) {
+    const byId = new Map();
+    for (const item of items) {
+        const existing = byId.get(item.id);
+        if (!existing) {
+            byId.set(item.id, item);
+            continue;
+        }
+        const existingTime = existing.updatedAt ? Date.parse(existing.updatedAt) : Number.NaN;
+        const incomingTime = item.updatedAt ? Date.parse(item.updatedAt) : Number.NaN;
+        if (Number.isNaN(existingTime) && Number.isNaN(incomingTime)) {
+            continue;
+        }
+        if (Number.isNaN(existingTime) || (!Number.isNaN(incomingTime) && incomingTime > existingTime)) {
+            byId.set(item.id, item);
+        }
+    }
+    return [...byId.values()];
+}
 const BOOKING_ATTRIBUTE_MAX_KEYS = 40;
 const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500;
 const DEFAULT_BOOKING_ALIASES = {
@@ -4591,6 +4610,7 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
             return -1;
         return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
     });
+    products = dedupeCatalogItemsById(products);
     if (!products.length) {
         let productsSnapshot;
         try {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3836,6 +3836,28 @@ function splitCatalogItemsByType<T extends { itemType: 'product' | 'service' | '
   return { publicProducts, publicServices }
 }
 
+function dedupeCatalogItemsById<T extends { id: string; updatedAt?: string | null }>(items: T[]): T[] {
+  const byId = new Map<string, T>()
+  for (const item of items) {
+    const existing = byId.get(item.id)
+    if (!existing) {
+      byId.set(item.id, item)
+      continue
+    }
+
+    const existingTime = existing.updatedAt ? Date.parse(existing.updatedAt) : Number.NaN
+    const incomingTime = item.updatedAt ? Date.parse(item.updatedAt) : Number.NaN
+
+    if (Number.isNaN(existingTime) && Number.isNaN(incomingTime)) {
+      continue
+    }
+    if (Number.isNaN(existingTime) || (!Number.isNaN(incomingTime) && incomingTime > existingTime)) {
+      byId.set(item.id, item)
+    }
+  }
+  return [...byId.values()]
+}
+
 const BOOKING_ATTRIBUTE_MAX_KEYS = 40
 const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500
 
@@ -5802,6 +5824,7 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
       if (!b.updatedAt) return -1
       return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
     })
+  products = dedupeCatalogItemsById(products)
 
   if (!products.length) {
     let productsSnapshot: admin.firestore.QuerySnapshot


### PR DESCRIPTION
### Motivation
- Prevent duplicate products in the public catalog response when a product temporarily exists in both `publicProducts` and `publicServices` collections.
- Ensure the API returns a single, deterministic record per product id by preferring the most recently updated entry.

### Description
- Added a new helper `dedupeCatalogItemsById<T>` which deduplicates items by `id` and keeps the entry with the newer `updatedAt` timestamp.
- Integrated `dedupeCatalogItemsById` into `integrationPublicCatalog` immediately after merging `publicProducts` and `publicServices` results and sorting the items.
- Implemented comparison using `Date.parse` of `updatedAt` and treated missing/invalid timestamps conservatively.
- Changes applied in `functions/src/index.ts` (and the compiled output in `functions/lib/index.js`).

### Testing
- Ran `npm --prefix functions run build` and the TypeScript build succeeded.
- Ran `npm --prefix functions test` and the existing `bookingNormalization` test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7863b49288322ad23a56d939e0906)