### PR TITLE
Remove WhatsApp floating chat CTA from auth landing page

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -102,35 +102,6 @@ body {
   z-index: 1;
 }
 
-.app-whatsapp-float {
-  position: fixed;
-  right: 18px;
-  bottom: 18px;
-  z-index: 60;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 48px;
-  border-radius: 999px;
-  padding: 10px 18px;
-  text-decoration: none;
-  font-weight: 700;
-  color: #ffffff;
-  background: linear-gradient(135deg, #16a34a, #15803d);
-  box-shadow:
-    0 16px 28px rgba(21, 128, 61, 0.33),
-    0 0 0 1px rgba(255, 255, 255, 0.22) inset;
-}
-
-.app-whatsapp-float:hover {
-  background: linear-gradient(135deg, #15803d, #166534);
-}
-
-.app-whatsapp-float:focus-visible {
-  outline: 3px solid rgba(22, 163, 74, 0.35);
-  outline-offset: 2px;
-}
-
 .app__pricing {
   width: min(1280px, 100%);
   display: grid;

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -38,7 +38,6 @@ const AUTH_VISUAL_IMAGE_URL =
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const PASSWORD_MIN_LENGTH = 8
 const MAX_BLOG_POSTS = 3
-const LANDING_WHATSAPP_NUMBER = '0205706589'
 
 type AuthMode = 'login' | 'signup'
 type StatusTone = 'idle' | 'loading' | 'success' | 'error'
@@ -735,7 +734,6 @@ export default function AuthPage() {
   }
 
   const appStyle: React.CSSProperties = { minHeight: '100dvh' }
-  const landingSupportWhatsappLink = `https://wa.me/${LANDING_WHATSAPP_NUMBER}?text=${encodeURIComponent('Hello Sedifex team, I need help getting started.')}`
 
   return (
     <main className="app" style={appStyle}>
@@ -1341,15 +1339,6 @@ export default function AuthPage() {
           </ul>
         </article>
       </section>
-      <a
-        className="app-whatsapp-float"
-        href={landingSupportWhatsappLink}
-        target="_blank"
-        rel="noreferrer noopener"
-        aria-label={`Reach out on WhatsApp at ${LANDING_WHATSAPP_NUMBER}`}
-      >
-        WhatsApp us: {LANDING_WHATSAPP_NUMBER}
-      </a>
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- The auth/landing page included a persistent WhatsApp support CTA floated at the bottom-right which should not appear on the landing experience.
- Cleaning up the unused landing WhatsApp link and related styles reduces UI clutter and removes unused constants.

### Description
- Removed the floating WhatsApp CTA markup and the `LANDING_WHATSAPP_NUMBER` / `landingSupportWhatsappLink` usage from `web/src/pages/AuthPage.tsx`.
- Deleted the `.app-whatsapp-float` CSS rules from `web/src/App.css` so no dangling styles remain.
- Changes affect `web/src/pages/AuthPage.tsx` and `web/src/App.css` and do not modify other app logic or routes.

### Testing
- Attempted a production build with `npm -C web run build`, which failed in this environment due to missing TypeScript type definitions for `vite/client` and `vitest/globals` (build failure unrelated to the UI change).
- No unit tests were added or removed; existing test suite was not executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed815d99b88321917351dc68e8217a)