### PR TITLE
feat: daily deterministic shuffle for integration public catalog

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -2979,6 +2979,41 @@ function dedupeCatalogItemsById(items) {
     }
     return [...byId.values()];
 }
+function resolveDailyCatalogShuffleEnabled(value) {
+    if (typeof value !== 'string')
+        return true;
+    const normalized = value.trim().toLowerCase();
+    if (!normalized)
+        return true;
+    return !['0', 'false', 'no', 'off'].includes(normalized);
+}
+function getUtcDayKeyFromMs(nowMs) {
+    return new Date(nowMs).toISOString().slice(0, 10);
+}
+function buildStableDailyOrderKey(params) {
+    return crypto
+        .createHash('sha256')
+        .update(`${params.storeId}:${params.utcDayKey}:${params.itemId}`)
+        .digest('hex');
+}
+function sortCatalogItemsByDailyStableOrder(params) {
+    const utcDayKey = getUtcDayKeyFromMs(params.nowMs);
+    return [...params.items].sort((a, b) => {
+        const aKey = buildStableDailyOrderKey({ storeId: params.storeId, itemId: a.id, utcDayKey });
+        const bKey = buildStableDailyOrderKey({ storeId: params.storeId, itemId: b.id, utcDayKey });
+        if (aKey !== bKey)
+            return aKey.localeCompare(bKey);
+        if (!a.updatedAt && !b.updatedAt)
+            return a.id.localeCompare(b.id);
+        if (!a.updatedAt)
+            return 1;
+        if (!b.updatedAt)
+            return -1;
+        if (a.updatedAt === b.updatedAt)
+            return a.id.localeCompare(b.id);
+        return a.updatedAt > b.updatedAt ? -1 : 1;
+    });
+}
 const BOOKING_ATTRIBUTE_MAX_KEYS = 40;
 const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500;
 const DEFAULT_BOOKING_ALIASES = {
@@ -4629,6 +4664,7 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
         return;
     }
     const { storeId, data: storeData } = storeContext;
+    const shuffleDaily = resolveDailyCatalogShuffleEnabled(req.query.shuffleDaily);
     const mapCatalogDoc = (docSnap) => {
         const data = docSnap.data();
         const name = typeof data.name === 'string' ? data.name.trim() : '';
@@ -4698,6 +4734,9 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
     products = dedupeCatalogItemsById(products);
     const nowMs = Date.now();
     products = products.filter(item => isPublishedForPublicRead(item, nowMs));
+    if (shuffleDaily) {
+        products = sortCatalogItemsByDailyStableOrder({ items: products, storeId, nowMs });
+    }
     if (!products.length) {
         let productsSnapshot;
         try {
@@ -4729,6 +4768,9 @@ exports.integrationPublicCatalog = functions.https.onRequest(async (req, res) =>
                 return -1;
             return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0;
         });
+        if (shuffleDaily) {
+            products = sortCatalogItemsByDailyStableOrder({ items: products, storeId, nowMs });
+        }
     }
     const { publicProducts, publicServices } = splitCatalogItemsByType(products);
     const syncHealth = {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3858,6 +3858,43 @@ function dedupeCatalogItemsById<T extends { id: string; updatedAt?: string | nul
   return [...byId.values()]
 }
 
+function resolveDailyCatalogShuffleEnabled(value: unknown): boolean {
+  if (typeof value !== 'string') return true
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return true
+  return !['0', 'false', 'no', 'off'].includes(normalized)
+}
+
+function getUtcDayKeyFromMs(nowMs: number): string {
+  return new Date(nowMs).toISOString().slice(0, 10)
+}
+
+function buildStableDailyOrderKey(params: { storeId: string; itemId: string; utcDayKey: string }): string {
+  return crypto
+    .createHash('sha256')
+    .update(`${params.storeId}:${params.utcDayKey}:${params.itemId}`)
+    .digest('hex')
+}
+
+function sortCatalogItemsByDailyStableOrder<T extends { id: string; updatedAt?: string | null }>(params: {
+  items: T[]
+  storeId: string
+  nowMs: number
+}): T[] {
+  const utcDayKey = getUtcDayKeyFromMs(params.nowMs)
+  return [...params.items].sort((a, b) => {
+    const aKey = buildStableDailyOrderKey({ storeId: params.storeId, itemId: a.id, utcDayKey })
+    const bKey = buildStableDailyOrderKey({ storeId: params.storeId, itemId: b.id, utcDayKey })
+    if (aKey !== bKey) return aKey.localeCompare(bKey)
+
+    if (!a.updatedAt && !b.updatedAt) return a.id.localeCompare(b.id)
+    if (!a.updatedAt) return 1
+    if (!b.updatedAt) return -1
+    if (a.updatedAt === b.updatedAt) return a.id.localeCompare(b.id)
+    return a.updatedAt > b.updatedAt ? -1 : 1
+  })
+}
+
 const BOOKING_ATTRIBUTE_MAX_KEYS = 40
 const BOOKING_ATTRIBUTE_MAX_VALUE_LENGTH = 500
 
@@ -5836,6 +5873,7 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
     return
   }
   const { storeId, data: storeData } = storeContext
+  const shuffleDaily = resolveDailyCatalogShuffleEnabled(req.query.shuffleDaily)
 
   const mapCatalogDoc = (docSnap: admin.firestore.QueryDocumentSnapshot) => {
     const data = docSnap.data() as Record<string, unknown>
@@ -5907,6 +5945,9 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
   products = dedupeCatalogItemsById(products)
   const nowMs = Date.now()
   products = products.filter(item => isPublishedForPublicRead(item as Record<string, unknown>, nowMs))
+  if (shuffleDaily) {
+    products = sortCatalogItemsByDailyStableOrder({ items: products, storeId, nowMs })
+  }
 
   if (!products.length) {
     let productsSnapshot: admin.firestore.QuerySnapshot
@@ -5937,6 +5978,9 @@ export const integrationPublicCatalog = functions.https.onRequest(async (req, re
         if (!b.updatedAt) return -1
         return a.updatedAt > b.updatedAt ? -1 : a.updatedAt < b.updatedAt ? 1 : 0
       })
+    if (shuffleDaily) {
+      products = sortCatalogItemsByDailyStableOrder({ items: products, storeId, nowMs })
+    }
   }
 
   const { publicProducts, publicServices } = splitCatalogItemsByType(products)


### PR DESCRIPTION
### Motivation
- Provide randomized but stable ordering of public products and services per UTC day so integrators pulling the feed see a rotated order that remains consistent for the same day.
- Allow integrators to opt out when the original ordering is required via a query flag.

### Description
- Added helper utilities `resolveDailyCatalogShuffleEnabled`, `getUtcDayKeyFromMs`, `buildStableDailyOrderKey`, and `sortCatalogItemsByDailyStableOrder` that compute a deterministic daily order using `storeId + UTC day + itemId` hashed with SHA-256.
- Applied the daily stable shuffle inside `integrationPublicCatalog` after publication filtering (including the fallback read from `products`) and wired a `shuffleDaily` query parameter (enabled by default; disable with `shuffleDaily=false|0|no|off`).
- Rebuilt the compiled output so `functions/lib/index.js` reflects the TypeScript changes.

### Testing
- Ran `npm --prefix functions run build` and TypeScript compilation completed successfully.
- Ran `npm --prefix functions test` and the `bookingNormalization` tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b7a8cc3c8322bb68c11bc151259f)