### PR TITLE
Auto-use selected product image for blog posts

### DIFF
--- a/web/src/pages/BlogPage.tsx
+++ b/web/src/pages/BlogPage.tsx
@@ -26,6 +26,7 @@ type CatalogItem = {
   itemType: 'product' | 'service'
   price: number | null
   description: string | null
+  imageUrl: string | null
 }
 
 type BlogPost = {
@@ -159,6 +160,12 @@ export default function BlogPage() {
           itemType: data.itemType === 'service' ? 'service' : 'product',
           price: typeof data.price === 'number' && Number.isFinite(data.price) ? data.price : null,
           description: typeof data.description === 'string' && data.description.trim() ? data.description.trim() : null,
+          imageUrl:
+            typeof data.imageUrl === 'string' && data.imageUrl.trim()
+              ? data.imageUrl.trim()
+              : Array.isArray(data.imageUrls)
+                ? (data.imageUrls.find((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)?.trim() ?? null)
+                : null,
         }
       })
       setCatalogItems(rows)
@@ -172,6 +179,17 @@ export default function BlogPage() {
     () => catalogItems.find(item => item.id === selectedCatalogItemId) ?? null,
     [catalogItems, selectedCatalogItemId],
   )
+
+
+  useEffect(() => {
+    if (!selectedCatalogItem) return
+    if (selectedCatalogItem.imageUrl) {
+      setImageUrl(selectedCatalogItem.imageUrl)
+      setUploadStatus(`Using ${selectedCatalogItem.name} image for this post.`)
+      return
+    }
+    setUploadStatus(`${selectedCatalogItem.name} has no product image yet.`)
+  }, [selectedCatalogItem])
 
   async function generateBlogWithAi() {
     if (!storeId) return
@@ -321,7 +339,7 @@ export default function BlogPage() {
                   reader.readAsDataURL(file)
                 }}
               />
-              Browse for image upload
+              Upload custom image (optional override)
             </label>
             {uploadStatus ? <p className="blog-page__upload-status">{uploadStatus}</p> : null}
             {imageUrl ? <img className="blog-page__image-preview" src={imageUrl} alt="Selected upload preview" /> : null}


### PR DESCRIPTION
### Motivation
- Avoid forcing creators to upload an image when a store product already has one by automatically using the selected product/service image for the blog post. 
- Prefer an existing `imageUrl` on the product and fall back to the first non-empty entry in `imageUrls` when present.

### Description
- Added `imageUrl` to the `CatalogItem` type and populated it when loading products from Firestore, falling back to the first non-empty `imageUrls` entry if `imageUrl` is missing. 
- Added a `useEffect` that watches the selected catalog item and auto-applies its `imageUrl` to the blog post `imageUrl` state and sets a human-readable `uploadStatus` message. 
- Kept manual file upload support but relabeled the input to `Upload custom image (optional override)` to make it clear that manual uploads are optional when a product image is available. 

### Testing
- Ran `cd web && npx eslint src/pages/BlogPage.tsx`, which failed in this environment due to a missing `@eslint/js` dependency required by the repo ESLint configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033d8e1a44832195422ba36099df1e)