### PR TITLE
Show Blog and Account links in trial-limited navigation

### DIFF
--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -118,6 +118,11 @@ export default function Shell({ children }: { children: React.ReactNode }) {
     if (hasTrialEnded) {
       return [
         {
+          to: '/blog',
+          label: 'Blog',
+          roles: [role],
+        },
+        {
           to: '/account',
           label: 'Account',
           end: true,


### PR DESCRIPTION
### Motivation
- When a workspace trial ends the sidebar was reduced to only the `Account` link which hid `Blog` from users, so the navigation should include `Blog` alongside `Account` for trial-limited workspaces.

### Description
- Update `navItems` in `web/src/layout/Shell.tsx` so that when `hasTrialEnded` is true it returns both the `Blog` (`to: '/blog'`) and `Account` (`to: '/account'`) navigation items while preserving roles and the `end` flag on `Account`.

### Testing
- Attempted to run `cd web && npm test -- --run web/src/layout/Shell.test.tsx`, but the test run could not be executed in this environment because `vitest` is not installed (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f52b8a988321a532311d20dad630)