### PR TITLE
docs: add canonical integration contract and tighten WordPress/webhook operability

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -2,6 +2,8 @@
 
 This guide explains how third-party clients (including Buy Sedifex) should authenticate, call endpoints, cache/deduplicate responses, and migrate safely as the API evolves.
 
+> Canonical contract authority: `docs/integration-contract.md` (mandatory header versioning and anti-path-versioning policy).
+
 ## 1) Authentication and API keys
 
 ### Required integration secrets/config
@@ -31,11 +33,14 @@ SEDIFEX_INTEGRATION_API_KEY=sk_live_xxx
 
 ## 2) Versioning contract
 
+This section is a summary only. The source of truth is `docs/integration-contract.md`.
+
 - Current contract version: `2026-04-13`.
-- Request header: `X-Sedifex-Contract-Version`.
+- Request header: `X-Sedifex-Contract-Version` (**mandatory on every integration request**).
 - Response headers:
   - `x-sedifex-contract-version`
   - `x-sedifex-request-id`
+- Path-based versioning is not allowed for this contract.
 - If versions mismatch, API returns `400`:
 
 ```json

--- a/docs/integration-contract.md
+++ b/docs/integration-contract.md
@@ -1,0 +1,47 @@
+# Sedifex Canonical Integration Contract
+
+This is the authoritative integration contract for all Sedifex partner-facing endpoints and webhooks.
+
+All integration documentation must link to this page and must not redefine contract semantics independently.
+
+## Mandatory versioning policy
+
+- **Current contract version:** `2026-04-13`
+- **Required request header (all integration API requests):** `X-Sedifex-Contract-Version: 2026-04-13`
+- **Response headers:**
+  - `x-sedifex-contract-version`
+  - `x-sedifex-request-id`
+
+### Enforcement
+
+- Missing or mismatched contract header returns `400` with:
+
+```json
+{
+  "error": "contract-version-mismatch",
+  "expectedVersion": "2026-04-13",
+  "receivedVersion": "<sent_version_or_empty>"
+}
+```
+
+- Integration clients must fail fast on contract mismatch and raise a visible operator error.
+
+## URL/versioning rules (mandatory)
+
+- **Do not use path-based versioning for integration contract dates** (for example, never append `/2026-04-13` to the base URL).
+- Keep contract versioning in the `X-Sedifex-Contract-Version` header only.
+- Base URL remains deployment/environment specific (for example, `https://us-central1-sedifex-web.cloudfunctions.net`).
+
+## Required operational behavior for partners
+
+- Send `x-api-key` and `X-Sedifex-Contract-Version` on every authenticated integration request.
+- Log `x-sedifex-request-id` for support/debugging correlation.
+- Treat contract-version mismatch as a deployment/configuration incident and escalate immediately.
+
+## Required behavior for Sedifex-owned docs
+
+Every integration doc (quickstarts, plugin guides, webhook docs, and plans) must:
+
+1. Link to this canonical contract page.
+2. State that header-based contract versioning is mandatory.
+3. Avoid introducing alternative versioning guidance.

--- a/docs/integration-delivery-sequence.md
+++ b/docs/integration-delivery-sequence.md
@@ -52,6 +52,7 @@ Provide the fastest path for merchants to embed Sedifex products on WordPress.
 - Plugin settings page for API key + store selection.
 - Product shortcode/block for storefront embedding.
 - Sync health panel (last success, last failure, item count, next retry).
+- Install-time acceptance instrumentation: first sync duration, categorized errors, copy diagnostics export.
 - 30-120 second cache window and manual "Sync now" trigger.
 
 ### Why second
@@ -61,8 +62,10 @@ Provide the fastest path for merchants to embed Sedifex products on WordPress.
 
 ### Exit criteria
 - Non-technical user can install and configure plugin in < 10 minutes.
+- First sync completes in `< 2 minutes` from activation/config save.
 - Product list renders via shortcode/block on a standard theme.
-- Health state clearly indicates success/failure and recovery actions.
+- Health state clearly indicates success/failure and recovery actions with visible error categories.
+- Diagnostics can be copied from UI for support handoff.
 
 ---
 
@@ -79,6 +82,9 @@ Enable event-driven sync for partners who need fresher data than polling.
 - Per-endpoint signing secret and `X-Sedifex-Signature` header.
 - Retry policy with exponential backoff for non-2xx responses.
 - Delivery log view (status, attempts, last response code).
+- Replay tooling: re-deliver any event by `X-Sedifex-Event-Id`.
+- Endpoint health status (active/degraded/failing) surfaced in dashboard.
+- Dead-letter visibility after final retry exhaustion with clear remediation action.
 - Documentation with concrete signature verification examples.
 
 ### Why third
@@ -89,7 +95,8 @@ Enable event-driven sync for partners who need fresher data than polling.
 ### Exit criteria
 - Event payloads match documented schema.
 - Signature verification examples work as copy/paste quickstarts.
-- Failed deliveries are visible and retryable.
+- Failed deliveries are visible and retryable (including dead-letter entries).
+- Partners can trigger replay by event id and confirm endpoint health from dashboard logs.
 
 ---
 

--- a/docs/integration-quickstart.md
+++ b/docs/integration-quickstart.md
@@ -89,6 +89,15 @@ SedifexMarket and public-product catalog guidance has been moved to a dedicated 
 
 - `docs/sedifexmarket-public-product-guide.md`
 
