### PR TITLE
Add OpenAI generation to Bulk Email and Blog pages

### DIFF
--- a/web/src/pages/BlogPage.tsx
+++ b/web/src/pages/BlogPage.tsx
@@ -13,6 +13,7 @@ import {
 } from 'firebase/firestore'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
+import { requestAiAdvisor } from '../api/aiAdvisor'
 import { uploadProductImage } from '../api/productImageUpload'
 
 type BlogPost = {
@@ -73,6 +74,39 @@ export default function BlogPage() {
   useEffect(() => {
     void loadPosts()
   }, [storeId])
+
+
+  const [isAiGenerating, setIsAiGenerating] = useState(false)
+
+  async function generateBlogWithAi() {
+    if (!storeId) return
+    setIsAiGenerating(true)
+    setMessage(null)
+    try {
+      const prompt = [
+        'Write a high quality blog post for a retail store website.',
+        `Working title: ${title.trim() || 'New Arrivals and Offers'}.`,
+        'Return this format exactly:',
+        'TITLE: <post title>',
+        'CONTENT: <blog post body with paragraphs>',
+      ].join('\n')
+      const result = await requestAiAdvisor({ question: prompt, storeId })
+      const advice = result.advice || ''
+      const titleMatch = advice.match(/TITLE:\s*([\s\S]*?)(?:\nCONTENT:|$)/i)
+      const contentMatch = advice.match(/CONTENT:\s*([\s\S]*)$/i)
+      if (titleMatch?.[1]?.trim()) setTitle(titleMatch[1].trim())
+      if (contentMatch?.[1]?.trim()) {
+        setContent(contentMatch[1].trim())
+      } else {
+        setContent(advice.trim())
+      }
+      setMessage('AI draft generated. Review before saving.')
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not generate blog draft.')
+    } finally {
+      setIsAiGenerating(false)
+    }
+  }
 
   async function onImageUpload(file: File) {
     const url = await uploadProductImage(file, { storagePath: 'blog-images' })
@@ -144,6 +178,11 @@ export default function BlogPage() {
             <input type="file" accept="image/*" onChange={e => e.target.files?.[0] && void onImageUpload(e.target.files[0])} />
           </label>
           {imageUrl ? <img src={imageUrl} alt="Cover" style={{ maxWidth: 260, borderRadius: 8 }} /> : null}
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button type="button" className="button button--ghost" onClick={() => void generateBlogWithAi()} disabled={isAiGenerating || saving || !storeId}>
+              {isAiGenerating ? 'Generating…' : 'Generate with OpenAI'}
+            </button>
+          </div>
           <label className="stack">
             <span>Text</span>
             <textarea value={content} onChange={e => setContent(e.target.value)} rows={8} required />

--- a/web/src/pages/BulkEmail.tsx
+++ b/web/src/pages/BulkEmail.tsx
@@ -6,6 +6,7 @@ import PageSection from '../layout/PageSection'
 import { db, functions } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useWorkspaceIdentity } from '../hooks/useWorkspaceIdentity'
+import { requestAiAdvisor } from '../api/aiAdvisor'
 
 type Customer = {
   id: string
@@ -195,6 +196,76 @@ export default function BulkEmail() {
 
   const clearSelection = () => setSelectedIds(new Set())
 
+
+  const [isAiGenerating, setIsAiGenerating] = useState(false)
+  const [aiError, setAiError] = useState('')
+
+  const generateEmailWithAi = async () => {
+    if (!storeId) {
+      setAiError('Workspace is missing. Refresh and try again.')
+      return
+    }
+    const prompt = [
+      'Write a conversion-focused bulk email campaign for a retail store.',
+      `Store name: ${fromName.trim() || 'Sedifex Campaign'}.`,
+      `Subject idea: ${subject.trim() || 'Weekend promotion for loyal customers'}.`,
+      'Return the response in this exact format:',
+      'SUBJECT: <subject line>',
+      'BODY_TEXT: <plain text email body>',
+      'BODY_HTML: <responsive HTML email body using inline styles and clear CTA button>',
+    ].join('\n')
+
+    setIsAiGenerating(true)
+    setAiError('')
+    try {
+      const result = await requestAiAdvisor({ question: prompt, storeId })
+      const advice = result.advice || ''
+      const subjectMatch = advice.match(/SUBJECT:\s*([\s\S]*?)(?:\nBODY_TEXT:|$)/i)
+      const textMatch = advice.match(/BODY_TEXT:\s*([\s\S]*?)(?:\nBODY_HTML:|$)/i)
+      const htmlMatch = advice.match(/BODY_HTML:\s*([\s\S]*)$/i)
+
+      if (subjectMatch?.[1]?.trim()) setSubject(subjectMatch[1].trim())
+      if (htmlMatch?.[1]?.trim()) {
+        setHtml(htmlMatch[1].trim())
+      } else if (textMatch?.[1]?.trim()) {
+        setHtml(textMatch[1].trim())
+      } else {
+        setHtml(advice.trim())
+      }
+    } catch (error) {
+      setAiError(error instanceof Error ? error.message : 'Unable to generate with AI right now.')
+    } finally {
+      setIsAiGenerating(false)
+    }
+  }
+
+  const convertToHtmlWithAi = async () => {
+    const message = html.trim()
+    if (!message) {
+      setAiError('Add plain text content first, then convert to HTML.')
+      return
+    }
+    if (!storeId) {
+      setAiError('Workspace is missing. Refresh and try again.')
+      return
+    }
+
+    setIsAiGenerating(true)
+    setAiError('')
+    try {
+      const result = await requestAiAdvisor({
+        question: `Convert this bulk email into clean HTML for email clients. Keep meaning unchanged, use inline styles, and return only HTML.\n\n${message}`,
+        storeId,
+      })
+      const cleanedHtml = result.advice.trim().replace(/^```html\s*/i, '').replace(/```$/, '').trim()
+      setHtml(cleanedHtml)
+    } catch (error) {
+      setAiError(error instanceof Error ? error.message : 'Unable to convert to HTML right now.')
+    } finally {
+      setIsAiGenerating(false)
+    }
+  }
+
   const handleSend = async () => {
     setSendStatus('')
     setSendError('')
@@ -306,6 +377,15 @@ export default function BulkEmail() {
               placeholder="Big weekend offer for loyal customers"
             />
           </label>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button type="button" className="button button--ghost" onClick={() => void generateEmailWithAi()} disabled={isAiGenerating || isSending}>
+              {isAiGenerating ? 'Generating…' : 'Generate with OpenAI'}
+            </button>
+            <button type="button" className="button button--ghost" onClick={() => void convertToHtmlWithAi()} disabled={isAiGenerating || isSending}>
+              {isAiGenerating ? 'Converting…' : 'Convert message to HTML with AI'}
+            </button>
+          </div>
+
           <label style={{ display: 'grid', gap: 6 }}>
             <span>Email content (HTML or plain text)</span>
             <textarea
@@ -379,6 +459,7 @@ export default function BulkEmail() {
           </Link>
         </div>
 
+        {aiError ? <p style={{ margin: 0, color: 'var(--danger, #b3261e)' }}>{aiError}</p> : null}
         {sendStatus ? <p style={{ margin: 0, color: 'var(--success, #137333)' }}>{sendStatus}</p> : null}
         {sendError ? <p style={{ margin: 0, color: 'var(--danger, #b3261e)' }}>{sendError}</p> : null}
         {sendResult ? (


### PR DESCRIPTION
### Motivation

- Provide in-app AI assistance so store owners can quickly draft bulk email campaigns and blog posts and convert plain text emails into email-ready HTML.

### Description

- Added `requestAiAdvisor` integration and imports to `web/src/pages/BulkEmail.tsx` and `web/src/pages/BlogPage.tsx` to call the AI backend.
- Implemented `generateEmailWithAi` and `convertToHtmlWithAi` in the Bulk Email composer which parse structured AI responses (`SUBJECT`, `BODY_TEXT`, `BODY_HTML`) and populate `subject`/`html` fields; added `isAiGenerating`/`aiError` state and UI buttons for generation and conversion.
- Implemented `generateBlogWithAi` in the Blog editor which parses structured AI responses (`TITLE`, `CONTENT`) and populates the `title` and `content` fields, and added a `Generate with OpenAI` button and `isAiGenerating` state.
- Wired UI controls into the existing forms and surfaced AI errors/status messages in the pages.

### Testing

- Ran `npm -C web run build` which failed due to missing installed dependencies/type defs in the local environment (build error: missing `vite/client` and `vitest/globals`).
- Ran `npm -C web ci` which failed due to registry access restrictions (npm returned `403 Forbidden` for `@azure/msal-browser`), so dependencies could not be installed and the app build/tests could not be executed further.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f78c70288321938174ecb39915cb)