### PR TITLE
Rename integration API token label and add Google Business connect button

### DIFF
--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -2141,7 +2141,7 @@ export default function AccountOverview({
                 className={`account-overview__tab ${visibleIntegrationTab === 'keys' ? 'is-active' : ''}`}
                 onClick={() => setIntegrationTab('keys')}
               >
-                API tokens
+                Website API tokens
               </button>
               <button
                 type="button"
@@ -2246,7 +2246,7 @@ export default function AccountOverview({
                 onClick={handleCopyApiToken}
                 disabled={isCopyingApiToken}
               >
-                {isCopyingApiToken ? 'Copying token…' : 'Copy API token'}
+                {isCopyingApiToken ? 'Copying token…' : 'Copy website API token'}
               </button>
               <button
                 type="button"

--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -629,6 +629,16 @@ export default function SocialMediaPage() {
           </select>
         </label>
 
+        {platform === 'google_business' ? (
+          <button
+            type="button"
+            className="button secondary"
+            onClick={() => window.open('https://business.google.com/', '_blank', 'noopener,noreferrer')}
+          >
+            Connect to Google Business
+          </button>
+        ) : null}
+
         <label style={{ display: 'grid', gap: 6 }}>
           <span id="social-product-search-label">Search products or services</span>
           <input

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -365,7 +365,7 @@ describe('AccountOverview', () => {
     })
 
     expect(await screen.findByText('Turn on website sync.')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /copy api token/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /copy website api token/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /test endpoint/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /install on wordpress/i })).toHaveAttribute(
       'href',
@@ -779,6 +779,6 @@ describe('AccountOverview', () => {
     })
 
     render(<AccountOverview defaultAccountTab="integrations" defaultIntegrationTab="keys" />)
-    expect(await screen.findByRole('button', { name: /copy api token/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /copy website api token/i })).toBeInTheDocument()
     expect(screen.queryByText(/new integration key name/i)).not.toBeInTheDocument()
   })


### PR DESCRIPTION
### Motivation
- Clarify which API tokens apply to the website by renaming the generic "API tokens" label to "Website API tokens" in the integrations section. 
- Provide an explicit CTA on the Social Media page to let users connect their Google Business account when they choose the Google Business platform.

### Description
- Updated `web/src/pages/AccountOverview.tsx` to change the integrations tab label from `API tokens` to `Website API tokens` and to update the copy button text to `Copy website API token`.
- Added a conditional `Connect to Google Business` button in `web/src/pages/SocialMediaPage.tsx` that appears when `google_business` is selected and opens `https://business.google.com/` in a new tab.
- Updated `web/src/pages/__tests__/AccountOverview.test.tsx` to expect the renamed button label (`/copy website api token/i`).
- Changes are limited to UI text and a small conditional CTA; no backend logic was modified.

### Testing
- Ran the repository test command `cd /workspace/sedifex/web && npm test -- --run web/src/pages/__tests__/AccountOverview.test.tsx` and it failed in this environment because the test runner (`vitest`) is not available (`sh: 1: vitest: not found`).
- No other automated tests were executed in this environment after the changes; updated unit test expectations were committed to match the UI text changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb88a1f18083219cf804e8460adec2)