### PR TITLE
Add opt-in daily featured product blog automation

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -203,6 +203,14 @@ const BOOKING_DEFAULT_SERVICE_ID_ENV_KEY = 'BOOKING_DEFAULT_SERVICE_ID'
 let openAiConfigWarned = false
 let integrationApiKeyWarned = false
 
+function hashString(value: string): number {
+  let hash = 0
+  for (let index = 0; index < value.length; index += 1) {
+    hash = ((hash << 5) - hash + value.charCodeAt(index)) | 0
+  }
+  return Math.abs(hash)
+}
+
 function getOpenAiConfig() {
   const apiKey = OPENAI_API_KEY.value()?.trim() || process.env.OPENAI_API_KEY?.trim() || ''
   const model = OPENAI_MODEL.value()?.trim() || process.env.OPENAI_MODEL?.trim() || 'gpt-4o-mini'
@@ -9391,3 +9399,66 @@ export const __testing = {
   normalizeBookingDateForSheet,
   normalizeBookingTimeForSheet,
 }
+
+export const publishDailyFeaturedProductBlogPost = functions.pubsub
+  .schedule('every day 09:00')
+  .timeZone('Etc/UTC')
+  .onRun(async () => {
+    const settingsSnap = await db
+      .collection('storeSettings')
+      .where('blogAutomation.dailyProductShareEnabled', '==', true)
+      .get()
+    const runDate = new Date().toISOString().slice(0, 10)
+
+    for (const settingsDoc of settingsSnap.docs) {
+      const storeId = settingsDoc.id
+      const productsSnap = await db
+        .collection('products')
+        .where('storeId', '==', storeId)
+        .orderBy('name', 'asc')
+        .limit(200)
+        .get()
+      if (productsSnap.empty) continue
+
+      const alreadyPublishedSnap = await db
+        .collection('blogPosts')
+        .where('storeId', '==', storeId)
+        .where('source', '==', 'daily-product-share')
+        .where('sourceDate', '==', runDate)
+        .limit(1)
+        .get()
+      if (!alreadyPublishedSnap.empty) continue
+
+      const productDocs = productsSnap.docs
+      const selectedProductDoc = productDocs[hashString(`${storeId}:${runDate}`) % productDocs.length]
+      const productData = (selectedProductDoc.data() ?? {}) as Record<string, unknown>
+      const productName =
+        typeof productData.name === 'string' && productData.name.trim() ? productData.name.trim() : 'Featured Product'
+      const productDescription = typeof productData.description === 'string' ? productData.description.trim() : ''
+      const safeSlug = productName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
+
+      await db.collection('blogPosts').add({
+        storeId,
+        title: `Featured today: ${productName}`,
+        slug: `featured-${runDate}-${safeSlug}`.slice(0, 120),
+        excerpt: productDescription
+          ? productDescription.slice(0, 180)
+          : `Discover today's featured item from our catalog: ${productName}.`,
+        content: productDescription
+          ? `${productName}\n\n${productDescription}\n\nVisit our store today to buy or learn more.`
+          : `${productName}\n\nThis is today's featured item from our catalog. Visit our store today to learn more.`,
+        status: 'published',
+        publishAt: null,
+        publishedAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        source: 'daily-product-share',
+        sourceDate: runDate,
+        productId: selectedProductDoc.id,
+      })
+    }
+    return null
+  })

--- a/web/src/pages/BlogPage.css
+++ b/web/src/pages/BlogPage.css
@@ -36,6 +36,7 @@
 .blog-page__editor-form { display: grid; gap: 12px; }
 .blog-page__toolbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
 .blog-page__toolbar--actions { justify-content: flex-start; }
+.blog-page__toggle { display: inline-flex; gap: 8px; align-items: center; font-size: 14px; color: #334155; }
 .blog-page__editor-form .stack { display: grid; gap: 6px; }
 .blog-page__editor-form textarea { width: 100%; min-height: 180px; resize: both; }
 .blog-page__feed code { font-size: 12px; color: #334155; }

--- a/web/src/pages/BlogPage.tsx
+++ b/web/src/pages/BlogPage.tsx
@@ -5,11 +5,13 @@ import {
   collection,
   deleteDoc,
   doc,
+  getDoc,
   getDocs,
   limit,
   orderBy,
   query,
   serverTimestamp,
+  setDoc,
   updateDoc,
   where,
 } from 'firebase/firestore'
@@ -78,6 +80,7 @@ export default function BlogPage() {
   const [catalogItems, setCatalogItems] = useState<CatalogItem[]>([])
   const [selectedCatalogItemId, setSelectedCatalogItemId] = useState('')
   const [imageUrl, setImageUrl] = useState<string | null>(null)
+  const [dailyShareEnabled, setDailyShareEnabled] = useState(false)
 
   const publicFeedUrl = useMemo(() => (storeId ? `/api/public-blog?storeId=${encodeURIComponent(storeId)}` : ''), [storeId])
 
@@ -112,6 +115,30 @@ export default function BlogPage() {
   useEffect(() => {
     void loadPosts()
   }, [storeId])
+
+  useEffect(() => {
+    async function loadAutomationSettings() {
+      if (!storeId) {
+        setDailyShareEnabled(false)
+        return
+      }
+      const settingsSnap = await getDoc(doc(db, 'storeSettings', storeId))
+      const data = settingsSnap.data() as Record<string, unknown> | undefined
+      const blogAutomation = (data?.blogAutomation ?? {}) as Record<string, unknown>
+      setDailyShareEnabled(blogAutomation.dailyProductShareEnabled === true)
+    }
+    void loadAutomationSettings()
+  }, [storeId])
+
+  async function saveDailyShareSetting() {
+    if (!storeId) return
+    await setDoc(
+      doc(db, 'storeSettings', storeId),
+      { blogAutomation: { dailyProductShareEnabled: dailyShareEnabled, updatedAt: serverTimestamp() } },
+      { merge: true },
+    )
+    setMessage('Daily featured product sharing preference saved.')
+  }
 
   useEffect(() => {
     async function loadCatalogItems() {
@@ -349,6 +376,13 @@ export default function BlogPage() {
               </div>
 
               <div className="blog-page__toolbar blog-page__toolbar--actions">
+                <label className="blog-page__toggle">
+                  <input type="checkbox" checked={dailyShareEnabled} onChange={e => setDailyShareEnabled(e.target.checked)} />
+                  <span>Auto-publish one product daily (opt-in)</span>
+                </label>
+                <button type="button" className="button button--ghost" onClick={() => void saveDailyShareSetting()} disabled={!storeId || saving}>
+                  Save daily share setting
+                </button>
                 <button type="button" className="button button--ghost" onClick={() => void generateBlogWithAi()} disabled={isAiGenerating || saving || !storeId}>
                   {isAiGenerating ? 'Generating…' : 'Generate with A.I'}
                 </button>


### PR DESCRIPTION
### Motivation
- Provide an opt-in automation so busy stores can have one product automatically published to their blog each day, with the store preference saved when the user toggles the option in the Blog UI.

### Description
- Added a scheduled Cloud Function `publishDailyFeaturedProductBlogPost` that runs at `09:00 UTC` daily, selects a deterministic product per store/day using `hashString`, and publishes a `blogPosts` entry with `source: 'daily-product-share'` and `sourceDate` to prevent duplicates.
- Persisted the opt-in setting to Firestore at `storeSettings/{storeId}.blogAutomation.dailyProductShareEnabled` and added UI to toggle and save the preference in `web/src/pages/BlogPage.tsx` using `getDoc`/`setDoc`.
- Added a small UI style for the toggle in `web/src/pages/BlogPage.css` and the `hashString` helper in `functions/src/index.ts` for deterministic selection.
- Files changed: `functions/src/index.ts`, `web/src/pages/BlogPage.tsx`, and `web/src/pages/BlogPage.css`.

### Testing
- Attempted a web build with `npm --prefix web run -s build`, which failed in this environment due to missing TypeScript type definitions (`vite/client` and `vitest/globals`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0316fca7e483219f258f66d1526238)