### PR TITLE
Improve blog AI topic variety and reduce repeated “new arrivals” drafts

### DIFF
--- a/web/src/pages/BlogPage.tsx
+++ b/web/src/pages/BlogPage.tsx
@@ -207,14 +207,28 @@ export default function BlogPage() {
             .join(' ')
         : null
 
+      const recentTitles = posts
+        .slice(0, 8)
+        .map(post => post.title.trim())
+        .filter(Boolean)
+      const strategy = [
+        'Do not keep repeating "new arrivals" unless the user explicitly asks for it.',
+        'Pick one fresh angle such as: how-to/use tips, customer story, seasonal advice, bundle offer, product comparison, FAQ, or behind-the-scenes.',
+        'Make the title specific and different from recent titles.',
+      ].join(' ')
+
       const prompt = [
         'Write a clear blog post for a retail store website in simple language.',
-        `Working title: ${title.trim() || 'New Arrivals and Offers'}.`,
+        `Working title: ${title.trim() || 'Helpful Product Spotlight and Tips'}.`,
+        strategy,
+        recentTitles.length ? `Recent titles to avoid repeating: ${recentTitles.join(' | ')}` : null,
         itemContext,
         'Return this format exactly:',
         'TITLE: <post title>',
         'CONTENT: <blog post body with paragraphs>',
-      ].join('\n')
+      ]
+        .filter(Boolean)
+        .join('\n')
       const result = await requestAiAdvisor({ question: prompt, storeId })
       const advice = result.advice || ''
       const titleMatch = advice.match(/TITLE:\s*([\s\S]*?)(?:\nCONTENT:|$)/i)


### PR DESCRIPTION
### Motivation
- Generated blog drafts were repeatedly biased toward “new arrivals,” producing low variety in store blog content.
- The blog generator should avoid repeating recent titles and prefer distinct, useful angles (how-to, customer story, seasonal advice, bundles, FAQ, etc.).
- The daily featured-product sharing behavior was inspected to confirm the automated-posting path exists and its scheduling semantics. 

### Description
- In `web/src/pages/BlogPage.tsx` the AI prompt builder now collects up to 8 recent post titles (`recentTitles`) and includes them in the prompt so the AI avoids repeating recent topics.
- The prompt now injects an explicit `strategy` string with guidance to avoid repeating “new arrivals” and to pick a fresh angle, and the fallback working title was changed from `New Arrivals and Offers` to `Helpful Product Spotlight and Tips`.
- The prompt array is normalized with `.filter(Boolean)` before joining to avoid injecting `null` entries; generated `TITLE` and `CONTENT` parsing behavior is unchanged.
- Confirmed backend Cloud Function `publishDailyFeaturedProductBlogPost` (in `functions/src/index.ts`) exists and runs on schedule (`every day 09:00` UTC), writing one `blogPosts` record per UTC date for stores with `storeSettings.blogAutomation.dailyProductShareEnabled == true` and when products are available.

### Testing
- Attempted unit/test run with `npm -C web run -s test -- BlogPage`, which failed in this environment due to missing `vitest` binary (`vitest: not found`).
- Attempted build with `npm -C web run -s build`, which failed due to missing TypeScript type definitions for `vite/client` and `vitest/globals` in the environment.
- No automated test failures were introduced by code changes in this repo-level check, but CI/test infra is required locally to execute the front-end tests and build successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0483e2e83c8321b37b5dcb653bb688)