### PR TITLE
Rename Bulk Email AI CTA to "Generate with A.I"

### DIFF
--- a/web/src/pages/BulkEmail.tsx
+++ b/web/src/pages/BulkEmail.tsx
@@ -379,7 +379,7 @@ export default function BulkEmail() {
           </label>
           <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
             <button type="button" className="button button--ghost" onClick={() => void generateEmailWithAi()} disabled={isAiGenerating || isSending}>
-              {isAiGenerating ? 'Generating…' : 'Generate with OpenAI'}
+              {isAiGenerating ? 'Generating…' : 'Generate with A.I'}
             </button>
             <button type="button" className="button button--ghost" onClick={() => void convertToHtmlWithAi()} disabled={isAiGenerating || isSending}>
               {isAiGenerating ? 'Converting…' : 'Convert message to HTML with AI'}


### PR DESCRIPTION
### Motivation
- Align the Bulk Email page CTA wording with the requested phrasing by changing the button label from `Generate with OpenAI` to `Generate with A.I` for the `/bulk-email` UI.

### Description
- Updated the string in `web/src/pages/BulkEmail.tsx` to replace `Generate with OpenAI` with `Generate with A.I` (single-line label change).

### Testing
- Committed the change with `git commit` which completed successfully. 
- Verified the updated label appears in source using `nl -ba web/src/pages/BulkEmail.tsx | sed -n '372,390p'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031096a50883218d29c354bfc47935)