### PR TITLE
Implement industry-aware and custom navigation labels

### DIFF
--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -1,4 +1,6 @@
 export type NavRole = 'owner' | 'staff'
+export type Industry = 'shop' | 'travel' | 'ngo' | 'school'
+export type NavigationLabelPolicy = 'shared' | 'industry_aliases'
 
 export type NavItem = {
   to: string
@@ -21,3 +23,44 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/public-page', label: 'Public page', roles: ['owner'] },
   { to: '/account', label: 'Account', roles: ['owner'] },
 ]
+
+const INDUSTRY_LABELS: Record<Industry, Partial<Record<string, string>>> = {
+  shop: {},
+  travel: {
+    '/customers': 'Travelers',
+    '/bookings': 'Trips',
+  },
+  ngo: {
+    '/customers': 'Donors',
+    '/bookings': 'Campaigns',
+  },
+  school: {
+    '/customers': 'Students',
+    '/bookings': 'Classes',
+  },
+}
+
+export type NavigationSettings = {
+  industry: Industry
+  labelPolicy: NavigationLabelPolicy
+  customLabels?: Partial<Record<string, string>>
+}
+
+export function resolveNavItems(
+  role: NavRole,
+  settings: NavigationSettings,
+): NavItem[] {
+  const aliasLabels =
+    settings.labelPolicy === 'industry_aliases'
+      ? INDUSTRY_LABELS[settings.industry]
+      : {}
+
+  return NAV_ITEMS.filter(item => item.roles.includes(role)).map(item => {
+    const customLabel = settings.customLabels?.[item.to]?.trim()
+    const aliasLabel = aliasLabels[item.to]
+    return {
+      ...item,
+      label: customLabel || aliasLabel || item.label,
+    }
+  })
+}

--- a/web/src/hooks/useStorePreferences.ts
+++ b/web/src/hooks/useStorePreferences.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { doc, onSnapshot, setDoc } from 'firebase/firestore'
 import { db } from '../firebase'
