### PR TITLE
Add catalog sync health metrics and reconciliation mode for public catalog

### DIFF
--- a/docs/public-catalog-backfill.md
+++ b/docs/public-catalog-backfill.md
@@ -58,3 +58,31 @@ Then verify a few sample product IDs:
 
 - A `service` item should only exist in `publicServices/<productId>`.
 - A non-service item should only exist in `publicProducts/<productId>`.
+
+## Reconciliation mode (verify + repair)
+
+Run reconciliation when you want to actively check for drift and repair it:
+
+```bash
+npm --prefix functions run backfill-public-catalog -- --mode=reconcile
+```
+
+Single-store reconciliation:
+
+```bash
+npm --prefix functions run backfill-public-catalog -- --mode=reconcile --store-id=YOUR_STORE_ID
+```
+
+Reconciliation validates published `products/<id>` documents map to exactly one target (`publicProducts` or `publicServices`), then repairs:
+
+- wrong-collection drift after `itemType` changes,
+- missing `publishedAt` / `updatedAt`,
+- non-normalized `category` values (trimmed, single-spaced, lowercase),
+- orphan public docs with no matching published source product.
+
+It also emits a per-store summary report and refreshes store health fields:
+
+- `publicCatalogLastSyncedAt`
+- `publicCatalogDocCount.products`
+- `publicCatalogDocCount.services`
+- `publicCatalogOutOfSyncCount`

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -4490,7 +4490,7 @@ exports.integrationGallery = functions.https.onRequest(async (req, res) => {
     if (!storeContext) {
         return;
     }
-    const { storeId } = storeContext;
+    const { storeId, data: storeData } = storeContext;
     const gallerySnapshot = await firestore_1.defaultDb
         .collection('stores')
         .doc(storeId)
@@ -4628,7 +4628,7 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
     if (!storeContext) {
         return;
     }
-    const { storeId } = storeContext;
+    const { storeId, data: storeData } = storeContext;
     const mapCatalogDoc = (docSnap) => {
         const data = docSnap.data();
         const name = typeof data.name === 'string' ? data.name.trim() : '';
@@ -4731,7 +4731,21 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
         });
     }
     const { publicProducts, publicServices } = splitCatalogItemsByType(products);
