### PR TITLE
Clarify Google Business social posting flow

### DIFF
--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -630,13 +630,18 @@ export default function SocialMediaPage() {
         </label>
 
         {platform === 'google_business' ? (
-          <button
-            type="button"
-            className="button secondary"
-            onClick={() => window.open('https://business.google.com/', '_blank', 'noopener,noreferrer')}
-          >
-            Connect to Google Business
-          </button>
+          <div style={{ display: 'grid', gap: 8 }}>
+            <button
+              type="button"
+              className="button secondary"
+              onClick={() => window.open('https://business.google.com/', '_blank', 'noopener,noreferrer')}
+            >
+              Open Google Business Profile
+            </button>
+            <p style={{ margin: 0, fontSize: 13, opacity: 0.85 }}>
+              Sedifex generates the Google post draft for you, then copies caption + hashtags + image link. Final posting still happens inside Google Business Profile.
+            </p>
+          </div>
         ) : null}
 
         <label style={{ display: 'grid', gap: 6 }}>


### PR DESCRIPTION
### Motivation
- Clarify that Sedifex only generates and copies a Google post draft and that final publishing must be done in Google Business Profile to reduce user confusion.

### Description
- Update UI copy in `web/src/pages/SocialMediaPage.tsx` to rename the action to `Open Google Business Profile` and add a short explanatory paragraph describing the manual publish flow.

### Testing
- Ran `cd web && npm test -- --run SocialMediaPage.test.tsx` and the test command could not run because `vitest` is not available in the environment (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc87db73248321b74db73ac01d040a)