### PR TITLE
Add BCC copy to sender in booking Apps Script template

### DIFF
--- a/docs/booking-apps-script-template.md
+++ b/docs/booking-apps-script-template.md
@@ -216,7 +216,11 @@ function dueDate_(appt, stage) {
 function sendImmediateEmail_(sheet, rowNum, row, stage) {
   if (!row.customer_email || !row.customer_name) return;
   const msg = messageForStage_(row, stage);
-  GmailApp.sendEmail(row.customer_email, msg.subject, msg.text, { htmlBody: msg.html, name: CONFIG.fromName });
+  GmailApp.sendEmail(row.customer_email, msg.subject, msg.text, {
+    htmlBody: msg.html,
+    name: CONFIG.fromName,
+    bcc: row.customer_email
+  });
   sheet.getRange(rowNum, COLS.indexOf('updated_at') + 1).setValue(new Date().toISOString());
 }
 


### PR DESCRIPTION
### Motivation
- Ensure booking notification emails also send a copy to the sender/customer so they receive a notification for their records.

### Description
- Updated the `GmailApp.sendEmail` call in `docs/booking-apps-script-template.md` inside `sendImmediateEmail_` to include `bcc: row.customer_email` and adjusted the options object formatting.

### Testing
- Validated the change by updating and inspecting `docs/booking-apps-script-template.md` to confirm the `GmailApp.sendEmail` invocation now includes the `bcc` option (appears at lines 216–224); no automated unit tests cover this template change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b69ad40c8321a975582df25c154f)