-    res.status(200).json({ storeId, products, publicProducts, publicServices });
+    const syncHealth = {
+        publicCatalogLastSyncedAt: normalizeTimestampIso(storeData.publicCatalogLastSyncedAt),
+        publicCatalogDocCount: {
+            products: typeof storeData.publicCatalogDocCount?.products === 'number'
+                ? Math.max(0, Math.floor(storeData.publicCatalogDocCount.products))
+                : null,
+            services: typeof storeData.publicCatalogDocCount?.services === 'number'
+                ? Math.max(0, Math.floor(storeData.publicCatalogDocCount.services))
+                : null,
+        },
+        publicCatalogOutOfSyncCount: typeof storeData.publicCatalogOutOfSyncCount === 'number'
+            ? Math.max(0, Math.floor(storeData.publicCatalogOutOfSyncCount))
+            : null,
+    };
+    res.status(200).json({ storeId, products, publicProducts, publicServices, syncHealth });
 });
 exports.integrationGoogleMerchantFeed = functions.https.onRequest(async (req, res) => {
     setIntegrationResponseHeaders(res);
@@ -5319,7 +5333,7 @@ function toPublicProductPayload(productId, source, existing, storeMeta) {
         websiteLink: toTrimmedStringOrNull(source.websiteLink) ?? storeMeta?.websiteLink ?? null,
         name,
         description: typeof source.description === 'string' && source.description.trim() ? source.description.trim() : null,
-        category: typeof source.category === 'string' && source.category.trim() ? source.category.trim() : null,
+        category: normalizeCatalogCategory(source.category),
         sku: toTrimmedStringOrNull(source.sku),
         barcode: toTrimmedStringOrNull(source.barcode),
         manufacturerName: toTrimmedStringOrNull(source.manufacturerName),
@@ -5350,6 +5364,52 @@ function toPublicProductPayload(productId, source, existing, storeMeta) {
 function resolvePublicCatalogCollectionName(itemType) {
     return itemType === 'service' ? 'publicServices' : 'publicProducts';
 }
+function normalizeCatalogCategory(value) {
+    if (typeof value !== 'string')
+        return null;
+    const normalized = value.trim().replace(/\s+/g, ' ').toLowerCase();
+    return normalized || null;
+}
+async function updateStorePublicCatalogHealth(storeId) {
+    const normalizedStoreId = toTrimmedStringOrNull(storeId);
+    if (!normalizedStoreId)
+        return;
+    const [publishedProductsSnap, publicProductsSnap, publicServicesSnap] = await Promise.all([
+        firestore_1.defaultDb.collection('products').where('storeId', '==', normalizedStoreId).where('isPublished', '==', true).get(),
+        firestore_1.defaultDb.collection('publicProducts').where('storeId', '==', normalizedStoreId).get(),
+        firestore_1.defaultDb.collection('publicServices').where('storeId', '==', normalizedStoreId).get(),
+    ]);
+    const publicProductIds = new Set(publicProductsSnap.docs.map(doc => doc.id));
+    const publicServiceIds = new Set(publicServicesSnap.docs.map(doc => doc.id));
+    const publishedSourceIds = new Set();
+    let outOfSyncCount = 0;
+    for (const sourceDoc of publishedProductsSnap.docs) {
+        publishedSourceIds.add(sourceDoc.id);
+        const sourceData = (sourceDoc.data() ?? {});
+        const expectedCollection = resolvePublicCatalogCollectionName(sourceData.itemType);
+        const existsInProducts = publicProductIds.has(sourceDoc.id);
+        const existsInServices = publicServiceIds.has(sourceDoc.id);
+        const isInSync = expectedCollection === 'publicServices'
+            ? existsInServices && !existsInProducts
+            : existsInProducts && !existsInServices;
+        if (!isInSync) {
+            outOfSyncCount += 1;
+        }
+    }
+    for (const publicDoc of [...publicProductsSnap.docs, ...publicServicesSnap.docs]) {
+        if (!publishedSourceIds.has(publicDoc.id)) {
+            outOfSyncCount += 1;
+        }
+    }
+    await firestore_1.defaultDb.collection('stores').doc(normalizedStoreId).set({
+        publicCatalogLastSyncedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+        publicCatalogDocCount: {
+            products: publicProductsSnap.size,
+            services: publicServicesSnap.size,
+        },
+        publicCatalogOutOfSyncCount: outOfSyncCount,
+    }, { merge: true });
+}
 async function deleteLegacyPublicCatalogDuplicates(productId) {
     const cleanupCollection = async (collectionName) => {
         const snapshot = await firestore_1.defaultDb.collection(collectionName).where('sourceProductId', '==', productId).limit(50).get();
@@ -5372,12 +5432,22 @@ exports.syncPublicProducts = functions.firestore
     const productId = context.params.productId;
     const publicProductRef = firestore_1.defaultDb.collection('publicProducts').doc(productId);
     const publicServiceRef = firestore_1.defaultDb.collection('publicServices').doc(productId);
+    const beforeData = change.before.exists ? (change.before.data() ?? {}) : null;
+    const afterData = change.after.exists ? (change.after.data() ?? {}) : null;
+    const touchedStoreIds = new Set();
+    const beforeStoreId = toTrimmedStringOrNull(beforeData?.storeId);
+    const afterStoreId = toTrimmedStringOrNull(afterData?.storeId);
+    if (beforeStoreId)
+        touchedStoreIds.add(beforeStoreId);
+    if (afterStoreId)
+        touchedStoreIds.add(afterStoreId);
     if (!change.after.exists) {
         await publicProductRef.delete().catch(() => undefined);
         await publicServiceRef.delete().catch(() => undefined);
+        await Promise.all([...touchedStoreIds].map(storeId => updateStorePublicCatalogHealth(storeId)));
         return;
     }
-    const sourceData = (change.after.data() ?? {});
+    const sourceData = afterData ?? {};
     const destinationCollectionName = resolvePublicCatalogCollectionName(sourceData.itemType);
     const destinationRef = firestore_1.defaultDb.collection(destinationCollectionName).doc(productId);
     const oppositeRef = destinationCollectionName === 'publicServices' ? publicProductRef : publicServiceRef;
@@ -5395,6 +5465,7 @@ exports.syncPublicProducts = functions.firestore
     await destinationRef.set(payload, { merge: true });
     await oppositeRef.delete().catch(() => undefined);
     await deleteLegacyPublicCatalogDuplicates(productId).catch(() => undefined);
+    await Promise.all([...touchedStoreIds].map(storeId => updateStorePublicCatalogHealth(storeId)));
 });
 exports.enrichProductDataAfterSave = functions.firestore
     .document('products/{productId}')

--- a/functions/scripts/backfillPublicProducts.js
+++ b/functions/scripts/backfillPublicProducts.js
@@ -13,6 +13,7 @@ function parseCliArgs(argv) {
   const options = {
     storeId: null,
     showHelp: false,
+    mode: 'backfill',
   }
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -31,6 +32,15 @@ function parseCliArgs(argv) {
       options.storeId = token.slice('--store-id='.length)
       continue
     }
+    if (token === '--mode') {
+      options.mode = argv[index + 1] ?? options.mode
+      index += 1
+      continue
+    }
+    if (token.startsWith('--mode=')) {
+      options.mode = token.slice('--mode='.length)
+      continue
+    }
     if (!token.startsWith('--') && !options.storeId) {
       // Backward-compatible positional form: node backfillPublicProducts.js <storeId>
       options.storeId = token
@@ -41,10 +51,11 @@ function parseCliArgs(argv) {
 }
 
 function printHelp() {
-  console.log('Usage: node scripts/backfillPublicProducts.js [--store-id=<storeId>]')
+  console.log('Usage: node scripts/backfillPublicProducts.js [--store-id=<storeId>] [--mode=backfill|reconcile]')
   console.log('')
-  console.log('Backfills products into publicProducts/publicServices based on itemType.')
-  console.log('If --store-id is omitted, the script processes all products.')
+  console.log('Modes:')
+  console.log('  backfill   Backfills products into publicProducts/publicServices (default).')
+  console.log('  reconcile Verify + repair published catalog consistency and metadata drift.')
 }
 
 function toTrimmedStringOrNull(value) {
@@ -111,52 +122,6 @@ function extractProductImageSet(data) {
   }
 }
 
-function toPublicProduct(productDoc, storeMetaByStoreId) {
-  const data = productDoc.data() || {}
-  const storeId = toTrimmedStringOrNull(data.storeId)
-  const name = toTrimmedStringOrNull(data.name)
-  const storeMeta = storeMetaByStoreId.get(storeId) || null
-
-  if (!storeId || !name) {
-    return null
-  }
-
-  return {
-    sourceProductId: productDoc.id,
-    storeId,
-    storeName: toTrimmedStringOrNull(data.storeName) || storeMeta?.storeName || null,
-    storeCity: toTrimmedStringOrNull(data.storeCity) || storeMeta?.storeCity || null,
-    storePhone: toTrimmedStringOrNull(data.storePhone) || storeMeta?.storePhone || null,
-    websiteLink: toTrimmedStringOrNull(data.websiteLink) || storeMeta?.websiteLink || null,
-    name,
-    description: toTrimmedStringOrNull(data.description),
-    category: toTrimmedStringOrNull(data.category),
-    sku: toTrimmedStringOrNull(data.sku),
-    barcode: toTrimmedStringOrNull(data.barcode),
-    manufacturerName: toTrimmedStringOrNull(data.manufacturerName),
-    price: typeof data.price === 'number' ? data.price : null,
-    stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
-    reorderPoint: typeof data.reorderPoint === 'number' ? data.reorderPoint : null,
-    taxRate: typeof data.taxRate === 'number' ? data.taxRate : null,
-    productionDate: isFirestoreTimestampLike(data.productionDate) || typeof data.productionDate === 'string' ? data.productionDate : null,
-    expiryDate: isFirestoreTimestampLike(data.expiryDate) || typeof data.expiryDate === 'string' ? data.expiryDate : null,
-    batchNumber: toTrimmedStringOrNull(data.batchNumber),
-    showOnReceipt: data.showOnReceipt === true,
-    itemType:
-      data.itemType === 'service'
-        ? 'service'
-        : data.itemType === 'made_to_order'
-          ? 'made_to_order'
-          : 'product',
-    isPublished: data.isPublished !== false,
-    ...extractProductImageSet(data),
-    publishedAt: data.publishedAt ?? data.createdAt ?? data.updatedAt ?? admin.firestore.FieldValue.serverTimestamp(),
-    createdAt: data.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
-    sourceUpdatedAt: data.updatedAt ?? null,
-    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-  }
-}
-
 function resolvePublicCatalogCollectionName(itemType) {
   return itemType === 'service' ? 'publicServices' : 'publicProducts'
 }
@@ -185,14 +150,84 @@ function resolvePublishedAtValue(data) {
   return admin.firestore.FieldValue.serverTimestamp()
 }
 
-async function run() {
-  const args = parseCliArgs(process.argv.slice(2))
-  if (args.showHelp) {
-    printHelp()
-    return
+function normalizeCategory(value) {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().replace(/\s+/g, ' ').toLowerCase()
+  return normalized || null
+}
+
+function toPublicProduct(productDoc, storeMetaByStoreId, existingDocData = null) {
+  const data = productDoc.data() || {}
+  const storeId = toTrimmedStringOrNull(data.storeId)
+  const name = toTrimmedStringOrNull(data.name)
+  const storeMeta = storeMetaByStoreId.get(storeId) || null
+
+  if (!storeId || !name) {
+    return null
   }
 
-  const targetStoreId = toTrimmedStringOrNull(args.storeId)
+  const category = normalizeCategory(data.category)
+
+  return {
+    sourceProductId: productDoc.id,
+    storeId,
+    storeName: toTrimmedStringOrNull(data.storeName) || storeMeta?.storeName || null,
+    storeCity: toTrimmedStringOrNull(data.storeCity) || storeMeta?.storeCity || null,
+    storePhone: toTrimmedStringOrNull(data.storePhone) || storeMeta?.storePhone || null,
+    websiteLink: toTrimmedStringOrNull(data.websiteLink) || storeMeta?.websiteLink || null,
+    name,
+    description: toTrimmedStringOrNull(data.description),
+    category,
+    sku: toTrimmedStringOrNull(data.sku),
+    barcode: toTrimmedStringOrNull(data.barcode),
+    manufacturerName: toTrimmedStringOrNull(data.manufacturerName),
+    price: typeof data.price === 'number' ? data.price : null,
+    stockCount: typeof data.stockCount === 'number' ? data.stockCount : null,
+    reorderPoint: typeof data.reorderPoint === 'number' ? data.reorderPoint : null,
+    taxRate: typeof data.taxRate === 'number' ? data.taxRate : null,
+    productionDate: isFirestoreTimestampLike(data.productionDate) || typeof data.productionDate === 'string' ? data.productionDate : null,
+    expiryDate: isFirestoreTimestampLike(data.expiryDate) || typeof data.expiryDate === 'string' ? data.expiryDate : null,
+    batchNumber: toTrimmedStringOrNull(data.batchNumber),
+    showOnReceipt: data.showOnReceipt === true,
+    itemType:
+      data.itemType === 'service'
+        ? 'service'
+        : data.itemType === 'made_to_order'
+          ? 'made_to_order'
+          : 'product',
+    isPublished: data.isPublished !== false,
+    ...extractProductImageSet(data),
+    publishedAt: resolvePublishedAtValue(existingDocData || data),
+    createdAt: data.createdAt ?? existingDocData?.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
+    sourceUpdatedAt: data.updatedAt ?? null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }
+}
+
+async function flushBatch(state) {
+  if (state.writes === 0) return
+  await state.batch.commit()
+  state.batch = db.batch()
+  state.writes = 0
+}
+
+function queueSet(state, ref, payload, options = { merge: true }) {
+  state.batch.set(ref, payload, options)
+  state.writes += 1
+}
+
+function queueDelete(state, ref) {
+  state.batch.delete(ref)
+  state.writes += 1
+}
+
+async function maybeFlushBatch(state) {
+  if (state.writes >= 450) {
+    await flushBatch(state)
+  }
+}
+
+async function runBackfill(targetStoreId) {
   let query = db.collection('products')
 
   if (targetStoreId) {
@@ -220,8 +255,7 @@ async function run() {
 
   let upserts = 0
   let skipped = 0
-  let batch = db.batch()
-  let writes = 0
+  const batchState = { batch: db.batch(), writes: 0 }
 
   for (const productDoc of productsSnapshot.docs) {
     const payload = toPublicProduct(productDoc, storeMetaByStoreId)
@@ -236,21 +270,15 @@ async function run() {
       targetCollectionName === 'publicServices'
         ? db.collection('publicProducts').doc(productDoc.id)
         : db.collection('publicServices').doc(productDoc.id)
-    batch.set(targetRef, payload, { merge: true })
-    batch.delete(oppositeRef)
+
+    queueSet(batchState, targetRef, payload, { merge: true })
+    queueDelete(batchState, oppositeRef)
     upserts += 1
-    writes += 2
 
-    if (writes >= 450) {
-      await batch.commit()
-      batch = db.batch()
-      writes = 0
-    }
+    await maybeFlushBatch(batchState)
   }
 
-  if (writes > 0) {
-    await batch.commit()
-  }
+  await flushBatch(batchState)
 
   console.log(
     `[backfillPublicProducts] done. upserts=${upserts}, skipped=${skipped}, total=${productsSnapshot.size}`,
@@ -269,40 +297,230 @@ async function run() {
       `[backfillPublicProducts] scanning ${publicSnapshot.size} ${collectionName} docs for publishedAt`,
     )
 
-    batch = db.batch()
-    writes = 0
+    const publicBatchState = { batch: db.batch(), writes: 0 }
     for (const publicDoc of publicSnapshot.docs) {
       const data = publicDoc.data() || {}
-      if (hasPublishedAt(data.publishedAt)) {
+      const needsPublishedAt = !hasPublishedAt(data.publishedAt)
+      const normalizedCategory = normalizeCategory(data.category)
+      const needsCategoryRepair = data.category !== normalizedCategory
+      const needsUpdatedAt = !isFirestoreTimestampLike(data.updatedAt) && !hasPublishedAt(data.updatedAt)
+
+      if (!needsPublishedAt && !needsCategoryRepair && !needsUpdatedAt) {
         continue
       }
 
-      batch.set(
+      queueSet(
+        publicBatchState,
         publicDoc.ref,
         {
-          publishedAt: resolvePublishedAtValue(data),
+          publishedAt: needsPublishedAt ? resolvePublishedAtValue(data) : data.publishedAt,
           updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          category: normalizedCategory,
         },
         { merge: true },
       )
       publishedAtBackfills += 1
-      writes += 1
-
-      if (writes >= 450) {
-        await batch.commit()
-        batch = db.batch()
-        writes = 0
-      }
+      await maybeFlushBatch(publicBatchState)
     }
 
-    if (writes > 0) {
-      await batch.commit()
-    }
+    await flushBatch(publicBatchState)
   }
 
   console.log(
-    `[backfillPublicProducts] publishedAt backfill complete across publicProducts/publicServices. updated=${publishedAtBackfills}`,
+    `[backfillPublicProducts] metadata backfill complete across publicProducts/publicServices. updated=${publishedAtBackfills}`,
   )
+}
+
+async function reconcileStore(storeId, storeMetaByStoreId) {
+  const productsSnapshot = await db
+    .collection('products')
+    .where('storeId', '==', storeId)
+    .where('isPublished', '==', true)
+    .get()
+  const [publicProductsSnapshot, publicServicesSnapshot] = await Promise.all([
+    db.collection('publicProducts').where('storeId', '==', storeId).get(),
+    db.collection('publicServices').where('storeId', '==', storeId).get(),
+  ])
+
+  const publicProductsById = new Map(publicProductsSnapshot.docs.map(doc => [doc.id, doc]))
+  const publicServicesById = new Map(publicServicesSnapshot.docs.map(doc => [doc.id, doc]))
+  const publishedIds = new Set(productsSnapshot.docs.map(doc => doc.id))
+
+  const summary = {
+    storeId,
+    publishedProducts: productsSnapshot.size,
+    existingPublicProducts: publicProductsSnapshot.size,
+    existingPublicServices: publicServicesSnapshot.size,
+    missingTarget: 0,
+    wrongCollectionRepaired: 0,
+    duplicateTargetRepaired: 0,
+    metadataRepairs: 0,
+    orphanPublicDocsRemoved: 0,
+    sourceMetadataRepairs: 0,
+    outOfSyncDetected: 0,
+  }
+
+  const batchState = { batch: db.batch(), writes: 0 }
+
+  for (const productDoc of productsSnapshot.docs) {
+    const productData = productDoc.data() || {}
+    const expectedCollection = resolvePublicCatalogCollectionName(productData.itemType)
+    const expectedRef = db.collection(expectedCollection).doc(productDoc.id)
+    const oppositeRef =
+      expectedCollection === 'publicServices'
+        ? db.collection('publicProducts').doc(productDoc.id)
+        : db.collection('publicServices').doc(productDoc.id)
+
+    const existingExpected = expectedCollection === 'publicServices'
+      ? publicServicesById.get(productDoc.id) || null
+      : publicProductsById.get(productDoc.id) || null
+    const existingOpposite = expectedCollection === 'publicServices'
+      ? publicProductsById.get(productDoc.id) || null
+      : publicServicesById.get(productDoc.id) || null
+
+    if (!existingExpected) {
+      summary.missingTarget += 1
+      summary.outOfSyncDetected += 1
+      const payload = toPublicProduct(productDoc, storeMetaByStoreId)
+      if (payload) {
+        queueSet(batchState, expectedRef, payload, { merge: true })
+      }
+    }
+
+    if (existingOpposite) {
+      summary.wrongCollectionRepaired += 1
+      summary.outOfSyncDetected += 1
+      queueDelete(batchState, oppositeRef)
+    }
+
+    if (existingExpected && existingOpposite) {
+      summary.duplicateTargetRepaired += 1
+    }
+
+    const normalizedSourceCategory = normalizeCategory(productData.category)
+    const needsSourceCategoryRepair = productData.category !== normalizedSourceCategory
+    const needsSourcePublishedAt = !hasPublishedAt(productData.publishedAt)
+    const needsSourceUpdatedAt = !isFirestoreTimestampLike(productData.updatedAt) && !hasPublishedAt(productData.updatedAt)
+
+    if (needsSourceCategoryRepair || needsSourcePublishedAt || needsSourceUpdatedAt) {
+      summary.sourceMetadataRepairs += 1
+      queueSet(batchState, productDoc.ref, {
+        category: normalizedSourceCategory,
+        publishedAt: needsSourcePublishedAt ? resolvePublishedAtValue(productData) : productData.publishedAt,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true })
+    }
+
+    const expectedData = existingExpected ? existingExpected.data() || {} : null
+    if (expectedData) {
+      const normalizedCategory = normalizeCategory(expectedData.category)
+      const needsCategoryRepair = expectedData.category !== normalizedCategory
+      const needsPublishedAtRepair = !hasPublishedAt(expectedData.publishedAt)
+      const needsUpdatedAtRepair = !isFirestoreTimestampLike(expectedData.updatedAt) && !hasPublishedAt(expectedData.updatedAt)
+      if (needsCategoryRepair || needsPublishedAtRepair || needsUpdatedAtRepair) {
+        summary.metadataRepairs += 1
+        queueSet(batchState, expectedRef, {
+          category: normalizedCategory,
+          publishedAt: needsPublishedAtRepair ? resolvePublishedAtValue(expectedData) : expectedData.publishedAt,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        }, { merge: true })
+      }
+    }
+
+    await maybeFlushBatch(batchState)
+  }
+
+  for (const publicDoc of [...publicProductsSnapshot.docs, ...publicServicesSnapshot.docs]) {
+    if (publishedIds.has(publicDoc.id)) continue
+    summary.orphanPublicDocsRemoved += 1
+    summary.outOfSyncDetected += 1
+    queueDelete(batchState, publicDoc.ref)
+    await maybeFlushBatch(batchState)
+  }
+
+  await flushBatch(batchState)
+
+  const [nextPublicProductsSnapshot, nextPublicServicesSnapshot] = await Promise.all([
+    db.collection('publicProducts').where('storeId', '==', storeId).get(),
+    db.collection('publicServices').where('storeId', '==', storeId).get(),
+  ])
+
+  await db.collection('stores').doc(storeId).set(
+    {
+      publicCatalogLastSyncedAt: admin.firestore.FieldValue.serverTimestamp(),
+      publicCatalogDocCount: {
+        products: nextPublicProductsSnapshot.size,
+        services: nextPublicServicesSnapshot.size,
+      },
+      publicCatalogOutOfSyncCount: 0,
+    },
+    { merge: true },
+  )
+
+  return summary
+}
+
+async function runReconciliation(targetStoreId) {
+  let productsQuery = db.collection('products').where('isPublished', '==', true)
+  if (targetStoreId) {
+    productsQuery = productsQuery.where('storeId', '==', targetStoreId)
+    console.log(`[backfillPublicProducts] reconcile mode for storeId=${targetStoreId}`)
+  } else {
+    console.log('[backfillPublicProducts] reconcile mode for all stores')
+  }
+
+  const publishedProductsSnapshot = await productsQuery.get()
+  const storeIds = new Set()
+  for (const productDoc of publishedProductsSnapshot.docs) {
+    const storeId = toTrimmedStringOrNull(productDoc.get('storeId'))
+    if (storeId) storeIds.add(storeId)
+  }
+  if (targetStoreId) {
+    storeIds.add(targetStoreId)
+  }
+
+  const storeMetaByStoreId = new Map()
+  for (const storeId of storeIds) {
+    const storeSnap = await db.collection('stores').doc(storeId).get()
+    if (!storeSnap.exists) continue
+    storeMetaByStoreId.set(storeId, buildStorePublicMeta(storeSnap.data() || {}))
+  }
+
+  const summaries = []
+  for (const storeId of [...storeIds]) {
+    const summary = await reconcileStore(storeId, storeMetaByStoreId)
+    summaries.push(summary)
+    console.log(
+      `[reconcile] store=${summary.storeId} published=${summary.publishedProducts} missingTarget=${summary.missingTarget} ` +
+      `wrongCollectionRepaired=${summary.wrongCollectionRepaired} metadataRepairs=${summary.metadataRepairs} ` +
+      `sourceMetadataRepairs=${summary.sourceMetadataRepairs} orphanRemoved=${summary.orphanPublicDocsRemoved} outOfSyncDetected=${summary.outOfSyncDetected}`,
+    )
+  }
+
+  console.log('[reconcile] summary report by store:')
+  console.log(JSON.stringify(summaries, null, 2))
+}
+
+async function run() {
+  const args = parseCliArgs(process.argv.slice(2))
+  if (args.showHelp) {
+    printHelp()
+    return
+  }
+
+  const mode = toTrimmedStringOrNull(args.mode) || 'backfill'
+  const targetStoreId = toTrimmedStringOrNull(args.storeId)
+
+  if (mode !== 'backfill' && mode !== 'reconcile') {
+    throw new Error(`Unsupported mode: ${mode}. Use --mode=backfill or --mode=reconcile`)
+  }
+
+  if (mode === 'reconcile') {
+    await runReconciliation(targetStoreId)
+    return
+  }
+
+  await runBackfill(targetStoreId)
 }
 
 run().catch(error => {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5683,7 +5683,7 @@ export const integrationGallery = functions.https.onRequest(async (req, res) => 
   if (!storeContext) {
     return
   }
-  const { storeId } = storeContext
+  const { storeId, data: storeData } = storeContext
 
   const gallerySnapshot = await db
     .collection('stores')
@@ -5835,7 +5835,7 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
   if (!storeContext) {
     return
   }
-  const { storeId } = storeContext
+  const { storeId, data: storeData } = storeContext
 
   const mapCatalogDoc = (docSnap: admin.firestore.QueryDocumentSnapshot) => {
     const data = docSnap.data() as Record<string, unknown>
@@ -5941,7 +5941,31 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
 
   const { publicProducts, publicServices } = splitCatalogItemsByType(products)
 
-  res.status(200).json({ storeId, products, publicProducts, publicServices })
+  const syncHealth = {
+    publicCatalogLastSyncedAt: normalizeTimestampIso(storeData.publicCatalogLastSyncedAt),
+    publicCatalogDocCount: {
+      products:
+        typeof (storeData.publicCatalogDocCount as Record<string, unknown> | undefined)?.products === 'number'
+          ? Math.max(
+              0,
+              Math.floor((storeData.publicCatalogDocCount as Record<string, unknown>).products as number),
+            )
+          : null,
+      services:
+        typeof (storeData.publicCatalogDocCount as Record<string, unknown> | undefined)?.services === 'number'
+          ? Math.max(
+              0,
+              Math.floor((storeData.publicCatalogDocCount as Record<string, unknown>).services as number),
+            )
+          : null,
+    },
+    publicCatalogOutOfSyncCount:
+      typeof storeData.publicCatalogOutOfSyncCount === 'number'
+        ? Math.max(0, Math.floor(storeData.publicCatalogOutOfSyncCount))
+        : null,
+  }
+
+  res.status(200).json({ storeId, products, publicProducts, publicServices, syncHealth })
 })
 
 export const integrationGoogleMerchantFeed = functions.https.onRequest(async (req, res) => {
@@ -6629,7 +6653,7 @@ function toPublicProductPayload(
     websiteLink: toTrimmedStringOrNull(source.websiteLink) ?? storeMeta?.websiteLink ?? null,
     name,
     description: typeof source.description === 'string' && source.description.trim() ? source.description.trim() : null,
-    category: typeof source.category === 'string' && source.category.trim() ? source.category.trim() : null,
+    category: normalizeCatalogCategory(source.category),
     sku: toTrimmedStringOrNull(source.sku),
     barcode: toTrimmedStringOrNull(source.barcode),
     manufacturerName: toTrimmedStringOrNull(source.manufacturerName),
@@ -6663,6 +6687,62 @@ function resolvePublicCatalogCollectionName(itemType: unknown): 'publicProducts'
   return itemType === 'service' ? 'publicServices' : 'publicProducts'
 }
 
+function normalizeCatalogCategory(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().replace(/\s+/g, ' ').toLowerCase()
+  return normalized || null
+}
+
+async function updateStorePublicCatalogHealth(storeId: string): Promise<void> {
+  const normalizedStoreId = toTrimmedStringOrNull(storeId)
+  if (!normalizedStoreId) return
+
+  const [publishedProductsSnap, publicProductsSnap, publicServicesSnap] = await Promise.all([
+    db.collection('products').where('storeId', '==', normalizedStoreId).where('isPublished', '==', true).get(),
+    db.collection('publicProducts').where('storeId', '==', normalizedStoreId).get(),
+    db.collection('publicServices').where('storeId', '==', normalizedStoreId).get(),
+  ])
+
+  const publicProductIds = new Set(publicProductsSnap.docs.map(doc => doc.id))
+  const publicServiceIds = new Set(publicServicesSnap.docs.map(doc => doc.id))
+  const publishedSourceIds = new Set<string>()
+  let outOfSyncCount = 0
+
+  for (const sourceDoc of publishedProductsSnap.docs) {
+    publishedSourceIds.add(sourceDoc.id)
+    const sourceData = (sourceDoc.data() ?? {}) as Record<string, unknown>
+    const expectedCollection = resolvePublicCatalogCollectionName(sourceData.itemType)
+    const existsInProducts = publicProductIds.has(sourceDoc.id)
+    const existsInServices = publicServiceIds.has(sourceDoc.id)
+    const isInSync =
+      expectedCollection === 'publicServices'
+        ? existsInServices && !existsInProducts
+        : existsInProducts && !existsInServices
+
+    if (!isInSync) {
+      outOfSyncCount += 1
+    }
+  }
+
+  for (const publicDoc of [...publicProductsSnap.docs, ...publicServicesSnap.docs]) {
+    if (!publishedSourceIds.has(publicDoc.id)) {
+      outOfSyncCount += 1
+    }
+  }
+
+  await db.collection('stores').doc(normalizedStoreId).set(
+    {
+      publicCatalogLastSyncedAt: admin.firestore.FieldValue.serverTimestamp(),
+      publicCatalogDocCount: {
+        products: publicProductsSnap.size,
+        services: publicServicesSnap.size,
+      },
+      publicCatalogOutOfSyncCount: outOfSyncCount,
+    },
+    { merge: true },
+  )
+}
+
 async function deleteLegacyPublicCatalogDuplicates(productId: string): Promise<void> {
   const cleanupCollection = async (collectionName: 'publicProducts' | 'publicServices') => {
     const snapshot = await db.collection(collectionName).where('sourceProductId', '==', productId).limit(50).get()
@@ -6686,14 +6766,23 @@ export const syncPublicProducts = functions.firestore
     const productId = context.params.productId
     const publicProductRef = db.collection('publicProducts').doc(productId)
     const publicServiceRef = db.collection('publicServices').doc(productId)
+    const beforeData = change.before.exists ? ((change.before.data() ?? {}) as Record<string, unknown>) : null
+    const afterData = change.after.exists ? ((change.after.data() ?? {}) as Record<string, unknown>) : null
+    const touchedStoreIds = new Set<string>()
+
+    const beforeStoreId = toTrimmedStringOrNull(beforeData?.storeId)
+    const afterStoreId = toTrimmedStringOrNull(afterData?.storeId)
+    if (beforeStoreId) touchedStoreIds.add(beforeStoreId)
+    if (afterStoreId) touchedStoreIds.add(afterStoreId)
 
     if (!change.after.exists) {
       await publicProductRef.delete().catch(() => undefined)
       await publicServiceRef.delete().catch(() => undefined)
+      await Promise.all([...touchedStoreIds].map(storeId => updateStorePublicCatalogHealth(storeId)))
       return
     }
 
-    const sourceData = (change.after.data() ?? {}) as Record<string, unknown>
+    const sourceData = afterData ?? {}
     const destinationCollectionName = resolvePublicCatalogCollectionName(sourceData.itemType)
     const destinationRef = db.collection(destinationCollectionName).doc(productId)
     const oppositeRef = destinationCollectionName === 'publicServices' ? publicProductRef : publicServiceRef
@@ -6716,6 +6805,7 @@ export const syncPublicProducts = functions.firestore
     await destinationRef.set(payload, { merge: true })
     await oppositeRef.delete().catch(() => undefined)
     await deleteLegacyPublicCatalogDuplicates(productId).catch(() => undefined)
+    await Promise.all([...touchedStoreIds].map(storeId => updateStorePublicCatalogHealth(storeId)))
   })
 
 export const enrichProductDataAfterSave = functions.firestore

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -79,6 +79,10 @@ type StoreProfile = {
   bulkEmailWebAppUrl: string | null
   bulkEmailSharedToken: string | null
   bulkEmailFromName: string | null
+  publicCatalogLastSyncedAt: Timestamp | null
+  publicCatalogDocCountProducts: number
+  publicCatalogDocCountServices: number
+  publicCatalogOutOfSyncCount: number
 }
 
 type SubscriptionProfile = {
@@ -241,6 +245,10 @@ function mapStoreSnapshot(
     data.bulkEmailIntegration && typeof data.bulkEmailIntegration === 'object'
       ? (data.bulkEmailIntegration as Record<string, unknown>)
       : {}
+  const publicCatalogDocCountRaw =
+    data.publicCatalogDocCount && typeof data.publicCatalogDocCount === 'object'
+      ? (data.publicCatalogDocCount as Record<string, unknown>)
+      : {}
 
   return {
     name: toNullableString(data.name),
@@ -280,6 +288,20 @@ function mapStoreSnapshot(
     bulkEmailWebAppUrl: toNullableString(bulkEmailRaw.webAppUrl),
     bulkEmailSharedToken: toNullableString(bulkEmailRaw.sharedToken),
     bulkEmailFromName: toNullableString(bulkEmailRaw.fromName),
+    publicCatalogLastSyncedAt: toTimestamp((data as any).publicCatalogLastSyncedAt),
+    publicCatalogDocCountProducts:
+      typeof publicCatalogDocCountRaw.products === 'number' && Number.isFinite(publicCatalogDocCountRaw.products)
+        ? Math.max(0, Math.floor(publicCatalogDocCountRaw.products))
+        : 0,
+    publicCatalogDocCountServices:
+      typeof publicCatalogDocCountRaw.services === 'number' && Number.isFinite(publicCatalogDocCountRaw.services)
+        ? Math.max(0, Math.floor(publicCatalogDocCountRaw.services))
+        : 0,
+    publicCatalogOutOfSyncCount:
+      typeof (data as any).publicCatalogOutOfSyncCount === 'number' &&
+      Number.isFinite((data as any).publicCatalogOutOfSyncCount)
+        ? Math.max(0, Math.floor((data as any).publicCatalogOutOfSyncCount))
+        : 0,
   }
 }
 
@@ -2235,6 +2257,22 @@ export default function AccountOverview({
               <code>{storeId}</code>
               . You can find it in <strong>Account overview → Workspace details</strong>.
             </p>
+            {profile && (
+              <div className="account-overview__website-sync-keys">
+                <p className="account-overview__hint"><strong>Catalog sync health</strong></p>
+                <p className="account-overview__hint">
+                  Last synced: {formatTimestamp(profile.publicCatalogLastSyncedAt)}
+                </p>
+                <p className="account-overview__hint">
+                  Public products: {profile.publicCatalogDocCountProducts}
+                  {' · '}
+                  Public services: {profile.publicCatalogDocCountServices}
+                </p>
+                <p className="account-overview__hint">
+                  Out-of-sync items: {profile.publicCatalogOutOfSyncCount}
+                </p>
+              </div>
+            )}
               </>
             )}
             {(integrationTab === 'overview' || integrationTab === 'keys') && (


### PR DESCRIPTION
### Motivation

- Provide operational visibility for public catalog freshness and sync health so owners and integrations can detect issues quickly. 
- Prevent and repair drift between source `products` and the derived `publicProducts` / `publicServices` collections to keep public indexes correct. 

### Description

- Add store-level sync health fields (`publicCatalogLastSyncedAt`, `publicCatalogDocCount.products`, `publicCatalogDocCount.services`, `publicCatalogOutOfSyncCount`) and compute/update them from Cloud Functions via `updateStorePublicCatalogHealth` called by the `syncPublicProducts` trigger.  
- Expose a `syncHealth` object on the `integrationPublicCatalog` response so integration consumers can read freshness and out-of-sync signals.  
- Normalize `category` values in public payloads using `normalizeCatalogCategory` and ensure `category`, `publishedAt`, and `updatedAt` are repaired where missing.  
- Extend backfill tooling with a new `--mode=reconcile` in `functions/scripts/backfillPublicProducts.js` to verify published source items map to exactly one public target, repair wrong-collection drift, fix missing metadata and non-normalized categories, remove orphan public docs, and emit a per-store summary report; backfill mode retained and refactored for batching.  
- Surface catalog sync health in the owner dashboard (`web/src/pages/AccountOverview.tsx`) and document reconciliation usage in `docs/public-catalog-backfill.md`. 

### Testing

- Built functions with `npm --prefix functions run build` and the TypeScript build succeeded.  
- Verified the backfill script help output with `node functions/scripts/backfillPublicProducts.js --help` which reports the new `--mode=reconcile` option.  
- `npm --prefix web run build` failed in this environment due to missing local type packages (`vite/client`, `vitest/globals`), which is an environment/tooling issue and not a functional regression in the changes applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7975ee61c83228e7719569f4436b8)