### PR TITLE
Add webhook unrevoke/delete controls and relax Apps Script /exec guidance

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -160,6 +160,10 @@ type RevokeWebhookEndpointPayload = {
   endpointId?: unknown
 }
 
+type DeleteWebhookEndpointPayload = {
+  endpointId?: unknown
+}
+
 type StartTikTokConnectPayload = {
   storeId?: unknown
 }
@@ -3010,6 +3014,73 @@ export const revokeWebhookEndpoint = functions.https.onCall(
     await db.collection('integrationAuditLogs').add({
       storeId,
       action: 'webhook.revoked',
+      actorUid: uid,
+      targetId: endpointId,
+      createdAt: timestamp,
+    })
+    return { ok: true, endpointId }
+  },
+)
+
+
+export const activateWebhookEndpoint = functions.https.onCall(
+  async (data: RevokeWebhookEndpointPayload | undefined, context: functions.https.CallableContext) => {
+    assertOwnerAccess(context)
+    const uid = context.auth!.uid
+    const storeId = await resolveStaffStoreId(uid)
+    await verifyOwnerForStore(uid, storeId)
+    const endpointId = normalizeWebhookEndpointId(data?.endpointId)
+    const endpointRef = db.collection('webhookEndpoints').doc(endpointId)
+    const endpointSnapshot = await endpointRef.get()
+    if (!endpointSnapshot.exists) {
+      throw new functions.https.HttpsError('not-found', 'Webhook endpoint not found.')
+    }
+    const endpointData = (endpointSnapshot.data() ?? {}) as Record<string, unknown>
+    if (endpointData.storeId !== storeId) {
+      throw new functions.https.HttpsError('permission-denied', 'Endpoint does not belong to this store.')
+    }
+    const timestamp = admin.firestore.FieldValue.serverTimestamp()
+    await endpointRef.set(
+      {
+        status: 'active',
+        revokedAt: null,
+        revokedBy: null,
+        updatedAt: timestamp,
+      },
+      { merge: true },
+    )
+    await db.collection('integrationAuditLogs').add({
+      storeId,
+      action: 'webhook.activated',
+      actorUid: uid,
+      targetId: endpointId,
+      createdAt: timestamp,
+    })
+    return { ok: true, endpointId }
+  },
+)
+
+export const deleteWebhookEndpoint = functions.https.onCall(
+  async (data: DeleteWebhookEndpointPayload | undefined, context: functions.https.CallableContext) => {
+    assertOwnerAccess(context)
+    const uid = context.auth!.uid
+    const storeId = await resolveStaffStoreId(uid)
+    await verifyOwnerForStore(uid, storeId)
+    const endpointId = normalizeWebhookEndpointId(data?.endpointId)
+    const endpointRef = db.collection('webhookEndpoints').doc(endpointId)
+    const endpointSnapshot = await endpointRef.get()
+    if (!endpointSnapshot.exists) {
+      throw new functions.https.HttpsError('not-found', 'Webhook endpoint not found.')
+    }
+    const endpointData = (endpointSnapshot.data() ?? {}) as Record<string, unknown>
+    if (endpointData.storeId !== storeId) {
+      throw new functions.https.HttpsError('permission-denied', 'Endpoint does not belong to this store.')
+    }
+    const timestamp = admin.firestore.FieldValue.serverTimestamp()
+    await endpointRef.delete()
+    await db.collection('integrationAuditLogs').add({
+      storeId,
+      action: 'webhook.deleted',
       actorUid: uid,
       targetId: endpointId,
       createdAt: timestamp,

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -1564,6 +1564,37 @@ export default function AccountOverview({
     }
   }
 
+
+  async function handleActivateWebhookEndpoint(endpoint: WebhookEndpoint) {
+    try {
+      setActioningWebhookEndpointId(endpoint.id)
+      const callable = httpsCallable(functions, 'activateWebhookEndpoint')
+      await callable({ endpointId: endpoint.id })
+      publish({ message: 'Webhook endpoint activated.', tone: 'success' })
+      await refreshWebhookEndpoints()
+    } catch (error) {
+      console.error('[account] Failed to activate webhook endpoint', error)
+      publish({ message: 'Unable to activate webhook endpoint.', tone: 'error' })
+    } finally {
+      setActioningWebhookEndpointId(null)
+    }
+  }
+
+  async function handleDeleteWebhookEndpoint(endpointId: string) {
+    try {
+      setActioningWebhookEndpointId(endpointId)
+      const callable = httpsCallable(functions, 'deleteWebhookEndpoint')
+      await callable({ endpointId })
+      publish({ message: 'Webhook endpoint deleted.', tone: 'success' })
+      await refreshWebhookEndpoints()
+    } catch (error) {
+      console.error('[account] Failed to delete webhook endpoint', error)
+      publish({ message: 'Unable to delete webhook endpoint.', tone: 'error' })
+    } finally {
+      setActioningWebhookEndpointId(null)
+    }
+  }
+
   async function handleSaveBulkEmailIntegration() {
     if (!storeId) {
       publish({ message: 'No store selected for email integration.', tone: 'error' })
@@ -2346,7 +2377,7 @@ export default function AccountOverview({
                 <p className="account-overview__hint">Sedifex booking webhooks</p>
                 <p className="account-overview__hint">
                   Add your Google Apps Script <code>/exec</code> URL and a secret.
-                  Sedifex will sign booking webhook events with this secret.
+                  The URL can be plain <code>/exec</code> (no query token required). Sedifex will sign booking webhook events with this secret.
                 </p>
                 <div className="account-overview__website-sync-test">
                   <label>
@@ -2395,15 +2426,32 @@ export default function AccountOverview({
                           </p>
                         </div>
                         <div className="account-overview__website-sync-actions">
+                          {endpoint.status === 'revoked' ? (
+                            <button
+                              type="button"
+                              className="button button--secondary"
+                              onClick={() => handleActivateWebhookEndpoint(endpoint)}
+                              disabled={actioningWebhookEndpointId === endpoint.id}
+                            >
+                              Unrevoke
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              className="button button--secondary"
+                              onClick={() => handleRevokeWebhookEndpoint(endpoint.id)}
+                              disabled={actioningWebhookEndpointId === endpoint.id}
+                            >
+                              Revoke
+                            </button>
+                          )}
                           <button
                             type="button"
                             className="button button--secondary"
-                            onClick={() => handleRevokeWebhookEndpoint(endpoint.id)}
-                            disabled={
-                              actioningWebhookEndpointId === endpoint.id || endpoint.status === 'revoked'
-                            }
+                            onClick={() => handleDeleteWebhookEndpoint(endpoint.id)}
+                            disabled={actioningWebhookEndpointId === endpoint.id}
                           >
-                            Revoke
+                            Delete
                           </button>
                         </div>
                       </li>


### PR DESCRIPTION
### Motivation
- Make booking webhook integration more flexible by accepting Google Apps Script `/exec` URLs without requiring a query token and by providing UI controls to unrevoke or delete endpoints in addition to revoke.

### Description
- Relaxed the webhook guidance text in `web/src/pages/AccountOverview.tsx` to state that Apps Script `/exec` URLs are accepted without a query token and still require the shared secret.
- Added UI handlers `handleActivateWebhookEndpoint` and `handleDeleteWebhookEndpoint` in `web/src/pages/AccountOverview.tsx` and wired new `Unrevoke` / `Delete` buttons alongside the existing `Revoke` action.
- Implemented two new Firebase callables in `functions/src/index.ts`: `activateWebhookEndpoint` to reactivate a revoked endpoint and `deleteWebhookEndpoint` to remove an endpoint document, both performing owner/store checks and writing audit logs (`webhook.activated` and `webhook.deleted`).
- Added `DeleteWebhookEndpointPayload` type and kept existing audit logging and permission checks consistent with `revokeWebhookEndpoint` behavior.

### Testing
- Ran `cd /workspace/sedifex && npm run typecheck` at the repo root which failed due to missing root `package.json` in this environment (expected repository layout limitation). (failed)
- Ran `cd /workspace/sedifex/web && npm run lint` which failed in this environment due to a missing dependency (`@eslint/js`) referenced by the ESLint config. (failed)
- No other automated test suites were executed in this environment; UI/functional behavior should be validated in staging with the deployed functions and the web client calling `activateWebhookEndpoint` / `deleteWebhookEndpoint`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00eeaab99483218b6abab3738550b2)