### PR TITLE
Add Google Business OAuth hint to Account → Integrations

### DIFF
--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -2132,6 +2132,13 @@ export default function AccountOverview({
             <p className="account-overview__subtitle">
               Manage integration settings for website, bookings, email, and webhooks.
             </p>
+            <p className="account-overview__hint">
+              Need Google Business OAuth? Open
+              {' '}
+              <Link to="/settings/integrations/google-business">Google settings</Link>
+              {' '}
+              and click <strong>Connect Google Business</strong>.
+            </p>
           </div>
           <div className="account-overview__website-sync" role="status" aria-live="polite">
             {!isFocusedIntegrationView && (


### PR DESCRIPTION
### Motivation
- Make the Google Business OAuth path discoverable from the Account → Integrations screen so users can find the flow shown in support docs and screenshots. 
- Align in-product guidance with the expected path to start OAuth for Google Business.

### Description
- Added an in-context help hint to `AccountOverview` under the Integrations section header that reads: “Need Google Business OAuth? Open `Google settings` and click **Connect Google Business**.”
- The hint includes a link that navigates to `/settings/integrations/google-business` and is rendered as a `<p className="account-overview__hint">` with a `Link` to the settings page in `web/src/pages/AccountOverview.tsx`.

### Testing
- Attempted to run the frontend test for `AccountOverview` with `cd web && npm test -- --run src/pages/__tests__/AccountOverview.test.tsx`, but the test runner failed because `vitest` is not available in the environment (`sh: 1: vitest: not found`).
- Attempted `npm test` from the repository root, but the command failed due to no `package.json` at the root, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf0ae3e348321a5245f9ce5eb8e2b)