### PR TITLE
Add queued webhook delivery with retries/dead-letter, clientOrderId dedupe, and webhook docs

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -579,6 +579,53 @@ Partner receiver requirements:
 
 Retry policy (when non-2xx or timeout): `1m`, `5m`, `30m`, `2h`, `12h`.
 
+Dead-letter behavior:
+
+- Sedifex stores outbound attempts in `webhookDeliveries`.
+- After max attempts, delivery is marked `deadLetter: true` with `deadLetterReason: "max-attempts-exhausted"`.
+- Partners can request replay support from Sedifex support using `deliveryId` and `reference`.
+
+### Signature verification examples (partner receivers)
+
+Use your endpoint secret and the **raw** request body bytes.
+
+Node.js (Express):
+
+```js
+import crypto from 'crypto'
+
+function verifySedifexSignature(rawBodyBuffer, headerSignature, endpointSecret) {
+  const digest = crypto.createHmac('sha256', endpointSecret).update(rawBodyBuffer).digest('hex')
+  const expected = `sha256=${digest}`
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(headerSignature || ''))
+}
+```
+
+PHP:
+
+```php
+<?php
+function verify_sedifex_signature(string $rawBody, string $headerSignature, string $secret): bool {
+  $expected = 'sha256=' . hash_hmac('sha256', $rawBody, $secret);
+  return hash_equals($expected, $headerSignature);
+}
+```
+
+Python:
+
+```python
+import hmac
+import hashlib
+
+def verify_sedifex_signature(raw_body: bytes, header_signature: str, secret: str) -> bool:
+    expected = "sha256=" + hmac.new(
+        secret.encode("utf-8"),
+        raw_body,
+        hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, header_signature or "")
+```
+
 ### Golden path sequence
 
 1. Partner website fetches catalog via `/v1IntegrationProducts` (server-side) or `/integrationPublicCatalog` (public mode).
@@ -598,3 +645,20 @@ Retry policy (when non-2xx or timeout): `1m`, `5m`, `30m`, `2h`, `12h`.
 - Validate webhook signature and timestamp tolerance.
 - Force-test retry path by returning `500` once from webhook receiver.
 - Validate reconciliation export includes `reference`, amounts, and final status.
+
+## 9) Operational dashboards (recommended)
+
+Before production, add internal dashboards for:
+
+- **Integration Orders Monitor**
+  - pending > 15 minutes
+  - failed payments by store/day
+  - duplicate `clientOrderId` conflicts
+- **Webhook Delivery Monitor**
+  - queued/retrying/sent/failed counts
+  - dead-letter queue (`deadLetter == true`)
+  - median delivery latency (createdAt → sentAt)
+- **Partner Health**
+  - failure rate per endpoint URL
+  - top failing status codes
+  - last successful delivery timestamp per endpoint

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -36,8 +36,8 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.sendBulkMessage = exports.emitIntegrationOrderWebhooks = exports.emitBookingWebhooks = exports.emitProductWebhooks = exports.enrichProductDataAfterSave = exports.syncPublicProducts = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.integrationOrderStatus = exports.integrationCheckoutCreate = exports.v1IntegrationBookings = exports.v1IntegrationAvailability = exports.v1IntegrationPromo = exports.integrationPromo = exports.v1IntegrationProducts = exports.integrationProducts = exports.v1Products = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.revokeWebhookEndpoint = exports.upsertWebhookEndpoint = exports.listWebhookEndpoints = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.acceptStoreMasterInvite = exports.createStoreMasterInviteLink = exports.manageStaffAccount = exports.generateSocialPost = exports.generateAiAdvice = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
-exports.__testing = exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkEmail = void 0;
+exports.processIntegrationWebhookDeliveries = exports.emitIntegrationOrderWebhooks = exports.emitBookingWebhooks = exports.emitProductWebhooks = exports.enrichProductDataAfterSave = exports.syncPublicProducts = exports.integrationTopSelling = exports.integrationCustomers = exports.integrationGoogleMerchantFeed = exports.integrationPublicCatalog = exports.integrationTikTokVideos = exports.integrationGallery = exports.integrationOrderStatus = exports.integrationCheckoutCreate = exports.v1IntegrationBookings = exports.v1IntegrationAvailability = exports.v1IntegrationPromo = exports.integrationPromo = exports.v1IntegrationProducts = exports.integrationProducts = exports.v1Products = exports.tiktokOAuthCallback = exports.startTikTokConnect = exports.revokeWebhookEndpoint = exports.upsertWebhookEndpoint = exports.listWebhookEndpoints = exports.rotateIntegrationApiKey = exports.revokeIntegrationApiKey = exports.createIntegrationApiKey = exports.listIntegrationApiKeys = exports.listStoreProducts = exports.logPaymentReminder = exports.logReceiptShareAttempt = exports.logReceiptShare = exports.commitSale = exports.acceptStoreMasterInvite = exports.createStoreMasterInviteLink = exports.manageStaffAccount = exports.generateSocialPost = exports.generateAiAdvice = exports.resolveStoreAccess = exports.initializeStore = exports.handleUserCreate = exports.googleBusinessUploadLocationMedia = exports.googleBusinessLocations = exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.checkSignupUnlock = void 0;
+exports.__testing = exports.handlePaystackWebhook = exports.createBulkCreditsCheckout = exports.cancelPaystackSubscription = exports.createCheckout = exports.createPaystackCheckout = exports.sendBulkEmail = exports.sendBulkMessage = void 0;
 // functions/src/index.ts
 const functions = __importStar(require("firebase-functions/v1"));
 const crypto = __importStar(require("crypto"));
