### PR TITLE
Add booking Delete action; nest Close day & Invoice under /sell; remove Social media nav/route

### DIFF
--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -12,13 +12,10 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/dashboard', label: 'Dashboard', end: true, roles: ['owner'] },
   { to: '/products', label: 'Items', roles: ['owner'] },
   { to: '/sell', label: 'Sell', roles: ['owner', 'staff'] },
-  { to: '/close-day', label: 'Close day', parentTo: '/sell', roles: ['owner', 'staff'] },
   { to: '/customers', label: 'Customers', roles: ['owner', 'staff'] },
   { to: '/bookings', label: 'Bookings', roles: ['owner', 'staff'] },
-  { to: '/social-media', label: 'Social media', roles: ['owner'] },
   { to: '/bulk-messaging', label: 'SMS', roles: ['owner'] },
   { to: '/bulk-email', label: 'Bulk email', roles: ['owner'] },
-  { to: '/finance', label: 'Invoice', parentTo: '/sell', roles: ['owner'] },
   { to: '/public-page', label: 'Public page', roles: ['owner'] },
   { to: '/account', label: 'Account', roles: ['owner'] },
 ]

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -31,7 +31,6 @@ import PricingPage from './pages/PricingPage'
 import DataTransfer from './pages/DataTransfer'
 import PromoLandingPage from './pages/PromoLandingPage'
 import PublicPageSettings from './pages/PublicPageSettings'
-import SocialMediaPage from './pages/SocialMediaPage'
 import BookingMappingSettings from './pages/BookingMappingSettings'
 import IntegrationWebsiteSettings from './pages/IntegrationWebsiteSettings'
 import IntegrationBookingsSettings from './pages/IntegrationBookingsSettings'
@@ -92,12 +91,14 @@ const router = createBrowserRouter([
           { path: 'logi', element: <Logi /> },
 
           // Finance
-          { path: 'finance', element: <DocumentsGenerator /> },
-          { path: 'finance/documents', element: <Navigate to="/finance" replace /> },
+          { path: 'sell/invoice', element: <DocumentsGenerator /> },
+          { path: 'finance', element: <Navigate to="/sell/invoice" replace /> },
+          { path: 'finance/documents', element: <Navigate to="/sell/invoice" replace /> },
           { path: 'expenses', element: <Expenses /> },
 
           // Close day
-          { path: 'close-day', element: <CloseDay /> },
+          { path: 'sell/close-day', element: <CloseDay /> },
+          { path: 'close-day', element: <Navigate to="/sell/close-day" replace /> },
 
           // Other authenticated pages
           { path: 'onboarding', element: <Onboarding /> },
@@ -105,8 +106,7 @@ const router = createBrowserRouter([
           { path: 'account', element: <AccountOverview /> },
           { path: 'account/overview', element: <AccountOverview /> },
           { path: 'public-page', element: <PublicPageSettings /> },
-          { path: 'social-media', element: <SocialMediaPage /> },
-          { path: 'merchant-feed', element: <Navigate to="/social-media" replace /> },
+          { path: 'merchant-feed', element: <Navigate to="/sell" replace /> },
           { path: 'support', element: <Support /> },
           { path: 'settings/integrations/booking-mapping', element: <BookingMappingSettings /> },
           { path: 'settings/integrations/website', element: <IntegrationWebsiteSettings /> },

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -604,6 +604,14 @@ export default function Bookings() {
                           <td>
                             <div className="bookings-page__row-actions">
                               <Link to={`/bookings/${booking.id}`} className="btn btn-secondary">Edit</Link>
+                              <button
+                                type="button"
+                                className="btn btn-secondary"
+                                onClick={() => void handleDeleteBooking(booking.id)}
+                                disabled={updatingBookingId === booking.id}
+                              >
+                                {updatingBookingId === booking.id ? 'Deleting…' : 'Delete'}
+                              </button>
                             </div>
                           </td>
                         </tr>

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -1742,10 +1742,10 @@ export default function Sell() {
         <Link to="/sell" className="sell-page__workspace-tab is-active" aria-current="page">
           Sell
         </Link>
-        <Link to="/close-day" className="sell-page__workspace-tab">
+        <Link to="/sell/close-day" className="sell-page__workspace-tab">
           Close day
         </Link>
-        <Link to="/finance" className="sell-page__workspace-tab">
+        <Link to="/sell/invoice" className="sell-page__workspace-tab">
           Invoice
         </Link>
       </nav>


### PR DESCRIPTION
### Motivation
- Allow store users to remove bookings from the Bookings page via a simple UI action. 
- Group sales-related workspace views (`Close day` and `Invoice`) under the `Sell` workspace for clearer navigation. 
- Remove the Social media page from primary navigation and routing to hide that feature from the authenticated UI.

### Description
- Added a per-row `Delete` button to `web/src/pages/Bookings.tsx` that calls the existing `handleDeleteBooking` handler and shows a disabled/loading state when deletion is in progress. 
- Removed top-level navigation items for `Close day`, `Invoice`, and `Social media` from `web/src/config/navigation.ts`. 
- Updated the Sell workspace tabs in `web/src/pages/Sell.tsx` to link to `/sell/close-day` and `/sell/invoice`. 
- Reworked routes in `web/src/main.tsx` so `DocumentsGenerator` is available at `sell/invoice`, `CloseDay` at `sell/close-day`, and legacy paths (`/finance`, `/finance/documents`, `/close-day`) redirect to the new `/sell/*` subpaths; `merchant-feed` was updated to redirect to `/sell` and the authenticated `social-media` route was removed (the implementation file remains unchanged). 

### Testing
- Ran a production build with `npm --prefix web run -s build`, which failed in this environment due to missing TypeScript type definitions for `vite/client` and `vitest/globals`. 
- No unit/integration test changes were made or executed as part of this change set; existing tests referencing the Social media page remain in the tree but the route/nav exposure was removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02cfb5fe6c832188dffbdcc4c30851)