### PR TITLE
Refactor integrations hub into concise Overview and dedicated settings routes

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -33,6 +33,10 @@ import PromoLandingPage from './pages/PromoLandingPage'
 import PublicPageSettings from './pages/PublicPageSettings'
 import SocialMediaPage from './pages/SocialMediaPage'
 import BookingMappingSettings from './pages/BookingMappingSettings'
+import IntegrationWebsiteSettings from './pages/IntegrationWebsiteSettings'
+import IntegrationBookingsSettings from './pages/IntegrationBookingsSettings'
+import IntegrationEmailSettings from './pages/IntegrationEmailSettings'
+import IntegrationGoogleBusinessSettings from './pages/IntegrationGoogleBusinessSettings'
 
 // ✅ NEW: public receipt page used by QR/share
 import ReceiptView from './pages/ReceiptView'
@@ -105,6 +109,10 @@ const router = createBrowserRouter([
           { path: 'merchant-feed', element: <Navigate to="/social-media" replace /> },
           { path: 'support', element: <Support /> },
           { path: 'settings/integrations/booking-mapping', element: <BookingMappingSettings /> },
+          { path: 'settings/integrations/website', element: <IntegrationWebsiteSettings /> },
+          { path: 'settings/integrations/bookings', element: <IntegrationBookingsSettings /> },
+          { path: 'settings/integrations/email', element: <IntegrationEmailSettings /> },
+          { path: 'settings/integrations/google-business', element: <IntegrationGoogleBusinessSettings /> },
         ],
       },
 

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -380,6 +380,8 @@ type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4'
 type AccountOverviewProps = {
   headingLevel?: HeadingLevel
   viewMode?: 'full' | 'promotions'
+  defaultAccountTab?: AccountTab
+  defaultIntegrationTab?: IntegrationTab
 }
 
 type AccountTab =