@@ -4601,6 +4601,39 @@ exports.integrationCheckoutCreate = functions.https.onRequest(async (req, res) =
         res.status(400).json({ error: 'invalid-request', message: 'customer.email and amount are required' });
         return;
     }
+    if (clientOrderId) {
+        const duplicateSnap = await firestore_1.defaultDb
+            .collection('stores')
+            .doc(authContext.storeId)
+            .collection('integrationOrders')
+            .where('clientOrderId', '==', clientOrderId)
+            .orderBy('createdAt', 'desc')
+            .limit(1)
+            .get();
+        if (!duplicateSnap.empty) {
+            const existing = duplicateSnap.docs[0].data();
+            const existingStatus = toTrimmedStringOrNull(existing.paymentStatus)?.toLowerCase() ?? 'pending';
+            if (existingStatus === 'pending') {
+                res.status(200).json({
+                    ok: true,
+                    reference: existing.reference ?? duplicateSnap.docs[0].id,
+                    sedifexOrderId: existing.sedifexOrderId ?? null,
+                    authorizationUrl: existing.authorizationUrl ?? null,
+                    expiresAt: null,
+                    reusedPendingOrder: true,
+                });
+                return;
+            }
+            res.status(409).json({
+                ok: false,
+                error: 'duplicate-client-order-id',
+                message: 'clientOrderId already exists for this store',
+                reference: existing.reference ?? duplicateSnap.docs[0].id,
+                paymentStatus: existingStatus,
+            });
+            return;
+        }
+    }
     const paystackConfig = ensurePaystackConfig();
     const reference = `${authContext.storeId}_${Date.now()}`;
     const sedifexOrderId = `ord_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -4642,6 +4675,7 @@ exports.integrationCheckoutCreate = functions.https.onRequest(async (req, res) =
         currency,
         paymentStatus: 'pending',
         orderStatus: 'pending',
+        authorizationUrl: responseJson?.data?.authorization_url ?? null,
         createdAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
         updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
     });
@@ -5258,6 +5292,28 @@ exports.integrationTopSelling = functions.https.onRequest(async (req, res) => {
 function computeWebhookSignature(secret, payload) {
     const digest = crypto.createHmac('sha256', secret).update(payload).digest('hex');
     return `sha256=${digest}`;
+}
+const INTEGRATION_WEBHOOK_BACKOFF_MINUTES = [1, 5, 30, 120, 720];
+const INTEGRATION_WEBHOOK_MAX_ATTEMPTS = INTEGRATION_WEBHOOK_BACKOFF_MINUTES.length;
+async function enqueueIntegrationWebhookDelivery(params) {
+    const now = firestore_1.admin.firestore.Timestamp.now();
+    await firestore_1.defaultDb.collection('webhookDeliveries').add({
+        storeId: params.storeId,
+        endpointId: params.endpointId,
+        endpointUrl: params.endpointUrl,
+        endpointSecret: params.endpointSecret,
+        eventType: params.eventType,
+        reference: params.reference,
+        payload: params.payload,
+        deliveryId: params.deliveryId,
+        attemptCount: 0,
+        maxAttempts: INTEGRATION_WEBHOOK_MAX_ATTEMPTS,
+        nextAttemptAt: now,
+        status: 'queued',
+        deadLetter: false,
+        createdAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+    });
 }
 function shouldDeliverWebhookEvent(endpointEventsRaw, eventType) {
     if (!Array.isArray(endpointEventsRaw) || endpointEventsRaw.length === 0)
@@ -6003,6 +6059,7 @@ exports.emitIntegrationOrderWebhooks = functions.firestore
         netAmount: typeof afterData.netAmount === 'number' ? afterData.netAmount : null,
     };
     const payload = JSON.stringify(payloadObject);
+    const deliveryId = `d_${context.eventId}`;
     const endpointSnapshot = await firestore_1.defaultDb.collection('webhookEndpoints').where('storeId', '==', storeId).where('status', '==', 'active').get();
     if (endpointSnapshot.empty)
         return;
@@ -6012,26 +6069,112 @@ exports.emitIntegrationOrderWebhooks = functions.firestore
         const secret = typeof endpoint.secret === 'string' ? endpoint.secret : '';
         if (!url || !secret)
             return;
-        const signature = computeWebhookSignature(secret, payload);
+        await enqueueIntegrationWebhookDelivery({
+            storeId,
+            endpointId: endpointDoc.id,
+            endpointUrl: url,
+            endpointSecret: secret,
+            eventType,
+            reference,
+            payload,
+            deliveryId,
+        });
+    }));
+});
+exports.processIntegrationWebhookDeliveries = functions.pubsub
+    .schedule('every 1 minutes')
+    .onRun(async () => {
+    const now = firestore_1.admin.firestore.Timestamp.now();
+    const queueSnap = await firestore_1.defaultDb
+        .collection('webhookDeliveries')
+        .where('status', 'in', ['queued', 'retrying'])
+        .where('deadLetter', '==', false)
+        .where('nextAttemptAt', '<=', now)
+        .limit(50)
+        .get();
+    if (queueSnap.empty)
+        return null;
+    for (const docSnap of queueSnap.docs) {
+        const data = docSnap.data();
+        const endpointUrl = toTrimmedStringOrNull(data.endpointUrl);
+        const endpointSecret = toTrimmedStringOrNull(data.endpointSecret);
+        const payload = typeof data.payload === 'string' ? data.payload : '';
+        const eventType = toTrimmedStringOrNull(data.eventType) ?? 'payment.succeeded';
+        const deliveryId = toTrimmedStringOrNull(data.deliveryId) ?? `d_${docSnap.id}`;
+        const attemptCount = typeof data.attemptCount === 'number' ? data.attemptCount : 0;
+        const maxAttempts = typeof data.maxAttempts === 'number' ? data.maxAttempts : INTEGRATION_WEBHOOK_MAX_ATTEMPTS;
+        if (!endpointUrl || !endpointSecret || !payload) {
+            await docSnap.ref.set({
+                status: 'failed',
+                deadLetter: true,
+                deadLetterReason: 'missing-delivery-fields',
+                updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+            }, { merge: true });
+            continue;
+        }
+        const signature = computeWebhookSignature(endpointSecret, payload);
+        let ok = false;
+        let statusCode = null;
+        let errorMessage = null;
         try {
-            const response = await fetch(url, {
+            const response = await fetch(endpointUrl, {
                 method: 'POST',
                 headers: {
                     'content-type': 'application/json',
                     'x-sedifex-event': eventType,
-                    'x-sedifex-delivery-id': `d_${context.eventId}`,
+                    'x-sedifex-delivery-id': deliveryId,
                     'x-sedifex-timestamp': `${Date.now()}`,
-                    'x-sedifex-signature': `sha256=${signature}`,
+                    'x-sedifex-signature': signature,
                     'x-sedifex-contract-version': INTEGRATION_CONTRACT_VERSION.value().trim() || '2026-04-13',
                 },
                 body: payload,
             });
-            await firestore_1.defaultDb.collection('webhookDeliveries').add({ storeId, endpointId: endpointDoc.id, eventType, reference, ok: response.ok, statusCode: response.status, createdAt: firestore_1.admin.firestore.FieldValue.serverTimestamp() });
+            ok = response.ok;
+            statusCode = response.status;
         }
         catch (error) {
-            await firestore_1.defaultDb.collection('webhookDeliveries').add({ storeId, endpointId: endpointDoc.id, eventType, reference, ok: false, statusCode: null, error: error instanceof Error ? error.message : 'unknown error', createdAt: firestore_1.admin.firestore.FieldValue.serverTimestamp() });
+            errorMessage = error instanceof Error ? error.message : 'unknown error';
         }
-    }));
+        const nextAttemptCount = attemptCount + 1;
+        if (ok) {
+            await docSnap.ref.set({
+                status: 'sent',
+                ok: true,
+                statusCode,
+                attemptCount: nextAttemptCount,
+                sentAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+                updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+                deadLetter: false,
+            }, { merge: true });
+            continue;
+        }
+        if (nextAttemptCount >= maxAttempts) {
+            await docSnap.ref.set({
+                status: 'failed',
+                ok: false,
+                statusCode,
+                error: errorMessage,
+                attemptCount: nextAttemptCount,
+                deadLetter: true,
+                deadLetterReason: 'max-attempts-exhausted',
+                updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+            }, { merge: true });
+            continue;
+        }
+        const delayMinutes = INTEGRATION_WEBHOOK_BACKOFF_MINUTES[Math.min(nextAttemptCount - 1, INTEGRATION_WEBHOOK_BACKOFF_MINUTES.length - 1)];
+        const nextAttemptAt = firestore_1.admin.firestore.Timestamp.fromMillis(Date.now() + delayMinutes * 60 * 1000);
+        await docSnap.ref.set({
+            status: 'retrying',
+            ok: false,
+            statusCode,
+            error: errorMessage,
+            attemptCount: nextAttemptCount,
+            nextAttemptAt,
+            deadLetter: false,
+            updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
+        }, { merge: true });
+    }
+    return null;
 });
 /** ============================================================================
  *  HUBTEL BULK MESSAGING

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5805,6 +5805,40 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     return
   }
 
+  if (clientOrderId) {
+    const duplicateSnap = await db
+      .collection('stores')
+      .doc(authContext.storeId)
+      .collection('integrationOrders')
+      .where('clientOrderId', '==', clientOrderId)
+      .orderBy('createdAt', 'desc')
+      .limit(1)
+      .get()
+    if (!duplicateSnap.empty) {
+      const existing = duplicateSnap.docs[0].data() as Record<string, unknown>
+      const existingStatus = toTrimmedStringOrNull(existing.paymentStatus)?.toLowerCase() ?? 'pending'
+      if (existingStatus === 'pending') {
+        res.status(200).json({
+          ok: true,
+          reference: existing.reference ?? duplicateSnap.docs[0].id,
+          sedifexOrderId: existing.sedifexOrderId ?? null,
+          authorizationUrl: existing.authorizationUrl ?? null,
+          expiresAt: null,
+          reusedPendingOrder: true,
+        })
+        return
+      }
+      res.status(409).json({
+        ok: false,
+        error: 'duplicate-client-order-id',
+        message: 'clientOrderId already exists for this store',
+        reference: existing.reference ?? duplicateSnap.docs[0].id,
+        paymentStatus: existingStatus,
+      })
+      return
+    }
+  }
+
   const paystackConfig = ensurePaystackConfig()
   const reference = `${authContext.storeId}_${Date.now()}`
   const sedifexOrderId = `ord_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
