### PR TITLE
Update refund page contact address to Ghana

### DIFF
--- a/web/src/pages/legal/RefundPage.tsx
+++ b/web/src/pages/legal/RefundPage.tsx
@@ -241,9 +241,7 @@ export default function RefundPage() {
             <strong>Email:</strong> info@sedifex.com
           </li>
           <li>
-            <strong>Address:</strong> Kofo Abayomi Street 101233, Victoria
-            Island, Lagos, Nigeria (West Africa hub) or Riverside Drive 00100,
-            Nairobi, Kenya (East Africa hub)
+            <strong>Address:</strong> Kwamisa street, Awoshie, Ghana
           </li>
           <li>
             <strong>Owner:</strong> Learn Language Education Academy


### PR DESCRIPTION
### Motivation
- Replace the previous Lagos/Nairobi contact addresses on the refund policy page with the requested Ghana address so the site contact details are up to date.

### Description
- Update `web/src/pages/legal/RefundPage.tsx` to replace the contact address block with `Kwamisa street, Awoshie, Ghana` in the Contact section.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0357aae31c83218b45d0d95e7d26a5)