### PR TITLE
Move workspace switch context out of sidebar nav

### DIFF
--- a/web/src/layout/Shell.tsx
+++ b/web/src/layout/Shell.tsx
@@ -9,7 +9,6 @@ import { useActiveStore } from '../hooks/useActiveStore'
 import { useMemberships } from '../hooks/useMemberships'
 import SupportTicketLauncher from '../components/SupportTicketLauncher'
 import { NavRole, resolveNavItems } from '../config/navigation'
-import { useWorkspaceIdentity } from '../hooks/useWorkspaceIdentity'
 import './Shell.css'
 import './Workspace.css'
 import { usePwaContext } from '../context/PwaContext'
@@ -90,7 +89,6 @@ export default function Shell({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate()
 
   const { isOnline, isReachable, queue } = connectivity
-  const { name: workspaceName, loading: workspaceLoading } = useWorkspaceIdentity()
   const { preferences } = useStorePreferences(storeId)
 
   const [dismissedOn, setDismissedOn] = useState<string | null>(null)
@@ -355,11 +353,6 @@ export default function Shell({ children }: { children: React.ReactNode }) {
   }, [isOnline, isReachable, queue, queue.lastError, queue.pending, queue.status])
 
   const workspaceStatus = billing?.planKey ?? 'Workspace ready'
-  const workspaceLabel = workspaceName || workspaceStatus
-  const connectedMembershipRows = useMemo(
-    () => memberships.filter(membership => membership.uid === user?.uid),
-    [memberships, user?.uid],
-  )
   const selectableMemberships = useMemo(() => {
     const byStore = new Map<string, (typeof memberships)[number]>()
 
@@ -388,26 +381,6 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
   const navSection = (
     <div className="shell__nav-group">
-      <div
-        className="shell__workspace-pill"
-        role="status"
-        aria-live="polite"
-      >
-        <span className="shell__workspace-label">Workspace</span>
-        <span className="shell__workspace-name">
-          {workspaceLoading && !workspaceLabel
-            ? 'Loading…'
-            : workspaceLabel}
-        </span>
-      </div>
-      {selectableMemberships.length <= 1 && (
-        <p className="shell__workspace-switch-hint">
-          {connectedMembershipRows.length > 1
-            ? 'We found multiple team rows, but they all point to the same workspace ID. Add this account to a different store ID to enable switching.'
-            : 'Workspace switch appears when this account is linked to 2+ workspaces.'}
-        </p>
-      )}
-
       <nav
         className="shell__nav"
         aria-label="Primary"


### PR DESCRIPTION
### Motivation
- Prevent the left sidebar primary navigation from being pushed down by workspace context UI so the nav list starts at the top and has more vertical space.
- Keep workspace switching accessible but move its visual context to the top controls area to mirror a top-positioned switcher pattern.

### Description
- Removed the workspace identity/status pill and helper hint from the sidebar nav block in `web/src/layout/Shell.tsx` so the nav now begins immediately with the primary navigation.
- Retained the workspace switching UI in the top controls area (`shell__store-switcher`) and left its behavior unchanged.
- Removed the now-unused `useWorkspaceIdentity` import and deleted related variables (`workspaceLabel`, `workspaceLoading`, `connectedMembershipRows`) and their rendering.
- Changes are limited to `web/src/layout/Shell.tsx` (about 27 lines removed) and do not alter CSS.

### Testing
- Ran the unit test command `npm --prefix web test -- Shell.test.tsx` in this environment and it failed because `vitest` is not installed here (`sh: 1: vitest: not found`).
- No other automated tests were executed in this environment due to the missing test runner dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a063d3d3cdc83219bbaf5921b87b3ce)