### PR TITLE
Replace blog header “New post” button with image upload browse control

### DIFF
--- a/web/src/pages/BlogPage.css
+++ b/web/src/pages/BlogPage.css
@@ -16,6 +16,14 @@
 .blog-page__title p { margin: 4px 0 0; color: #64748b; }
 
 .blog-page__top-actions { display: flex; gap: 10px; align-items: center; }
+.blog-page__image-upload {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-weight: 500;
+}
+.blog-page__image-upload input { display: none; }
 
 .blog-page__content {
   display: block;

--- a/web/src/pages/BlogPage.tsx
+++ b/web/src/pages/BlogPage.tsx
@@ -77,6 +77,7 @@ export default function BlogPage() {
   const [isAiGenerating, setIsAiGenerating] = useState(false)
   const [catalogItems, setCatalogItems] = useState<CatalogItem[]>([])
   const [selectedCatalogItemId, setSelectedCatalogItemId] = useState('')
+  const [imageUrl, setImageUrl] = useState<string | null>(null)
 
   const publicFeedUrl = useMemo(() => (storeId ? `/api/public-blog?storeId=${encodeURIComponent(storeId)}` : ''), [storeId])
 
@@ -202,7 +203,7 @@ export default function BlogPage() {
         tags: [],
         publishAt: publishAt ? new Date(publishAt) : null,
         linkUrl: null,
-        imageUrl: null,
+        imageUrl,
         status,
         publishedAt: status === 'published' ? serverTimestamp() : null,
         updatedAt: serverTimestamp(),
@@ -216,6 +217,7 @@ export default function BlogPage() {
       setMetaDescription('')
       setPublishAt('')
       setStatus('draft')
+      setImageUrl(null)
       setEditingPostId(null)
       setMessage(editingPostId ? 'Post updated.' : 'Post saved.')
       await loadPosts()
@@ -233,6 +235,7 @@ export default function BlogPage() {
     setMetaDescription(post.metaDescription ?? '')
     setPublishAt(post.publishAt ?? '')
     setStatus(post.status === 'archived' ? 'draft' : post.status)
+    setImageUrl(post.imageUrl)
   }
 
   async function archivePost(postId: string) {
@@ -259,7 +262,22 @@ export default function BlogPage() {
             <p>Write updates and publish polished posts for your public audience.</p>
           </div>
           <div className="blog-page__top-actions">
-            <button type="button" onClick={() => setEditingPostId(null)}>{editingPostId ? 'New post' : 'New post'}</button>
+            <label className="blog-page__image-upload">
+              <input
+                type="file"
+                accept="image/*"
+                onChange={event => {
+                  const file = event.currentTarget.files?.[0]
+                  if (!file) return
+                  const reader = new FileReader()
+                  reader.onload = () => {
+                    if (typeof reader.result === 'string') setImageUrl(reader.result)
+                  }
+                  reader.readAsDataURL(file)
+                }}
+              />
+              Browse for image upload
+            </label>
             {publicFeedUrl ? (
               <aside className="card blog-page__feed">
                 <strong>Public feed</strong>


### PR DESCRIPTION
### Motivation
- Provide a quick way to attach an image from the blog header area instead of the existing `New post` action button.
- Persist and restore a selected image with each blog post so editors can include a featured image when saving or editing posts.

### Description
- Replaced the header `New post` button with a labeled file input (`Browse for image upload`) in `web/src/pages/BlogPage.tsx` and added a hidden file input styled as a button. 
- Added `imageUrl` component state and client-side file handling using `FileReader` to read the selected file as a data URL and set `imageUrl`.
- Included `imageUrl` in the save payload written to `blogPosts` and restore it when calling `editPost`, and clear it after saving. 
- Added styles for the new control in `web/src/pages/BlogPage.css` (`.blog-page__image-upload` and hiding the raw input).

### Testing
- Ran `npm -C web run build`, which invokes `tsc -b && vite build`, and it failed due to missing type definition files for `vite/client` and `vitest/globals` in this environment. 
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a030ffbd08483218b6e271a2fcb7276)