@@ -5848,6 +5882,7 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     currency,
     paymentStatus: 'pending',
     orderStatus: 'pending',
+    authorizationUrl: responseJson?.data?.authorization_url ?? null,
     createdAt: admin.firestore.FieldValue.serverTimestamp(),
     updatedAt: admin.firestore.FieldValue.serverTimestamp(),
   })
@@ -6540,6 +6575,39 @@ export const integrationTopSelling = functions.https.onRequest(async (req, res) 
 function computeWebhookSignature(secret: string, payload: string) {
   const digest = crypto.createHmac('sha256', secret).update(payload).digest('hex')
   return `sha256=${digest}`
+}
+
+const INTEGRATION_WEBHOOK_BACKOFF_MINUTES = [1, 5, 30, 120, 720] as const
+const INTEGRATION_WEBHOOK_MAX_ATTEMPTS = INTEGRATION_WEBHOOK_BACKOFF_MINUTES.length
+
+async function enqueueIntegrationWebhookDelivery(params: {
+  storeId: string
+  endpointId: string
+  endpointUrl: string
+  endpointSecret: string
+  eventType: string
+  reference: string
+  payload: string
+  deliveryId: string
+}) {
+  const now = admin.firestore.Timestamp.now()
+  await db.collection('webhookDeliveries').add({
+    storeId: params.storeId,
+    endpointId: params.endpointId,
+    endpointUrl: params.endpointUrl,
+    endpointSecret: params.endpointSecret,
+    eventType: params.eventType,
+    reference: params.reference,
+    payload: params.payload,
+    deliveryId: params.deliveryId,
+    attemptCount: 0,
+    maxAttempts: INTEGRATION_WEBHOOK_MAX_ATTEMPTS,
+    nextAttemptAt: now,
+    status: 'queued',
+    deadLetter: false,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  })
 }
 
 function shouldDeliverWebhookEvent(endpointEventsRaw: unknown, eventType: string) {
@@ -7388,6 +7456,7 @@ export const emitIntegrationOrderWebhooks = functions.firestore
       netAmount: typeof afterData.netAmount === 'number' ? afterData.netAmount : null,
     }
     const payload = JSON.stringify(payloadObject)
+    const deliveryId = `d_${context.eventId}`
     const endpointSnapshot = await db.collection('webhookEndpoints').where('storeId', '==', storeId).where('status', '==', 'active').get()
     if (endpointSnapshot.empty) return
     await Promise.all(endpointSnapshot.docs.map(async endpointDoc => {
@@ -7395,25 +7464,119 @@ export const emitIntegrationOrderWebhooks = functions.firestore
       const url = typeof endpoint.url === 'string' ? endpoint.url.trim() : ''
       const secret = typeof endpoint.secret === 'string' ? endpoint.secret : ''
       if (!url || !secret) return
-      const signature = computeWebhookSignature(secret, payload)
+      await enqueueIntegrationWebhookDelivery({
+        storeId,
+        endpointId: endpointDoc.id,
+        endpointUrl: url,
+        endpointSecret: secret,
+        eventType,
+        reference,
+        payload,
+        deliveryId,
+      })
+    }))
+  })
+
+export const processIntegrationWebhookDeliveries = functions.pubsub
+  .schedule('every 1 minutes')
+  .onRun(async () => {
+    const now = admin.firestore.Timestamp.now()
+    const queueSnap = await db
+      .collection('webhookDeliveries')
+      .where('status', 'in', ['queued', 'retrying'])
+      .where('deadLetter', '==', false)
+      .where('nextAttemptAt', '<=', now)
+      .limit(50)
+      .get()
+
+    if (queueSnap.empty) return null
+
+    for (const docSnap of queueSnap.docs) {
+      const data = docSnap.data() as Record<string, unknown>
+      const endpointUrl = toTrimmedStringOrNull(data.endpointUrl)
+      const endpointSecret = toTrimmedStringOrNull(data.endpointSecret)
+      const payload = typeof data.payload === 'string' ? data.payload : ''
+      const eventType = toTrimmedStringOrNull(data.eventType) ?? 'payment.succeeded'
+      const deliveryId = toTrimmedStringOrNull(data.deliveryId) ?? `d_${docSnap.id}`
+      const attemptCount = typeof data.attemptCount === 'number' ? data.attemptCount : 0
+      const maxAttempts = typeof data.maxAttempts === 'number' ? data.maxAttempts : INTEGRATION_WEBHOOK_MAX_ATTEMPTS
+
+      if (!endpointUrl || !endpointSecret || !payload) {
+        await docSnap.ref.set({
+          status: 'failed',
+          deadLetter: true,
+          deadLetterReason: 'missing-delivery-fields',
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        }, { merge: true })
+        continue
+      }
+
+      const signature = computeWebhookSignature(endpointSecret, payload)
+      let ok = false
+      let statusCode: number | null = null
+      let errorMessage: string | null = null
       try {
-        const response = await fetch(url, {
+        const response = await fetch(endpointUrl, {
           method: 'POST',
           headers: {
             'content-type': 'application/json',
             'x-sedifex-event': eventType,
-            'x-sedifex-delivery-id': `d_${context.eventId}`,
+            'x-sedifex-delivery-id': deliveryId,
             'x-sedifex-timestamp': `${Date.now()}`,
-            'x-sedifex-signature': `sha256=${signature}`,
+            'x-sedifex-signature': signature,
             'x-sedifex-contract-version': INTEGRATION_CONTRACT_VERSION.value().trim() || '2026-04-13',
           },
           body: payload,
         })
-        await db.collection('webhookDeliveries').add({ storeId, endpointId: endpointDoc.id, eventType, reference, ok: response.ok, statusCode: response.status, createdAt: admin.firestore.FieldValue.serverTimestamp() })
+        ok = response.ok
+        statusCode = response.status
       } catch (error) {
-        await db.collection('webhookDeliveries').add({ storeId, endpointId: endpointDoc.id, eventType, reference, ok: false, statusCode: null, error: error instanceof Error ? error.message : 'unknown error', createdAt: admin.firestore.FieldValue.serverTimestamp() })
+        errorMessage = error instanceof Error ? error.message : 'unknown error'
       }
-    }))
+
+      const nextAttemptCount = attemptCount + 1
+      if (ok) {
+        await docSnap.ref.set({
+          status: 'sent',
+          ok: true,
+          statusCode,
+          attemptCount: nextAttemptCount,
+          sentAt: admin.firestore.FieldValue.serverTimestamp(),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          deadLetter: false,
+        }, { merge: true })
+        continue
+      }
+
+      if (nextAttemptCount >= maxAttempts) {
+        await docSnap.ref.set({
+          status: 'failed',
+          ok: false,
+          statusCode,
+          error: errorMessage,
+          attemptCount: nextAttemptCount,
+          deadLetter: true,
+          deadLetterReason: 'max-attempts-exhausted',
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        }, { merge: true })
+        continue
+      }
+
+      const delayMinutes = INTEGRATION_WEBHOOK_BACKOFF_MINUTES[Math.min(nextAttemptCount - 1, INTEGRATION_WEBHOOK_BACKOFF_MINUTES.length - 1)]
+      const nextAttemptAt = admin.firestore.Timestamp.fromMillis(Date.now() + delayMinutes * 60 * 1000)
+      await docSnap.ref.set({
+        status: 'retrying',
+        ok: false,
+        statusCode,
+        error: errorMessage,
+        attemptCount: nextAttemptCount,
+        nextAttemptAt,
+        deadLetter: false,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true })
+    }
+
+    return null
   })
 /** ============================================================================
  *  HUBTEL BULK MESSAGING


### PR DESCRIPTION
### Motivation

- Provide reliable, idempotent outbound webhooks with retry/backoff and dead-letter handling for integration order events. 
- Prevent duplicate orders from client integrations by reusing pending orders or returning a conflict for existing completed orders. 
- Document signature verification examples and operational guidance for partner receivers.

### Description

- Added `webhookDeliveries` queue: introduced `enqueueIntegrationWebhookDelivery` and a scheduled worker `processIntegrationWebhookDeliveries` that sends queued webhooks, applies exponential/backoff minutes `INTEGRATION_WEBHOOK_BACKOFF_MINUTES`, updates `attemptCount`, and marks deliveries as `deadLetter: true` with `deadLetterReason: "max-attempts-exhausted"` when exhausted. 
- Changed `emitIntegrationOrderWebhooks` to enqueue deliveries instead of firing requests inline and included `deliveryId` and proper `x-sedifex-signature` header when delivering. 
- Implemented persisted `authorizationUrl` in `integrationCheckoutCreate` and added `clientOrderId` de-duplication logic that reuses a pending order (returns `reusedPendingOrder: true`) or returns `409` with existing `reference` and `paymentStatus` if a non-pending duplicate exists. 
- Documentation updates in `docs/integration-api-guide.md` describing dead-letter behavior, signature verification examples for Node.js/PHP/Python, and recommended operational dashboards for monitors. 
- Export adjustments to expose `processIntegrationWebhookDeliveries` and small ordering tweaks in built `functions/lib/index.js` exports.

### Testing

- Ran TypeScript compilation (`npm run build`) to validate type changes and the generated `lib` output, which completed successfully. 
- Ran the project's unit test suite (`npm test`) and linters as part of the local verification, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e3964a8c8321b2283fbe728022e8)