### PR TITLE
Blog: add edit/delete, excerpt/detail pages, SEO, tags, and scheduling

### DIFF
--- a/web/api/public-blog.ts
+++ b/web/api/public-blog.ts
@@ -12,29 +12,46 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const postSlug = typeof req.query.slug === 'string' ? req.query.slug.trim() : ''
+  const tag = typeof req.query.tag === 'string' ? req.query.tag.trim() : ''
 
   const firestore = db()
-  let query = firestore.collection('blogPosts').where('storeId', '==', storeId).where('status', '==', 'published')
+  let query = firestore.collection('blogPosts').where('storeId', '==', storeId)
+
+  const now = new Date()
 
   if (postSlug) {
-    query = query.where('slug', '==', postSlug)
+    query = query.where('slug', '==', postSlug).limit(1)
   } else {
-    query = query.orderBy('publishedAt', 'desc').limit(20)
+    query = query.orderBy('updatedAt', 'desc').limit(50)
   }
 
   const snap = await query.get()
-  const items = snap.docs.map(doc => {
+  let items = snap.docs.map(doc => {
     const data = doc.data()
+    const status = data.status ?? 'draft'
+    const publishAt = data.publishAt?.toDate ? data.publishAt.toDate() : null
+    const isVisible = status === 'published' || (status === 'scheduled' && publishAt && publishAt <= now)
+    if (!isVisible) return null
     return {
       id: doc.id,
       title: data.title ?? '',
       slug: data.slug ?? '',
+      excerpt: data.excerpt ?? null,
       content: data.content ?? '',
       linkUrl: data.linkUrl ?? null,
       imageUrl: data.imageUrl ?? null,
+      metaTitle: data.metaTitle ?? null,
+      metaDescription: data.metaDescription ?? null,
+      canonicalUrl: data.canonicalUrl ?? null,
+      ogImage: data.ogImage ?? null,
+      tags: Array.isArray(data.tags) ? data.tags.filter((item: unknown) => typeof item === 'string') : [],
       publishedAt: data.publishedAt?.toDate ? data.publishedAt.toDate().toISOString() : null,
     }
-  })
+  }).filter(Boolean)
+
+  if (tag) {
+    items = items.filter(item => (item?.tags ?? []).includes(tag))
+  }
 
   return res.status(200).json({ items })
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -66,6 +66,7 @@ const router = createBrowserRouter([
   { path: '/join-customers/:inviteId', element: <PublicCustomerIntake /> },
   { path: '/join-customers/:inviteId/:mode', element: <PublicCustomerIntake /> },
   { path: '/public-blog/:storeId', element: <PublicBlogPage /> },
+  { path: '/public-blog/:storeId/:slug', element: <PublicBlogPage /> },
 
   {
     path: '/',

--- a/web/src/pages/BlogPage.tsx
+++ b/web/src/pages/BlogPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import {
   addDoc,
   collection,
+  deleteDoc,
   doc,
   getDocs,
   limit,
@@ -19,10 +20,18 @@ import { uploadProductImage } from '../api/productImageUpload'
 type BlogPost = {
   id: string
   title: string
+  slug: string
+  excerpt: string | null
   content: string
+  metaTitle: string | null
+  metaDescription: string | null
+  canonicalUrl: string | null
+  ogImage: string | null
+  tags: string[]
+  publishAt: string | null
   linkUrl: string | null
   imageUrl: string | null
-  status: 'draft' | 'published'
+  status: 'draft' | 'published' | 'scheduled' | 'archived'
 }
 
 function makeSlug(value: string): string {
@@ -38,12 +47,20 @@ export default function BlogPage() {
   const { storeId } = useActiveStore()
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
+  const [excerpt, setExcerpt] = useState('')
+  const [metaTitle, setMetaTitle] = useState('')
+  const [metaDescription, setMetaDescription] = useState('')
+  const [canonicalUrl, setCanonicalUrl] = useState('')
+  const [ogImage, setOgImage] = useState('')
+  const [tagsInput, setTagsInput] = useState('')
+  const [publishAt, setPublishAt] = useState('')
   const [linkUrl, setLinkUrl] = useState('')
   const [imageUrl, setImageUrl] = useState('')
-  const [status, setStatus] = useState<'draft' | 'published'>('draft')
+  const [status, setStatus] = useState<'draft' | 'published' | 'scheduled'>('draft')
   const [saving, setSaving] = useState(false)
   const [posts, setPosts] = useState<BlogPost[]>([])
   const [message, setMessage] = useState<string | null>(null)
+  const [editingPostId, setEditingPostId] = useState<string | null>(null)
 
   const publicFeedUrl = useMemo(() => (storeId ? `/api/public-blog?storeId=${encodeURIComponent(storeId)}` : ''), [storeId])
 
@@ -62,10 +79,21 @@ export default function BlogPage() {
         return {
           id: d.id,
           title: String(data.title ?? ''),
+          slug: String(data.slug ?? ''),
+          excerpt: typeof data.excerpt === 'string' ? data.excerpt : null,
           content: String(data.content ?? ''),
+          metaTitle: typeof data.metaTitle === 'string' ? data.metaTitle : null,
+          metaDescription: typeof data.metaDescription === 'string' ? data.metaDescription : null,
+          canonicalUrl: typeof data.canonicalUrl === 'string' ? data.canonicalUrl : null,
+          ogImage: typeof data.ogImage === 'string' ? data.ogImage : null,
+          tags: Array.isArray(data.tags) ? data.tags.filter((item): item is string => typeof item === 'string') : [],
+          publishAt: typeof data.publishAt?.toDate === 'function' ? data.publishAt.toDate().toISOString().slice(0, 16) : null,
           linkUrl: typeof data.linkUrl === 'string' ? data.linkUrl : null,
           imageUrl: typeof data.imageUrl === 'string' ? data.imageUrl : null,
-          status: data.status === 'published' ? 'published' : 'draft',
+          status:
+            data.status === 'published' || data.status === 'scheduled' || data.status === 'archived'
+              ? data.status
+              : 'draft',
         }
       }),
     )
@@ -124,30 +152,79 @@ export default function BlogPage() {
         throw new Error('Link must start with http:// or https://')
       }
       const slug = makeSlug(title)
-      await addDoc(collection(db, 'blogPosts'), {
+      const payload = {
         storeId,
         title: title.trim(),
         slug,
+        excerpt: excerpt.trim() || null,
         content: content.trim(),
+        metaTitle: metaTitle.trim() || null,
+        metaDescription: metaDescription.trim() || null,
+        canonicalUrl: canonicalUrl.trim() || null,
+        ogImage: ogImage.trim() || null,
+        tags: tagsInput.split(',').map(tag => tag.trim()).filter(Boolean),
+        publishAt: publishAt ? new Date(publishAt) : null,
         linkUrl: normalizedLink || null,
         imageUrl: imageUrl.trim() || null,
         status,
         publishedAt: status === 'published' ? serverTimestamp() : null,
-        createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
-      })
+      }
+
+      if (editingPostId) {
+        await updateDoc(doc(db, 'blogPosts', editingPostId), payload)
+      } else {
+        await addDoc(collection(db, 'blogPosts'), {
+          ...payload,
+          createdAt: serverTimestamp(),
+        })
+      }
       setTitle('')
+      setExcerpt('')
       setContent('')
+      setMetaTitle('')
+      setMetaDescription('')
+      setCanonicalUrl('')
+      setOgImage('')
+      setTagsInput('')
+      setPublishAt('')
       setLinkUrl('')
       setImageUrl('')
       setStatus('draft')
-      setMessage('Post saved.')
+      setEditingPostId(null)
+      setMessage(editingPostId ? 'Post updated.' : 'Post saved.')
       await loadPosts()
     } catch (error) {
       setMessage(error instanceof Error ? error.message : 'Failed to save post.')
     } finally {
       setSaving(false)
     }
+  }
+
+  function editPost(post: BlogPost) {
+    setEditingPostId(post.id)
+    setTitle(post.title)
+    setExcerpt(post.excerpt ?? '')
+    setContent(post.content)
+    setMetaTitle(post.metaTitle ?? '')
+    setMetaDescription(post.metaDescription ?? '')
+    setCanonicalUrl(post.canonicalUrl ?? '')
+    setOgImage(post.ogImage ?? '')
+    setTagsInput(post.tags.join(', '))
+    setPublishAt(post.publishAt ?? '')
+    setLinkUrl(post.linkUrl ?? '')
+    setImageUrl(post.imageUrl ?? '')
+    setStatus(post.status === 'archived' ? 'draft' : post.status)
+  }
+
+  async function archivePost(postId: string) {
+    await updateDoc(doc(db, 'blogPosts', postId), { status: 'archived', updatedAt: serverTimestamp() })
+    await loadPosts()
+  }
+
+  async function permanentlyDeletePost(postId: string) {
+    await deleteDoc(doc(db, 'blogPosts', postId))
+    await loadPosts()
   }
 
   async function publishPost(postId: string) {
@@ -184,17 +261,28 @@ export default function BlogPage() {
             </button>
           </div>
           <label className="stack">
+            <span>Excerpt (optional)</span>
+            <textarea value={excerpt} onChange={e => setExcerpt(e.target.value)} rows={3} maxLength={320} />
+          </label>
+          <label className="stack">
             <span>Text</span>
             <textarea value={content} onChange={e => setContent(e.target.value)} rows={8} required />
           </label>
+          <label className="stack"><span>Meta title</span><input value={metaTitle} onChange={e => setMetaTitle(e.target.value)} /></label>
+          <label className="stack"><span>Meta description</span><textarea value={metaDescription} onChange={e => setMetaDescription(e.target.value)} rows={2} /></label>
+          <label className="stack"><span>Canonical URL</span><input value={canonicalUrl} onChange={e => setCanonicalUrl(e.target.value)} placeholder="https://..." /></label>
+          <label className="stack"><span>OG image URL</span><input value={ogImage} onChange={e => setOgImage(e.target.value)} placeholder="https://..." /></label>
+          <label className="stack"><span>Tags (comma separated)</span><input value={tagsInput} onChange={e => setTagsInput(e.target.value)} placeholder="promo, sale" /></label>
+          <label className="stack"><span>Publish at</span><input type="datetime-local" value={publishAt} onChange={e => setPublishAt(e.target.value)} /></label>
           <label className="stack">
             <span>Status</span>
-            <select value={status} onChange={e => setStatus(e.target.value as 'draft' | 'published')}>
+            <select value={status} onChange={e => setStatus(e.target.value as 'draft' | 'published' | 'scheduled')}>
               <option value="draft">Draft</option>
               <option value="published">Published</option>
+              <option value="scheduled">Scheduled</option>
             </select>
           </label>
-          <button type="submit" disabled={saving || !storeId}>{saving ? 'Saving…' : 'Save Post'}</button>
+          <button type="submit" disabled={saving || !storeId}>{saving ? 'Saving…' : editingPostId ? 'Update Post' : 'Save Post'}</button>
         </form>
         {message ? <p>{message}</p> : null}
         {publicFeedUrl ? <p>Public feed: <code>{publicFeedUrl}</code></p> : null}
@@ -203,9 +291,12 @@ export default function BlogPage() {
         <ul className="stack">
           {posts.map(post => (
             <li key={post.id} className="card" style={{ padding: 12 }}>
-              <strong>{post.title}</strong> — {post.status}
+              <strong>{post.title}</strong> — {post.status} {post.slug ? <code>/{post.slug}</code> : null}
               <div>
                 {post.status !== 'published' ? <button onClick={() => void publishPost(post.id)}>Publish</button> : null}
+                <button onClick={() => editPost(post)}>Edit</button>
+                <button onClick={() => void archivePost(post.id)}>Archive</button>
+                <button onClick={() => void permanentlyDeletePost(post.id)}>Delete</button>
               </div>
             </li>
           ))}

--- a/web/src/pages/PublicBlogPage.tsx
+++ b/web/src/pages/PublicBlogPage.tsx
@@ -1,28 +1,44 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 
-type Post = { id: string; title: string; content: string; imageUrl?: string | null; linkUrl?: string | null }
+type Post = { id: string; title: string; slug: string; excerpt?: string | null; content: string; imageUrl?: string | null; linkUrl?: string | null; tags?: string[]; metaTitle?: string | null; metaDescription?: string | null; canonicalUrl?: string | null; ogImage?: string | null }
 
 export default function PublicBlogPage() {
-  const { storeId = '' } = useParams()
+  const { storeId = '', slug = '' } = useParams()
   const [posts, setPosts] = useState<Post[]>([])
+  const [selectedTag, setSelectedTag] = useState('all')
 
   useEffect(() => {
     if (!storeId) return
-    fetch(`/api/public-blog?storeId=${encodeURIComponent(storeId)}`)
+    const params = new URLSearchParams({ storeId })
+    if (slug) params.set('slug', slug)
+    if (selectedTag !== 'all') params.set('tag', selectedTag)
+    fetch(`/api/public-blog?${params.toString()}`)
       .then(r => r.json())
       .then(data => setPosts(Array.isArray(data.items) ? data.items : []))
       .catch(() => setPosts([]))
-  }, [storeId])
+  }, [storeId, slug, selectedTag])
+
+  const allTags = useMemo(() => ['all', ...new Set(posts.flatMap(post => post.tags ?? []))], [posts])
+  const detailPost = slug ? posts[0] : null
+
+  useEffect(() => {
+    if (!detailPost) return
+    document.title = detailPost.metaTitle || detailPost.title
+    const desc = document.querySelector('meta[name="description"]')
+    if (desc) desc.setAttribute('content', detailPost.metaDescription ?? detailPost.excerpt ?? '')
+  }, [detailPost])
 
   return (
     <main className="page" style={{ maxWidth: 900, margin: '0 auto', padding: 16 }}>
       <h1>Store Blog</h1>
+      {!slug ? <p><label>Filter by tag: <select value={selectedTag} onChange={e => setSelectedTag(e.target.value)}>{allTags.map(tag => <option key={tag} value={tag}>{tag}</option>)}</select></label></p> : null}
       {posts.map(post => (
         <article key={post.id} className="card" style={{ marginBottom: 16, padding: 16 }}>
           <h2>{post.title}</h2>
           {post.imageUrl ? <img src={post.imageUrl} alt={post.title} style={{ maxWidth: 320 }} /> : null}
-          <p>{post.content}</p>
+          <p>{slug ? post.content : (post.excerpt || `${post.content.slice(0, 220)}...`)}</p>
+          {!slug ? <p><Link to={`/public-blog/${storeId}/${post.slug}`}>Read article</Link></p> : null}
           {post.linkUrl ? <p><a href={post.linkUrl} target="_blank" rel="noreferrer">Read more</a></p> : null}
         </article>
       ))}


### PR DESCRIPTION
### Motivation
- Provide full blog post management in the admin UI so posts can be edited and removed after creation.
- Improve public consumption with shorter list previews, per-post detail pages, and SEO metadata for discoverability.
- Allow lightweight editorial features like tags and scheduled publishing so stores can plan and filter content.

### Description
- Added editing flow to the admin page `BlogPage.tsx` which loads a post into the form, switches between `addDoc` and `updateDoc`, and tracks `editingPostId` to persist updates.
- Implemented soft-delete (`status: 'archived'`) and hard-delete (`deleteDoc`) actions in `BlogPage.tsx` and exposed `Edit`, `Archive`, and `Delete` buttons in the posts list.
- Extended the post schema and form with new fields: `slug`, `excerpt`, `metaTitle`, `metaDescription`, `canonicalUrl`, `ogImage`, `tags`, and `publishAt`, and added a `scheduled` status option with client-side `datetime-local` input handling in `BlogPage.tsx`.
- Updated the public listing and detail UI in `PublicBlogPage.tsx` to show `excerpt` (or truncated content) on lists, add a `Read article` link to `/public-blog/:storeId/:slug`, support tag filtering UI, and set document `title`/description meta tags when rendering a detail page.
- Enhanced the public API `web/api/public-blog.ts` to accept a `tag` query param, return the new SEO/tags/excerpt fields, support slug lookup, and include scheduled posts only when `publishAt <= now`.
- Registered the detail route in routing (`web/src/main.tsx`) as `/public-blog/:storeId/:slug` and increased list limits/ordering for admin/public endpoints.

### Testing
- Ran a production build attempt with `cd web && npm run -s build`; the build failed in this environment due to missing type definition files (`vite/client`, `vitest/globals`) which are unrelated to the feature changes. No other automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f9aba9488321b9354b1ca04d41c3)