### PR TITLE
Add phase 1 navigation config layers for industry, module toggles, and custom links

### DIFF
--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -1,27 +1,67 @@
 export type NavRole = 'owner' | 'staff'
 export type Industry = 'shop' | 'travel' | 'ngo' | 'school'
 export type NavigationLabelPolicy = 'shared' | 'industry_aliases'
+export type NavItemType = 'module' | 'internal' | 'external'
 
 export type NavItem = {
-  to: string
+  id: string
   label: string
+  type: NavItemType
+  target: string
+  sortOrder: number
   end?: boolean
-  parentTo?: string
-  roles: NavRole[]
+  parentTarget?: string
+  rolesAllowed: NavRole[]
 }
 
 export const NAV_ITEMS: NavItem[] = [
-  { to: '/dashboard', label: 'Dashboard', end: true, roles: ['owner'] },
-  { to: '/products', label: 'Items', roles: ['owner'] },
-  { to: '/sell', label: 'Sell', roles: ['owner', 'staff'] },
-  { to: '/customers', label: 'Customers', roles: ['owner', 'staff'] },
-  { to: '/bookings', label: 'Bookings', roles: ['owner', 'staff'] },
-  { to: '/blog', label: 'Blog', roles: ['owner', 'staff'] },
-  { to: '/bulk-messaging', label: 'SMS', roles: ['owner'] },
-  { to: '/bulk-email', label: 'Bulk email', roles: ['owner'] },
-  { to: '/expenses', label: 'Business records', roles: ['owner', 'staff'] },
-  { to: '/public-page', label: 'Public page', roles: ['owner'] },
-  { to: '/account', label: 'Account', roles: ['owner'] },
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    type: 'module',
+    target: '/dashboard',
+    end: true,
+    rolesAllowed: ['owner'],
+    sortOrder: 10,
+  },
+  { id: 'products', label: 'Items', type: 'module', target: '/products', rolesAllowed: ['owner'], sortOrder: 20 },
+  {
+    id: 'sell',
+    label: 'Sell',
+    type: 'module',
+    target: '/sell',
+    rolesAllowed: ['owner', 'staff'],
+    sortOrder: 30,
+  },
+  {
+    id: 'customers',
+    label: 'Customers',
+    type: 'module',
+    target: '/customers',
+    rolesAllowed: ['owner', 'staff'],
+    sortOrder: 40,
+  },
+  {
+    id: 'bookings',
+    label: 'Bookings',
+    type: 'module',
+    target: '/bookings',
+    rolesAllowed: ['owner', 'staff'],
+    sortOrder: 50,
+  },
+  { id: 'blog', label: 'Blog', type: 'module', target: '/blog', rolesAllowed: ['owner', 'staff'], sortOrder: 60 },
+  { id: 'bulk-messaging', label: 'SMS', type: 'module', target: '/bulk-messaging', rolesAllowed: ['owner'], sortOrder: 70 },
+  { id: 'bulk-email', label: 'Bulk email', type: 'module', target: '/bulk-email', rolesAllowed: ['owner'], sortOrder: 80 },
+  {
+    id: 'expenses',
+    label: 'Business records',
+    type: 'module',
+    target: '/expenses',
+    rolesAllowed: ['owner', 'staff'],
+    sortOrder: 90,
+  },
+  { id: 'public-page', label: 'Public page', type: 'module', target: '/public-page', rolesAllowed: ['owner'], sortOrder: 100 },
+  { id: 'account', label: 'Account', type: 'module', target: '/account', rolesAllowed: ['owner'], sortOrder: 110 },
 ]
 
 const INDUSTRY_LABELS: Record<Industry, Partial<Record<string, string>>> = {
@@ -40,27 +80,65 @@ const INDUSTRY_LABELS: Record<Industry, Partial<Record<string, string>>> = {
   },
 }
 
+export type CustomNavItem = {
+  id: string
+  label: string
+  type: 'module' | 'internal' | 'external'
+  target: string
+  roles_allowed: NavRole[]
+  sort_order: number
+}
+
 export type NavigationSettings = {
   industry: Industry
   labelPolicy: NavigationLabelPolicy
   customLabels?: Partial<Record<string, string>>
+  enabledModules?: string[]
+  customNavItems?: CustomNavItem[]
 }
 