+import { Industry, NavigationLabelPolicy } from '../config/navigation'
 
 export type ProductDefaults = {
   defaultItemType: 'product' | 'service' | 'made_to_order'
@@ -10,6 +11,11 @@ export type ProductDefaults = {
 
 export type StorePreferences = {
   productDefaults: ProductDefaults
+  navigation: {
+    industry: Industry
+    labelPolicy: NavigationLabelPolicy
+    customLabels: Partial<Record<string, string>>
+  }
 }
 
 const DEFAULT_PREFERENCES: StorePreferences = {
@@ -17,6 +23,11 @@ const DEFAULT_PREFERENCES: StorePreferences = {
     defaultItemType: 'product',
     enableManufacturerFields: false,
     enableNonInventoryMode: false,
+  },
+  navigation: {
+    industry: 'shop',
+    labelPolicy: 'shared',
+    customLabels: {},
   },
 }
 
@@ -38,7 +49,36 @@ function mergePreferences(raw: Record<string, unknown> | undefined | null): Stor
       DEFAULT_PREFERENCES.productDefaults.enableNonInventoryMode,
   }
 
-  return { productDefaults }
+  const allowedIndustries: Industry[] = ['shop', 'travel', 'ngo', 'school']
+  const industry =
+    raw?.navigation &&
+    typeof (raw.navigation as any).industry === 'string' &&
+    allowedIndustries.includes((raw.navigation as any).industry)
+      ? ((raw.navigation as any).industry as Industry)
+      : DEFAULT_PREFERENCES.navigation.industry
+
+  const labelPolicy =
+    raw?.navigation &&
+    typeof (raw.navigation as any).labelPolicy === 'string' &&
+    ['shared', 'industry_aliases'].includes((raw.navigation as any).labelPolicy)
+      ? ((raw.navigation as any).labelPolicy as NavigationLabelPolicy)
+      : DEFAULT_PREFERENCES.navigation.labelPolicy
+
+  const customLabels =
+    raw?.navigation && typeof (raw.navigation as any).customLabels === 'object'
+      ? (Object.entries((raw.navigation as any).customLabels as Record<string, unknown>).reduce(
+          (acc, [key, value]) => {
+            if (typeof value === 'string') {
+              const trimmed = value.trim()
+              if (trimmed) acc[key] = trimmed
+            }
+            return acc
+          },
+          {} as Partial<Record<string, string>>,
+        ) as Partial<Record<string, string>>)
+      : DEFAULT_PREFERENCES.navigation.customLabels
+
+  return { productDefaults, navigation: { industry, labelPolicy, customLabels } }
 }
 
 export function useStorePreferences(storeId: string | null) {

--- a/web/src/layout/Shell.test.tsx
+++ b/web/src/layout/Shell.test.tsx
@@ -12,6 +12,7 @@ const mockUseStoreBilling = vi.fn()
 const mockUseActiveStore = vi.fn()
 const mockUseWorkspaceIdentity = vi.fn()
 const mockUseMemberships = vi.fn()
+const mockUseStorePreferences = vi.fn()
 const mockSetActiveStoreId = vi.fn()
 
 vi.mock('../hooks/useAuthUser', () => ({
@@ -36,6 +37,9 @@ vi.mock('../hooks/useWorkspaceIdentity', () => ({
 
 vi.mock('../hooks/useMemberships', () => ({
   useMemberships: () => mockUseMemberships(),
+}))
+vi.mock('../hooks/useStorePreferences', () => ({
+  useStorePreferences: () => mockUseStorePreferences(),
 }))
 
 vi.mock('../firebase', () => ({
@@ -68,6 +72,7 @@ describe('Shell', () => {
     mockUseActiveStore.mockReset()
     mockUseWorkspaceIdentity.mockReset()
     mockUseMemberships.mockReset()
+    mockUseStorePreferences.mockReset()
     mockSetActiveStoreId.mockReset()
 
     mockUseAuthUser.mockReturnValue({ uid: 'user-123', email: 'owner@example.com' })
@@ -97,6 +102,22 @@ describe('Shell', () => {
         paymentStatus: 'active',
         contractEnd: null,
       },
+    })
+    mockUseStorePreferences.mockReturnValue({
+      preferences: {
+        productDefaults: {
+          defaultItemType: 'product',
+          enableManufacturerFields: false,
+          enableNonInventoryMode: false,
+        },
+        navigation: {
+          industry: 'shop',
+          labelPolicy: 'shared',
+          customLabels: {},
+        },
+      },
+      loading: false,
+      updatePreferences: vi.fn(),
     })
   })
 
@@ -235,5 +256,52 @@ describe('Shell', () => {
     await user.click(screen.getByRole('button', { name: 'Dismiss' }))
 
     expect(screen.queryByText('Return to where you left off?')).not.toBeInTheDocument()
+  })
+
+  it('supports industry alias labels in navigation', () => {
+    mockUseStorePreferences.mockReturnValue({
+      preferences: {
+        productDefaults: {
+          defaultItemType: 'product',
+          enableManufacturerFields: false,
+          enableNonInventoryMode: false,
+        },
+        navigation: {
+          industry: 'school',
+          labelPolicy: 'industry_aliases',
+          customLabels: {},
+        },
+      },
+      loading: false,
+      updatePreferences: vi.fn(),
+    })
+    renderShell(['/dashboard'])
+    expect(screen.getByRole('link', { name: 'Students' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Classes' })).toBeInTheDocument()
+  })
+
+  it('prefers custom navigation labels over industry aliases', () => {
+    mockUseStorePreferences.mockReturnValue({
+      preferences: {
+        productDefaults: {
+          defaultItemType: 'product',
+          enableManufacturerFields: false,
+          enableNonInventoryMode: false,
+        },
+        navigation: {
+          industry: 'travel',
+          labelPolicy: 'industry_aliases',
+          customLabels: {
+            '/customers': 'Guests',
+          },
+        },
+      },
+      loading: false,
+      updatePreferences: vi.fn(),
+    })
+
+    renderShell(['/dashboard'])
+    expect(screen.getByRole('link', { name: 'Guests' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Trips' })).toBeInTheDocument()
   })
 })

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -8,11 +8,12 @@ import { useStoreBilling } from '../hooks/useStoreBilling'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useMemberships } from '../hooks/useMemberships'
 import SupportTicketLauncher from '../components/SupportTicketLauncher'
-import { NAV_ITEMS, NavRole } from '../config/navigation'
+import { NavRole, resolveNavItems } from '../config/navigation'
 import { useWorkspaceIdentity } from '../hooks/useWorkspaceIdentity'
 import './Shell.css'
 import './Workspace.css'
 import { usePwaContext } from '../context/PwaContext'
+import { useStorePreferences } from '../hooks/useStorePreferences'
 
 function navLinkClass(isActive: boolean, isSubItem: boolean) {
   return `shell__nav-link${isSubItem ? ' shell__nav-link--sub' : ''}${isActive ? ' is-active' : ''}`
@@ -90,6 +91,7 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
   const { isOnline, isReachable, queue } = connectivity
   const { name: workspaceName, loading: workspaceLoading } = useWorkspaceIdentity()
+  const { preferences } = useStorePreferences(storeId)
 
   const [dismissedOn, setDismissedOn] = useState<string | null>(null)
   const [navSearchQuery, setNavSearchQuery] = useState('')
@@ -131,8 +133,8 @@ export default function Shell({ children }: { children: React.ReactNode }) {
       ]
     }
 
-    return NAV_ITEMS.filter(item => item.roles.includes(role))
-  }, [hasTrialEnded, role])
+    return resolveNavItems(role, preferences.navigation)
+  }, [hasTrialEnded, role, preferences.navigation])
 
   const navTree = useMemo(
     () =>


### PR DESCRIPTION
### Motivation

- Provide v1 navigation controls so different industries can surface appropriate labels without forking data models. 
- Support the Phase 0 naming policy choices: shared labels or industry-specific aliases for routes like `/customers` and `/bookings`.
- Keep role-based access unchanged (Owner/Admin vs Staff) while enabling per-workspace label configuration.

### Description

- Added `Industry` and `NavigationLabelPolicy` types and an `INDUSTRY_LABELS` map with aliases for `shop`, `travel`, `ngo`, and `school` in `web/src/config/navigation.ts` and implemented `resolveNavItems(...)` to apply label resolution with precedence: `custom label > industry alias > default label`.
- Extended `useStorePreferences` (`web/src/hooks/useStorePreferences.ts`) to include a `navigation` block (`industry`, `labelPolicy`, `customLabels`) with safe defaults and merge/normalization logic that reads from `storeSettings/{storeId}`.
- Wired `Shell` to consume store-level preferences and call `resolveNavItems` so navigation labels are driven by workspace settings (`web/src/layout/Shell.tsx`).
- Added unit tests to `web/src/layout/Shell.test.tsx` covering industry alias rendering and custom-label precedence.

### Testing

- Added unit tests in `web/src/layout/Shell.test.tsx` that assert industry alias labels (e.g., `school` → `Students`/`Classes`) and that custom labels override industry aliases.
- Attempted to run `npm --prefix web test -- src/layout/Shell.test.tsx`, which failed in the execution environment with `vitest: not found`, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062c41897483218499d97f6b019351)