### PR TITLE
docs: add explicit service booking integration flow for partner websites

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -594,6 +594,78 @@ Retry policy (when non-2xx or timeout): `1m`, `5m`, `30m`, `2h`, `12h`.
 7. Partner website updates local order status and storefront UI.
 8. If webhook is delayed, partner polls `GET /integration/orders/:reference`.
 
+### Service booking integration flow
+
+Use this exact flow when the website is selling **services** (`orderType: "service"`).
+
+**Step 1: Create the booking**
+
+`POST /v1IntegrationBookings?storeId=store_123`
+
+```json
+{
+  "serviceId": "svc_travel_001",
+  "customer": {
+    "name": "Ada Mensah",
+    "phone": "+233201234567",
+    "email": "ada@example.com"
+  },
+  "bookingDate": "2026-08-01",
+  "bookingTime": "10:00 AM",
+  "notes": "Schengen support",
+  "paymentMethod": "paystack",
+  "paymentAmount": 250,
+  "attributes": {
+    "source": "website_booking_form"
+  }
+}
+```
+
+Store the returned `bookingId`.
+
+**Step 2: Create hosted checkout**
+
+`POST /integration/checkout/create`
+
+```json
+{
+  "storeId": "store_123",
+  "clientOrderId": "BOOKING-bk_001",
+  "orderType": "service",
+  "currency": "GHS",
+  "amount": 250,
+  "customer": {
+    "email": "ada@example.com",
+    "phone": "+233201234567",
+    "name": "Ada Mensah"
+  },
+  "returnUrl": "https://clientsite.com/payment/return",
+  "metadata": {
+    "bookingId": "bk_001",
+    "channel": "client-website"
+  }
+}
+```
+
+Redirect the customer to the returned `authorizationUrl`.
+
+**Step 3: Confirm final status**
+
+Do **not** trust browser return alone. Confirm with:
+
+- Sedifex payment webhook (`POST /integration/webhooks/payment-status` delivery), or
+- `GET /integration/orders/:reference`
+
+**Step 4: Update website UI**
+
+Render booking/payment state from Sedifex values:
+
+- `pending`
+- `awaiting_verification`
+- `partial`
+- `confirmed`
+- `cancelled`
+
 ### Security and go-live checklist
 
 - Keep Sedifex API key server-side only (never in browser code).


### PR DESCRIPTION
### Motivation

- Close the onboarding gap for new partner developers by providing a clear booking-to-checkout-to-confirmation golden path for service transactions.
- Ensure website integrators understand how to link bookings to hosted checkouts (`orderType: "service"`) and reconcile records using `bookingId`/`clientOrderId` metadata.
- Reinforce that the browser `returnUrl` is not authoritative and that webhook or server-side polling must be used to confirm final payment/booking state.

### Description

- Added a new `Service booking integration flow` section to `docs/integration-api-guide.md` describing a 4-step flow for services: create booking, create hosted checkout, confirm final status, and update UI.
- Included a canonical example payload for `POST /v1IntegrationBookings?storeId=...` that returns a `bookingId` to be persisted by the partner site.
- Added a `POST /integration/checkout/create` example using `orderType: "service"` and `metadata.bookingId`, and instruction to redirect customers to the returned `authorizationUrl`.
- Documented confirmation guidance to rely on the Sedifex webhook (`POST /integration/webhooks/payment-status`) or `GET /integration/orders/:reference`, plus recommended UI states (`pending`, `awaiting_verification`, `partial`, `confirmed`, `cancelled`).

### Testing

- Documentation-only change; no runtime code changes were required and no unit/integration test changes were run.
- Verified file modification, staged, and committed with `git add docs/integration-api-guide.md` and `git commit` which completed successfully.
- Created PR metadata via `make_pr` which returned the PR title and body successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b95a5dac83218d946f6a5820bc49)