-export function resolveNavItems(
-  role: NavRole,
-  settings: NavigationSettings,
-): NavItem[] {
-  const aliasLabels =
-    settings.labelPolicy === 'industry_aliases'
-      ? INDUSTRY_LABELS[settings.industry]
-      : {}
+function toShellNavItem(item: NavItem): NavItem {
+  return {
+    ...item,
+    label: item.label.trim(),
+  }
+}
 
-  return NAV_ITEMS.filter(item => item.roles.includes(role)).map(item => {
-    const customLabel = settings.customLabels?.[item.to]?.trim()
-    const aliasLabel = aliasLabels[item.to]
-    return {
+export function resolveNavItems(role: NavRole, settings: NavigationSettings): NavItem[] {
+  const aliasLabels =
+    settings.labelPolicy === 'industry_aliases' ? INDUSTRY_LABELS[settings.industry] : {}
+
+  const enabledModules =
+    settings.enabledModules && settings.enabledModules.length > 0
+      ? new Set(settings.enabledModules)
+      : null
+
+  const baseItems = NAV_ITEMS.filter(item => {
+    if (!item.rolesAllowed.includes(role)) return false
+    if (!enabledModules) return true
+    return enabledModules.has(item.id)
+  }).map(item => {
+    const customLabel = settings.customLabels?.[item.target]?.trim()
+    const aliasLabel = aliasLabels[item.target]
+    return toShellNavItem({
       ...item,
       label: customLabel || aliasLabel || item.label,
-    }
+    })
   })
+
+  const customItems = (settings.customNavItems ?? []).filter(item => {
+    if (!item.roles_allowed.includes(role)) return false
+    if (!item.label.trim() || !item.target.trim()) return false
+    return ['module', 'internal', 'external'].includes(item.type)
+  }).map<NavItem>(item => ({
+    id: item.id,
+    label: item.label.trim(),
+    type: item.type,
+    target: item.target.trim(),
+    rolesAllowed: item.roles_allowed,
+    sortOrder: item.sort_order,
+    end: false,
+  }))
+
+  return [...baseItems, ...customItems].sort((a, b) => a.sortOrder - b.sortOrder)
 }

--- a/web/src/hooks/useStorePreferences.ts
+++ b/web/src/hooks/useStorePreferences.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { doc, onSnapshot, setDoc } from 'firebase/firestore'
 import { db } from '../firebase'
-import { Industry, NavigationLabelPolicy } from '../config/navigation'
+import { CustomNavItem, Industry, NavigationLabelPolicy } from '../config/navigation'
 
 export type ProductDefaults = {
   defaultItemType: 'product' | 'service' | 'made_to_order'
@@ -14,7 +14,9 @@ export type StorePreferences = {
   navigation: {
     industry: Industry
     labelPolicy: NavigationLabelPolicy
+    enabledModules: string[]
     customLabels: Partial<Record<string, string>>
+    customNavItems: CustomNavItem[]
   }
 }
 
@@ -27,7 +29,9 @@ const DEFAULT_PREFERENCES: StorePreferences = {
   navigation: {
     industry: 'shop',
     labelPolicy: 'shared',
+    enabledModules: [],
     customLabels: {},
+    customNavItems: [],
   },
 }
 
@@ -78,7 +82,47 @@ function mergePreferences(raw: Record<string, unknown> | undefined | null): Stor
         ) as Partial<Record<string, string>>)
       : DEFAULT_PREFERENCES.navigation.customLabels
 
-  return { productDefaults, navigation: { industry, labelPolicy, customLabels } }
+
+  const enabledModules =
+    raw?.navigation && Array.isArray((raw.navigation as any).enabled_modules)
+      ? ((raw.navigation as any).enabled_modules as unknown[]).reduce<string[]>((acc, value) => {
+          if (typeof value === 'string' && value.trim()) acc.push(value.trim())
+          return acc
+        }, [])
+      : DEFAULT_PREFERENCES.navigation.enabledModules
+
+  const customNavItems =
+    raw?.navigation && Array.isArray((raw.navigation as any).custom_nav_items)
+      ? ((raw.navigation as any).custom_nav_items as Record<string, unknown>[]).reduce<CustomNavItem[]>((acc, item) => {
+          const id = typeof item.id === 'string' ? item.id.trim() : ''
+          const label = typeof item.label === 'string' ? item.label.trim() : ''
+          const type = item.type
+          const target = typeof item.target === 'string' ? item.target.trim() : ''
+          const sortOrder = typeof item.sort_order === 'number' ? item.sort_order : 0
+          const rolesAllowed = Array.isArray(item.roles_allowed)
+            ? item.roles_allowed.filter(role => role === 'owner' || role === 'staff')
+            : []
+
+          if (!id || !label || !target || rolesAllowed.length === 0) return acc
+          if (type !== 'module' && type !== 'internal' && type !== 'external') return acc
+
+          acc.push({
+            id,
+            label,
+            type,
+            target,
+            sort_order: sortOrder,
+            roles_allowed: rolesAllowed as Array<'owner' | 'staff'>,
+          })
+          return acc
+        }, [])
+      : DEFAULT_PREFERENCES.navigation.customNavItems
+
+  return {
+    productDefaults,
+    navigation: { industry, labelPolicy, enabledModules, customLabels, customNavItems },
+  }
+
 }
 
 export function useStorePreferences(storeId: string | null) {

--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -120,15 +120,21 @@ export default function Shell({ children }: { children: React.ReactNode }) {
     if (hasTrialEnded) {
       return [
         {
-          to: '/blog',
+          id: 'blog',
+          type: 'module',
+          target: '/blog',
+          sortOrder: 10,
           label: 'Blog',
-          roles: [role],
+          rolesAllowed: [role],
         },
         {
-          to: '/account',
+          id: 'account',
+          type: 'module',
+          target: '/account',
+          sortOrder: 20,
           label: 'Account',
           end: true,
-          roles: [role],
+          rolesAllowed: [role],
         },
       ]
     }
@@ -139,10 +145,10 @@ export default function Shell({ children }: { children: React.ReactNode }) {
   const navTree = useMemo(
     () =>
       navItems
-        .filter(item => !item.parentTo)
+        .filter(item => !item.parentTarget)
         .map(item => ({
           item,
-          children: navItems.filter(child => child.parentTo === item.to),
+          children: navItems.filter(child => child.parentTarget === item.target),
         })),
     [navItems],
   )
@@ -281,8 +287,8 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
     const isAllowed = navItems.some(
       item =>
-        location.pathname === item.to ||
-        location.pathname.startsWith(`${item.to}/`),
+        location.pathname === item.target ||
+        location.pathname.startsWith(`${item.target}/`),
     )
 
     if (!isAllowed) {
@@ -420,10 +426,10 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
         {filteredNavItems.map(item => (
           <NavLink
-            key={item.to}
-            to={item.to}
+            key={item.id}
+            to={item.target}
             end={item.end}
-            className={({ isActive }) => navLinkClass(isActive, Boolean(item.parentTo))}
+            className={({ isActive }) => navLinkClass(isActive, Boolean(item.parentTarget))}
           >
             {item.label}
           </NavLink>


### PR DESCRIPTION
### Motivation
- Introduce a phase‑1 data model to support industry presets, per‑workspace module enablement, and workspace‑defined custom navigation links. 
- Allow workspaces to override labels and add links while keeping a stable default module nav for rollout and future UI controls.

### Description
- Replace the simple `to`/`roles` nav model with a richer nav schema in `web/src/config/navigation.ts` including `id`, `type`, `target`, `rolesAllowed`, and `sortOrder` and add `CustomNavItem` and `enabledModules` support. 
- Update the nav resolver (`resolveNavItems`) to apply industry label aliases, filter modules by `enabledModules`, merge validated `custom_nav_items`, and sort the final nav by `sortOrder`. 
- Extend `useStorePreferences` (`web/src/hooks/useStorePreferences.ts`) to normalize and validate Firestore fields `navigation.enabled_modules` and `navigation.custom_nav_items` while keeping sensible defaults when fields are absent. 
- Update shell code (`web/src/layout/Shell.tsx`) to consume the new nav shape (`target`/`id`/`parentTarget`) and preserve existing behaviors like staff route guarding and trial‑locked fallback nav. 
- Preserve backward compatibility: when `enabled_modules` is omitted or empty all default modules remain available, and no UI changes for editing settings are included in this phase. 

### Testing
- Attempted to run the unit test command `npm -C web test -- Shell.test.tsx --runInBand`, but the run failed because `vitest` was not available in the execution environment (`sh: 1: vitest: not found`).
- No other automated test runs were executed in this environment; typechecking and CI runs should be executed in CI where `vitest` and project tooling are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062d4a79d48321a2fc4ad95457404a)