### PR TITLE
Refine bookings page copy and improve empty-state readability

### DIFF
--- a/web/src/pages/Bookings.css
+++ b/web/src/pages/Bookings.css
@@ -103,3 +103,26 @@
   font-weight: 600;
   word-break: break-word;
 }
+
+
+.bookings-page__summary,
+.bookings-page__empty-title,
+.bookings-page__empty-text {
+  color: #111827;
+}
+
+.bookings-page__summary {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.bookings-page__empty-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.bookings-page__empty-text {
+  margin: 0;
+  font-size: 0.95rem;
+}

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -397,9 +397,9 @@ export default function Bookings() {
         <header className="stack gap-1">
           <h1>Bookings</h1>
           <p className="bookings-page__intro">
-            Every website booking appears here in real time, including new appointments, reschedules, and cancellations, so your calendar always reflects the latest client
-            activity without manual updates. When a booking includes a phone number or email, we automatically map those contact details into Customers to reduce duplicate
-            entries, preserve complete client history, and make it easier for your team to confirm visits, send reminders, and deliver faster support.
+            Connect your website booking form to Sedifex and every new booking, reschedule, or cancellation will appear here in real time.
+            If you prefer, your team can also add bookings manually using <strong>Add booking</strong>.
+            When a booking includes a phone number or email, Sedifex automatically links it to the customer profile to keep history complete and avoid duplicates.
           </p>
           <Link to="/bookings/new" className="btn btn-secondary">
             Add booking
@@ -462,9 +462,8 @@ export default function Bookings() {
         )}
         {!loading && !errorMessage && (
           <>
-            <p className="form__hint">
-              Total bookings: <strong>{bookings.length}</strong> • Confirmed: <strong>{confirmedCount}</strong> • Page:{' '}
-              <strong>{pageNumber}</strong>
+            <p className="bookings-page__summary">
+              Total bookings: <strong>{bookings.length}</strong> • Confirmed: <strong>{confirmedCount}</strong> • Page: <strong>{pageNumber}</strong>
             </p>
             {filteredBookings.length ? (
               <>
@@ -545,9 +544,9 @@ export default function Bookings() {
               </>
             ) : (
               <div className="stack gap-2">
-                <p className="form__hint">No bookings yet.</p>
-                <p className="form__hint">
-                  Set up your booking widget and integration to start receiving appointments.
+                <p className="bookings-page__empty-title">No bookings yet.</p>
+                <p className="bookings-page__empty-text">
+                  Connect your website to Sedifex bookings, or add appointments manually to get started.
                 </p>
                 <Link to="/docs/integration-quickstart" className="btn btn-secondary" style={{ width: 'fit-content' }}>
                   Open integration guide


### PR DESCRIPTION
### Motivation

- Make the Bookings page copy clearer and more actionable by telling stores they can connect their website to Sedifex for real-time bookings or add appointments manually. 
- Improve readability of the booking summary and empty-state messaging because the original text was too light and low-contrast.

### Description

- Rewrote the intro copy in `web/src/pages/Bookings.tsx` to explicitly describe the two onboarding paths (website integration and manual `Add booking`).
- Replaced the lightweight summary and empty-state helper paragraphs with dedicated elements: `bookings-page__summary`, `bookings-page__empty-title`, and `bookings-page__empty-text` in `web/src/pages/Bookings.tsx`.
- Added new styles in `web/src/pages/Bookings.css` for `bookings-page__summary`, `bookings-page__empty-title`, and `bookings-page__empty-text` to increase contrast and improve typography.

### Testing

- Attempted to run the web linter with `cd /workspace/sedifex/web && npm run -s lint`, which failed due to a missing ESLint dependency (`@eslint/js`).
- No other automated tests were run in this environment; files were committed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e515c7d08321b319d246cc0858b4)