### PR TITLE
Improve invoice page text contrast on dark cards

### DIFF
--- a/web/src/pages/DocumentsGenerator.css
+++ b/web/src/pages/DocumentsGenerator.css
@@ -80,7 +80,12 @@
 }
 
 .documents-generator__item .form__hint {
-  color: var(--color-text-secondary);
+  color: #e2e8f0;
+  font-weight: 700;
+}
+
+.documents-generator__item .input {
+  color: #0f172a;
   font-weight: 600;
 }
 
@@ -101,6 +106,15 @@
   justify-content: space-between;
 }
 
+
+.documents-generator__summary .card__title {
+  color: #f8fafc;
+}
+
+.documents-generator__summary .card__subtitle {
+  color: #e2e8f0;
+}
+
 .documents-generator__totals {
   display: grid;
   gap: 8px;
@@ -115,7 +129,8 @@
 }
 
 .documents-generator__totals .form__hint {
-  color: #cbd5e1;
+  color: #e2e8f0;
+  font-weight: 600;
 }
 
 .documents-generator__actions {


### PR DESCRIPTION
### Motivation
- Increase legibility of faint text on the invoice/document generator page by deepening contrast and weight for labels, totals, and summary text shown on dark card backgrounds.

### Description
- Modify `web/src/pages/DocumentsGenerator.css` to set `.documents-generator__item .form__hint` to `color: #e2e8f0` and `font-weight: 700` for stronger labels.
- Add `.documents-generator__item .input` rule to ensure input text uses `color: #0f172a` with semibold weight for clearer input content.
- Add overrides for `.documents-generator__summary .card__title` and `.card__subtitle` to brighter colors for readability on the dark summary card.
- Strengthen `.documents-generator__totals .form__hint` by changing its color to `#e2e8f0` and adding `font-weight: 600` for improved visibility of totals labels.

### Testing
- No automated tests were run because this is a style-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a955bce8832194972e55ac76b910)