### PR TITLE
Remove duplicate finalCostPrice declaration in Products form

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -1115,7 +1115,6 @@ export default function Products() {
 
     let finalPrice: number | null = null
     let finalCostPrice: number | null = null
-    let finalCostPrice: number | null = null
     if (!Number.isNaN(priceNumber) && priceNumber >= 0) {
       finalPrice = Number(priceNumber.toFixed(2)) // 🔹 respect user input (2dp)
     }


### PR DESCRIPTION
### Motivation
- Fix a TypeScript/esbuild compile error caused by a redeclared `finalCostPrice` variable in `web/src/pages/Products.tsx`.

### Description
- Remove the duplicate `let finalCostPrice: number | null = null` declaration so only a single declaration remains before the price parsing logic.

### Testing
- No automated test suite was executed; validated the fix by running `rg "let finalCostPrice" -n web/src/pages/Products.tsx` and inspecting the file to confirm only one declaration remained and then committing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ea27a5ac8321a4a4603feb50b972)