### PR TITLE
Add Sell page workspace sub-tabs for Sell/Close day/Invoice

### DIFF
--- a/web/src/pages/Sell.css
+++ b/web/src/pages/Sell.css
@@ -546,6 +546,31 @@
   }
 }
 
+
+.sell-page__workspace-tabs {
+  margin: 0 0 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.sell-page__workspace-tab {
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.sell-page__workspace-tab.is-active {
+  border-color: #4338ca;
+  background: #eef2ff;
+  color: #312e81;
+}
+
 .sell-page__grid {
   display: grid;
   grid-template-columns: 1.1fr 0.9fr;

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -1738,6 +1738,18 @@ export default function Sell() {
         </div>
       </header>
 
+      <nav className="sell-page__workspace-tabs" aria-label="Sales workspace pages">
+        <Link to="/sell" className="sell-page__workspace-tab is-active" aria-current="page">
+          Sell
+        </Link>
+        <Link to="/close-day" className="sell-page__workspace-tab">
+          Close day
+        </Link>
+        <Link to="/finance" className="sell-page__workspace-tab">
+          Invoice
+        </Link>
+      </nav>
+
       {reachedDailySalesLimit && (
         <p className="products__message products__message--error" role="alert">
           You have hit your daily sales limit ({dailySalesLimit} sales/day). Upgrade your plan to


### PR DESCRIPTION
### Motivation
- Simplify navigation for high-traffic sales pages by surfacing quick links to Sell, Close day, and Invoice from the Sell page header.

### Description
- Inserted a workspace sub-tab row under the Sell page header in `web/src/pages/Sell.tsx` with `Link` entries to `/sell`, `/close-day`, and `/finance` and an `aria-label` for accessibility.
- Added pill-style CSS for `.sell-page__workspace-tabs` and `.sell-page__workspace-tab` (including an `.is-active` state) in `web/src/pages/Sell.css` to match the app look-and-feel.

### Testing
- Ran `npm --prefix web run test -- Sell.test.tsx` to exercise the Sell page tests, but the command failed in this environment with `vitest: not found`, so no automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02434659408321951dfa705f948d93)