### PR TITLE
Deduplicate public catalog items and remove legacy duplicate documents

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -2960,6 +2960,25 @@ function splitCatalogItemsByType(items) {
     }
     return { publicProducts, publicServices };
 }
+function dedupeCatalogItemsById(items) {
+    const byId = new Map();
+    for (const item of items) {
+        const existing = byId.get(item.id);
+        if (!existing) {
+            byId.set(item.id, item);
+            continue;
+        }
+        const existingTime = existing.updatedAt ? Date.parse(existing.updatedAt) : Number.NaN;
+        const incomingTime = item.updatedAt ? Date.parse(item.updatedAt) : Number.NaN;
+        if (Number.isNaN(existingTime) && Number.isNaN(incomingTime)) {
+            continue;
+        }
+        if (Number.isNaN(existingTime) || (!Number.isNaN(incomingTime) && incomingTime > existingTime)) {
+            byId.set(item.id, item);
+        }
+    }
+    return [...byId.values()];
+}
 const BOOKING_ATTRIBUTE_MAX_KEYS = 40;
 const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500;
 const DEFAULT_BOOKING_ALIASES = {
@@ -4591,6 +4610,7 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
             return -1;
         return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
     });
+    products = dedupeCatalogItemsById(products);
     if (!products.length) {
         let productsSnapshot;
         try {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3836,6 +3836,28 @@ function splitCatalogItemsByType<T extends { itemType: 'product' | 'service' | '
   return { publicProducts, publicServices }
 }
 
+function dedupeCatalogItemsById<T extends { id: string; updatedAt?: string | null }>(items: T[]): T[] {
+  const byId = new Map<string, T>()
+  for (const item of items) {
+    const existing = byId.get(item.id)
+    if (!existing) {
+      byId.set(item.id, item)
+      continue
+    }
+
+    const existingTime = existing.updatedAt ? Date.parse(existing.updatedAt) : Number.NaN
+    const incomingTime = item.updatedAt ? Date.parse(item.updatedAt) : Number.NaN
+
+    if (Number.isNaN(existingTime) && Number.isNaN(incomingTime)) {
+      continue
+    }
+    if (Number.isNaN(existingTime) || (!Number.isNaN(incomingTime) && incomingTime > existingTime)) {
+      byId.set(item.id, item)
+    }
+  }
+  return [...byId.values()]
+}
+
 const BOOKING_ATTRIBUTE_MAX_KEYS = 40
 const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500
 
@@ -5802,6 +5824,7 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
       if (!b.updatedAt) return -1
       return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
     })
+  products = dedupeCatalogItemsById(products)
 
   if (!products.length) {
     let productsSnapshot: admin.firestore.QuerySnapshot
@@ -6546,6 +6569,23 @@ function resolvePublicCatalogCollectionName(itemType: unknown): 'publicProducts'
   return itemType === 'service' ? 'publicServices' : 'publicProducts'
 }
 
+async function deleteLegacyPublicCatalogDuplicates(productId: string): Promise<void> {
+  const cleanupCollection = async (collectionName: 'publicProducts' | 'publicServices') => {
+    const snapshot = await db.collection(collectionName).where('sourceProductId', '==', productId).limit(50).get()
+    if (snapshot.empty) return
+    const staleDocs = snapshot.docs.filter(doc => doc.id !== productId)
+    if (!staleDocs.length) return
+
+    const batch = db.batch()
+    for (const doc of staleDocs) {
+      batch.delete(doc.ref)
+    }
+    await batch.commit()
+  }
+
+  await Promise.all([cleanupCollection('publicProducts'), cleanupCollection('publicServices')])
+}
+
 export const syncPublicProducts = functions.firestore
   .document('products/{productId}')
   .onWrite(async (change, context) => {
@@ -6581,6 +6621,7 @@ export const syncPublicProducts = functions.firestore
 
     await destinationRef.set(payload, { merge: true })
     await oppositeRef.delete().catch(() => undefined)
+    await deleteLegacyPublicCatalogDuplicates(productId).catch(() => undefined)
   })
 
 export const enrichProductDataAfterSave = functions.firestore


### PR DESCRIPTION
### Motivation
- Prevent duplicate catalog entries when merging `publicProducts` and `publicServices` snapshots and prefer the most recently updated record.
- Remove stale legacy documents in public catalog collections when a product is synced to ensure a single canonical public doc per product.

### Description
- Added `dedupeCatalogItemsById` (JS/TS) that deduplicates an array of items by `id`, preferring the entry with the later `updatedAt` timestamp.
- Integrated `dedupeCatalogItemsById` into `integrationPublicCatalog` to dedupe the combined product/service list before further processing.
- Added `deleteLegacyPublicCatalogDuplicates` to remove stale docs in `publicProducts` and `publicServices` whose `sourceProductId` matches a product but whose doc ID differs from the product ID.
- Invoked `deleteLegacyPublicCatalogDuplicates` from `syncPublicProducts` after writing the destination public doc and deleting the opposite collection entry, with errors ignored to avoid blocking the sync.
- Added TypeScript generics/typing for the new helper in `src/index.ts`.

### Testing
- Compiled the TypeScript code with `tsc` to validate types and build; compilation succeeded.
- Executed the repository unit test suite with `npm test`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7863b49288322ad23a56d939e0906)