@@ -396,6 +398,8 @@ type IntegrationTab = 'overview' | 'keys' | 'booking' | 'webhooks' | 'email' | '
 export default function AccountOverview({
   headingLevel = 'h1',
   viewMode = 'full',
+  defaultAccountTab = 'workspace',
+  defaultIntegrationTab = 'overview',
 }: AccountOverviewProps) {
   const { storeId, isLoading: storeLoading, error: storeError } = useActiveStore()
   const {
@@ -440,8 +444,8 @@ export default function AccountOverview({
   const [logoImageUploadError, setLogoImageUploadError] = useState<string | null>(null)
   const [isSavingProfile, setIsSavingProfile] = useState(false)
   const [isEditingProfile, setIsEditingProfile] = useState(false)
-  const [activeTab, setActiveTab] = useState<AccountTab>('workspace')
-  const [integrationTab, setIntegrationTab] = useState<IntegrationTab>('overview')
+  const [activeTab, setActiveTab] = useState<AccountTab>(defaultAccountTab)
+  const [integrationTab, setIntegrationTab] = useState<IntegrationTab>(defaultIntegrationTab)
 
   const [isSavingPromo, setIsSavingPromo] = useState(false)
   const [promoDraft, setPromoDraft] = useState({
@@ -2131,45 +2135,56 @@ export default function AccountOverview({
           <div className="account-overview__website-sync" role="status" aria-live="polite">
             <p className="account-overview__website-sync-title">Choose your integration tutorial.</p>
             <div className="account-overview__integration-hub">
-              <article className="account-overview__integration-hub-card">
-                <h3>Website integration</h3>
-                <p className="account-overview__hint">
+              <article className="account-overview__integration-hub-card" role="region" aria-labelledby="hub-website-title" aria-describedby="hub-website-hint">
+                <h3 id="hub-website-title">Website integration</h3>
+                <p className="account-overview__hint" id="hub-website-hint">
                   API keys, webhooks, and endpoint testing for WordPress/Next.js websites.
                 </p>
-                <button type="button" className="button button--secondary" onClick={() => setIntegrationTab('keys')}>
-                  Open website setup
-                </button>
+                <p className="account-overview__hint"><strong>Status:</strong> {integrationApiKeys.length} active API keys</p>
+                <div className="account-overview__website-sync-actions">
+                  <Link to="/settings/integrations/website" className="button button--secondary">Open settings page</Link>
+                  <button type="button" className="button button--secondary" onClick={() => setIntegrationTab('keys')}>Open tab</button>
+                </div>
               </article>
-              <article className="account-overview__integration-hub-card">
-                <h3>Bookings</h3>
-                <p className="account-overview__hint">
+              <article className="account-overview__integration-hub-card" role="region" aria-labelledby="hub-bookings-title" aria-describedby="hub-bookings-hint">
+                <h3 id="hub-bookings-title">Bookings</h3>
+                <p className="account-overview__hint" id="hub-bookings-hint">
                   Manage booking records on the dedicated bookings page and configure booking mapping.
                 </p>
+                <p className="account-overview__hint"><strong>Status:</strong> {webhookEndpoints.some(endpoint => endpoint.hasSecret) ? 'Mapping configured' : 'Mapping missing'}</p>
                 <div className="account-overview__website-sync-actions">
                   <Link to="/bookings" className="button button--secondary">Open bookings page</Link>
+                  <Link to="/settings/integrations/bookings" className="button button--secondary">Bookings settings</Link>
                   <button type="button" className="button button--secondary" onClick={() => setIntegrationTab('booking')}>
                     Booking setup
                   </button>
                 </div>
               </article>
-              <article className="account-overview__integration-hub-card">
-                <h3>Bulk email</h3>
-                <p className="account-overview__hint">
+              <article className="account-overview__integration-hub-card" role="region" aria-labelledby="hub-email-title" aria-describedby="hub-email-hint">
+                <h3 id="hub-email-title">Bulk email</h3>
+                <p className="account-overview__hint" id="hub-email-hint">
                   Send campaigns from the Bulk Email page and keep delivery credentials in one place.
                 </p>
+                <p className="account-overview__hint"><strong>Status:</strong> {bulkEmailWebAppUrl ? 'Connected' : 'Not configured'}</p>
                 <div className="account-overview__website-sync-actions">
                   <Link to="/bulk-email" className="button button--secondary">Open bulk email page</Link>
+                  <Link to="/settings/integrations/email" className="button button--secondary">Email settings</Link>
                   <button type="button" className="button button--secondary" onClick={() => setIntegrationTab('email')}>
                     Email setup
                   </button>
                 </div>
               </article>
-              <article className="account-overview__integration-hub-card">
-                <h3>Google Business</h3>
-                <p className="account-overview__hint">
-                  Prepare Google Business content from Social Media and keep website integrations separate.
+              <article className="account-overview__integration-hub-card" role="region" aria-labelledby="hub-google-title" aria-describedby="hub-google-hint">
+                <h3 id="hub-google-title">Google Business</h3>
+                <p className="account-overview__hint" id="hub-google-hint">
+                  Connect Google account and prepare Google Business content from Social Media.
                 </p>
-                <Link to="/social-media" className="button button--secondary">Open social media page</Link>
+                <p className="account-overview__hint"><strong>Status:</strong> {profile.googleBusinessConnected ? `Connected (${profile.googleBusinessEmail || 'Google account'})` : 'Not connected'}</p>
+                <div className="account-overview__website-sync-actions">
+                  <a href={`/api/google/oauth-start?storeId=${encodeURIComponent(storeId)}&integration=business`} className="button button--secondary">{profile.googleBusinessConnected ? 'Reconnect Google account' : 'Connect Google account'}</a>
+                  <Link to="/settings/integrations/google-business" className="button button--secondary">Google settings</Link>
+                  <Link to="/social-media" className="button button--secondary">Disconnect in Social Media</Link>
+                </div>
               </article>
             </div>
             <div className="account-overview__tabs" aria-label="Integration sections">
@@ -2217,7 +2232,17 @@ export default function AccountOverview({
               </button>
             </div>
 
-            {(integrationTab === 'overview' || integrationTab === 'booking') && (
+            {integrationTab === 'overview' && (
+              <div className="account-overview__website-sync-keys">
+                <p className="account-overview__hint"><strong>Integration health summary</strong></p>
+                <p className="account-overview__hint">Website: {integrationApiKeys.length} active API keys</p>
+                <p className="account-overview__hint">Bookings: {webhookEndpoints.some(endpoint => endpoint.hasSecret) ? 'Mapping configured' : 'Mapping missing'}</p>
+                <p className="account-overview__hint">Bulk email: {bulkEmailWebAppUrl ? 'Connected' : 'Not configured'}</p>
+                <p className="account-overview__hint">Google Business: {profile.googleBusinessConnected ? 'Connected' : 'Not connected'}</p>
+              </div>
+            )}
+
+            {integrationTab === 'booking' && (
               <>
             <p className="account-overview__hint">
               Booking ingestion mapping can be managed in
@@ -2281,7 +2306,7 @@ export default function AccountOverview({
             )}
               </>
             )}
-            {(integrationTab === 'overview' || integrationTab === 'keys') && (
+            {integrationTab === 'keys' && (
             <div className="account-overview__website-sync-actions">
               <button
                 type="button"
@@ -2300,7 +2325,7 @@ export default function AccountOverview({
               </button>
             </div>
             )}
-            {isOwner && (integrationTab === 'overview' || integrationTab === 'keys') && (
+            {isOwner && integrationTab === 'keys' && (
               <div className="account-overview__website-sync-test">
                 <label>
                   <span>New integration key name</span>
@@ -2321,7 +2346,7 @@ export default function AccountOverview({
                 </button>
               </div>
             )}
-            {isOwner && latestIntegrationToken && (integrationTab === 'overview' || integrationTab === 'keys') && (
+            {isOwner && latestIntegrationToken && integrationTab === 'keys' && (
               <div className="account-overview__integration-token-notice" role="status" aria-live="polite">
                 <p>
                   <strong>This is your integration key.</strong>
@@ -2332,7 +2357,7 @@ export default function AccountOverview({
                 <code className="account-overview__integration-token-value">{latestIntegrationToken}</code>
               </div>
             )}
-            {isOwner && (integrationTab === 'overview' || integrationTab === 'keys') && (
+            {isOwner && integrationTab === 'keys' && (
               <div className="account-overview__website-sync-keys">
                 <p className="account-overview__hint">Active integration keys</p>
                 {integrationKeysLoading ? (
@@ -2377,7 +2402,7 @@ export default function AccountOverview({
                 )}
               </div>
             )}
-            {isOwner && (integrationTab === 'overview' || integrationTab === 'webhooks') && (
+            {isOwner && integrationTab === 'webhooks' && (
               <div className="account-overview__website-sync-keys">
                 <p className="account-overview__hint">Sedifex booking webhooks</p>
                 <p className="account-overview__hint">
@@ -2448,7 +2473,7 @@ export default function AccountOverview({
                 )}
               </div>
             )}
-            {(integrationTab === 'overview' || integrationTab === 'email') && (
+            {integrationTab === 'email' && (
               <div className="account-overview__website-sync-keys">
                 <p className="account-overview__hint">Bulk email delivery integration</p>
                 <p className="account-overview__hint">
@@ -2494,7 +2519,7 @@ export default function AccountOverview({
                 </div>
               </div>
             )}
-            {(integrationTab === 'overview' || integrationTab === 'tests') && (
+            {integrationTab === 'tests' && (
             <div className="account-overview__website-sync-test">
               <label>
                 <span>Test your endpoint</span>

--- a/web/src/pages/IntegrationBookingsSettings.tsx
+++ b/web/src/pages/IntegrationBookingsSettings.tsx
@@ -1,0 +1,5 @@
+import AccountOverview from './AccountOverview'
+
+export default function IntegrationBookingsSettings() {
+  return <AccountOverview headingLevel="h2" defaultAccountTab="integrations" defaultIntegrationTab="booking" />
+}

--- a/web/src/pages/IntegrationEmailSettings.tsx
+++ b/web/src/pages/IntegrationEmailSettings.tsx
@@ -1,0 +1,5 @@
+import AccountOverview from './AccountOverview'
+
+export default function IntegrationEmailSettings() {
+  return <AccountOverview headingLevel="h2" defaultAccountTab="integrations" defaultIntegrationTab="email" />
+}

--- a/web/src/pages/IntegrationGoogleBusinessSettings.tsx
+++ b/web/src/pages/IntegrationGoogleBusinessSettings.tsx
@@ -1,0 +1,5 @@
+import AccountOverview from './AccountOverview'
+
+export default function IntegrationGoogleBusinessSettings() {
+  return <AccountOverview headingLevel="h2" defaultAccountTab="integrations" defaultIntegrationTab="overview" />
+}

--- a/web/src/pages/IntegrationWebsiteSettings.tsx
+++ b/web/src/pages/IntegrationWebsiteSettings.tsx
@@ -1,0 +1,5 @@
+import AccountOverview from './AccountOverview'
+
+export default function IntegrationWebsiteSettings() {
+  return <AccountOverview headingLevel="h2" defaultAccountTab="integrations" defaultIntegrationTab="keys" />
+}

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -750,4 +750,35 @@ describe('AccountOverview', () => {
       }),
     )
   })
-})
+
+  it('shows integration settings links and overview health cards', async () => {
+    render(<AccountOverview defaultAccountTab="integrations" />)
+
+    expect(await screen.findByRole('link', { name: /open settings page/i })).toHaveAttribute('href', '/settings/integrations/website')
+    expect(screen.getByRole('link', { name: /bookings settings/i })).toHaveAttribute('href', '/settings/integrations/bookings')
+    expect(screen.getByRole('link', { name: /email settings/i })).toHaveAttribute('href', '/settings/integrations/email')
+    expect(screen.getByRole('link', { name: /google settings/i })).toHaveAttribute('href', '/settings/integrations/google-business')
+    expect(screen.getByText(/integration health summary/i)).toBeInTheDocument()
+  })
+
+  it('switches integration sections from shortcut buttons', async () => {
+    render(<AccountOverview defaultAccountTab="integrations" />)
+
+    await userEvent.click(await screen.findByRole('button', { name: /booking setup/i }))
+    expect(await screen.findByText(/booking ingestion mapping can be managed in/i)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /email setup/i }))
+    expect(await screen.findByText(/bulk email delivery integration/i)).toBeInTheDocument()
+  })
+
+  it('keeps owner-only integration key controls restricted for non-owners', async () => {
+    mockUseMemberships.mockReturnValue({
+      memberships: [{ storeId: 'store-123', role: 'staff', status: 'active', email: 'staff@example.com' }],
+      loading: false,
+      error: null,
+    })
+
+    render(<AccountOverview defaultAccountTab="integrations" defaultIntegrationTab="keys" />)
+    expect(await screen.findByRole('button', { name: /copy api token/i })).toBeInTheDocument()
+    expect(screen.queryByText(/new integration key name/i)).not.toBeInTheDocument()
+  })


### PR DESCRIPTION
### Motivation
- Reduce duplication and visual noise by making the Integrations Overview only show navigation cards and a short health summary instead of all setup forms.
- Provide true, focused settings pages for each integration so the Account page becomes a directory rather than a giant form page.
- Expose Google connect/reconnect flow in the integration hub and surface per-integration health to reduce clicks.
- Improve accessibility semantics for hub cards (defined regions, labelled headings/descriptions) and keep owner-only controls restricted.

### Description
- Updated `AccountOverview` to accept `defaultAccountTab` and `defaultIntegrationTab` props and use them for initial state, and adjusted integration rendering so detailed forms are only shown in their specific `integrationTab` (e.g. `keys`, `booking`, `webhooks`, `email`, `tests`) instead of always rendering on `overview`.
- Converted hub cards into ARIA-friendly regions with `role="region"`, `aria-labelledby` and `aria-describedby`, added per-card status text (API keys count, booking mapping state, bulk email config, Google Business connection), and added an integration health summary shown when `integrationTab === 'overview'`.
- Added Google Business connect/reconnect CTA that links to the existing OAuth start endpoint (`/api/google/oauth-start?storeId=...&integration=business`), surfaces connection email/status, and provides a path to disconnect through Social Media settings.
- Added new dedicated route components (`IntegrationWebsiteSettings`, `IntegrationBookingsSettings`, `IntegrationEmailSettings`, `IntegrationGoogleBusinessSettings`) and wired routes under `/settings/integrations/*` in `web/src/main.tsx` to open `AccountOverview` into the appropriate integration tab.
- Expanded `web/src/pages/__tests__/AccountOverview.test.tsx` with tests that assert integration settings links route correctly, shortcut buttons switch integration sections, and owner-only controls remain hidden for non-owners.

### Testing
- Added/updated unit tests in `web/src/pages/__tests__/AccountOverview.test.tsx` to cover hub links, shortcut button interactions, and owner-only control restrictions; tests were added to the repo but could not be executed in this environment because the test runner binary is missing.
- Attempted to run `cd web && npm test -- AccountOverview.test.tsx --runInBand`, which failed here with `vitest: not found` (test runner not available in PATH), so automated tests were not executed in CI during this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb699628e08321941638e01c636f04)