### PR TITLE
docs: provide clean copy-paste Google Apps Script template for bulk email

### DIFF
--- a/docs/bulk-email-google-sheets-guide.md
+++ b/docs/bulk-email-google-sheets-guide.md
@@ -1,6 +1,6 @@
 # Sedifex Bulk Email: Google Sheets + Apps Script Setup
 
-Use this guide when each store should own its Google Sheet and Apps Script deployment, while Sedifex remains the single source of truth for customers.
+Use this guide when each store should own its Google Sheet and Google Apps Script deployment, while Sedifex remains the single source of truth for customers.
 
 ## Architecture
 - Sedifex stores customers and campaign audience logic.
@@ -10,15 +10,16 @@ Use this guide when each store should own its Google Sheet and Apps Script deplo
 
 ## Setup steps
 1. Store owner creates a Google Sheet.
-2. In **Extensions → Apps Script**, paste the Sedifex Apps Script sample.
+2. In **Extensions → Apps Script**, paste the full template below.
 3. Add Script Property: `SEDIFEX_SHARED_TOKEN`.
-4. Deploy as **Web App** and copy deployment URL.
-5. In Sedifex, open **Account → Integrations → Bulk Email (Google Sheets)**.
-6. Paste Web App URL + shared token, then verify connection.
+4. (Optional) Add the optional Script Properties listed in the template header.
+5. Deploy as **Web App** and copy deployment URL.
+6. In Sedifex, open **Account → Integrations → Bulk Email (Google Sheets)**.
+7. Paste Web App URL + shared token, then verify connection.
 
 ## Sheet template (what the store should create)
 Create one tab with this exact name:
-- **Tab name:** `Recipients` *(change this in script if you use another name)*
+- **Tab name:** `Recipients` *(change this in script property `RECIPIENTS_TAB_NAME` if needed)*
 
 Use row 1 as headers:
 
@@ -36,222 +37,17 @@ Use row 1 as headers:
 | ama@example.com | Ama |  |  | VIP |
 | kojo@example.com | Kojo |  |  | Follow up in May |
 
-## Where the topic and message go
-- **Topic (email subject):** set in Sedifex campaign **Subject** field. It is sent as `payload.subject`.
-- **Message (email body):** set in Sedifex campaign **Message** editor. It is sent as `payload.html`.
-- The sheet is mainly for recipients (`email`, optional `name`) and delivery tracking (`status`, `last_sent_at`).
-- In the script, these are used here:
-  - `subject: payload.subject || 'Update from your store'`
-  - `htmlBody: payload.html || ''`
+## Where the subject and message come from
+- **Subject** is set in Sedifex campaign **Subject** and sent as `payload.subject`.
+- **Message body** is set in Sedifex campaign **Message** and sent as `payload.html`.
+- The Google Sheet is mainly for recipients and delivery tracking (`status`, `last_sent_at`).
 
-If you want to type subject/body in Google Sheets instead, add columns like `subject` and `message_html`, then replace `payload.subject` and `payload.html` with those cell values.
+---
 
