### PR TITLE
docs: clarify Partner Spec v1 behavior for service bookings

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -454,6 +454,8 @@ Use `shared/integrationTypes.ts` as the shared source of truth for:
 
 For partner websites, keep checkout communication limited to three endpoints and one webhook contract.
 
+This contract supports both **product sales** and **service bookings**. Set `orderType` accordingly (`product` or `service`) and consume `bookingStatus` when the transaction represents a booking.
+
 ### Canonical IDs (required on every transaction)
 
 Persist all three IDs together for reconciliation and support:
@@ -461,6 +463,8 @@ Persist all three IDs together for reconciliation and support:
 - `reference`: Paystack/Sedifex payment reference (authoritative payment lookup key).
 - `sedifexOrderId`: internal Sedifex order/booking id.
 - `clientOrderId`: partner website order id.
+
+For service bookings, include your booking identifier in `clientOrderId` (or in `metadata.bookingId`) so customer support can reconcile website bookings to Sedifex records.
 
 ### `POST /integration/checkout/create` (authenticated)
 


### PR DESCRIPTION
### Motivation
- Clarify that the existing Partner Spec v1 checkout/webhook contract applies to both product sales and service bookings so integrators know to set `orderType` and consume `bookingStatus` for booking flows.

### Description
- Updated `docs/integration-api-guide.md` to state that the contract supports `product` or `service` via `orderType`, to advise using `bookingStatus` for bookings, and to recommend including a booking identifier in `clientOrderId` or `metadata.bookingId` for reconciliation.

### Testing
- No automated tests were required for this docs-only change; the updated file contents were inspected to verify the inserted guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ef2c814c8321b05eb42c884fb412)