### PR TITLE
Normalize product publication fields and reconcile public catalog

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -45,6 +45,7 @@ const params_1 = require("firebase-functions/params");
 const firestore_1 = require("./firestore");
 const phone_1 = require("./phone");
 const publicSlug_1 = require("./utils/publicSlug");
+const catalogPublication_1 = require("./catalogPublication");
 var paystack_1 = require("./paystack");
 Object.defineProperty(exports, "checkSignupUnlock", { enumerable: true, get: function () { return paystack_1.checkSignupUnlock; } });
 var googleAds_1 = require("./googleAds");
@@ -5998,22 +5999,6 @@ function isFirestoreTimestampLike(value) {
             'toDate' in value &&
             typeof value.toDate === 'function'));
 }
-function resolvePublicProductPublishedAt(source, existing) {
-    const candidates = [
-        source.publishedAt,
-        existing?.publishedAt,
-        source.createdAt,
-        source.updatedAt,
-        existing?.createdAt,
-        existing?.updatedAt,
-    ];
-    for (const candidate of candidates) {
-        if (isFirestoreTimestampLike(candidate) || typeof candidate === 'string') {
-            return candidate;
-        }
-    }
-    return firestore_1.admin.firestore.FieldValue.serverTimestamp();
-}
 function toPublicProductPayload(productId, source, existing, storeMeta) {
     const storeId = typeof source.storeId === 'string' ? source.storeId.trim() : '';
     const name = normalizeProductName(source.name);
@@ -6021,12 +6006,10 @@ function toPublicProductPayload(productId, source, existing, storeMeta) {
         return null;
     }
     const isPublished = source.isPublished === true;
-    const unpublishedAt = isPublished
-        ? null
-        : source.unpublishedAt ??
-            existing?.unpublishedAt ??
-            source.updatedAt ??
-            firestore_1.admin.firestore.FieldValue.serverTimestamp();
+    const publication = (0, catalogPublication_1.normalizeCatalogPublicationFields)(source, {
+        fallbackCreatedAt: existing?.createdAt,
+        fallbackUpdatedAt: existing?.updatedAt,
+    });
     return {
         sourceProductId: productId,
         storeId,
@@ -6057,8 +6040,8 @@ function toPublicProductPayload(productId, source, existing, storeMeta) {
         searchTokens: buildSearchTokens(source),
         namePrefix: buildNamePrefix(source),
         ...extractProductImageSet(source),
-        publishedAt: isPublished ? resolvePublicProductPublishedAt(source, existing) : null,
-        unpublishedAt,
+        publishedAt: isPublished ? publication.updates.publishedAt ?? (0, catalogPublication_1.resolvePublicationTimestampCandidate)(source.createdAt, existing?.createdAt) : null,
+        unpublishedAt: isPublished ? null : publication.updates.unpublishedAt ?? existing?.unpublishedAt ?? firestore_1.admin.firestore.FieldValue.serverTimestamp(),
         createdAt: source.createdAt ?? existing?.createdAt ?? firestore_1.admin.firestore.FieldValue.serverTimestamp(),
         sourceUpdatedAt: source.updatedAt ?? null,
         updatedAt: firestore_1.admin.firestore.FieldValue.serverTimestamp(),
@@ -6151,6 +6134,20 @@ exports.syncPublicProducts = functions.firestore
         return;
     }
     const sourceData = afterData ?? {};
+    const normalizedPublication = (0, catalogPublication_1.normalizeCatalogPublicationFields)(sourceData, {
+        fallbackCreatedAt: sourceData.createdAt,
+        fallbackUpdatedAt: sourceData.updatedAt,
+    });
+    if (Object.keys(normalizedPublication.updates).length || normalizedPublication.removeUnpublishedAt) {
+        const sourceUpdates = { ...normalizedPublication.updates };
+        if (normalizedPublication.removeUnpublishedAt) {
+            sourceUpdates.unpublishedAt = firestore_1.admin.firestore.FieldValue.delete();
+        }
+        await change.after.ref.set(sourceUpdates, { merge: true });
+        Object.assign(sourceData, normalizedPublication.updates);
+        if (normalizedPublication.removeUnpublishedAt)
+            delete sourceData.unpublishedAt;
+    }
     const destinationCollectionName = resolvePublicCatalogCollectionName(sourceData.itemType);
     const destinationRef = firestore_1.defaultDb.collection(destinationCollectionName).doc(productId);
     const oppositeRef = destinationCollectionName === 'publicServices' ? publicProductRef : publicServiceRef;

--- a/functions/scripts/backfillPublicProducts.js
+++ b/functions/scripts/backfillPublicProducts.js
@@ -89,6 +89,8 @@ function pickStoreCity(storeData) {
 
 function buildStorePublicMeta(storeData) {
   const promoSlug = toTrimmedStringOrNull(storeData.promoSlug)
+  const publication = normalizePublicationFields(data, { fallbackCreatedAt: existingDocData?.createdAt, fallbackUpdatedAt: existingDocData?.updatedAt })
+
   return {
     storeName: toTrimmedStringOrNull(storeData.displayName) || toTrimmedStringOrNull(storeData.name),
     storeCity: pickStoreCity(storeData),
@@ -150,6 +152,46 @@ function resolvePublishedAtValue(data) {
   return admin.firestore.FieldValue.serverTimestamp()
 }
 
+
+function normalizePublicationFields(data, options = {}) {
+  const isPublishedValue = data.isPublished
+  if (isPublishedValue !== true && isPublishedValue !== false) {
+    return { updates: {}, removeUnpublishedAt: false, repairedPublishedProduct: false }
+  }
+
+  if (isPublishedValue === true) {
+    const hasUnpublishedAt = data.unpublishedAt !== undefined && data.unpublishedAt !== null
+    return {
+      updates: {
+        isPublished: true,
+        publishedAt: resolvePublishedAtValue({
+          publishedAt: data.publishedAt,
+          createdAt: data.createdAt ?? options.fallbackCreatedAt,
+          sourceUpdatedAt: data.updatedAt ?? options.fallbackUpdatedAt,
+          updatedAt: data.updatedAt ?? options.fallbackUpdatedAt,
+        }),
+      },
+      removeUnpublishedAt: hasUnpublishedAt,
+      repairedPublishedProduct: hasUnpublishedAt,
+    }
+  }
+
+  return {
+    updates: {
+      isPublished: false,
+      unpublishedAt: hasPublishedAt(data.unpublishedAt)
+        ? data.unpublishedAt
+        : hasPublishedAt(data.updatedAt)
+          ? data.updatedAt
+          : hasPublishedAt(data.createdAt)
+            ? data.createdAt
+            : admin.firestore.FieldValue.serverTimestamp(),
+    },
+    removeUnpublishedAt: false,
+    repairedPublishedProduct: false,
+  }
+}
+
 function normalizeCategory(value) {
   if (typeof value !== 'string') return null
   const normalized = value.trim().replace(/\s+/g, ' ').toLowerCase()
@@ -167,6 +209,8 @@ function toPublicProduct(productDoc, storeMetaByStoreId, existingDocData = null)
   }
 
   const category = normalizeCategory(data.category)
+
+  const publication = normalizePublicationFields(data, { fallbackCreatedAt: existingDocData?.createdAt, fallbackUpdatedAt: existingDocData?.updatedAt })
 
   return {
     sourceProductId: productDoc.id,
@@ -195,9 +239,10 @@ function toPublicProduct(productDoc, storeMetaByStoreId, existingDocData = null)
         : data.itemType === 'made_to_order'
           ? 'made_to_order'
           : 'product',
-    isPublished: data.isPublished !== false,
+    isPublished: data.isPublished === true,
     ...extractProductImageSet(data),
-    publishedAt: resolvePublishedAtValue(existingDocData || data),
+    publishedAt: data.isPublished === true ? publication.updates.publishedAt : null,
+    unpublishedAt: data.isPublished === false ? publication.updates.unpublishedAt : null,
     createdAt: data.createdAt ?? existingDocData?.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
     sourceUpdatedAt: data.updatedAt ?? null,
     updatedAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -348,22 +393,32 @@ async function reconcileStore(storeId, storeMetaByStoreId) {
 
   const summary = {
     storeId,
-    publishedProducts: productsSnapshot.size,
-    existingPublicProducts: publicProductsSnapshot.size,
-    existingPublicServices: publicServicesSnapshot.size,
-    missingTarget: 0,
-    wrongCollectionRepaired: 0,
-    duplicateTargetRepaired: 0,
-    metadataRepairs: 0,
-    orphanPublicDocsRemoved: 0,
-    sourceMetadataRepairs: 0,
-    outOfSyncDetected: 0,
+    scannedProducts: productsSnapshot.size,
+    repairedPublishedProducts: 0,
+    removedExpiredUnpublishedAt: 0,
+    publicProductsWritten: 0,
+    publicServicesWritten: 0,
+    skippedUnpublished: 0,
+    errors: 0,
   }
 
   const batchState = { batch: db.batch(), writes: 0 }
 
   for (const productDoc of productsSnapshot.docs) {
     const productData = productDoc.data() || {}
+    const sourcePublication = normalizePublicationFields(productData)
+    const sourceUpdates = {}
+    if (Object.keys(sourcePublication.updates).length) Object.assign(sourceUpdates, sourcePublication.updates)
+    if (sourcePublication.removeUnpublishedAt) {
+      sourceUpdates.unpublishedAt = admin.firestore.FieldValue.delete()
+      summary.removedExpiredUnpublishedAt += 1
+    }
+    if (Object.keys(sourceUpdates).length) {
+      queueSet(batchState, productDoc.ref, sourceUpdates, { merge: true })
+      summary.repairedPublishedProducts += 1
+      Object.assign(productData, sourcePublication.updates)
+      if (sourcePublication.removeUnpublishedAt) delete productData.unpublishedAt
+    }
     const expectedCollection = resolvePublicCatalogCollectionName(productData.itemType)
     const expectedRef = db.collection(expectedCollection).doc(productDoc.id)
     const oppositeRef =
@@ -379,22 +434,19 @@ async function reconcileStore(storeId, storeMetaByStoreId) {
       : publicServicesById.get(productDoc.id) || null
 
     if (!existingExpected) {
-      summary.missingTarget += 1
-      summary.outOfSyncDetected += 1
       const payload = toPublicProduct(productDoc, storeMetaByStoreId)
       if (payload) {
         queueSet(batchState, expectedRef, payload, { merge: true })
+        if (expectedCollection === 'publicServices') summary.publicServicesWritten += 1
+        else summary.publicProductsWritten += 1
       }
     }
 
     if (existingOpposite) {
-      summary.wrongCollectionRepaired += 1
-      summary.outOfSyncDetected += 1
       queueDelete(batchState, oppositeRef)
     }
 
     if (existingExpected && existingOpposite) {
-      summary.duplicateTargetRepaired += 1
     }
 
     const normalizedSourceCategory = normalizeCategory(productData.category)
@@ -403,7 +455,6 @@ async function reconcileStore(storeId, storeMetaByStoreId) {
     const needsSourceUpdatedAt = !isFirestoreTimestampLike(productData.updatedAt) && !hasPublishedAt(productData.updatedAt)
 
     if (needsSourceCategoryRepair || needsSourcePublishedAt || needsSourceUpdatedAt) {
-      summary.sourceMetadataRepairs += 1
       queueSet(batchState, productDoc.ref, {
         category: normalizedSourceCategory,
         publishedAt: needsSourcePublishedAt ? resolvePublishedAtValue(productData) : productData.publishedAt,
@@ -418,7 +469,6 @@ async function reconcileStore(storeId, storeMetaByStoreId) {
       const needsPublishedAtRepair = !hasPublishedAt(expectedData.publishedAt)
       const needsUpdatedAtRepair = !isFirestoreTimestampLike(expectedData.updatedAt) && !hasPublishedAt(expectedData.updatedAt)
       if (needsCategoryRepair || needsPublishedAtRepair || needsUpdatedAtRepair) {
-        summary.metadataRepairs += 1
         queueSet(batchState, expectedRef, {
           category: normalizedCategory,
           publishedAt: needsPublishedAtRepair ? resolvePublishedAtValue(expectedData) : expectedData.publishedAt,
@@ -432,8 +482,6 @@ async function reconcileStore(storeId, storeMetaByStoreId) {
 
   for (const publicDoc of [...publicProductsSnapshot.docs, ...publicServicesSnapshot.docs]) {
     if (publishedIds.has(publicDoc.id)) continue
-    summary.orphanPublicDocsRemoved += 1
-    summary.outOfSyncDetected += 1
     queueDelete(batchState, publicDoc.ref)
     await maybeFlushBatch(batchState)
   }
@@ -491,9 +539,9 @@ async function runReconciliation(targetStoreId) {
     const summary = await reconcileStore(storeId, storeMetaByStoreId)
     summaries.push(summary)
     console.log(
-      `[reconcile] store=${summary.storeId} published=${summary.publishedProducts} missingTarget=${summary.missingTarget} ` +
-      `wrongCollectionRepaired=${summary.wrongCollectionRepaired} metadataRepairs=${summary.metadataRepairs} ` +
-      `sourceMetadataRepairs=${summary.sourceMetadataRepairs} orphanRemoved=${summary.orphanPublicDocsRemoved} outOfSyncDetected=${summary.outOfSyncDetected}`,
+      `[reconcile] store=${summary.storeId} scannedProducts=${summary.scannedProducts} repairedPublishedProducts=${summary.repairedPublishedProducts} ` +
+      `removedExpiredUnpublishedAt=${summary.removedExpiredUnpublishedAt} publicProductsWritten=${summary.publicProductsWritten} ` +
+      `publicServicesWritten=${summary.publicServicesWritten} skippedUnpublished=${summary.skippedUnpublished} errors=${summary.errors}`,
     )
   }
 

--- a/functions/src/catalogPublication.ts
+++ b/functions/src/catalogPublication.ts
@@ -1,0 +1,59 @@
+import * as admin from 'firebase-admin'
+
+function isTimestampLike(value: unknown): boolean {
+  return (
+    value instanceof admin.firestore.Timestamp ||
+    (typeof value === 'object' && value !== null && 'toDate' in value && typeof (value as { toDate?: unknown }).toDate === 'function')
+  )
+}
+
+export function resolvePublicationTimestampCandidate(...candidates: unknown[]): unknown {
+  for (const candidate of candidates) {
+    if (isTimestampLike(candidate) || typeof candidate === 'string') return candidate
+  }
+  return admin.firestore.FieldValue.serverTimestamp()
+}
+
+export function normalizeCatalogPublicationFields(
+  source: Record<string, unknown>,
+  options: { fallbackCreatedAt?: unknown; fallbackUpdatedAt?: unknown } = {},
+): { updates: Record<string, unknown>; removeUnpublishedAt: boolean; repairedPublishedProduct: boolean } {
+  const isPublishedValue = source.isPublished
+  if (isPublishedValue !== true && isPublishedValue !== false) {
+    return { updates: {}, removeUnpublishedAt: false, repairedPublishedProduct: false }
+  }
+
+  if (isPublishedValue === true) {
+    const publishedAt = resolvePublicationTimestampCandidate(
+      source.publishedAt,
+      source.createdAt,
+      options.fallbackCreatedAt,
+      source.updatedAt,
+      options.fallbackUpdatedAt,
+    )
+    const hasUnpublishedAt = source.unpublishedAt !== undefined && source.unpublishedAt !== null
+    return {
+      updates: {
+        isPublished: true,
+        publishedAt,
+      },
+      removeUnpublishedAt: hasUnpublishedAt,
+      repairedPublishedProduct: hasUnpublishedAt,
+    }
+  }
+
+  return {
+    updates: {
+      isPublished: false,
+      unpublishedAt: resolvePublicationTimestampCandidate(
+        source.unpublishedAt,
+        source.updatedAt,
+        options.fallbackUpdatedAt,
+        source.createdAt,
+        options.fallbackCreatedAt,
+      ),
+    },
+    removeUnpublishedAt: false,
+    repairedPublishedProduct: false,
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,6 +6,7 @@ import { admin, defaultDb as db } from './firestore'
 import { normalizePhoneE164, normalizePhoneForWhatsApp } from './phone'
 import { normalizePublicSlugValue } from './utils/publicSlug'
 import type { ProductReadModel } from './types/product'
+import { normalizeCatalogPublicationFields, resolvePublicationTimestampCandidate } from './catalogPublication'
 export { checkSignupUnlock } from './paystack'
 export {
   googleAdsOAuthStart,
@@ -7422,26 +7423,6 @@ function isFirestoreTimestampLike(value: unknown): boolean {
   )
 }
 
-function resolvePublicProductPublishedAt(
-  source: Record<string, unknown>,
-  existing: Record<string, unknown> | null,
-): admin.firestore.FieldValue | unknown {
-  const candidates = [
-    source.publishedAt,
-    existing?.publishedAt,
-    source.createdAt,
-    source.updatedAt,
-    existing?.createdAt,
-    existing?.updatedAt,
-  ]
-  for (const candidate of candidates) {
-    if (isFirestoreTimestampLike(candidate) || typeof candidate === 'string') {
-      return candidate
-    }
-  }
-  return admin.firestore.FieldValue.serverTimestamp()
-}
-
 function toPublicProductPayload(
   productId: string,
   source: Record<string, unknown>,
@@ -7454,13 +7435,10 @@ function toPublicProductPayload(
     return null
   }
   const isPublished = source.isPublished === true
-  const unpublishedAt =
-    isPublished
-      ? null
-      : source.unpublishedAt ??
-        existing?.unpublishedAt ??
-        source.updatedAt ??
-        admin.firestore.FieldValue.serverTimestamp()
+  const publication = normalizeCatalogPublicationFields(source, {
+    fallbackCreatedAt: existing?.createdAt,
+    fallbackUpdatedAt: existing?.updatedAt,
+  })
 
   return {
     sourceProductId: productId,
@@ -7493,8 +7471,8 @@ function toPublicProductPayload(
     searchTokens: buildSearchTokens(source),
     namePrefix: buildNamePrefix(source),
     ...extractProductImageSet(source),
-    publishedAt: isPublished ? resolvePublicProductPublishedAt(source, existing) : null,
-    unpublishedAt,
+    publishedAt: isPublished ? publication.updates.publishedAt ?? resolvePublicationTimestampCandidate(source.createdAt, existing?.createdAt) : null,
+    unpublishedAt: isPublished ? null : publication.updates.unpublishedAt ?? existing?.unpublishedAt ?? admin.firestore.FieldValue.serverTimestamp(),
     createdAt: source.createdAt ?? existing?.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
     sourceUpdatedAt: source.updatedAt ?? null,
     updatedAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -7601,6 +7579,19 @@ export const syncPublicProducts = functions.firestore
     }
 
     const sourceData = afterData ?? {}
+    const normalizedPublication = normalizeCatalogPublicationFields(sourceData, {
+      fallbackCreatedAt: sourceData.createdAt,
+      fallbackUpdatedAt: sourceData.updatedAt,
+    })
+    if (Object.keys(normalizedPublication.updates).length || normalizedPublication.removeUnpublishedAt) {
+      const sourceUpdates: Record<string, unknown> = { ...normalizedPublication.updates }
+      if (normalizedPublication.removeUnpublishedAt) {
+        sourceUpdates.unpublishedAt = admin.firestore.FieldValue.delete()
+      }
+      await change.after.ref.set(sourceUpdates, { merge: true })
+      Object.assign(sourceData, normalizedPublication.updates)
+      if (normalizedPublication.removeUnpublishedAt) delete sourceData.unpublishedAt
+    }
     const destinationCollectionName = resolvePublicCatalogCollectionName(sourceData.itemType)
     const destinationRef = db.collection(destinationCollectionName).doc(productId)
     const oppositeRef = destinationCollectionName === 'publicServices' ? publicProductRef : publicServiceRef


### PR DESCRIPTION
### Motivation
- Some products were marked `isPublished: true` but still carried legacy `unpublishedAt` timestamps, causing public catalog logic to treat them as unpublished and hide them from Sedifex Market.
- Make Sedifex the source of truth by normalizing publish/unpublish fields everywhere and repairing existing drift automatically.

### Description
- Added a shared helper `functions/src/catalogPublication.ts` that centralizes publication normalization logic and timestamp resolution (`normalizeCatalogPublicationFields`, `resolvePublicationTimestampCandidate`).
- Wired the helper into public payload generation (`toPublicProductPayload`) so `publishedAt`/`unpublishedAt` are derived from normalized publication state and `isPublished` is enforced consistently.
- Updated `syncPublicProducts` to run normalization on the source product doc and repair it in-place (deleting `unpublishedAt` when `isPublished === true`) before writing the correct document to `publicProducts` or `publicServices` and removing opposite-collection drift.
- Extended `functions/scripts/backfillPublicProducts.js` reconcile flow to repair bad source metadata, preserve `itemType` routing (`service` → `publicServices`, others → `publicProducts`), remove wrong-collection duplicates, and emit per-store counters (`scannedProducts`, `repairedPublishedProducts`, `removedExpiredUnpublishedAt`, `publicProductsWritten`, `publicServicesWritten`, `skippedUnpublished`, `errors`).

### Testing
- `node --check functions/scripts/backfillPublicProducts.js` executed and returned without syntax errors (success).
- TypeScript build `npm --prefix functions run build` completed successfully (compiled without errors).
- The repo changes were validated by running the backfill script checks and TypeScript compilation during development (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ec8e3dc08321a4ae268e5024a8f2)