### PR TITLE
Refactor integration endpoints into handlers and add unified `integration` router

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6013,7 +6013,7 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res) 
   })
 })
 
-export const integrationCheckoutCreate = functions.https.onRequest(async (req, res) => {
+async function handleIntegrationCheckoutCreate(req: functions.Request, res: functions.Response<any>) {
   setIntegrationResponseHeaders(res)
   if (!validateIntegrationContractVersionOrReply(req, res)) return
   if (req.method === 'OPTIONS') {
@@ -6122,9 +6122,11 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     authorizationUrl: responseJson?.data?.authorization_url ?? null,
     expiresAt: null,
   })
-})
+}
 
-export const integrationOrderStatus = functions.https.onRequest(async (req, res) => {
+export const integrationCheckoutCreate = functions.https.onRequest(handleIntegrationCheckoutCreate)
+
+async function handleIntegrationOrderStatus(req: functions.Request, res: functions.Response<any>) {
   setIntegrationResponseHeaders(res)
   if (!validateIntegrationContractVersionOrReply(req, res)) return
   if (req.method !== 'GET') {
@@ -6166,6 +6168,24 @@ export const integrationOrderStatus = functions.https.onRequest(async (req, res)
     currency: data.currency ?? null,
     updatedAt: normalizeTimestampIso(data.updatedAt),
   })
+}
+
+export const integrationOrderStatus = functions.https.onRequest(handleIntegrationOrderStatus)
+
+export const integration = functions.https.onRequest(async (req, res) => {
+  const path = req.path.replace(/^\/+/, '')
+
+  if (path === 'checkout/create') {
+    await handleIntegrationCheckoutCreate(req, res)
+    return
+  }
+  if (path.startsWith('orders/')) {
+    await handleIntegrationOrderStatus(req, res)
+    return
+  }
+
+  setIntegrationResponseHeaders(res)
+  res.status(404).json({ ok: false, error: 'not-found' })
 })
 
 export const integrationBookingPaymentVerify = functions.https.onRequest(async (req, res) => {


### PR DESCRIPTION
### Motivation
- Consolidate duplicated logic for integration-related HTTP endpoints and improve route handling.
- Make handlers reusable so the same logic can be invoked from multiple exported endpoints.
- Provide a single entrypoint that can route requests to specific integration actions and return a clear `not-found` for unknown paths.

### Description
- Extracted the inline handler for checkout creation into `handleIntegrationCheckoutCreate` and exported it via `export const integrationCheckoutCreate = functions.https.onRequest(handleIntegrationCheckoutCreate)` while adding typed parameters `functions.Request` and `functions.Response<any>`.
- Extracted the inline handler for order status into `handleIntegrationOrderStatus` and exported it via `export const integrationOrderStatus = functions.https.onRequest(handleIntegrationOrderStatus)`.
- Added a new `export const integration = functions.https.onRequest(...)` router that inspects `req.path` and dispatches requests to `handleIntegrationCheckoutCreate` for `checkout/create` and to `handleIntegrationOrderStatus` for `orders/*`, and returns `404` for other paths.
- Preserved existing behavior and response formats while reorganizing code for clarity and reuse.

### Testing
- Ran TypeScript build via `npm run build` to ensure compilation after refactor and it succeeded.
- Ran linter via `npm run lint` to validate code style and it succeeded.
- Ran unit tests via `npm test` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c88de4388321ae8b769d41f2558d)