### PR TITLE
Add Bookings availability management page and route

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -13,6 +13,7 @@ import CloseDay from './pages/CloseDay'
 import Customers from './pages/Customers'
 import Bookings from './pages/Bookings'
 import BookingEditor from './pages/BookingEditor'
+import BookingsAvailability from './pages/BookingsAvailability'
 import Logi from './pages/Logi'
 import Onboarding from './pages/Onboarding'
 import AccountOverview from './pages/AccountOverview'
@@ -88,6 +89,7 @@ const router = createBrowserRouter([
           { path: 'customers', element: <Customers /> },
           { path: 'bookings', element: <Bookings /> },
           { path: 'bookings/new', element: <BookingEditor /> },
+          { path: 'bookings/availability', element: <BookingsAvailability /> },
           { path: 'bookings/:bookingId', element: <BookingEditor /> },
           { path: 'data-transfer', element: <DataTransfer /> },
           { path: 'bulk-messaging', element: <BulkMessaging /> },

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -506,9 +506,14 @@ export default function Bookings() {
             If you prefer, your team can also add bookings manually using <strong>Add booking</strong>.
             When a booking includes a phone number or email, Sedifex automatically links it to the customer profile to keep history complete and avoid duplicates.
           </p>
-          <Link to="/bookings/new" className="btn btn-secondary">
-            Add booking
-          </Link>
+          <div className="bookings-page__row-actions">
+            <Link to="/bookings/new" className="btn btn-secondary">
+              Add booking
+            </Link>
+            <Link to="/bookings/availability" className="btn btn-secondary">
+              Manage availability
+            </Link>
+          </div>
         </header>
 
         <div className="bookings-page__filters">

--- a/web/src/pages/BookingsAvailability.css
+++ b/web/src/pages/BookingsAvailability.css
@@ -1,0 +1,16 @@
+.availability-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.availability-form label {
+  display: grid;
+  gap: 6px;
+}
+
+.availability-page__row-actions,
+.availability-page__actions {
+  display: flex;
+  gap: 8px;
+}

--- a/web/src/pages/BookingsAvailability.tsx
+++ b/web/src/pages/BookingsAvailability.tsx
@@ -1,0 +1,231 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Timestamp, addDoc, collection, deleteDoc, doc, getDocs, orderBy, query, updateDoc } from 'firebase/firestore'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import './BookingsAvailability.css'
+
+type ServiceRecord = { id: string; name: string }
+type SlotRecord = {
+  id: string
+  serviceId: string
+  serviceName: string
+  startAt: Date
+  endAt: Date
+  timezone: string
+  capacity: number
+  seatsBooked: number
+  status: 'open' | 'closed'
+}
+
+function toLocalInputValue(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+export default function BookingsAvailability() {
+  const { storeId } = useActiveStore()
+  const [services, setServices] = useState<ServiceRecord[]>([])
+  const [slots, setSlots] = useState<SlotRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [serviceId, setServiceId] = useState('')
+  const [startAt, setStartAt] = useState(toLocalInputValue(new Date(Date.now() + 60 * 60 * 1000)))
+  const [endAt, setEndAt] = useState(toLocalInputValue(new Date(Date.now() + 2 * 60 * 60 * 1000)))
+  const [timezone, setTimezone] = useState(Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC')
+  const [capacity, setCapacity] = useState('20')
+
+  const serviceMap = useMemo(() => new Map(services.map(service => [service.id, service.name])), [services])
+
+  const loadServices = useCallback(async (activeStoreId: string) => {
+    const map = new Map<string, string>()
+    for (const collectionName of ['services', 'integrationServices']) {
+      const snapshot = await getDocs(collection(db, 'stores', activeStoreId, collectionName))
+      snapshot.forEach(serviceDoc => {
+        const data = serviceDoc.data() as Record<string, unknown>
+        const nameCandidate = [data.name, data.title, data.serviceName].find(
+          value => typeof value === 'string' && value.trim(),
+        ) as string | undefined
+        if (nameCandidate) map.set(serviceDoc.id, nameCandidate.trim())
+      })
+    }
+    const nextServices = Array.from(map.entries())
+      .map(([id, name]) => ({ id, name }))
+      .sort((left, right) => left.name.localeCompare(right.name))
+    setServices(nextServices)
+    setServiceId(previous => (previous && map.has(previous) ? previous : nextServices[0]?.id ?? ''))
+    return map
+  }, [])
+
+  const loadSlots = useCallback(async (activeStoreId: string, serviceLookup: Map<string, string>) => {
+    const slotQuery = query(collection(db, 'stores', activeStoreId, 'integrationAvailabilitySlots'), orderBy('startAt', 'asc'))
+    const snapshot = await getDocs(slotQuery)
+    const nextSlots: SlotRecord[] = snapshot.docs
+      .map(slotDoc => {
+        const data = slotDoc.data() as Record<string, unknown>
+        const start = data.startAt && typeof (data.startAt as Timestamp).toDate === 'function' ? (data.startAt as Timestamp).toDate() : null
+        const end = data.endAt && typeof (data.endAt as Timestamp).toDate === 'function' ? (data.endAt as Timestamp).toDate() : null
+        if (!start || !end) return null
+        const normalizedServiceId = typeof data.serviceId === 'string' && data.serviceId.trim() ? data.serviceId.trim() : 'unknown'
+        return {
+          id: slotDoc.id,
+          serviceId: normalizedServiceId,
+          serviceName: serviceLookup.get(normalizedServiceId) ?? normalizedServiceId,
+          startAt: start,
+          endAt: end,
+          timezone: typeof data.timezone === 'string' && data.timezone.trim() ? data.timezone.trim() : 'UTC',
+          capacity: typeof data.capacity === 'number' && Number.isFinite(data.capacity) ? Math.max(1, Math.floor(data.capacity)) : 1,
+          seatsBooked: typeof data.seatsBooked === 'number' && Number.isFinite(data.seatsBooked) ? Math.max(0, Math.floor(data.seatsBooked)) : 0,
+          status: data.status === 'closed' ? 'closed' : 'open',
+        } as SlotRecord
+      })
+      .filter((slot): slot is SlotRecord => slot !== null)
+    setSlots(nextSlots)
+  }, [])
+
+  const reload = useCallback(async () => {
+    if (!storeId) {
+      setErrorMessage('Select a workspace before managing availability.')
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setErrorMessage(null)
+    try {
+      const lookup = await loadServices(storeId)
+      await loadSlots(storeId, lookup)
+    } catch (error) {
+      console.error('[availability] Failed to load', error)
+      setErrorMessage('Unable to load availability right now. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }, [loadServices, loadSlots, storeId])
+
+  useEffect(() => {
+    void reload()
+  }, [reload])
+
+  const handleCreateSlot = useCallback(async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!storeId) return
+    const startDate = new Date(startAt)
+    const endDate = new Date(endAt)
+    const nextCapacity = Math.max(1, Math.floor(Number(capacity) || 1))
+    if (!(startDate instanceof Date) || Number.isNaN(startDate.getTime())) {
+      setErrorMessage('Enter a valid start date/time.')
+      return
+    }
+    if (!(endDate instanceof Date) || Number.isNaN(endDate.getTime()) || endDate <= startDate) {
+      setErrorMessage('End date/time must be after start date/time.')
+      return
+    }
+    if (!serviceId) {
+      setErrorMessage('Choose a service first.')
+      return
+    }
+
+    setSaving(true)
+    setErrorMessage(null)
+    try {
+      await addDoc(collection(db, 'stores', storeId, 'integrationAvailabilitySlots'), {
+        storeId,
+        serviceId,
+        startAt: Timestamp.fromDate(startDate),
+        endAt: Timestamp.fromDate(endDate),
+        timezone,
+        capacity: nextCapacity,
+        seatsBooked: 0,
+        status: 'open',
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now(),
+      })
+      await loadSlots(storeId, serviceMap)
+    } catch (error) {
+      console.error('[availability] Failed to create slot', error)
+      setErrorMessage('Failed to create slot. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }, [capacity, endAt, loadSlots, serviceId, serviceMap, startAt, storeId, timezone])
+
+  const toggleStatus = useCallback(async (slot: SlotRecord) => {
+    if (!storeId) return
+    try {
+      await updateDoc(doc(db, 'stores', storeId, 'integrationAvailabilitySlots', slot.id), {
+        status: slot.status === 'open' ? 'closed' : 'open',
+        updatedAt: Timestamp.now(),
+      })
+      await loadSlots(storeId, serviceMap)
+    } catch (error) {
+      console.error('[availability] Failed to update slot status', error)
+      setErrorMessage('Failed to update slot status.')
+    }
+  }, [loadSlots, serviceMap, storeId])
+
+  const deleteSlot = useCallback(async (slotId: string) => {
+    if (!storeId) return
+    try {
+      await deleteDoc(doc(db, 'stores', storeId, 'integrationAvailabilitySlots', slotId))
+      await loadSlots(storeId, serviceMap)
+    } catch (error) {
+      console.error('[availability] Failed to delete slot', error)
+      setErrorMessage('Failed to delete slot.')
+    }
+  }, [loadSlots, serviceMap, storeId])
+
+  return (
+    <main className="page availability-page">
+      <section className="card stack gap-4">
+        <header className="stack gap-1">
+          <h1>Class availability</h1>
+          <p className="bookings-page__intro">
+            Create and manage upcoming class/session slots. Your website can use these slots to show the next available session.
+          </p>
+          <div className="availability-page__actions">
+            <Link to="/bookings" className="btn btn-secondary">Back to bookings</Link>
+          </div>
+        </header>
+
+        <form className="availability-form" onSubmit={handleCreateSlot}>
+          <label><span>Service</span><select value={serviceId} onChange={event => setServiceId(event.target.value)}>{services.map(service => <option key={service.id} value={service.id}>{service.name}</option>)}</select></label>
+          <label><span>Start</span><input type="datetime-local" value={startAt} onChange={event => setStartAt(event.target.value)} required /></label>
+          <label><span>End</span><input type="datetime-local" value={endAt} onChange={event => setEndAt(event.target.value)} required /></label>
+          <label><span>Timezone</span><input value={timezone} onChange={event => setTimezone(event.target.value)} required /></label>
+          <label><span>Capacity</span><input type="number" min={1} value={capacity} onChange={event => setCapacity(event.target.value)} required /></label>
+          <button className="btn btn-secondary" type="submit" disabled={saving}>{saving ? 'Saving…' : 'Add slot'}</button>
+        </form>
+
+        {loading && <p className="form__hint">Loading slots…</p>}
+        {errorMessage && <p className="form__error">{errorMessage}</p>}
+
+        {!loading && (
+          <div className="table-wrap">
+            <table className="table">
+              <thead><tr><th>Service</th><th>Start</th><th>End</th><th>Status</th><th>Capacity</th><th>Booked</th><th>Actions</th></tr></thead>
+              <tbody>
+                {slots.map(slot => (
+                  <tr key={slot.id}>
+                    <td>{slot.serviceName}</td>
+                    <td>{slot.startAt.toLocaleString()}</td>
+                    <td>{slot.endAt.toLocaleString()}</td>
+                    <td>{slot.status}</td>
+                    <td>{slot.capacity}</td>
+                    <td>{slot.seatsBooked}</td>
+                    <td>
+                      <div className="availability-page__row-actions">
+                        <button type="button" className="btn btn-secondary" onClick={() => void toggleStatus(slot)}>{slot.status === 'open' ? 'Close' : 'Open'}</button>
+                        <button type="button" className="btn btn-secondary" onClick={() => void deleteSlot(slot.id)}>Delete</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation

- Provide a UI for creating and managing class/session availability slots so website booking forms can show upcoming sessions and staff can manage capacity and status.

### Description

- Add a new `BookingsAvailability` page (`web/src/pages/BookingsAvailability.tsx`) implementing listing, creation, status toggling, and deletion of availability slots backed by Firestore.
- Add styles for the page in `web/src/pages/BookingsAvailability.css` and wire the page into the app router by importing it and registering the `/bookings/availability` route in `web/src/main.tsx`.
- Add a "Manage availability" action button to the bookings header in `web/src/pages/Bookings.tsx` to navigate to the new page. 
- Implement service discovery merging `services` and `integrationServices`, robust slot parsing, validation for create flow, and Firestore CRUD operations (`addDoc`, `getDocs`, `updateDoc`, `deleteDoc`).

### Testing

- No new automated tests were added for this feature. 
- Ran TypeScript type-check (`yarn tsc`) locally which completed successfully. 
- Performed a local frontend build (`yarn build`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049a24c7088321879402bf8bdee078)