### PR TITLE
Stabilize booking IDs for Apps Script booking sync

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4525,6 +4525,8 @@ function buildAppsScriptBookingPayload(options: {
   afterData: Record<string, unknown> | null
 }) {
   const after = options.afterData ?? {}
+  const stableBookingId =
+    toTrimmedStringOrNull(after.bookingId) ?? toTrimmedStringOrNull(after.booking_id) ?? options.bookingId
   const customer = toPlainObject(after.customer)
   const attributes = toPlainObject(after.attributes)
   const payment = toPlainObject(after.payment)
@@ -4535,7 +4537,8 @@ function buildAppsScriptBookingPayload(options: {
       : 'confirmed'
 
   return {
-    bookingId: options.bookingId,
+    bookingId: stableBookingId,
+    booking_id: stableBookingId,
     storeId: options.storeId,
     eventType: options.eventType,
     status: bookingStatus,

--- a/web/src/pages/BookingEditor.tsx
+++ b/web/src/pages/BookingEditor.tsx
@@ -189,6 +189,8 @@ export default function BookingEditor() {
             phone: form.phone.trim(),
             email: form.email.trim(),
           },
+          bookingId: targetId,
+          booking_id: targetId,
           source: isCreateMode ? 'manual' : 'manual-edit',
           syncStatus: 'pending',
           syncRequestedAt: Timestamp.now(),


### PR DESCRIPTION
### Motivation
- Incoming website bookings often omit a `bookingId`/`booking_id`, which prevents Apps Script row upserts and causes duplicate rows when rescheduling; the backend must guarantee a stable id. 
- Make the Apps Script payloads and manually-saved bookings use a single, stable identifier so reschedule/cancel/update actions consistently target the same sheet row.

### Description
- In `functions/src/index.ts` added a `stableBookingId` resolved as `toTrimmedStringOrNull(after.bookingId) || toTrimmedStringOrNull(after.booking_id) || options.bookingId` and included both `bookingId` and `booking_id` in the Apps Script payload using that stable value. 
- In `web/src/pages/BookingEditor.tsx` updated the editor save to write `bookingId: targetId` and `booking_id: targetId` into the `integrationBookings/{bookingId}` document so manual bookings immediately carry the stable Firestore document id. 
- This makes the Firestore document id the guaranteed fallback booking id when the website does not supply one and keeps payloads backwards-compatible with `booking_id` consumers.

### Testing
- Ran `npm --prefix functions run -s build` and it completed successfully. 
- Ran `npm --prefix web run -s typecheck` which exited with code `1` and produced no diagnostic output in this environment, so typecheck issues (if any) are unconfirmed. 
- Confirmed the code diffs include the added `stableBookingId` logic and the `bookingId`/`booking_id` writes in the booking editor save path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fc122e448321acdf3fb0d9a1c399)