### PR TITLE
Add integrations hub to Account → Integrations for clearer navigation

### DIFF
--- a/web/src/pages/AccountOverview.css
+++ b/web/src/pages/AccountOverview.css
@@ -287,6 +287,27 @@
   color: #1e3a8a;
 }
 
+.account-overview__integration-hub {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.account-overview__integration-hub-card {
+  border: 1px solid #bfdbfe;
+  border-radius: 10px;
+  background: #fff;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.account-overview__integration-hub-card h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
 .account-overview__website-sync-actions {
   display: flex;
   flex-wrap: wrap;

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -2130,6 +2130,48 @@ export default function AccountOverview({
 
           <div className="account-overview__website-sync" role="status" aria-live="polite">
             <p className="account-overview__website-sync-title">Choose your integration tutorial.</p>
+            <div className="account-overview__integration-hub">
+              <article className="account-overview__integration-hub-card">
+                <h3>Website integration</h3>
+                <p className="account-overview__hint">
+                  API keys, webhooks, and endpoint testing for WordPress/Next.js websites.
+                </p>
+                <button type="button" className="button button--secondary" onClick={() => setIntegrationTab('keys')}>
+                  Open website setup
+                </button>
+              </article>
+              <article className="account-overview__integration-hub-card">
+                <h3>Bookings</h3>
+                <p className="account-overview__hint">
+                  Manage booking records on the dedicated bookings page and configure booking mapping.
+                </p>
+                <div className="account-overview__website-sync-actions">
+                  <Link to="/bookings" className="button button--secondary">Open bookings page</Link>
+                  <button type="button" className="button button--secondary" onClick={() => setIntegrationTab('booking')}>
+                    Booking setup
+                  </button>
+                </div>
+              </article>
+              <article className="account-overview__integration-hub-card">
+                <h3>Bulk email</h3>
+                <p className="account-overview__hint">
+                  Send campaigns from the Bulk Email page and keep delivery credentials in one place.
+                </p>
+                <div className="account-overview__website-sync-actions">
+                  <Link to="/bulk-email" className="button button--secondary">Open bulk email page</Link>
+                  <button type="button" className="button button--secondary" onClick={() => setIntegrationTab('email')}>
+                    Email setup
+                  </button>
+                </div>
+              </article>
+              <article className="account-overview__integration-hub-card">
+                <h3>Google Business</h3>
+                <p className="account-overview__hint">
+                  Prepare Google Business content from Social Media and keep website integrations separate.
+                </p>
+                <Link to="/social-media" className="button button--secondary">Open social media page</Link>
+              </article>
+            </div>
             <div className="account-overview__tabs" aria-label="Integration sections">
               <button
                 type="button"


### PR DESCRIPTION
### Motivation
- The Integrations area in Account was long and mixed multiple flows (website, bookings, bulk email, social/Google) causing duplicated setup and poor discoverability.
- Surface top-level entry points so each integration workflow can live on its own page while still allowing quick access to the original setup tabs.

### Description
- Added an integrations hub UI to `web/src/pages/AccountOverview.tsx` with cards for Website integration, Bookings, Bulk email, and Google Business that provide direct actions and shortcut buttons to open the related setup tab or dedicated page (`/bookings`, `/bulk-email`, `/social-media`).
- The new hub cards call `setIntegrationTab(...)` to jump to existing setup sections and use `Link` to navigate to dedicated pages for each workflow.
- Introduced responsive grid and card styles in `web/src/pages/AccountOverview.css` (`.account-overview__integration-hub`, `.account-overview__integration-hub-card`) to improve scanability and layout.

### Testing
- Attempted to run the integration page unit test with `npm --prefix web test -- --run web/src/pages/__tests__/AccountOverview.test.tsx` but the test run failed in this environment due to `vitest: not found` so automated tests could not be executed here.
- Verified the changes compile locally in the editor and inspected the updated markup and styles via code review of `AccountOverview.tsx` and `AccountOverview.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb66a85d308321a048eaa928d82b28)