### PR TITLE
Queue recipients when Gmail quota is reached and expose queued status in logs/docs

### DIFF
--- a/docs/bulk-email-google-sheets-guide.md
+++ b/docs/bulk-email-google-sheets-guide.md
@@ -84,7 +84,8 @@ const CONFIG = {
   statusValues: {
     sent: 'SENT',
     skipped: 'SKIPPED',
-    error: 'ERROR'
+    error: 'ERROR',
+    queued: 'QUEUED'
   }
 };
 
@@ -232,17 +233,9 @@ function doPost(e) {
 
     const mailQuotaRemaining = MailApp.getRemainingDailyQuota();
 
-    if (recipients.length > mailQuotaRemaining) {
-      return jsonOutput({
-        ok: false,
-        error: 'gmail quota too low for this request',
-        quotaRemaining: mailQuotaRemaining,
-        requested: recipients.length
-      });
-    }
-
     let attempted = 0;
     let sent = 0;
+    let queuedForRetry = 0;
     let skipped = 0;
     const errors = [];
     const rowUpdates = [];
@@ -257,6 +250,18 @@ function doPost(e) {
           rowUpdates.push({
             rowIndex: recipient.rowIndex,
             status: CONFIG.statusValues.skipped,
+            lastSentAt: ''
+          });
+        }
+        return;
+      }
+
+      if (attempted >= mailQuotaRemaining) {
+        queuedForRetry += 1;
+        if (recipient.rowIndex && statusCol !== undefined) {
+          rowUpdates.push({
+            rowIndex: recipient.rowIndex,
+            status: CONFIG.statusValues.queued,
             lastSentAt: ''
           });
         }
@@ -317,6 +322,8 @@ function doPost(e) {
       attempted: attempted,
       sent: sent,
       failed: attempted - sent,
+      queuedForRetry: queuedForRetry,
+      quotaRemainingBeforeSend: mailQuotaRemaining,
       skipped: skipped,
       timestamp: new Date().toISOString()
     });
@@ -327,6 +334,8 @@ function doPost(e) {
       attempted: attempted,
       sent: sent,
       failed: attempted - sent,
+      queuedForRetry: queuedForRetry,
+      quotaRemainingBeforeSend: mailQuotaRemaining,
       skipped: skipped,
       errors: errors,
       quotaRemainingAfterSend: MailApp.getRemainingDailyQuota()
@@ -536,4 +545,5 @@ function escapeRegex_(text) {
 ## Important notes
 - Keep customer records in Sedifex only (avoid duplicate manual entry).
 - Google sending quotas apply.
+- Recipients marked `QUEUED` are deferred and will send on the next script run (for example, a scheduled trigger or a manual rerun).
 - Rotate shared tokens when ownership/staff changes.

--- a/web/src/pages/docs/BulkEmailGoogleSheetsPage.tsx
+++ b/web/src/pages/docs/BulkEmailGoogleSheetsPage.tsx
@@ -23,12 +23,24 @@ function doPost(e) {
     const html = payload.html || ''
     const recipients = Array.isArray(payload.recipients) ? payload.recipients : []
 
+    const quotaRemaining = MailApp.getRemainingDailyQuota()
     let sent = 0
+    let queued = 0
+    let attempted = 0
     const failures = []
+    const queuedRecipients = []
 
     recipients.forEach((row) => {
       const email = (row?.email || '').toString().trim()
       if (!email) return
+
+      // 3) Queue overflow once we hit Gmail daily quota
+      if (attempted >= quotaRemaining) {
+        queued += 1
+        queuedRecipients.push({ email, status: 'queued_for_next_run_quota_reached' })
+        return
+      }
+      attempted += 1
 
       try {
         MailApp.sendEmail({
@@ -44,29 +56,32 @@ function doPost(e) {
       }
     })
 
-    // 3) Optional logging in a tab named "send_logs"
-    logSendResult(campaignId, sent, failures.length)
+    // 4) Optional logging in a tab named "send_logs"
+    logSendResult(campaignId, sent, failures.length, queued)
 
     return jsonResponse({
       ok: true,
       campaignId,
-      attempted: recipients.length,
+      attempted,
       sent,
+      queued,
+      queuedRecipients,
       failed: failures.length,
       failures,
+      quotaRemainingBeforeSend: quotaRemaining,
     })
   } catch (err) {
     return jsonResponse({ ok: false, error: String(err) }, 500)
   }
 }
 
-function logSendResult(campaignId, sent, failed) {
+function logSendResult(campaignId, sent, failed, queued) {
   const ss = SpreadsheetApp.getActiveSpreadsheet()
   const sheet = ss.getSheetByName('send_logs') || ss.insertSheet('send_logs')
   if (sheet.getLastRow() === 0) {
-    sheet.appendRow(['timestamp', 'campaignId', 'sent', 'failed'])
+    sheet.appendRow(['timestamp', 'campaignId', 'sent', 'failed', 'queued'])
   }
-  sheet.appendRow([new Date().toISOString(), campaignId, sent, failed])
+  sheet.appendRow([new Date().toISOString(), campaignId, sent, failed, queued])
 }
 
 function jsonResponse(data, statusCode) {


### PR DESCRIPTION
### Motivation
- Avoid failing entire send jobs when Gmail daily quota is insufficient by deferring excess recipients for the next run. 
- Provide visibility into deferred recipients in logs, responses, and the documentation so operators can retry them later.

### Description
- Add a `QUEUED` status to `CONFIG.statusValues` and mark recipient rows as `QUEUED` when the script hits `MailApp.getRemainingDailyQuota()` during processing. 
- Track `queuedForRetry` / `queued` counts and include `queuedForRetry`, `queued`, and `quotaRemainingBeforeSend` in the run summary and JSON response. 
- Update the Apps Script sample in the web docs to queue overflow recipients (`queuedRecipients`) and to log the `queued` count by changing `logSendResult` signature and sheet columns. 
- Clarify the docs with a note that recipients marked `QUEUED` are deferred for the next scheduled/manual run.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f2df9efc83218b28c315f843cba8)