-## Apps Script sample (starter, with CHANGE ME markers)
-> Paste this into **Extensions → Apps Script**. If needed, change the values under `CONFIG` to match your own sheet/tab/columns.
+## Copy‑paste template for Google Apps Script (complete)
+> Copy everything inside this code block into **Extensions → Apps Script** (`Code.gs`).
 
 ```javascript
-function doPost(e) {
-  const payload = JSON.parse(e.postData.contents || '{}')
-  const token = payload?.token || ''
-
-  if (token !== PropertiesService.getScriptProperties().getProperty('SEDIFEX_SHARED_TOKEN')) {
-    return ContentService.createTextOutput(JSON.stringify({ ok: false, error: 'unauthorized' }))
-      .setMimeType(ContentService.MimeType.JSON)
-  }
-
-  // CHANGE ME: update these if your tab name or column layout is different.
-  const CONFIG = {
-    sheetTabName: 'Recipients', // CHANGE ME
-    headers: {
-      email: 'email',           // CHANGE ME
-      name: 'name',             // CHANGE ME
-      status: 'status',         // CHANGE ME
-      lastSentAt: 'last_sent_at' // CHANGE ME
-    }
-  }
-
-  const recipientsFromPayload = Array.isArray(payload.recipients) ? payload.recipients : []
-  const ss = SpreadsheetApp.getActiveSpreadsheet()
-  const sheet = ss.getSheetByName(CONFIG.sheetTabName)
-
-  if (!sheet) {
-    return ContentService.createTextOutput(JSON.stringify({
-      ok: false,
-      error: `sheet tab not found: ${CONFIG.sheetTabName}`,
-    })).setMimeType(ContentService.MimeType.JSON)
-  }
-
-  const values = sheet.getDataRange().getValues()
-  if (!values.length) {
-    return ContentService.createTextOutput(JSON.stringify({ ok: false, error: 'sheet is empty' }))
-      .setMimeType(ContentService.MimeType.JSON)
-  }
-
-  const headers = values[0].map((h) => (h || '').toString().trim().toLowerCase())
-  const emailCol = headers.indexOf(CONFIG.headers.email.toLowerCase())
-  const nameCol = headers.indexOf(CONFIG.headers.name.toLowerCase())
-  const statusCol = headers.indexOf(CONFIG.headers.status.toLowerCase())
-  const lastSentAtCol = headers.indexOf(CONFIG.headers.lastSentAt.toLowerCase())
-
-  if (emailCol < 0) {
-    return ContentService.createTextOutput(JSON.stringify({
-      ok: false,
-      error: `missing required header: ${CONFIG.headers.email}`,
-    })).setMimeType(ContentService.MimeType.JSON)
-  }
-
-  let attempted = 0
-  let sent = 0
-  const errors = []
-
-  // Priority: use Sedifex payload recipients if provided; otherwise fall back to sheet rows.
-  const sheetRows = values.slice(1).map((row, i) => ({
-    rowIndex: i + 2,
-    email: (row[emailCol] || '').toString().trim(),
-    name: nameCol >= 0 ? (row[nameCol] || '').toString().trim() : '',
-  }))
-
-  const recipients = recipientsFromPayload.length
-    ? recipientsFromPayload.map((r) => ({
-        rowIndex: null,
-        email: (r?.email || '').toString().trim(),
-        name: (r?.name || '').toString().trim(),
-      }))
-    : sheetRows
-
-  recipients.forEach((recipient) => {
-    const email = recipient.email
-    if (!email) {
-      if (recipient.rowIndex && statusCol >= 0) {
-        sheet.getRange(recipient.rowIndex, statusCol + 1).setValue('SKIPPED')
-      }
-      return
-    }
-
-    attempted += 1
-
-    try {
-      MailApp.sendEmail({
-        to: email,
-        subject: payload.subject || 'Update from your store',
-        htmlBody: payload.html || '',
-        name: payload.fromName || 'Sedifex Campaign',
-      })
-      sent += 1
-
-      if (recipient.rowIndex && statusCol >= 0) {
-        sheet.getRange(recipient.rowIndex, statusCol + 1).setValue('SENT')
-      }
-      if (recipient.rowIndex && lastSentAtCol >= 0) {
-        sheet.getRange(recipient.rowIndex, lastSentAtCol + 1).setValue(new Date())
-      }
-    } catch (err) {
-      errors.push({ email, message: String(err) })
-      if (recipient.rowIndex && statusCol >= 0) {
-        sheet.getRange(recipient.rowIndex, statusCol + 1).setValue('ERROR')
-      }
-    }
-  })
-
-  return ContentService.createTextOutput(JSON.stringify({
-    ok: true,
-    attempted,
-    sent,
-    failed: attempted - sent,
-    errors,
-  })).setMimeType(ContentService.MimeType.JSON)
-}
-
-function isDailyLimitError(message) {
-  const text = (message || '').toLowerCase()
-  return text.includes('limit exceeded') || text.includes('quota')
-}
-
-function getOrCreateQueueSheet(ss, queueTabName) {
-  const sheet = ss.getSheetByName(queueTabName) || ss.insertSheet(queueTabName)
-  if (sheet.getLastRow() === 0) {
-    sheet.appendRow([
-      'queued_at',
-      'email',
-      'name',
-      'subject',
-      'html',
-      'from_name',
-      'status',
-      'last_attempt_at',
-      'error',
-    ])
-  }
-  return sheet
-}
-
-function enqueueEmail(ss, queueTabName, item) {
-  const queueSheet = getOrCreateQueueSheet(ss, queueTabName)
-  queueSheet.appendRow([
-    new Date(),
-    item.email || '',
-    item.name || '',
-    item.subject || '',
-    item.html || '',
-    item.fromName || '',
-    'QUEUED',
-    '',
-    item.error || '',
-  ])
-}
-
-/**
- * Optional: run this with a time-based trigger every 15-60 minutes.
- * It retries queued emails after daily limits reset.
- */
-function processEmailQueue() {
-  const ss = SpreadsheetApp.getActiveSpreadsheet()
-  const queueSheet = getOrCreateQueueSheet(ss, 'EmailQueue') // CHANGE ME if renamed
-  const values = queueSheet.getDataRange().getValues()
-  if (values.length <= 1) return
-
-  const data = values.slice(1)
-  data.forEach((row, idx) => {
-    const rowNumber = idx + 2
-    const status = (row[6] || '').toString().trim().toUpperCase()
-    if (status !== 'QUEUED') return
-
-    const email = (row[1] || '').toString().trim()
-    if (!email) return
-
-    try {
-      MailApp.sendEmail({
-        to: email,
-        subject: (row[3] || '').toString(),
-        htmlBody: (row[4] || '').toString(),
-        name: (row[5] || 'Sedifex Campaign').toString(),
-      })
-      queueSheet.getRange(rowNumber, 7).setValue('SENT') // status
-      queueSheet.getRange(rowNumber, 8).setValue(new Date()) // last_attempt_at
-      queueSheet.getRange(rowNumber, 9).setValue('') // error
-    } catch (err) {
-      queueSheet.getRange(rowNumber, 8).setValue(new Date())
-      queueSheet.getRange(rowNumber, 9).setValue(String(err))
-    }
-  })
-}
-```
-
-## Payload example from Sedifex
-```json
-{
-  "token": "shared-secret",
-  "campaignId": "cmp_2026_04_18_001",
-  "fromName": "Acme Store",
-  "subject": "Weekend Promo",
-  "html": "<p>Hello {{name}}, enjoy 10% off this weekend.</p>",
-  "recipients": [
-    { "id": "cus_1", "name": "Ama", "email": "ama@example.com" },
-    { "id": "cus_2", "name": "Kojo", "email": "kojo@example.com" }
-  ]
-}
-```
-
 /***************************************
  * Glittering Med Spa - Sedifex Bulk Email Web App
  * -----------------------------------------------
@@ -720,9 +516,24 @@ function safeString_(value) {
 function escapeRegex_(text) {
   return String(text).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+```
+
+## Payload example from Sedifex
+```json
+{
+  "token": "shared-secret",
+  "campaignId": "cmp_2026_04_18_001",
+  "fromName": "Acme Store",
+  "subject": "Weekend Promo",
+  "html": "<p>Hello {{name}}, enjoy 10% off this weekend.</p>",
+  "recipients": [
+    { "id": "cus_1", "name": "Ama", "email": "ama@example.com" },
+    { "id": "cus_2", "name": "Kojo", "email": "kojo@example.com" }
+  ]
+}
+```
 
 ## Important notes
-- Keep customer records in Sedifex only (no duplicate manual entry).
+- Keep customer records in Sedifex only (avoid duplicate manual entry).
 - Google sending quotas apply.
-- If quota is reached, script can queue unsent emails to `EmailQueue` and retry later with a time-based trigger.
 - Rotate shared tokens when ownership/staff changes.


### PR DESCRIPTION
### Motivation
- Make it trivial for store owners to deploy the Apps Script by providing a single, complete copy‑paste template rather than duplicated/truncated fragments.
- Reduce user errors when installing the script by clarifying required sheet headers, script properties, and deployment steps.

### Description
- Rewrote `docs/bulk-email-google-sheets-guide.md` to include one full, ready-to-paste Google Apps Script block for `Code.gs` and removed duplicated/truncated script snippets.
- Clarified setup steps and the sheet template (tab name, required headers, sample rows) and documented optional script properties and payload format.
- Ensured the code block has proper boundaries and that the template includes healthcheck (`doGet`), main endpoint (`doPost`), helpers, dedupe/queue support, and template placeholders.
- Kept concise implementation notes (quota, token rotation) and preserved a payload example for integration testing.

### Testing
- Validated the updated markdown file content and code block boundaries by inspecting the rendered file locally and confirming the template is a single contiguous code block (success).
- Verified the repository diff is limited to the bulk email guide and no unrelated files were modified (success).
- Saved the updated documentation into the repository and confirmed the change was recorded (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e893dfb3488322b25ca3d31d1da4d4)