### PR TITLE
Bookings availability: add manual service input and include products; refine UI styles

### DIFF
--- a/web/src/layout/Shell.css
+++ b/web/src/layout/Shell.css
@@ -19,9 +19,9 @@ body.shell--menu-open {
   position: sticky;
   top: 0;
   z-index: 30;
-  background: rgba(15, 23, 42, 0.94);
+  background: rgba(255, 255, 255, 0.92);
   backdrop-filter: saturate(180%) blur(12px);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  border-bottom: 1px solid #e2e8f0;
 }
 
 .shell__header-inner {
@@ -138,12 +138,12 @@ body.shell--menu-open {
 .shell__logo {
   font-size: 24px;
   font-weight: 800;
-  color: #a5b4fc;
+  color: #4338ca;
 }
 
 .shell__tagline {
   font-size: 13px;
-  color: #cbd5e1;
+  color: #64748b;
   font-weight: 500;
 }
 
@@ -165,7 +165,7 @@ body.shell--menu-open {
 .shell__nav-search-label {
   font-size: 12px;
   font-weight: 700;
-  color: #334155;
+  color: #475569;
 }
 
 .shell__nav-search-input {
@@ -181,7 +181,7 @@ body.shell--menu-open {
   padding: 8px 12px;
   border-radius: 10px;
   font-size: 13px;
-  color: #334155;
+  color: #475569;
   background: #f8fafc;
   border: 1px dashed #cbd5e1;
 }
@@ -216,7 +216,7 @@ body.shell--menu-open {
   border-radius: 16px;
   border: 1px solid #e2e8f0;
   background: #ffffff;
-  box-shadow: 0 16px 36px -26px rgba(15, 23, 42, 0.48);
+  box-shadow: 0 12px 28px -24px rgba(15, 23, 42, 0.45);
 }
 
 .shell__workspace-pill {
@@ -259,8 +259,8 @@ body.shell--menu-open {
   text-decoration: none;
   font-size: 14px;
   font-weight: 500;
-  color: #334155;
-  background-color: #f1f5f9;
+  color: #4338ca;
+  background-color: #eef2ff;
   border: 1px solid transparent;
   box-shadow: none;
   transition: all 0.2s ease;
@@ -268,10 +268,8 @@ body.shell--menu-open {
 }
 
 .shell__nav-link:is(:hover, :focus-visible) {
-  color: #1e293b;
-  background-color: #e2e8f0;
-  border-color: #cbd5e1;
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+  border-color: rgba(67, 56, 202, 0.25);
+  box-shadow: 0 6px 18px rgba(67, 56, 202, 0.1);
 }
 
 .shell__nav-link.is-active {
@@ -317,7 +315,7 @@ body.shell--menu-open {
 .shell__store-label {
   font-size: 12px;
   font-weight: 700;
-  color: #334155;
+  color: #475569;
 }
 
 .shell__store-select {
@@ -338,7 +336,7 @@ body.shell--menu-open {
 .shell__store-link-hint {
   margin: 0;
   font-size: 12px;
-  color: #334155;
+  color: #475569;
 }
 
 .shell__resume-banner {
@@ -373,7 +371,7 @@ body.shell--menu-open {
 
 .shell__account-email {
   font-size: 13px;
-  color: #1e1b4b;
+  color: #4338ca;
   font-weight: 600;
   min-width: 0;
   overflow: hidden;
@@ -413,17 +411,12 @@ body.shell--menu-open {
   color: #0f172a;
   padding: 10px 12px;
   border-radius: 12px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid #cbd5f5;
   background: #ffffff;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 
-
-.shell input::placeholder,
-.shell textarea::placeholder {
-  color: #64748b;
-}
 .shell label {
   color: #0f172a;
 }
@@ -432,7 +425,7 @@ body.shell--menu-open {
 .shell select:focus,
 .shell textarea:focus {
   border-color: #4338ca;
-  box-shadow: 0 0 0 3px rgba(67, 56, 202, 0.2);
+  box-shadow: 0 0 0 3px rgba(67, 56, 202, 0.12);
   outline: none;
 }
 
@@ -581,7 +574,7 @@ body.shell--menu-open {
 
   .shell__tagline {
     font-size: 12px;
-    color: #334155;
+    color: #475569;
     flex: 1;
   }
 

--- a/web/src/layout/Workspace.css
+++ b/web/src/layout/Workspace.css
@@ -22,15 +22,14 @@
 .page__title {
   margin: 0;
   font-size: clamp(24px, 3vw, 30px);
-  font-weight: 800;
-  line-height: 1.15;
+  font-weight: 700;
   letter-spacing: -0.02em;
-  color: #0f172a;
+  color: #1e293b;
 }
 
 .page__subtitle {
   margin: 4px 0 0;
-  color: #475569;
+  color: #64748b;
   font-size: 15px;
   max-width: 56ch;
 }
@@ -59,12 +58,12 @@
   margin: 0;
   font-size: 18px;
   font-weight: 600;
-  color: #0f172a;
+  color: #1e293b;
 }
 
 .card__subtitle {
   margin: 0;
-  color: #475569;
+  color: #64748b;
   font-size: 14px;
 }
 
@@ -81,7 +80,7 @@
 
 .field__hint {
   font-size: 13px;
-  color: #64748b;
+  color: #94a3b8;
 }
 
 .button {
@@ -175,11 +174,11 @@
 }
 
 .table thead {
-  background: #e2e8f0;
+  background: #f1f5f9;
   text-transform: uppercase;
   font-size: 12px;
   letter-spacing: 0.08em;
-  color: #475569;
+  color: #64748b;
 }
 
 .table th,
@@ -286,7 +285,7 @@
 .empty-state {
   padding: 48px 24px;
   text-align: center;
-  color: #475569;
+  color: #64748b;
   display: grid;
   gap: 12px;
 }
@@ -295,7 +294,7 @@
   margin: 0;
   font-size: 18px;
   font-weight: 600;
-  color: #0f172a;
+  color: #1e293b;
 }
 
 .feedback {

--- a/web/src/pages/BookingsAvailability.tsx
+++ b/web/src/pages/BookingsAvailability.tsx
@@ -30,7 +30,9 @@ export default function BookingsAvailability() {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [serviceMode, setServiceMode] = useState<'catalog' | 'manual'>('catalog')
   const [serviceId, setServiceId] = useState('')
+  const [manualServiceName, setManualServiceName] = useState('')
   const [startAt, setStartAt] = useState(toLocalInputValue(new Date(Date.now() + 60 * 60 * 1000)))
   const [endAt, setEndAt] = useState(toLocalInputValue(new Date(Date.now() + 2 * 60 * 60 * 1000)))
   const [timezone, setTimezone] = useState(Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC')
@@ -50,6 +52,15 @@ export default function BookingsAvailability() {
         if (nameCandidate) map.set(serviceDoc.id, nameCandidate.trim())
       })
     }
+    const productSnapshot = await getDocs(collection(db, 'stores', activeStoreId, 'products'))
+    productSnapshot.forEach(productDoc => {
+      const data = productDoc.data() as Record<string, unknown>
+      const nameCandidate = [data.name, data.title, data.productName].find(
+        value => typeof value === 'string' && value.trim(),
+      ) as string | undefined
+      if (nameCandidate) map.set(productDoc.id, nameCandidate.trim())
+    })
+
     const nextServices = Array.from(map.entries())
       .map(([id, name]) => ({ id, name }))
       .sort((left, right) => left.name.localeCompare(right.name))
@@ -71,7 +82,10 @@ export default function BookingsAvailability() {
         return {
           id: slotDoc.id,
           serviceId: normalizedServiceId,
-          serviceName: serviceLookup.get(normalizedServiceId) ?? normalizedServiceId,
+          serviceName:
+            (typeof data.serviceName === 'string' && data.serviceName.trim()) ||
+            serviceLookup.get(normalizedServiceId) ||
+            normalizedServiceId,
           startAt: start,
           endAt: end,
           timezone: typeof data.timezone === 'string' && data.timezone.trim() ? data.timezone.trim() : 'UTC',
@@ -121,8 +135,17 @@ export default function BookingsAvailability() {
       setErrorMessage('End date/time must be after start date/time.')
       return
     }
-    if (!serviceId) {
-      setErrorMessage('Choose a service first.')
+    const manualName = manualServiceName.trim()
+    const selectedName = serviceMap.get(serviceId)?.trim() ?? ''
+    const resolvedServiceName = serviceMode === 'manual' ? manualName : selectedName
+    const resolvedServiceId = serviceMode === 'manual' ? `manual:${manualName.toLowerCase().replace(/\s+/g, '-')}` : serviceId
+
+    if (!resolvedServiceName) {
+      setErrorMessage(serviceMode === 'manual' ? 'Enter a service or product name.' : 'Choose a service or product first.')
+      return
+    }
+    if (serviceMode === 'catalog' && !serviceId) {
+      setErrorMessage('Choose a service or product first.')
       return
     }
 
@@ -131,7 +154,8 @@ export default function BookingsAvailability() {
     try {
       await addDoc(collection(db, 'stores', storeId, 'integrationAvailabilitySlots'), {
         storeId,
-        serviceId,
+        serviceId: resolvedServiceId,
+        serviceName: resolvedServiceName,
         startAt: Timestamp.fromDate(startDate),
         endAt: Timestamp.fromDate(endDate),
         timezone,
@@ -148,7 +172,7 @@ export default function BookingsAvailability() {
     } finally {
       setSaving(false)
     }
-  }, [capacity, endAt, loadSlots, serviceId, serviceMap, startAt, storeId, timezone])
+  }, [capacity, endAt, loadSlots, manualServiceName, serviceId, serviceMap, serviceMode, startAt, storeId, timezone])
 
   const toggleStatus = useCallback(async (slot: SlotRecord) => {
     if (!storeId) return
@@ -189,7 +213,12 @@ export default function BookingsAvailability() {
         </header>
 
         <form className="availability-form" onSubmit={handleCreateSlot}>
-          <label><span>Service</span><select value={serviceId} onChange={event => setServiceId(event.target.value)}>{services.map(service => <option key={service.id} value={service.id}>{service.name}</option>)}</select></label>
+          <label><span>Service source</span><select value={serviceMode} onChange={event => setServiceMode(event.target.value === 'manual' ? 'manual' : 'catalog')}><option value="catalog">Select existing service/product</option><option value="manual">Manual input</option></select></label>
+          {serviceMode === 'catalog' ? (
+            <label><span>Service or product</span><select value={serviceId} onChange={event => setServiceId(event.target.value)}><option value="">Select item</option>{services.map(service => <option key={service.id} value={service.id}>{service.name}</option>)}</select></label>
+          ) : (
+            <label><span>Service or product name</span><input value={manualServiceName} onChange={event => setManualServiceName(event.target.value)} placeholder="e.g. Hair Braiding" required={serviceMode === 'manual'} /></label>
+          )}
           <label><span>Start</span><input type="datetime-local" value={startAt} onChange={event => setStartAt(event.target.value)} required /></label>
           <label><span>End</span><input type="datetime-local" value={endAt} onChange={event => setEndAt(event.target.value)} required /></label>
           <label><span>Timezone</span><input value={timezone} onChange={event => setTimezone(event.target.value)} required /></label>


### PR DESCRIPTION
### Motivation
- Allow creating availability slots for products and ad-hoc (manual) service names in addition to existing services.
- Improve clarity and consistency of the workspace UI palette, borders and shadows across layout components.

### Description
- Include the `products` collection when loading service-like items in `loadServices` so products appear in the service selection list.
- Resolve a slot's `serviceName` from `data.serviceName`, then the service lookup, then a fallback id to preserve original names when present.
- Add `serviceMode` and `manualServiceName` state and UI to `BookingsAvailability` to let users choose between `catalog` selection and `manual` input, with the form creating a `serviceId` like `manual:your-name` when manual input is used.
- Update slot creation to use `resolvedServiceId` and `resolvedServiceName` and validate accordingly; update `useCallback` dependencies.
- Apply multiple UI refinements in `Shell.css` and `Workspace.css` including color, border, shadow and typography adjustments, removal of a placeholder color rule, and minor input transition/focus tweaks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05a549b9748321a84ba2dda59f9886)