### PR TITLE
Redirect /login to authentication entrypoint

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -54,6 +54,7 @@ const router = createBrowserRouter([
   // Public receipt route bypasses App-level redirects
   { path: '/receipt/:saleId', element: <ReceiptView /> },
   { path: '/promo/:slug', element: <PromoLandingPage /> },
+  { path: '/login', element: <Navigate to="/" replace /> },
   { path: '/:slug', element: <PromoLandingPage /> },
   { path: '/customer-display', element: <CustomerDisplay /> },
   { path: '/display', element: <CustomerDisplay /> },


### PR DESCRIPTION
### Motivation
- Prevent `/login` from being captured by the generic `/:slug` promo route which caused `https://sedifex.com/login` to error instead of showing the login experience.

### Description
- Added an explicit route in `web/src/main.tsx`: `{ path: '/login', element: <Navigate to="/" replace /> }` so `/login` now redirects to the app root (the authentication entrypoint for signed-out users).

### Testing
- Attempted to run `npm --prefix web run test -- src/pages/AuthPage.test.tsx`, but the test runner could not execute because `vitest` is not available in this environment (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea263d948c83229ec6a3fb61e994b2)