+
+## Canonical integration contract (required)
+
+Before setup, review `docs/integration-contract.md`.
+
+- `X-Sedifex-Contract-Version` is mandatory for authenticated integration calls.
+- Do not implement path-based contract versioning in URLs.
+- Treat this contract page as authoritative when this quickstart and other docs differ.
+
 ## Prerequisites
 
 1. Sedifex Firebase project configured (Firestore + Functions).

--- a/docs/webhooks-signature-verification.md
+++ b/docs/webhooks-signature-verification.md
@@ -1,5 +1,7 @@
 # Sedifex Product Webhooks (MVP)
 
+Canonical integration contract: `docs/integration-contract.md`.
+
 Sedifex emits product events to endpoints configured in Firestore `webhookEndpoints` documents (`status = active`).
 
 ## Events
@@ -54,3 +56,23 @@ function verify_sedifex_signature(string $rawBody, string $signatureHeader, stri
 - Reject unsigned requests with `401` or `403`.
 - Log `X-Sedifex-Event-Id` to ensure idempotent processing.
 - Respond with 2xx only after durable processing (or accepted queueing).
+
+
+## Operability requirements (production)
+
+Beyond signature verification and retries, partner operations require:
+
+- **Replay by event ID:** allow re-delivery using `X-Sedifex-Event-Id` from delivery logs.
+- **Endpoint health status:** expose endpoint state (active/degraded/failing) from recent delivery outcomes.
+- **Dead-letter visibility:** show events that exhausted retries, with timestamp, endpoint, last response code/body snippet, and replay action.
+
+### Minimum dashboard log fields
+
+- `eventId`
+- `eventType`
+- `endpointId` + target URL label
+- `attemptCount`
+- `lastResponseCode`
+- `lastAttemptAt`
+- `status` (`delivered`, `retrying`, `dead-letter`)
+- replay action state (`not-replayed`, `replayed`, `replay-succeeded`, `replay-failed`)

--- a/docs/wordpress-install-guide.md
+++ b/docs/wordpress-install-guide.md
@@ -4,6 +4,10 @@ Use this guide to connect a **WordPress** site to your Sedifex product catalog.
 
 > If you are using **Next.js on Vercel**, use `docs/integration-quickstart.md` instead.
 
+## Canonical contract requirement
+
+This guide depends on `docs/integration-contract.md` as the source of truth for integration versioning and headers.
+
 ## What this setup does
 
 1. Uses one integration key (`SEDIFEX_INTEGRATION_API_KEY` or a store integration key).
@@ -54,12 +58,20 @@ Store these values in WordPress config or plugin settings:
 - `SEDIFEX_STORE_ID`
 - `SEDIFEX_INTEGRATION_API_KEY` (or your store integration key variable)
 
-## Step 5: Validate sync
+## Step 5: Install-time success flow (strict acceptance criteria)
 
-1. Open the page containing `[sedifex_products]`.
-2. Confirm products render by category.
-3. Confirm out-of-stock behavior (`stockCount <= 0`) is handled as expected.
-4. Force a failed fetch and confirm fallback products still render.
+Use the following acceptance gates before calling the install complete:
+
+1. **First sync under 2 minutes:** from plugin activation/config save to first successful product render must be `< 2 minutes`.
+2. **Visible error categories:** admin UI must show categorized failures at minimum for:
+   - authentication/config (`API_KEY_INVALID`, missing store/base URL),
+   - contract/version (`CONTRACT_VERSION_MISMATCH`),
+   - upstream/network (`UPSTREAM_TIMEOUT`, `NETWORK_ERROR`),
+   - data/validation (`INVALID_PAYLOAD`, parsing/shape mismatch).
+3. **Copy diagnostics action:** provide a **Copy diagnostics** button that includes store id, request id (if available), last success/failure timestamp, last error category/code/message, and plugin version.
+4. Open the page containing `[sedifex_products]` and confirm products render by category.
+5. Confirm out-of-stock behavior (`stockCount <= 0`) is handled as expected.
+6. Force a failed fetch and confirm fallback products still render while diagnostics remain copyable.
 
 ## Recommended hardening
 


### PR DESCRIPTION
### Motivation

- Prevent endpoint/versioning drift by centralizing contract semantics into a single authoritative page so all integration docs reference the same rules. 
- Make the WordPress plugin flow reliably supportable by turning MVP guidance into strict install-time acceptance criteria. 
- Raise webhook guidance from delivery-only to full operability (replay, health, dead-letter) so partners can run in production with clear support signals.

### Description

- Add a new canonical contract file `docs/integration-contract.md` that mandates `X-Sedifex-Contract-Version: 2026-04-13`, defines mismatch `400` behavior, and forbids path-based contract versioning. 
- Update `docs/integration-api-guide.md` and `docs/integration-quickstart.md` to link to and defer to the canonical contract and to mark header-based versioning as mandatory. 
- Convert WordPress guidance in `docs/wordpress-install-guide.md` and `docs/integration-delivery-sequence.md` into an install-time success flow with explicit acceptance metrics including first-sync < 2 minutes, visible error categories, and a `Copy diagnostics` action. 
- Extend webhook docs in `docs/webhooks-signature-verification.md` with operability requirements: replay by `X-Sedifex-Event-Id`, endpoint health status, dead-letter visibility, and a minimum set of dashboard log fields.

### Testing

- Documentation-only changes; reviewed local diffs with `git diff` and staged file list with `git status --short`, and committed the updates successfully with `git commit` (all commands returned success). 
- No automated runtime tests were required or modified since this is docs work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065a5c5b4883218db69374abb3e3b7)