### PR TITLE
Sync integrationBookings to Apps Script endpoints and include stable booking IDs

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4525,6 +4525,8 @@ function buildAppsScriptBookingPayload(options: {
   afterData: Record<string, unknown> | null
 }) {
   const after = options.afterData ?? {}
+  const stableBookingId =
+    toTrimmedStringOrNull(after.bookingId) ?? toTrimmedStringOrNull(after.booking_id) ?? options.bookingId
   const customer = toPlainObject(after.customer)
   const attributes = toPlainObject(after.attributes)
   const payment = toPlainObject(after.payment)
@@ -4535,7 +4537,8 @@ function buildAppsScriptBookingPayload(options: {
       : 'confirmed'
 
   return {
-    bookingId: options.bookingId,
+    bookingId: stableBookingId,
+    booking_id: stableBookingId,
     storeId: options.storeId,
     eventType: options.eventType,
     status: bookingStatus,
@@ -7777,6 +7780,94 @@ export const emitBookingWebhooks = functions.firestore
           createdAt: admin.firestore.FieldValue.serverTimestamp(),
         }),
       ),
+    )
+  })
+
+
+export const syncPendingIntegrationBookingToAppsScript = functions.firestore
+  .document('stores/{storeId}/integrationBookings/{bookingId}')
+  .onWrite(async (change, context) => {
+    if (!change.after.exists) return
+
+    const storeId = typeof context.params.storeId === 'string' ? context.params.storeId.trim() : ''
+    const bookingId = typeof context.params.bookingId === 'string' ? context.params.bookingId.trim() : ''
+    if (!storeId || !bookingId) return
+
+    const afterData = (change.after.data() ?? {}) as Record<string, unknown>
+    const syncStatus = toTrimmedStringOrNull(afterData.syncStatus)?.toLowerCase() ?? ''
+    if (syncStatus !== 'pending') return
+
+    const endpointSnapshot = await db
+      .collection('webhookEndpoints')
+      .where('storeId', '==', storeId)
+      .where('status', '==', 'active')
+      .get()
+
+    const appsScriptEndpoints = endpointSnapshot.docs.filter(docSnap => {
+      const endpoint = docSnap.data() as Record<string, unknown>
+      const url = typeof endpoint.url === 'string' ? endpoint.url.trim() : ''
+      const secret = typeof endpoint.secret === 'string' ? endpoint.secret.trim() : ''
+      return Boolean(url && secret && /^https:\/\/script\.google\.com\/macros\//i.test(url))
+    })
+
+    if (appsScriptEndpoints.length === 0) {
+      await change.after.ref.set(
+        {
+          syncStatus: 'failed',
+          syncLastAttemptAt: admin.firestore.FieldValue.serverTimestamp(),
+          syncError: 'no-active-apps-script-endpoint',
+        },
+        { merge: true },
+      )
+      return
+    }
+
+    const bodyObject = buildAppsScriptBookingPayload({
+      storeId,
+      bookingId,
+      eventType: 'booking.updated',
+      afterData,
+    })
+    const body = JSON.stringify(bodyObject)
+
+    let firstError: string | null = null
+
+    for (const endpointDoc of appsScriptEndpoints) {
+      const endpoint = endpointDoc.data() as Record<string, unknown>
+      const url = typeof endpoint.url === 'string' ? endpoint.url.trim() : ''
+      const secret = typeof endpoint.secret === 'string' ? endpoint.secret : ''
+      const signature = computeWebhookSignature(secret, body)
+
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-sedifex-signature': signature,
+            'x-sedifex-event': 'booking.updated',
+            'x-sedifex-event-id': `evt_${context.eventId}`,
+          },
+          body,
+        })
+
+        if (!response.ok) {
+          firstError = firstError ?? `endpoint ${endpointDoc.id} returned ${response.status}`
+        }
+      } catch (error) {
+        firstError = firstError ?? (error instanceof Error ? error.message : 'unknown error')
+      }
+    }
+
+    const existingAttempts = Math.max(0, Math.floor(toFiniteNumber(afterData.syncAttempts, 0)))
+    await change.after.ref.set(
+      {
+        syncStatus: firstError ? 'failed' : 'synced',
+        syncError: firstError,
+        syncAttempts: existingAttempts + 1,
+        syncLastAttemptAt: admin.firestore.FieldValue.serverTimestamp(),
+        syncLastSuccessAt: firstError ? null : admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true },
     )
   })
 

--- a/web/src/pages/BookingEditor.tsx
+++ b/web/src/pages/BookingEditor.tsx
@@ -189,6 +189,8 @@ export default function BookingEditor() {
             phone: form.phone.trim(),
             email: form.email.trim(),
           },
+          bookingId: targetId,
+          booking_id: targetId,
           source: isCreateMode ? 'manual' : 'manual-edit',
           syncStatus: 'pending',
           syncRequestedAt: Timestamp.now(),


### PR DESCRIPTION
### Motivation

- Ensure integration booking documents are reliably forwarded to Google Apps Script webhook endpoints with a stable booking identifier and clear sync state.
- Provide a retryable sync flow that records attempts, errors, and timestamps on the Firestore document.
- Make the web editor create integration booking docs with the necessary identifier fields and mark them for syncing.

### Description

- Added `stableBookingId` resolution inside `buildAppsScriptBookingPayload` and include both `bookingId` and `booking_id` in the Apps Script payload to ensure consistent identifiers. 
- Implemented a new Cloud Function `syncPendingIntegrationBookingToAppsScript` that triggers on writes to `stores/{storeId}/integrationBookings/{bookingId}`, discovers active Apps Script webhook endpoints, posts the JSON payload with computed signature headers, and updates `syncStatus`, `syncAttempts`, `syncError`, `syncLastAttemptAt`, and `syncLastSuccessAt` on the document. 
- Updated the web `BookingEditor.tsx` to write `bookingId` and `booking_id` into the `integrationBookings` document and set `syncStatus: 'pending'` with `syncRequestedAt` when creating or editing from the editor. 
- The function filters endpoints by URL pattern `/^https://script\.google\.com\/macros\//i`, uses `computeWebhookSignature` to sign requests, and increments attempt counters on each run. 

### Testing

- Ran TypeScript compilation for the functions and web projects (`tsc` / `yarn build`) which completed successfully. 
- Ran linting (`eslint`) which passed without errors. 
- Executed the Firebase Functions locally in the emulator and verified that a document with `syncStatus: 'pending'` triggers the function and updates the document sync fields accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fc122e448321acdf3fb0d9a1c399)