### PR TITLE
Add sheet-driven 5-minute Apps Script trigger setup

### DIFF
--- a/docs/booking-apps-script-template.md
+++ b/docs/booking-apps-script-template.md
@@ -398,17 +398,52 @@ function str_(v) { return v === null || v === undefined ? '' : String(v).trim();
 function numOrDefault_(v, d) { const n = Number(v); return isNaN(n) ? d : n; }
 function numOrBlank_(v) { if (v === null || v === undefined || v === '') return ''; const n = Number(v); return isNaN(n) ? '' : n; }
 
+
+
+function onOpen() {
+  SpreadsheetApp.getUi()
+    .createMenu('Sedifex Automation')
+    .addItem('Install 5-minute trigger', 'installFiveMinuteTrigger')
+    .addItem('Remove scheduled trigger', 'removeScheduledTrigger')
+    .addItem('Run scheduled messages now', 'runScheduledMessagesNow')
+    .addToUi();
+}
+
+function installFiveMinuteTrigger() {
+  removeScheduledTrigger();
+  ScriptApp.newTrigger('processScheduledMessages')
+    .timeBased()
+    .everyMinutes(5)
+    .create();
+  SpreadsheetApp.getActive().toast('5-minute trigger installed for processScheduledMessages.');
+}
+
+function removeScheduledTrigger() {
+  const triggers = ScriptApp.getProjectTriggers();
+  triggers.forEach(function(t) {
+    if (t.getHandlerFunction && t.getHandlerFunction() === 'processScheduledMessages') {
+      ScriptApp.deleteTrigger(t);
+    }
+  });
+}
+
+function runScheduledMessagesNow() {
+  processScheduledMessages();
+  SpreadsheetApp.getActive().toast('Scheduled messages run complete.');
+}
 function json_(status, payload) {
   payload.httpStatus = status;
   return ContentService.createTextOutput(JSON.stringify(payload)).setMimeType(ContentService.MimeType.JSON);
 }
 ```
 
-## Trigger setup
+## Trigger setup (no code edits needed after paste)
 
-1. In Apps Script, open **Triggers**.
-2. Add trigger for `processScheduledMessages`.
-3. Select **Time-driven**, every 15 minutes (or every 30 minutes).
+1. Reload the Google Sheet (or run `onOpen` once) to show the **Sedifex Automation** menu.
+2. Click **Sedifex Automation → Install 5-minute trigger**.
+3. Authorize when prompted.
+4. Optional: click **Sedifex Automation → Run scheduled messages now** any time you want to force a manual run from the sheet.
+5. Optional cleanup: click **Sedifex Automation → Remove scheduled trigger** to delete all time-driven triggers for `processScheduledMessages`.
 
 ## Minimum webhook payload
 


### PR DESCRIPTION
### Motivation

- Make scheduled booking processing manageable by non-technical users by allowing trigger installation and manual runs from the Google Sheet UI. 
- Provide a convenient 5-minute cadence option requested for more frequent processing without requiring users to edit code or open the Triggers dialog.

### Description

- Modified `docs/booking-apps-script-template.md` to insert Apps Script UI helpers and trigger helpers into the template file. 
- Added `onOpen` which creates a `Sedifex Automation` menu with items to install/remove a trigger and run scheduled messages manually. 
- Added `installFiveMinuteTrigger`, `removeScheduledTrigger`, and `runScheduledMessagesNow` functions that create a 5-minute time-driven trigger, remove triggers for `processScheduledMessages`, and run `processScheduledMessages` on demand respectively. 
- Updated the Trigger setup instructions to describe using the sheet menu so users can install/run/clean up triggers without editing the code again.

### Testing

- Read the template with `sed -n` and applied the insertion via a small Python script to ensure correct placement before the `json_` function, and the script completed successfully. 
- Verified the change diff using `git diff -- docs/booking-apps-script-template.md` to confirm the new functions and updated instructions are present. 
- Inspecting the updated file section with `nl -ba docs/booking-apps-script-template.md | sed -n '390,470p'` showed the new menu and helper functions in place as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f23106388321974f5076fb6c390b)