### PR TITLE
Refactor bookings table into summary rows with detail drawer

### DIFF
--- a/web/src/pages/Bookings.css
+++ b/web/src/pages/Bookings.css
@@ -66,10 +66,82 @@
   color: #5b21b6;
 }
 
+.bookings-page__status--payment-pending {
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+.bookings-page__status--payment-confirmed {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.bookings-page__status--payment-partial {
+  background: #ffedd5;
+  color: #9a3412;
+}
+
+.bookings-page__status--payment-rejected {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.bookings-page__status--payment-refunded {
+  background: #e0e7ff;
+  color: #3730a3;
+}
+
 .bookings-page__actions {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+.bookings-page__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 14px;
+}
+
+.bookings-page__drawer {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px;
+  background: #f8fafc;
+}
+
+.bookings-page__drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.bookings-page__drawer-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+.bookings-page__row-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.bookings-page__more-menu summary {
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.bookings-page__more-menu-list {
+  display: grid;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.bookings-page__actions-group h5 {
+  margin: 0 0 8px;
 }
 
 .bookings-page__pagination {
@@ -78,32 +150,6 @@
   justify-content: flex-end;
   margin-top: 12px;
 }
-
-.bookings-page__row--selected {
-  background: #eef2ff;
-}
-
-.bookings-page__details {
-  margin-top: 14px;
-}
-
-.bookings-page__details-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 10px 16px;
-}
-
-.bookings-page__details-grid dt {
-  font-size: 12px;
-  color: #64748b;
-}
-
-.bookings-page__details-grid dd {
-  margin: 0;
-  font-weight: 600;
-  word-break: break-word;
-}
-
 
 .bookings-page__summary,
 .bookings-page__empty-title,
@@ -125,4 +171,20 @@
 .bookings-page__empty-text {
   margin: 0;
   font-size: 0.95rem;
+}
+
+@media (min-width: 1080px) {
+  .bookings-page__content {
+    grid-template-columns: minmax(0, 2fr) minmax(360px, 1fr);
+    align-items: start;
+  }
+
+  .bookings-page__drawer {
+    position: sticky;
+    top: 12px;
+  }
+
+  .bookings-page__drawer-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
 }

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -157,6 +157,7 @@ export default function Bookings() {
   const [hasNextPage, setHasNextPage] = useState(false)
   const [pageNumber, setPageNumber] = useState(1)
   const [updatingBookingId, setUpdatingBookingId] = useState<string | null>(null)
+  const [selectedBookingId, setSelectedBookingId] = useState<string | null>(null)
 
   const hydrateBooking = useCallback((docSnap: QueryDocumentSnapshot<DocumentData>, serviceMap: Map<string, string>) => {
     const data = docSnap.data() as Record<string, unknown>
@@ -484,6 +485,10 @@ export default function Bookings() {
   }, [bookings, searchTerm])
 
   const confirmedCount = useMemo(() => bookings.filter(booking => booking.status === 'confirmed').length, [bookings])
+  const selectedBooking = useMemo(
+    () => filteredBookings.find(booking => booking.id === selectedBookingId) ?? null,
+    [filteredBookings, selectedBookingId],
+  )
 
   return (
     <main className="page bookings-page">
@@ -561,6 +566,7 @@ export default function Bookings() {
             </p>
             {filteredBookings.length ? (
               <>
+                <div className="bookings-page__content">
                 <div className="table-wrap">
                   <table className="table">
                     <thead>
@@ -569,10 +575,9 @@ export default function Bookings() {
                         <th>Service</th>
                         <th>Customer</th>
                         <th>Qty</th>
-                        <th>Status</th>
+                        <th>Booking</th>
                         <th>Payment</th>
-                        <th>Audit</th>
-                        <th>Notes</th>
+                        <th>Amount</th>
                         <th>Actions</th>
                       </tr>
                     </thead>
@@ -596,58 +601,90 @@ export default function Bookings() {
                             </span>
                           </td>
                           <td>
-                            <div className="stack gap-1">
-                              <div><strong>Booking:</strong> {statusLabel(booking.status)}</div>
-                              <div><strong>Payment:</strong> {paymentStatusLabel(booking.paymentStatus)}</div>
-                              <div><strong>Amount:</strong> {booking.paymentAmount ?? booking.depositAmount ?? '—'}</div>
-                            </div>
+                            <span className={`bookings-page__status bookings-page__status--payment-${booking.paymentStatus}`}>
+                              {paymentStatusLabel(booking.paymentStatus)}
+                            </span>
                           </td>
+                          <td>{booking.paymentAmount ?? booking.depositAmount ?? '—'}</td>
                           <td>
-                            <div className="stack gap-1">
-                              <div><strong>Payment ref:</strong> {booking.paymentReference ?? '—'}</div>
-                              <div><strong>Sedifex order id:</strong> {booking.sedifexOrderId ?? '—'}</div>
-                              <div><strong>Client order id:</strong> {booking.clientOrderId ?? '—'}</div>
-                              <div><strong>Confirmed at:</strong> {formatDate(booking.paymentConfirmedAt)}</div>
-                              <div><strong>Verified at:</strong> {formatDate(booking.paymentVerifiedAt)}</div>
-                              <div><strong>Verified by:</strong> {booking.paymentVerifiedBy ?? '—'}</div>
-                            </div>
-                          </td>
-                          <td>{booking.notes ?? '—'}</td>
-                          <td>
-                            <div className="bookings-page__actions">
-                              {(STATUS_ACTIONS[booking.status] ?? []).map(action => (
-                                <button
-                                  key={action.nextStatus}
-                                  className="btn btn-secondary"
-                                  type="button"
-                                  disabled={updatingBookingId === booking.id}
-                                  onClick={() => void handleStatusUpdate(booking.id, action.nextStatus)}
-                                >
-                                  {action.label}
-                                </button>
-                              ))}
-                              <Link to={`/bookings/${booking.id}`} className="btn btn-secondary">
-                                Edit
-                              </Link>
-                              <button
-                                className="btn btn-secondary"
-                                type="button"
-                                disabled={updatingBookingId === booking.id}
-                                onClick={() => void handleDeleteBooking(booking.id)}
-                              >
-                                Delete
-                              </button>
-                              <button className="btn btn-secondary" type="button" disabled={updatingBookingId === booking.id} onClick={() => void handlePaymentOverride(booking.id, 'confirm')}>Confirm payment</button>
-                              <button className="btn btn-secondary" type="button" disabled={updatingBookingId === booking.id} onClick={() => void handlePaymentOverride(booking.id, 'partial')}>Mark partial</button>
-                              <button className="btn btn-secondary" type="button" disabled={updatingBookingId === booking.id} onClick={() => void handlePaymentOverride(booking.id, 'reject')}>Reject payment</button>
-                              <button className="btn btn-secondary" type="button" disabled={updatingBookingId === booking.id} onClick={() => void handlePaymentOverride(booking.id, 'refund')}>Refund</button>
-                              <button className="btn btn-secondary" type="button" disabled={updatingBookingId === booking.id} onClick={() => void handlePaymentOverride(booking.id, 'resend_sync')}>Resend sync to sheet</button>
+                            <div className="bookings-page__row-actions">
+                              <button className="btn btn-secondary" type="button" onClick={() => setSelectedBookingId(booking.id)}>View</button>
+                              <details className="bookings-page__more-menu">
+                                <summary>⋯ More</summary>
+                                <div className="bookings-page__more-menu-list">
+                                  <button className="btn btn-secondary" type="button" disabled={updatingBookingId === booking.id} onClick={() => void handleDeleteBooking(booking.id)}>Delete</button>
+                                  <button className="btn btn-secondary" type="button" disabled={updatingBookingId === booking.id} onClick={() => void handlePaymentOverride(booking.id, 'refund')}>Refund</button>
+                                  <button className="btn btn-secondary" type="button" disabled={updatingBookingId === booking.id} onClick={() => void handlePaymentOverride(booking.id, 'reject')}>Reject payment</button>
+                                  <button className="btn btn-secondary" type="button" disabled={updatingBookingId === booking.id} onClick={() => void handlePaymentOverride(booking.id, 'resend_sync')}>Resend sync</button>
+                                </div>
+                              </details>
                             </div>
                           </td>
                         </tr>
                       ))}
                     </tbody>
                   </table>
+                </div>
+                {selectedBooking && (
+                  <aside className="bookings-page__drawer">
+                    <div className="bookings-page__drawer-header">
+                      <h3>Booking details</h3>
+                      <button className="btn btn-secondary" type="button" onClick={() => setSelectedBookingId(null)}>Close</button>
+                    </div>
+                    <div className="bookings-page__drawer-grid">
+                      <section className="card stack gap-1">
+                        <h4>Booking details</h4>
+                        <p><strong>Customer:</strong> {selectedBooking.customerName ?? selectedBooking.bookingName ?? '—'}</p>
+                        <p><strong>Phone:</strong> {selectedBooking.customerPhone ?? selectedBooking.bookingPhone ?? '—'}</p>
+                        <p><strong>Email:</strong> {selectedBooking.customerEmail ?? selectedBooking.bookingEmail ?? '—'}</p>
+                        <p><strong>Service:</strong> {selectedBooking.serviceName || selectedBooking.serviceId}</p>
+                        <p><strong>Date:</strong> {selectedBooking.bookingDate ?? '—'}</p>
+                        <p><strong>Time:</strong> {selectedBooking.bookingTime ?? '—'}</p>
+                        <p><strong>Notes:</strong> {selectedBooking.notes ?? '—'}</p>
+                      </section>
+                      <section className="card stack gap-1">
+                        <h4>Payment</h4>
+                        <p><strong>Status:</strong> <span className={`bookings-page__status bookings-page__status--payment-${selectedBooking.paymentStatus}`}>{paymentStatusLabel(selectedBooking.paymentStatus)}</span></p>
+                        <p><strong>Amount:</strong> {selectedBooking.paymentAmount ?? selectedBooking.depositAmount ?? '—'}</p>
+                        <p><strong>Payment ref:</strong> {selectedBooking.paymentReference ?? '—'}</p>
+                        <p><strong>Sedifex order id:</strong> {selectedBooking.sedifexOrderId ?? '—'}</p>
+                        <p><strong>Client order id:</strong> {selectedBooking.clientOrderId ?? '—'}</p>
+                      </section>
+                      <section className="card stack gap-1">
+                        <h4>Audit</h4>
+                        <p><strong>Confirmed at:</strong> {formatDate(selectedBooking.paymentConfirmedAt)}</p>
+                        <p><strong>Verified at:</strong> {formatDate(selectedBooking.paymentVerifiedAt)}</p>
+                        <p><strong>Verified by:</strong> {selectedBooking.paymentVerifiedBy ?? '—'}</p>
+                      </section>
+                      <section className="card stack gap-2">
+                        <h4>Actions</h4>
+                        <div className="bookings-page__actions-group">
+                          <h5>Booking actions</h5>
+                          <div className="bookings-page__actions">
+                            {(STATUS_ACTIONS[selectedBooking.status] ?? []).map(action => (
+                              <button key={action.nextStatus} className="btn btn-secondary" type="button" disabled={updatingBookingId === selectedBooking.id} onClick={() => void handleStatusUpdate(selectedBooking.id, action.nextStatus)}>{action.label}</button>
+                            ))}
+                            <Link to={`/bookings/${selectedBooking.id}`} className="btn btn-secondary">Edit</Link>
+                            <button className="btn btn-secondary" type="button" disabled={updatingBookingId === selectedBooking.id} onClick={() => void handleDeleteBooking(selectedBooking.id)}>Delete</button>
+                          </div>
+                        </div>
+                        <div className="bookings-page__actions-group">
+                          <h5>Payment actions</h5>
+                          <div className="bookings-page__actions">
+                            <button className="btn btn-secondary" type="button" disabled={updatingBookingId === selectedBooking.id} onClick={() => void handlePaymentOverride(selectedBooking.id, 'confirm')}>Confirm payment</button>
+                            <button className="btn btn-secondary" type="button" disabled={updatingBookingId === selectedBooking.id} onClick={() => void handlePaymentOverride(selectedBooking.id, 'partial')}>Mark partial</button>
+                            <button className="btn btn-secondary" type="button" disabled={updatingBookingId === selectedBooking.id} onClick={() => void handlePaymentOverride(selectedBooking.id, 'reject')}>Reject payment</button>
+                            <button className="btn btn-secondary" type="button" disabled={updatingBookingId === selectedBooking.id} onClick={() => void handlePaymentOverride(selectedBooking.id, 'refund')}>Refund</button>
+                          </div>
+                        </div>
+                        <div className="bookings-page__actions-group">
+                          <h5>Sync</h5>
+                          <button className="btn btn-secondary" type="button" disabled={updatingBookingId === selectedBooking.id} onClick={() => void handlePaymentOverride(selectedBooking.id, 'resend_sync')}>Resend sync to sheet</button>
+                        </div>
+                      </section>
+                    </div>
+                  </aside>
+                )}
                 </div>
                 <div className="bookings-page__pagination">
                   <button className="btn btn-secondary" type="button" disabled={pageNumber <= 1} onClick={handlePreviousPage}>


### PR DESCRIPTION
### Motivation
- The bookings table was overly dense with details and many action buttons per row, making it hard to scan. 
- The change aims to move heavy details and operational actions out of the table and into a focused detail panel to improve readability and workflow. 
- Provide a single primary per-row action (`View`) plus a compact overflow menu for secondary actions so the list becomes concise and scannable.

### Description
- Simplified the table row in `web/src/pages/Bookings.tsx` to show only `Created`, `Service`, `Customer`, `Qty`, `Booking` (status badge), `Payment` (status badge), `Amount`, and a single `View` action. 
- Added `selectedBookingId` state and `selectedBooking` memo to open a right-side detail drawer with grouped sections for Booking details, Payment, Audit, and Actions when `View` is clicked. 
- Moved operational controls (status transitions, edit, delete, payment overrides, resend sync) into grouped cards inside the drawer, and added a per-row `⋯ More` overflow menu for secondary quick actions. 
- Updated styles in `web/src/pages/Bookings.css` to introduce payment badges, a `bookings-page__drawer` layout, row-action styles, and a responsive two-column desktop layout that stacks into cards on mobile.

### Testing
- Ran the project build with `npm --prefix web run build`, which failed in this environment due to missing type definitions for `vite/client` and `vitest/globals`, so a full production build could not be validated here. 
- No other automated tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0222c468008321baa44b816c4c227e)