### PR TITLE
Add navigation resolver with permission gating and custom items

### DIFF
--- a/web/src/config/navigation.test.ts
+++ b/web/src/config/navigation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { resolveNavigation } from './navigation'
+
+describe('resolveNavigation', () => {
+  it('applies industry preset aliases, module toggles, custom items, role and permissions', () => {
+    const items = resolveNavigation({
+      role: 'staff',
+      permissions: ['view_reports'],
+      workspaceProfile: {
+        industry: 'travel',
+        labelPolicy: 'industry_aliases',
+        enabledModules: ['sell', 'customers', 'blog'],
+        customNavItems: [
+          {
+            id: 'reports',
+            label: ' Reports ',
+            type: 'internal',
+            target: '/reports',
+            sort_order: 5,
+            roles_allowed: ['staff'],
+            required_permissions: ['view_reports'],
+          },
+          {
+            id: 'admin',
+            label: 'Admin',
+            type: 'internal',
+            target: '/admin',
+            sort_order: 1,
+            roles_allowed: ['staff'],
+            required_permissions: ['manage_admin'],
+          },
+        ],
+      },
+    })
+
+    expect(items.map(item => item.id)).toEqual(['reports', 'sell', 'customers', 'blog'])
+    expect(items.find(item => item.id === 'customers')?.label).toBe('Travelers')
+  })
+
+  it('prefers custom labels over industry aliases', () => {
+    const items = resolveNavigation({
+      role: 'owner',
+      workspaceProfile: {
+        industry: 'school',
+        labelPolicy: 'industry_aliases',
+        customLabels: {
+          '/customers': 'Learners',
+        },
+      },
+    })
+
+    expect(items.find(item => item.target === '/customers')?.label).toBe('Learners')
+    expect(items.find(item => item.target === '/bookings')?.label).toBe('Classes')
+  })
+})

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -12,6 +12,7 @@ export type NavItem = {
   end?: boolean
   parentTarget?: string
   rolesAllowed: NavRole[]
+  requiredPermissions?: string[]
 }
 
 export const NAV_ITEMS: NavItem[] = [
@@ -87,6 +88,7 @@ export type CustomNavItem = {
   target: string
   roles_allowed: NavRole[]
   sort_order: number
+  required_permissions?: string[]
 }
 
 export type NavigationSettings = {
@@ -97,6 +99,12 @@ export type NavigationSettings = {
   customNavItems?: CustomNavItem[]
 }
 
+export type NavigationResolverInput = {
+  role: NavRole
+  workspaceProfile: NavigationSettings
+  permissions?: string[]
+}
+
 function toShellNavItem(item: NavItem): NavItem {
   return {
     ...item,
@@ -104,21 +112,32 @@ function toShellNavItem(item: NavItem): NavItem {
   }
 }
 
-export function resolveNavItems(role: NavRole, settings: NavigationSettings): NavItem[] {
+function hasPermissions(requiredPermissions: string[] | undefined, grantedPermissions: Set<string> | null) {
+  if (!requiredPermissions || requiredPermissions.length === 0) return true
+  if (!grantedPermissions) return false
+  return requiredPermissions.every(permission => grantedPermissions.has(permission))
+}
+
+export function resolveNavigation(input: NavigationResolverInput): NavItem[] {
+  const { role, workspaceProfile } = input
   const aliasLabels =
-    settings.labelPolicy === 'industry_aliases' ? INDUSTRY_LABELS[settings.industry] : {}
+    workspaceProfile.labelPolicy === 'industry_aliases' ? INDUSTRY_LABELS[workspaceProfile.industry] : {}
 
   const enabledModules =
-    settings.enabledModules && settings.enabledModules.length > 0
-      ? new Set(settings.enabledModules)
+    workspaceProfile.enabledModules && workspaceProfile.enabledModules.length > 0
+      ? new Set(workspaceProfile.enabledModules)
       : null
+
+  const grantedPermissions = input.permissions && input.permissions.length > 0
+    ? new Set(input.permissions)
+    : null
 
   const baseItems = NAV_ITEMS.filter(item => {
     if (!item.rolesAllowed.includes(role)) return false
-    if (!enabledModules) return true
-    return enabledModules.has(item.id)
+    if (enabledModules && !enabledModules.has(item.id)) return false
+    return hasPermissions(item.requiredPermissions, grantedPermissions)
   }).map(item => {
-    const customLabel = settings.customLabels?.[item.target]?.trim()
+    const customLabel = workspaceProfile.customLabels?.[item.target]?.trim()
     const aliasLabel = aliasLabels[item.target]
     return toShellNavItem({
       ...item,
@@ -126,10 +145,11 @@ export function resolveNavItems(role: NavRole, settings: NavigationSettings): Na
     })
   })
 
-  const customItems = (settings.customNavItems ?? []).filter(item => {
+  const customItems = (workspaceProfile.customNavItems ?? []).filter(item => {
     if (!item.roles_allowed.includes(role)) return false
     if (!item.label.trim() || !item.target.trim()) return false
-    return ['module', 'internal', 'external'].includes(item.type)
+    if (!['module', 'internal', 'external'].includes(item.type)) return false
+    return hasPermissions(item.required_permissions, grantedPermissions)
   }).map<NavItem>(item => ({
     id: item.id,
     label: item.label.trim(),
@@ -137,8 +157,16 @@ export function resolveNavItems(role: NavRole, settings: NavigationSettings): Na
     target: item.target.trim(),
     rolesAllowed: item.roles_allowed,
     sortOrder: item.sort_order,
+    requiredPermissions: item.required_permissions,
     end: false,
   }))
 
   return [...baseItems, ...customItems].sort((a, b) => a.sortOrder - b.sortOrder)
+}
+
+export function resolveNavItems(role: NavRole, settings: NavigationSettings): NavItem[] {
+  return resolveNavigation({
+    role,
+    workspaceProfile: settings,
+  })
 }


### PR DESCRIPTION
### Motivation
- Implement Phase 2 navigation resolver that decides what each user sees by composing workspace profile, role, enabled modules, custom nav items and permissions at runtime.
- Extend the existing role-based navigation model rather than replacing it so current callers remain compatible.

### Description
- Added `resolveNavigation(input: NavigationResolverInput)` in `web/src/config/navigation.ts` which applies industry alias labels, enabled-module filtering, merges custom nav items, filters by role and optional permission gates, and sorts by `sortOrder`.
- Introduced `requiredPermissions` on resolved `NavItem` and `required_permissions` on `CustomNavItem`, and added the `NavigationResolverInput` type, while keeping `resolveNavItems(role, settings)` as a compatibility wrapper.
- Preserved label precedence so `customLabels` override industry aliases which override default labels, and ensured labels are trimmed before returning.
- Added unit tests in `web/src/config/navigation.test.ts` that validate module toggles, custom items, permission gating and label precedence.

### Testing
- Attempted `cd web && npm test -- --run src/config/navigation.test.ts src/layout/Shell.test.tsx`, but the run failed in this environment because `vitest` is not available on `PATH` (`sh: 1: vitest: not found`).
- No automated tests were executed successfully in this environment beyond the attempted run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062e61a7948321b6092bb1f073fe4a)