### PR TITLE
Add phase 4 industry navigation presets

### DIFF
--- a/web/src/components/NavigationSettingsSection.tsx
+++ b/web/src/components/NavigationSettingsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { NAV_ITEMS, type CustomNavItem, type Industry, type NavItemType, type NavRole } from '../config/navigation'
+import { INDUSTRY_ENABLED_MODULE_PRESETS, NAV_ITEMS, type CustomNavItem, type Industry, type NavItemType, type NavRole } from '../config/navigation'
 import type { StorePreferences } from '../hooks/useStorePreferences'
 
 type Props = {
@@ -73,7 +73,14 @@ export default function NavigationSettingsSection({ preferences, onSave, canEdit
     <div className="account-overview__section-header"><h2 id="account-nav-settings">Navigation settings</h2></div>
     <div className="account-overview__form-grid">
       <label><span>Industry profile</span>
-        <select value={draft.industry} disabled={!canEdit} onChange={e => setDraft(c => ({ ...c, industry: e.target.value as Industry }))}>
+        <select
+          value={draft.industry}
+          disabled={!canEdit}
+          onChange={e => {
+            const industry = e.target.value as Industry
+            setDraft(c => ({ ...c, industry, enabledModules: INDUSTRY_ENABLED_MODULE_PRESETS[industry] }))
+          }}
+        >
           {INDUSTRY_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
         </select>
       </label>

--- a/web/src/config/navigation.test.ts
+++ b/web/src/config/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveNavigation } from './navigation'
+import { INDUSTRY_ENABLED_MODULE_PRESETS, resolveNavigation } from './navigation'
 
 describe('resolveNavigation', () => {
   it('applies industry preset aliases, module toggles, custom items, role and permissions', () => {
@@ -51,5 +51,40 @@ describe('resolveNavigation', () => {
 
     expect(items.find(item => item.target === '/customers')?.label).toBe('Learners')
     expect(items.find(item => item.target === '/bookings')?.label).toBe('Classes')
+  })
+
+  it('defines the phase 4 enabled module presets by industry', () => {
+    expect(INDUSTRY_ENABLED_MODULE_PRESETS.shop).toEqual([
+      'dashboard',
+      'products',
+      'sell',
+      'customers',
+      'expenses',
+      'public-page',
+    ])
+    expect(INDUSTRY_ENABLED_MODULE_PRESETS.travel).toEqual([
+      'dashboard',
+      'bookings',
+      'customers',
+      'bulk-messaging',
+      'bulk-email',
+      'expenses',
+    ])
+    expect(INDUSTRY_ENABLED_MODULE_PRESETS.ngo).toEqual([
+      'dashboard',
+      'customers',
+      'bulk-messaging',
+      'bulk-email',
+      'expenses',
+      'public-page',
+    ])
+    expect(INDUSTRY_ENABLED_MODULE_PRESETS.school).toEqual([
+      'dashboard',
+      'bookings',
+      'customers',
+      'bulk-messaging',
+      'bulk-email',
+      'expenses',
+    ])
   })
 })

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -99,6 +99,13 @@ export type NavigationSettings = {
   customNavItems?: CustomNavItem[]
 }
 
+export const INDUSTRY_ENABLED_MODULE_PRESETS: Record<Industry, string[]> = {
+  shop: ['dashboard', 'products', 'sell', 'customers', 'expenses', 'public-page'],
+  travel: ['dashboard', 'bookings', 'customers', 'bulk-messaging', 'bulk-email', 'expenses'],
+  ngo: ['dashboard', 'customers', 'bulk-messaging', 'bulk-email', 'expenses', 'public-page'],
+  school: ['dashboard', 'bookings', 'customers', 'bulk-messaging', 'bulk-email', 'expenses'],
+}
+
 export type NavigationResolverInput = {
   role: NavRole
   workspaceProfile: NavigationSettings

--- a/web/src/hooks/useStorePreferences.ts
+++ b/web/src/hooks/useStorePreferences.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { doc, onSnapshot, setDoc } from 'firebase/firestore'
 import { db } from '../firebase'
-import { CustomNavItem, Industry, NavigationLabelPolicy } from '../config/navigation'
+import { CustomNavItem, Industry, INDUSTRY_ENABLED_MODULE_PRESETS, NavigationLabelPolicy } from '../config/navigation'
 
 export type ProductDefaults = {
   defaultItemType: 'product' | 'service' | 'made_to_order'
@@ -89,7 +89,7 @@ function mergePreferences(raw: Record<string, unknown> | undefined | null): Stor
           if (typeof value === 'string' && value.trim()) acc.push(value.trim())
           return acc
         }, [])
-      : DEFAULT_PREFERENCES.navigation.enabledModules
+      : INDUSTRY_ENABLED_MODULE_PRESETS[industry]
 
   const customNavItems =
     raw?.navigation && Array.isArray((raw.navigation as any).custom_nav_items)


### PR DESCRIPTION
### Motivation
- Provide day-one good defaults for navigation per industry (Shop, Travel, NGO, School) so new workspaces get sensible modules enabled immediately.
- Make industry selection in the navigation settings immediately seed the matching module set to reduce manual configuration.

### Description
- Added `INDUSTRY_ENABLED_MODULE_PRESETS` to `web/src/config/navigation.ts` that defines module lists for `shop`, `travel`, `ngo`, and `school`.
- Updated `mergePreferences` in `web/src/hooks/useStorePreferences.ts` to default `enabledModules` to the chosen industry preset when `enabled_modules` is not present in stored settings.
- Updated `web/src/components/NavigationSettingsSection.tsx` so changing the `Industry profile` selector immediately sets `enabledModules` to the selected industry preset.
- Added assertions to `web/src/config/navigation.test.ts` that validate the preset lists for each industry.

### Testing
- Added unit assertions in `web/src/config/navigation.test.ts` to verify `INDUSTRY_ENABLED_MODULE_PRESETS` contents and existing navigation behavior.
- Attempted to run `npm --prefix web test -- web/src/config/navigation.test.ts`, but the run failed in this environment because `vitest` is not available (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0631896e5c83218889dd51fc45b3de)