### PR TITLE
Legal: Document public-facing page social content (TikTok & YouTube)

### DIFF
--- a/web/src/pages/legal/PrivacyPage.tsx
+++ b/web/src/pages/legal/PrivacyPage.tsx
@@ -66,6 +66,11 @@ export default function PrivacyPage() {
             approximate location, and in-app actions.
           </li>
           <li>
+            <strong>Public page social content</strong> – if you enable a public
+            Sedifex page and connect social channels, we may display selected
+            TikTok and YouTube content on that public page.
+          </li>
+          <li>
             <strong>Support information</strong> – messages and attachments sent
             through support channels.
           </li>

--- a/web/src/pages/legal/TermsPage.tsx
+++ b/web/src/pages/legal/TermsPage.tsx
@@ -79,7 +79,9 @@ export default function TermsPage() {
         <h2 className="text-xl font-semibold">6. Third-party services</h2>
         <p>
           Some features depend on third-party services (for example, payment processors or social
-          integration providers). Their services are subject to their own terms and policies.
+          integration providers). Sedifex may offer a public-facing page for your business that can
+          display your TikTok and YouTube content where you choose to connect those channels. Their
+          services are subject to their own terms and policies.
         </p>
       </section>
 


### PR DESCRIPTION
### Motivation
- Clarify that Sedifex may offer a public-facing business page that can surface user-connected TikTok and YouTube content and ensure this is reflected in both Terms of Service and the Privacy Policy.

### Description
- Add wording to `web/src/pages/legal/TermsPage.tsx` and `web/src/pages/legal/PrivacyPage.tsx` to note the public page feature and introduce a `Public page social content` data category describing that selected TikTok and YouTube content may be displayed when channels are connected.

### Testing
- Ran the lint script with `cd web && npm run lint`, which failed in this environment due to a missing dependency (`@eslint/js`) required by `web/eslint.config.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e46dfdc88322b17284093a915f03)