### PR TITLE
Fix TypeScript errors in marketplace sorting and product webhook payload

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4863,7 +4863,7 @@ export const v1Products = functions.https.onRequest(async (req, res) => {
   const maxPerStoreRaw = Number(req.query.maxPerStore ?? 0)
   const maxPerStoreCandidate = Number.isFinite(maxPerStoreRaw) ? Math.floor(maxPerStoreRaw) : 0
   const maxPerStore = maxPerStoreCandidate > 0 ? maxPerStoreCandidate : null
-  const effectiveMaxPerStore = maxPerStore ?? (sort === 'balanced' ? 3 : null)
+  const effectiveMaxPerStore = maxPerStore ?? (sort === 'store-diverse' ? 3 : null)
 
   let productsSnap: admin.firestore.QuerySnapshot
   try {
@@ -7320,7 +7320,7 @@ export const emitProductWebhooks = functions.firestore
 
         const isGoogleAppsScriptEndpoint = /^https:\/\/script\.google\.com\/macros\//i.test(url)
         const bodyObject = isGoogleAppsScriptEndpoint
-          ? buildAppsScriptBookingPayload({ storeId, bookingId, eventType, afterData })
+          ? buildAppsScriptBookingPayload({ storeId, bookingId: productId, eventType, afterData })
           : payloadObject
         const body = JSON.stringify(bodyObject)
         const signature = computeWebhookSignature(secret, body)


### PR DESCRIPTION
### Motivation
- Resolve TypeScript errors blocking builds: a sort-mode comparison used an invalid literal and a webhook payload call used an undefined shorthand property, causing `TS2367` and `TS18004` respectively.
- Ensure marketplace paging logic and product webhook delivery construct valid runtime payloads for Google Apps Script endpoints.

### Description
- Replace the invalid fallback check `sort === 'balanced'` with `sort === 'store-diverse'` when computing `effectiveMaxPerStore` in `v1Products` to match the `MarketplaceSortMode` union.
- Pass `productId` explicitly into `buildAppsScriptBookingPayload` as `bookingId` in `emitProductWebhooks` to avoid an undefined shorthand and produce a valid Apps Script payload.
- Changes made in `functions/src/index.ts` (small, targeted edits).

### Testing
- Ran `npm run -s build` in the `functions/` directory and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01aa385e748321a478c5ee9797f912)