### PR TITLE
Fix product edit save bug and improve form field contrast

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1229,10 +1229,36 @@ label {
   color: rgba(148, 163, 184, 0.6);
 }
 
+.form textarea,
+.form select,
+.form input[type="number"],
+.form input[type="date"] {
+  width: 100%;
+  padding: 15px 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  font-size: 15px;
+  background: rgba(15, 23, 42, 0.88);
+  color: var(--color-text-primary);
+  transition: border 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  backdrop-filter: blur(8px);
+}
+
+.form textarea::placeholder,
+.form input[type="number"]::placeholder,
+.form input[type="date"]::placeholder {
+  color: rgba(148, 163, 184, 0.78);
+  opacity: 1;
+}
+
 .form input[type="email"]:focus-visible,
 .form input[type="password"]:focus-visible,
 .form input[type="text"]:focus-visible,
-.form input[type="tel"]:focus-visible {
+.form input[type="tel"]:focus-visible,
+.form textarea:focus-visible,
+.form select:focus-visible,
+.form input[type="number"]:focus-visible,
+.form input[type="date"]:focus-visible {
   outline: none;
   border-color: var(--color-border-strong);
   box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.25);

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -1502,6 +1502,7 @@ export default function Products() {
     }
 
     let finalPrice: number | null = null
+    let finalCostPrice: number | null = null
     if (!Number.isNaN(priceNumber) && priceNumber >= 0) {
       finalPrice = Number(priceNumber.toFixed(2))
     }


### PR DESCRIPTION
### Motivation
- Users reported that saving edits on the Items page could fail and that helper/placeholder text on forms (add product, expenses, invoices, donations) was too light to read.
- The UI should keep form inputs consistent so `select`, `textarea`, `number`, and `date` fields match the other text inputs for readability and accessibility.

### Description
- Fixes a regression in the Items edit flow by declaring `finalCostPrice` before it is assigned/used in `handleSaveEdit` in `web/src/pages/Products.tsx` to prevent save failures.
- Extends the shared `.form` styles in `web/src/App.css` to include `textarea`, `select`, `input[type="number"]`, and `input[type="date"]` so these controls use the same dark field, padding, border, and color as other inputs.
- Increases placeholder contrast for `textarea`, `number`, and `date` inputs and adds matching `:focus-visible` rules for these controls for consistent focus styling.

### Testing
- Attempted to build the web app with `cd web && npm run -s build`, but the build failed in this environment due to missing type definition dependencies (`vite/client`, `vitest/globals`).
- No other automated tests were run in this environment; changes are limited to a small variable declaration fix and CSS improvements and should be safe to validate with the normal CI build once type dev-dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0644ab4b888321b584fc5a357ea777)