### PR TITLE
Add Google Business as a supported social platform for post generation

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -251,7 +251,8 @@ function normalizeAiAdvicePayload(raw: GenerateAiAdvicePayload | undefined) {
 function normalizeSocialPostPayload(raw: GenerateSocialPostPayload | undefined) {
   const storeId = typeof raw?.storeId === 'string' ? raw.storeId.trim() : ''
   const platformRaw = typeof raw?.platform === 'string' ? raw.platform.trim().toLowerCase() : ''
-  const platform = platformRaw === 'tiktok' ? 'tiktok' : 'instagram'
+  const platform =
+    platformRaw === 'tiktok' ? 'tiktok' : platformRaw === 'google_business' ? 'google_business' : 'instagram'
   const productId = typeof raw?.productId === 'string' ? raw.productId.trim() : ''
 
   const productRaw =
@@ -1444,9 +1445,9 @@ export const generateSocialPost = functions.https.onCall(
       `Workspace: ${storeId}`,
       `Platform: ${platform}`,
       'Return JSON schema:',
-      '{"platform":"instagram|tiktok","caption":"string","hashtags":["#tag"],"imagePrompt":"string","cta":"string","designSpec":{"aspectRatio":"string","safeTextZones":["string"],"visualStyle":"string"},"disclaimer":"string|null"}',
+      '{"platform":"instagram|tiktok|google_business","caption":"string","hashtags":["#tag"],"imagePrompt":"string","cta":"string","designSpec":{"aspectRatio":"string","safeTextZones":["string"],"visualStyle":"string"},"disclaimer":"string|null"}',
       'Rules:',
-      '- caption max 220 chars for instagram, 150 chars for tiktok.',
+      '- caption max 220 chars for instagram, 150 chars for tiktok, 1500 chars for google_business.',
       '- hashtags: 5 to 10 relevant hashtags.',
       '- include clear CTA.',
       '- if price or measurable claim appears, add disclaimer; else null.',
@@ -1511,7 +1512,12 @@ export const generateSocialPost = functions.https.onCall(
       throw new functions.https.HttpsError('internal', 'AI returned invalid JSON for social post.')
     }
 
-    const safePlatform = parsed.platform === 'tiktok' ? 'tiktok' : 'instagram'
+    const safePlatform =
+      parsed.platform === 'tiktok'
+        ? 'tiktok'
+        : parsed.platform === 'google_business'
+          ? 'google_business'
+          : 'instagram'
     const safeHashtags = Array.isArray(parsed.hashtags)
       ? parsed.hashtags
           .map(tag => (typeof tag === 'string' ? tag.trim() : ''))

--- a/web/src/api/socialPost.ts
+++ b/web/src/api/socialPost.ts
@@ -3,7 +3,7 @@ import { FirebaseError } from 'firebase/app'
 import { functions } from '../firebase'
 import { requestAiAdvisor } from './aiAdvisor'
 
-export type SocialPlatform = 'instagram' | 'tiktok'
+export type SocialPlatform = 'instagram' | 'tiktok' | 'google_business'
 
 export type SocialPostProductPayload = {
   id?: string
@@ -67,7 +67,7 @@ async function requestSocialPostFallback(payload: GenerateSocialPostPayload): Pr
     'Generate a social media post draft as strict JSON only (no markdown, no prose).',
     `Platform: ${payload.platform}`,
     'Return this schema exactly:',
-    '{"platform":"instagram|tiktok","caption":"string","hashtags":["#tag"],"imagePrompt":"string","cta":"string","designSpec":{"aspectRatio":"string","safeTextZones":["string"],"visualStyle":"string"},"disclaimer":"string|null"}',
+    '{"platform":"instagram|tiktok|google_business","caption":"string","hashtags":["#tag"],"imagePrompt":"string","cta":"string","designSpec":{"aspectRatio":"string","safeTextZones":["string"],"visualStyle":"string"},"disclaimer":"string|null"}',
     'Product JSON:',
     JSON.stringify(product).slice(0, 3_000),
   ].join('\n')
@@ -103,7 +103,12 @@ async function requestSocialPostFallback(payload: GenerateSocialPostPayload): Pr
       itemType: product.itemType === 'service' || product.itemType === 'made_to_order' ? product.itemType : 'product',
     },
     post: {
-      platform: parsed.platform === 'tiktok' ? 'tiktok' : payload.platform,
+      platform:
+        parsed.platform === 'tiktok'
+          ? 'tiktok'
+          : parsed.platform === 'google_business'
+            ? 'google_business'
+            : payload.platform,
       caption: typeof parsed.caption === 'string' ? parsed.caption.trim() : '',
       hashtags,
       imagePrompt: typeof parsed.imagePrompt === 'string' ? parsed.imagePrompt.trim() : '',

--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -33,6 +33,8 @@ body.shell--menu-open {
 
 .shell__header-controls {
   margin-left: auto;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .shell__toolbar {
@@ -297,6 +299,7 @@ body.shell--menu-open {
   gap: 12px;
   flex-wrap: wrap;
   justify-content: flex-end;
+  min-width: 0;
 }
 
 .shell__store-switcher {
@@ -362,12 +365,19 @@ body.shell--menu-open {
   padding: 6px 10px;
   background: #eef2ff;
   border-radius: 999px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .shell__account-email {
   font-size: 13px;
   color: #4338ca;
   font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: min(36vw, 260px);
 }
 
 .shell__main {

--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -26,7 +26,7 @@ type ProductOption = {
 type RegenerateTarget = 'all' | 'caption' | 'hashtags'
 type ContentTone = 'standard' | 'playful' | 'professional'
 type ContentLength = 'short' | 'medium' | 'long'
-type LaunchPlatformTarget = 'instagram' | 'tiktok'
+type LaunchPlatformTarget = 'instagram' | 'tiktok' | 'google_business'
 type SocialHistoryEntry = {
   id: string
   createdAtIso: string
@@ -557,7 +557,7 @@ export default function SocialMediaPage() {
     if (copied) {
       publish({
         tone: 'success',
-        message: `Draft copied with image link. Paste it in ${target === 'instagram' ? 'Instagram' : 'TikTok'}.`,
+        message: `Draft copied with image link. Paste it in ${target === 'instagram' ? 'Instagram' : target === 'tiktok' ? 'TikTok' : 'Google Business Profile'}.`,
       })
     } else {
       publish({
@@ -566,7 +566,12 @@ export default function SocialMediaPage() {
       })
     }
 
-    const destination = target === 'instagram' ? 'https://www.instagram.com/' : 'https://www.tiktok.com/upload?lang=en'
+    const destination =
+      target === 'instagram'
+        ? 'https://www.instagram.com/'
+        : target === 'tiktok'
+          ? 'https://www.tiktok.com/upload?lang=en'
+          : 'https://business.google.com/'
     window.open(destination, '_blank', 'noopener,noreferrer')
   }
 
@@ -580,7 +585,7 @@ export default function SocialMediaPage() {
       'Manual upload steps:',
       '1. Open the original image link.',
       '2. Hold (mobile) or right-click (desktop) the picture to save it.',
-      `3. Upload image in the ${result.post.platform === 'instagram' ? 'Instagram' : 'TikTok'} app.`,
+      `3. Upload image in the ${result.post.platform === 'instagram' ? 'Instagram' : result.post.platform === 'tiktok' ? 'TikTok' : 'Google Business Profile'} app.`,
       '4. Paste caption + hashtags + image link.',
       '',
       'Draft content:',
@@ -605,7 +610,7 @@ export default function SocialMediaPage() {
 
 
   return (
-    <PageSection title="Social media" subtitle="Generate Instagram or TikTok-ready captions, hashtags, and CTA from your existing product catalog.">
+    <PageSection title="Social media" subtitle="Generate Instagram, TikTok, or Google Business-ready captions, hashtags, and CTA from your existing product catalog.">
       <div
         style={{ display: 'grid', gap: 12 }}
         onKeyDown={event => {
@@ -620,6 +625,7 @@ export default function SocialMediaPage() {
           <select aria-labelledby="social-platform-label" value={platform} onChange={event => setPlatform(event.target.value as SocialPlatform)}>
             <option value="instagram">Instagram</option>
             <option value="tiktok">TikTok</option>
+            <option value="google_business">Google Business</option>
           </select>
         </label>
 
@@ -735,7 +741,7 @@ export default function SocialMediaPage() {
               </p>
             ) : null}
             <p style={{ margin: 0, fontSize: 13, opacity: 0.8 }}>
-              Step 1: Open original image and hold/right-click the picture to save. Step 2: Use Send to Instagram/TikTok (or open app manually). Step 3: Paste caption + hashtags + image link.
+              Step 1: Open original image and hold/right-click the picture to save. Step 2: Use Send to Instagram/TikTok/Google Business (or open app manually). Step 3: Paste caption + hashtags + image link.
             </p>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
               <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('instagram')}>
@@ -743,6 +749,9 @@ export default function SocialMediaPage() {
               </button>
               <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('tiktok')}>
                 Send to TikTok
+              </button>
+              <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('google_business')}>
+                Send to Google Business
               </button>
               <button type="button" className="button secondary" onClick={() => void handleCopyPost()}>Copy text + image link</button>
               <button type="button" className="button secondary" onClick={handleDownload}>Download .txt</button>


### PR DESCRIPTION
### Motivation
- Extend social post generation to support Google Business Profile (GBP) alongside Instagram and TikTok and ensure UI and backend handle the new platform consistently.
- Fix header/control layout overflow in the shell to prevent long account emails or control groups from breaking layout.

### Description
- Backend: extended `normalizeSocialPostPayload` platform parsing to accept `google_business`, updated the AI prompt schema to include `google_business`, and updated response sanitization (`safePlatform`) to allow `google_business` as a valid platform.
- Web API: added `google_business` to the `SocialPlatform` type and updated the fallback prompt in `requestSocialPostFallback` and its parsed `platform` handling to support `google_business`.
- UI: updated `SocialMediaPage` to offer `Google Business` as a selectable platform, added a send destination URL for Google Business, adjusted user-facing messages and download text to mention Google Business, and added a `Send to Google Business` action button.
- Styling: adjusted `Shell.css` to add `min-width` and overflow handling for header controls and account email to prevent layout breakage.

### Testing
- Performed a local TypeScript build (`yarn build`) to ensure compilation and type-checking succeeded.
- Ran a manual dev smoke test of the Social Media page in the local app to verify platform selection, send/copy/download flows, and that generated posts accept and return `google_business` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa01779650832183b5840a5fbfff99)