### PR TITLE
Add store blog feature: admin UI, public API endpoint, public page and docs

### DIFF
--- a/docs/blog-page-implementation.md
+++ b/docs/blog-page-implementation.md
@@ -1,0 +1,133 @@
+# Blog page implementation plan (store-managed + public + embeddable)
+
+## Goal
+Enable each store to:
+1. Create blog posts (title, image upload, rich text, links).
+2. Publish posts to a public Sedifex-hosted page.
+3. Pull posts into their own website using an API (and optionally webhooks).
+
+## Architecture overview
+
+- **Authoring UI (Sedifex app):** New "Blog" admin page for store staff.
+- **Storage:** Firestore collection `blogPosts` with `storeId` tenant scoping.
+- **Images:** Reuse existing upload pipeline (`POST /api/uploads`) and store returned URL.
+- **Public read model:** Mirror published posts to `publicBlogPosts` for unauthenticated reads.
+- **Public page route:** `/s/:storeSlug/blog` + `/s/:storeSlug/blog/:postSlug`.
+- **External website pull:** `GET /api/public/blog?storeSlug=...` and `GET /api/public/blog/:postSlug?...`.
+- **Optional push model:** Webhook event on publish/update/unpublish for site sync.
+
+## Firestore schema
+
+### `blogPosts/{postId}` (private, tenant-protected)
+- `storeId: string`
+- `storeSlug: string`
+- `title: string`
+- `slug: string`
+- `excerpt: string | null`
+- `coverImageUrl: string | null`
+- `coverImageAlt: string | null`
+- `contentHtml: string` (sanitized)
+- `status: 'draft' | 'published' | 'archived'`
+- `publishedAt: Timestamp | null`
+- `createdBy: string`
+- `createdAt: Timestamp`
+- `updatedAt: Timestamp`
+
+Indexes:
+- `(storeId, updatedAt desc)`
+- `(storeId, status, publishedAt desc)`
+
+### `publicBlogPosts/{storeSlug_postSlug}` (public projection)
+- `storeSlug: string`
+- `postSlug: string`
+- `title: string`
+- `excerpt: string | null`
+- `coverImageUrl: string | null`
+- `coverImageAlt: string | null`
+- `contentHtml: string`
+- `publishedAt: Timestamp`
+- `updatedAt: Timestamp`
+
+Indexes:
+- `(storeSlug, publishedAt desc)`
+
+## Security model
+
+- `blogPosts`: only authenticated members for matching `storeId` can read/write.
+- `publicBlogPosts`: public read allowed, no client writes.
+- Only backend/admin path can copy from `blogPosts` -> `publicBlogPosts`.
+
+## Authoring UX requirements
+
+### Form fields
+- **Title** (required, 5–120 chars)
+- **Cover image upload** (optional, image/*, max 5MB)
+- **Content editor** (required): rich text with links
+- **Link insert**: URL validation (`http://` or `https://`)
+- **Excerpt** (optional)
+- **Status**: Draft / Publish
+
+### Editor options
+- Bold, italic, headings, bullets, quote
+- Link add/remove
+- Paste sanitization
+
+### Slug generation
+- Auto-generate from title (`my-first-post`), allow manual override, unique per store.
+
+## API contract (for "pull into their website")
+
+### List posts
+`GET /api/public/blog?storeSlug=<slug>&limit=20&cursor=<optional>`
+
+Returns:
+```json
+{
+  "items": [
+    {
+      "title": "...",
+      "slug": "...",
+      "excerpt": "...",
+      "coverImageUrl": "...",
+      "publishedAt": "2026-05-12T10:00:00.000Z"
+    }
+  ],
+  "nextCursor": "..."
+}
+```
+
+### Get single post
+`GET /api/public/blog/:postSlug?storeSlug=<slug>`
+
+Returns post body (`contentHtml`) for rendering.
+
+## Public page behavior
+
+- `/s/:storeSlug/blog`: list page with title, image, excerpt, date.
+- `/s/:storeSlug/blog/:postSlug`: full post page.
+- SEO basics:
+  - `<title>` and meta description from post.
+  - Open Graph image from `coverImageUrl`.
+  - Canonical URL.
+
+## Content safety
+
+- Sanitize rich HTML on write (server-side) and on render (defense in depth).
+- Allowlist tags/attributes (`a[href]`, `p`, `h1-h4`, `ul`, `ol`, `li`, `strong`, `em`, `blockquote`, `img[src|alt]` if needed).
+- Add `rel="noopener noreferrer"` on external links.
+
+## Rollout plan
+
+1. Add collections + indexes + rules.
+2. Build store Blog admin page (create/edit/list/publish).
+3. Add public projection writer (on publish/update/unpublish).
+4. Build public routes.
+5. Expose public API endpoints for website pull.
+6. Add docs and optional webhook for push sync.
+
+## Future enhancement (recommended)
+
+- RSS feed per store: `/api/public/blog/rss?storeSlug=...`
+- Category/tag filtering
+- Scheduled publishing
+- Import from Markdown

--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -144,6 +144,59 @@ Query parameters:
 2. **Public website without secret storage:** `GET /integrationPublicCatalog?slug=<promoSlug>` (or `storeId`).
 3. In both cases, render from `publicProducts` and `publicServices` directly.
 
+
+### `GET /api/public-blog?storeId=<storeId>[&slug=<postSlug>]` (public, no API key)
+
+Use this endpoint when a store wants its website to **pull published blog posts** from Sedifex.
+
+- `storeId` is required.
+- `slug` is optional. If provided, Sedifex filters to one post slug.
+- Returns only posts with `status = "published"`.
+
+Example list response:
+
+```json
+{
+  "items": [
+    {
+      "id": "post_123",
+      "title": "How to choose the right product",
+      "slug": "how-to-choose-the-right-product",
+      "content": "<p>...</p>",
+      "linkUrl": "https://example.com/more-details",
+      "imageUrl": "https://storage.googleapis.com/.../blog-image.jpg",
+      "publishedAt": "2026-05-12T10:00:00.000Z"
+    }
+  ]
+}
+```
+
+#### Blog pull integration steps (website)
+
+1. Save the store's `storeId` in your website backend config.
+2. Fetch posts server-side:
+   - `GET ${SEDIFEX_SITE_BASE_URL}/api/public-blog?storeId=<storeId>`
+3. Cache response for 30-120 seconds to reduce repeated fetches.
+4. Render list cards (title, image, excerpt from content) and optionally deep-link by slug.
+5. For one post page, call:
+   - `GET ${SEDIFEX_SITE_BASE_URL}/api/public-blog?storeId=<storeId>&slug=<postSlug>`
+
+#### Minimal Node/Next.js server example
+
+```ts
+const base = process.env.SEDIFEX_SITE_BASE_URL ?? 'https://www.sedifex.com'
+const storeId = process.env.SEDIFEX_STORE_ID ?? ''
+
+const res = await fetch(`${base}/api/public-blog?storeId=${encodeURIComponent(storeId)}`, {
+  // next.js cache hint (optional)
+  next: { revalidate: 60 },
+})
+
+if (!res.ok) throw new Error(`Blog pull failed: ${res.status}`)
+const payload = await res.json()
+const items = Array.isArray(payload.items) ? payload.items : []
+```
+
 ### `GET /v1IntegrationPromo?storeId=<storeId>` (authenticated) or `?slug=<promoSlug>` (public)
 
 ```json

--- a/web/api/public-blog.ts
+++ b/web/api/public-blog.ts
@@ -1,0 +1,40 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { db } from './_firebase-admin.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const storeId = typeof req.query.storeId === 'string' ? req.query.storeId.trim() : ''
+  if (!storeId) {
+    return res.status(400).json({ error: 'storeId is required' })
+  }
+
+  const postSlug = typeof req.query.slug === 'string' ? req.query.slug.trim() : ''
+
+  const firestore = db()
+  let query = firestore.collection('blogPosts').where('storeId', '==', storeId).where('status', '==', 'published')
+
+  if (postSlug) {
+    query = query.where('slug', '==', postSlug)
+  } else {
+    query = query.orderBy('publishedAt', 'desc').limit(20)
+  }
+
+  const snap = await query.get()
+  const items = snap.docs.map(doc => {
+    const data = doc.data()
+    return {
+      id: doc.id,
+      title: data.title ?? '',
+      slug: data.slug ?? '',
+      content: data.content ?? '',
+      linkUrl: data.linkUrl ?? null,
+      imageUrl: data.imageUrl ?? null,
+      publishedAt: data.publishedAt?.toDate ? data.publishedAt.toDate().toISOString() : null,
+    }
+  })
+
+  return res.status(200).json({ items })
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -37,6 +37,7 @@ import IntegrationWebsiteSettings from './pages/IntegrationWebsiteSettings'
 import IntegrationBookingsSettings from './pages/IntegrationBookingsSettings'
 import IntegrationEmailSettings from './pages/IntegrationEmailSettings'
 import IntegrationGoogleBusinessSettings from './pages/IntegrationGoogleBusinessSettings'
+import BlogPage from './pages/BlogPage'
 
 // ✅ NEW: public receipt page used by QR/share
 import ReceiptView from './pages/ReceiptView'
@@ -51,6 +52,7 @@ import ReturnPolicyPage from './pages/legal/ReturnPolicyPage'
 import IntegrationQuickstartPage from './pages/docs/IntegrationQuickstartPage'
 import WordpressInstallGuidePage from './pages/docs/WordpressInstallGuidePage'
 import BulkEmailGoogleSheetsPage from './pages/docs/BulkEmailGoogleSheetsPage'
+import PublicBlogPage from './pages/PublicBlogPage'
 
 import { ToastProvider } from './components/ToastProvider'
 
@@ -64,6 +66,7 @@ const router = createBrowserRouter([
   { path: '/display', element: <CustomerDisplay /> },
   { path: '/join-customers/:inviteId', element: <PublicCustomerIntake /> },
   { path: '/join-customers/:inviteId/:mode', element: <PublicCustomerIntake /> },
+  { path: '/public-blog/:storeId', element: <PublicBlogPage /> },
 
   {
     path: '/',
@@ -108,6 +111,7 @@ const router = createBrowserRouter([
           { path: 'social-media', element: <SocialMediaPage /> },
           { path: 'merchant-feed', element: <Navigate to="/social-media" replace /> },
           { path: 'support', element: <Support /> },
+          { path: 'blog', element: <BlogPage /> },
           { path: 'settings/integrations/booking-mapping', element: <BookingMappingSettings /> },
           { path: 'settings/integrations/website', element: <IntegrationWebsiteSettings /> },
           { path: 'settings/integrations/bookings', element: <IntegrationBookingsSettings /> },

--- a/web/src/pages/BlogPage.tsx
+++ b/web/src/pages/BlogPage.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  addDoc,
+  collection,
+  doc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  serverTimestamp,
+  updateDoc,
+  where,
+} from 'firebase/firestore'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import { uploadProductImage } from '../api/productImageUpload'
+
+type BlogPost = {
+  id: string
+  title: string
+  content: string
+  linkUrl: string | null
+  imageUrl: string | null
+  status: 'draft' | 'published'
+}
+
+function makeSlug(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+}
+
+export default function BlogPage() {
+  const { storeId } = useActiveStore()
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [linkUrl, setLinkUrl] = useState('')
+  const [imageUrl, setImageUrl] = useState('')
+  const [status, setStatus] = useState<'draft' | 'published'>('draft')
+  const [saving, setSaving] = useState(false)
+  const [posts, setPosts] = useState<BlogPost[]>([])
+  const [message, setMessage] = useState<string | null>(null)
+
+  const publicFeedUrl = useMemo(() => (storeId ? `/api/public-blog?storeId=${encodeURIComponent(storeId)}` : ''), [storeId])
+
+  async function loadPosts() {
+    if (!storeId) return
+    const q = query(
+      collection(db, 'blogPosts'),
+      where('storeId', '==', storeId),
+      orderBy('updatedAt', 'desc'),
+      limit(50),
+    )
+    const snap = await getDocs(q)
+    setPosts(
+      snap.docs.map(d => {
+        const data = d.data() as Record<string, unknown>
+        return {
+          id: d.id,
+          title: String(data.title ?? ''),
+          content: String(data.content ?? ''),
+          linkUrl: typeof data.linkUrl === 'string' ? data.linkUrl : null,
+          imageUrl: typeof data.imageUrl === 'string' ? data.imageUrl : null,
+          status: data.status === 'published' ? 'published' : 'draft',
+        }
+      }),
+    )
+  }
+
+  useEffect(() => {
+    void loadPosts()
+  }, [storeId])
+
+  async function onImageUpload(file: File) {
+    const url = await uploadProductImage(file, { storagePath: 'blog-images' })
+    setImageUrl(url)
+  }
+
+  async function onSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    if (!storeId) return
+    setSaving(true)
+    setMessage(null)
+    try {
+      const normalizedLink = linkUrl.trim()
+      if (normalizedLink && !/^https?:\/\//i.test(normalizedLink)) {
+        throw new Error('Link must start with http:// or https://')
+      }
+      const slug = makeSlug(title)
+      await addDoc(collection(db, 'blogPosts'), {
+        storeId,
+        title: title.trim(),
+        slug,
+        content: content.trim(),
+        linkUrl: normalizedLink || null,
+        imageUrl: imageUrl.trim() || null,
+        status,
+        publishedAt: status === 'published' ? serverTimestamp() : null,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      })
+      setTitle('')
+      setContent('')
+      setLinkUrl('')
+      setImageUrl('')
+      setStatus('draft')
+      setMessage('Post saved.')
+      await loadPosts()
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Failed to save post.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function publishPost(postId: string) {
+    await updateDoc(doc(db, 'blogPosts', postId), {
+      status: 'published',
+      publishedAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    })
+    await loadPosts()
+  }
+
+  return (
+    <main className="page">
+      <section className="card stack" style={{ maxWidth: 880, margin: '0 auto' }}>
+        <h1>Store Blog</h1>
+        <p>Create blog posts and publish them for public viewing and website pull.</p>
+        <form className="stack" onSubmit={onSubmit}>
+          <label className="stack">
+            <span>Title</span>
+            <input value={title} onChange={e => setTitle(e.target.value)} required minLength={5} />
+          </label>
+          <label className="stack">
+            <span>Insert link (optional)</span>
+            <input value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder="https://..." />
+          </label>
+          <label className="stack">
+            <span>Image upload</span>
+            <input type="file" accept="image/*" onChange={e => e.target.files?.[0] && void onImageUpload(e.target.files[0])} />
+          </label>
+          {imageUrl ? <img src={imageUrl} alt="Cover" style={{ maxWidth: 260, borderRadius: 8 }} /> : null}
+          <label className="stack">
+            <span>Text</span>
+            <textarea value={content} onChange={e => setContent(e.target.value)} rows={8} required />
+          </label>
+          <label className="stack">
+            <span>Status</span>
+            <select value={status} onChange={e => setStatus(e.target.value as 'draft' | 'published')}>
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+            </select>
+          </label>
+          <button type="submit" disabled={saving || !storeId}>{saving ? 'Saving…' : 'Save Post'}</button>
+        </form>
+        {message ? <p>{message}</p> : null}
+        {publicFeedUrl ? <p>Public feed: <code>{publicFeedUrl}</code></p> : null}
+
+        <h2>Posts</h2>
+        <ul className="stack">
+          {posts.map(post => (
+            <li key={post.id} className="card" style={{ padding: 12 }}>
+              <strong>{post.title}</strong> — {post.status}
+              <div>
+                {post.status !== 'published' ? <button onClick={() => void publishPost(post.id)}>Publish</button> : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  )
+}

--- a/web/src/pages/PublicBlogPage.tsx
+++ b/web/src/pages/PublicBlogPage.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+
+type Post = { id: string; title: string; content: string; imageUrl?: string | null; linkUrl?: string | null }
+
+export default function PublicBlogPage() {
+  const { storeId = '' } = useParams()
+  const [posts, setPosts] = useState<Post[]>([])
+
+  useEffect(() => {
+    if (!storeId) return
+    fetch(`/api/public-blog?storeId=${encodeURIComponent(storeId)}`)
+      .then(r => r.json())
+      .then(data => setPosts(Array.isArray(data.items) ? data.items : []))
+      .catch(() => setPosts([]))
+  }, [storeId])
+
+  return (
+    <main className="page" style={{ maxWidth: 900, margin: '0 auto', padding: 16 }}>
+      <h1>Store Blog</h1>
+      {posts.map(post => (
+        <article key={post.id} className="card" style={{ marginBottom: 16, padding: 16 }}>
+          <h2>{post.title}</h2>
+          {post.imageUrl ? <img src={post.imageUrl} alt={post.title} style={{ maxWidth: 320 }} /> : null}
+          <p>{post.content}</p>
+          {post.linkUrl ? <p><a href={post.linkUrl} target="_blank" rel="noreferrer">Read more</a></p> : null}
+        </article>
+      ))}
+      <p><Link to="/">Back</Link></p>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation

- Provide stores with a simple, store-scoped blog authoring experience that can publish to a public Sedifex-hosted feed and be pulled into external sites.  
- Support image uploads, link validation, slugging, and status (draft/published) to enable controlled publishing.  
- Expose a lightweight public API and a public listing page so sites can embed or fetch published posts without secrets.

### Description

- Added a design/implementation doc `docs/blog-page-implementation.md` describing schema, security, API contract, and rollout plan.  
- Updated `docs/integration-api-guide.md` to document the new public blog pull API at `GET /api/public-blog`.  
- Implemented a serverless endpoint handler at `web/api/public-blog.ts` that queries `blogPosts` in Firestore for `status === 'published'` and returns a JSON `items` list (supports optional `slug` filter).  
- Added a new admin React page `web/src/pages/BlogPage.tsx` that allows store staff to create posts, upload images via the existing image upload helper, generate slugs, and publish posts to Firestore.  
- Added a public-facing React page `web/src/pages/PublicBlogPage.tsx` that fetches and renders the public feed for a `storeId`.  
- Wired the new pages into the app router in `web/src/main.tsx` by importing `BlogPage` and `PublicBlogPage` and registering routes for `/blog` (authenticated admin) and `/public-blog/:storeId` (public). 

### Testing

- Ran TypeScript type-check (`tsc`) and the project build to validate typings and compilation, which completed successfully.  
- Ran linter checks (`eslint`) against modified files with no blocking errors.  
- No new automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02cffc9bc48321a6029d3df9456738)