### PR TITLE
Add 'How to Use Sedifex' docs page, sitemap entry, and reporting aggregation (function + backfill)

### DIFF
--- a/docs/how-to-use-sedifex.md
+++ b/docs/how-to-use-sedifex.md
@@ -1,261 +1,49 @@
-# How to Use Sedifex (Current Navigation Guide)
-
-Sedifex is a POS and operations platform for retail and service businesses. This guide reflects the current app navigation and core workflows.
-
-## Who this guide is for
-
-- **Owners/Admins** setting up and managing billing, integrations, and growth channels.
-- **Staff/Cashiers** handling sales, customers, bookings, and day-to-day records.
-
----
-
-## 1) Sign in and confirm workspace access
-
-1. Open your Sedifex app URL (for example, `https://app.sedifex.com`).
-2. Sign in with your approved account.
-3. Confirm your active workspace/store.
-4. If you manage multiple stores, switch from the workspace selector before starting work.
-
-If data looks missing after sign-in, confirm you are in the correct workspace and role.
-
----
-
-## 2) Understand the current navigation
-
-### Owner navigation
-
-- **Dashboard**
-- **Items**
-- **Sell**
-- **Customers**
-- **Bookings**
-- **Blog**
-- **SMS**
-- **Bulk email**
-- **Business records**
-- **Public page**
-- **Account**
-
-### Staff navigation
-
-- **Sell**
-- **Customers**
-- **Bookings**
-- **Blog**
-- **Business records**
-
-> Note: Navigation is role-based, so owners and staff do not see the same sections.
-
----
-
-## 3) Dashboard (owner)
-
-Use **Dashboard** for an at-a-glance view of sales, performance trends, and priorities.
-
-Typical use:
-
-- Review today’s performance snapshot.
-- Check progress against recent periods.
-- Jump quickly to items, SMS, and other actions.
-
-Start each day here to set priorities.
-
----
-
-## 4) Items
-
-Use **Items** to manage your product/service catalog.
-
-Common tasks:
-
-- Add or edit item name, category, price, and stock.
-- Maintain barcode/SKU values for quick selling.
-- Keep descriptions/images clean for team clarity and customer receipts.
-
-Tip: Set a consistent naming convention (size/unit/variant format).
-
----
-
-## 5) Sell
-
-Use **Sell** for checkout and transaction processing.
-
-Typical flow:
-
-1. Search or scan item.
-2. Add to cart and adjust quantity.
-3. Confirm totals/discounts.
-4. Select payment method.
-5. Complete sale and issue receipt.
-
-Also available from Sell:
-
-- **Close day**: daily reconciliation and shift close checks.
-- **Invoice**: owner invoice generation and sharing for customers who need formal billing.
-
----
-
-## 6) Customers
-
-Use **Customers** to build and maintain customer records.
-
-- Add and update customer profiles.
-- Link customers to sales and follow-ups.
-- Improve delivery, reminders, and campaign targeting quality.
-
-Accurate contact data reduces failed communication.
-
----
-
-## 7) Bookings
-
-Use **Bookings** for appointment and schedule management.
-
-- Create bookings.
-- Update booking statuses.
-- Keep customer notes and timing accurate for team handoffs.
-
-Consistent status updates improve service reliability.
-
----
-
-## 8) Blog
-
-Use **Blog** to publish content and promotions tied to your store.
-
-Common uses:
-
-- Share offers and updates.
-- Publish featured products.
-- Keep your public-facing content fresh.
-
-When available, use product-linked imagery to speed up post creation.
-
----
-
-## 9) SMS
-
-Use **SMS** for targeted customer outreach.
-
-Best practices:
-
-- Segment recipients before sending.
-- Keep messages short and clear.
-- Check estimated usage/credits before launch.
-- Avoid duplicate campaigns.
-
----
-
-## 10) Bulk email
-
-Use **Bulk email** for longer-form campaigns and announcements.
-
-Typical workflow:
-
-- Prepare audience and subject.
-- Draft campaign content.
-- Verify sender/delivery setup in **Account → Integrations**.
-- Send and monitor response.
-
-Use email for richer content and SMS for urgent/short reminders.
-
----
-
-## 11) Business records
-
-Use **Business records** to manage business income/expense records.
-
-Typical uses:
-
-- Log business expenses with meaningful labels.
-- Keep records current for reporting and reviews.
-- Support profit tracking alongside sales.
-
-Update records daily to avoid end-of-month backlogs.
-
----
-
-## 12) Public page
-
-Use **Public page** to manage your customer-facing store profile.
-
-Update regularly:
-
-- Store details and contact channels.
-- Public catalog visibility.
-- Promotions and brand content.
-
-Keep this page current so customers see accurate information.
-
----
-
-## 13) Account (owner)
-
-Use **Account** for workspace controls and setup.
-
-Typical tasks:
-
-- Billing/subscription management.
-- Integrations and API keys.
-- Team/workspace configuration and security settings.
-- Email delivery and other channel setup.
-
-Review account settings weekly.
-
----
-
-## 14) Daily operating checklist
-
-### Start of day
-
-- Confirm internet/device readiness.
-- Review **Dashboard** (owner) or pending tasks (staff).
-- Check critical stock in **Items**.
-- Confirm cashier/staff access.
-
-### During operations
-
-- Process transactions in **Sell**.
-- Keep customer records current.
-- Update **Bookings** statuses in real time.
-- Log expenses in **Business records**.
-
-### End of day
-
-- Run **Close day** checks.
-- Review pending invoices.
-- Complete priority SMS/email follow-ups.
-- Confirm important public updates are live.
-
----
-
-## 15) Quick troubleshooting
-
-### “I can’t find Product tab”
-
-It is now **Items**.
-
-### “I can’t find invoice”
-
-Open **Sell** and use the **Invoice** option.
-
-### “My navigation looks different”
-
-Your account role controls which pages are visible.
-
-### “Campaign sending is blocked”
-
-Check credits (SMS) and integration setup in **Account → Integrations** (email/SMS-related services).
-
-### “My public details are wrong”
-
-Update in **Public page**, then confirm your changes were saved/published.
-
----
-
-## Related docs
-
-- Main setup: `README.md`
-- Integration API guide: `docs/integration-api-guide.md`
-- Checkout preview contract: `docs/checkout-preview-reference.md`
-- Webhook signatures: `docs/webhooks-signature-verification.md`
+# How to Use Sedifex (Shop, Travel, NGO, School)
+
+Canonical onboarding URL: `/docs/how-to-use-sedifex`
+
+## Navigation model
+
+Sedifex supports workspace navigation presets by industry:
+
+- **Shop:** Dashboard, Items, Sell, Customers, Business records, Public page.
+- **Travel:** Dashboard, Trips, Travelers, SMS, Bulk email, Business records.
+- **NGO:** Dashboard, Donors, Campaigns, SMS, Bulk email, Business records, Public page.
+- **School:** Dashboard, Classes, Students, SMS, Bulk email, Business records.
+
+Labels are resolved through industry aliases while keeping the same core modules.
+
+## Role-based access
+
+### Owner
+- Dashboard
+- Items
+- Sell
+- Customers (or alias)
+- Bookings (or alias)
+- Blog
+- SMS
+- Bulk email
+- Business records
+- Public page
+- Account
+
+### Staff
+- Sell
+- Customers (or alias)
+- Bookings (or alias)
+- Blog
+- Business records
+
+## Recommended onboarding flow
+
+1. Open `/docs/how-to-use-sedifex`.
+2. Confirm workspace and billing setup in Account.
+3. Add catalog in Items and test checkout in Sell.
+4. Start operational usage with Customers + Bookings (or industry aliases).
+
+## Why this page exists
+
+- Shareable link for onboarding messages and contracts.
+- Crawlable URL for search engines and AI assistants.
+- Single source of truth for changing navigation patterns.

--- a/docs/reporting-aggregation-pipeline.md
+++ b/docs/reporting-aggregation-pipeline.md
@@ -1,0 +1,26 @@
+# Reporting Aggregation Pipeline
+
+Server-side reporting aggregation is now supported with:
+
+- `dailySummaries/{storeId}_{YYYY-MM-DD}`
+- `weeklySummaries/{storeId}_{weekStartYYYY-MM-DD}`
+- `monthlySummaries/{storeId}_{YYYY-MM}`
+- `reportSnapshots/{storeId}_{bucket}_{bucketKey}` denormalized snapshot docs for fast report reads.
+
+## Trigger
+
+Cloud Function: `onSaleReportingAggregate`
+
+- Source: `sales/{saleId}` on create.
+- Writes aggregate increments for sales count, totals, units sold, and tender split (`cashTotal`, `cardTotal`) into all three buckets.
+
+## Historical backfill
+
+Run:
+
+```bash
+cd functions
+npm run backfill-reporting-aggregates
+```
+
+This scans historical `sales` docs and incrementally builds summary buckets and snapshots.

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,8 @@
     "backfill-public-products": "node scripts/backfillPublicProducts.js",
     "backfill-public-services": "node scripts/backfillPublicProducts.js",
     "backfill-public-catalog": "node scripts/backfillPublicProducts.js",
-    "backfill-product-normalization": "node scripts/backfillProductNormalization.js"
+    "backfill-product-normalization": "node scripts/backfillProductNormalization.js",
+    "backfill-reporting-aggregates": "node scripts/backfillReportingAggregates.js"
   },
   "dependencies": {
     "firebase-admin": "^13.6.0",

--- a/functions/scripts/backfillReportingAggregates.js
+++ b/functions/scripts/backfillReportingAggregates.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const admin = require('firebase-admin')
+
+if (!admin.apps.length) admin.initializeApp()
+const db = admin.firestore()
+
+function dateKey(date) { return date.toISOString().slice(0, 10) }
+function weekKey(date) {
+  const utc = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+  const day = (utc.getUTCDay() + 6) % 7
+  utc.setUTCDate(utc.getUTCDate() - day)
+  return utc.toISOString().slice(0, 10)
+}
+function monthKey(date) { return `${date.getUTCFullYear()}-${String(date.getUTCMonth()+1).padStart(2,'0')}` }
+function key(bucket, date){ return bucket==='daily'?dateKey(date):bucket==='weekly'?weekKey(date):monthKey(date)}
+
+async function run() {
+  const snapshot = await db.collection('sales').get()
+  console.log(`Found ${snapshot.size} sales for backfill`)
+  let processed = 0
+  for (const doc of snapshot.docs) {
+    const sale = doc.data() || {}
+    const storeId = String(sale.storeId || '').trim()
+    if (!storeId) continue
+    const createdAt = sale.createdAt && typeof sale.createdAt.toDate === 'function' ? sale.createdAt.toDate() : new Date()
+    const total = Number(sale.total || 0)
+    const tenders = sale.tenders || {}
+    const items = Array.isArray(sale.items) ? sale.items : []
+    const unitsSold = items.reduce((s, it) => s + Number(it.qty || 0), 0)
+
+    const batch = db.batch()
+    for (const bucket of ['daily', 'weekly', 'monthly']) {
+      const bucketValue = key(bucket, createdAt)
+      const summaryRef = db.collection(`${bucket}Summaries`).doc(`${storeId}_${bucketValue}`)
+      batch.set(summaryRef, {
+        storeId, bucket, bucketKey: bucketValue,
+        salesCount: admin.firestore.FieldValue.increment(1),
+        salesTotal: admin.firestore.FieldValue.increment(total),
+        unitsSold: admin.firestore.FieldValue.increment(unitsSold),
+        cashTotal: admin.firestore.FieldValue.increment(Number(tenders.cash || 0)),
+        cardTotal: admin.firestore.FieldValue.increment(Number(tenders.card || 0)),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true })
+
+      const snapRef = db.collection('reportSnapshots').doc(`${storeId}_${bucket}_${bucketValue}`)
+      batch.set(snapRef, {
+        storeId, bucket, bucketKey: bucketValue,
+        metrics: {
+          salesCount: admin.firestore.FieldValue.increment(1),
+          salesTotal: admin.firestore.FieldValue.increment(total),
+          unitsSold: admin.firestore.FieldValue.increment(unitsSold),
+        },
+        source: 'sales-backfill',
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true })
+    }
+    await batch.commit()
+    processed += 1
+    if (processed % 100 === 0) console.log(`Processed ${processed}`)
+  }
+  console.log(`Backfill complete. Processed ${processed} sales.`)
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,6 +15,7 @@ export {
   googleAdsMetricsSync,
 } from './googleAds'
 export * from './googleShopping'
+export * from './reporting'
 export {
   googleBusinessLocations,
   googleBusinessUploadLocationMedia,

--- a/functions/src/reporting.ts
+++ b/functions/src/reporting.ts
@@ -1,0 +1,102 @@
+import * as functions from 'firebase-functions/v1'
+import { admin, defaultDb as db } from './firestore'
+
+type SaleItem = {
+  productId?: string
+  name?: string
+  qty?: number
+  total?: number
+}
+
+type SaleRecord = {
+  storeId?: string
+  createdAt?: admin.firestore.Timestamp
+  total?: number
+  tenders?: Record<string, number>
+  items?: SaleItem[]
+}
+
+type SummaryBucket = 'daily' | 'weekly' | 'monthly'
+
+function toDate(value: unknown): Date {
+  if (value instanceof admin.firestore.Timestamp) return value.toDate()
+  if (value instanceof Date) return value
+  if (typeof value === 'string' || typeof value === 'number') return new Date(value)
+  return new Date()
+}
+
+function dateKeyFromDate(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function weekKeyFromDate(date: Date): string {
+  const utc = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+  const day = (utc.getUTCDay() + 6) % 7
+  utc.setUTCDate(utc.getUTCDate() - day)
+  return utc.toISOString().slice(0, 10)
+}
+
+function monthKeyFromDate(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`
+}
+
+function bucketKey(bucket: SummaryBucket, date: Date): string {
+  if (bucket === 'daily') return dateKeyFromDate(date)
+  if (bucket === 'weekly') return weekKeyFromDate(date)
+  return monthKeyFromDate(date)
+}
+
+async function writeAggregateForSale(sale: SaleRecord, saleId: string) {
+  const storeId = sale.storeId?.trim()
+  if (!storeId) return
+  const eventDate = toDate(sale.createdAt)
+  const total = Number(sale.total ?? 0)
+  const tenders = sale.tenders ?? {}
+  const cashTotal = Number(tenders.cash ?? 0)
+  const cardTotal = Number(tenders.card ?? 0)
+  const items = Array.isArray(sale.items) ? sale.items : []
+  const unitsSold = items.reduce((sum, item) => sum + Number(item.qty ?? 0), 0)
+
+  const batch = db.batch()
+
+  for (const bucket of ['daily', 'weekly', 'monthly'] as SummaryBucket[]) {
+    const key = bucketKey(bucket, eventDate)
+    const id = `${storeId}_${key}`
+    const summaryRef = db.collection(`${bucket}Summaries`).doc(id)
+    batch.set(summaryRef, {
+      storeId,
+      bucket,
+      bucketKey: key,
+      salesCount: admin.firestore.FieldValue.increment(1),
+      salesTotal: admin.firestore.FieldValue.increment(total),
+      unitsSold: admin.firestore.FieldValue.increment(unitsSold),
+      cashTotal: admin.firestore.FieldValue.increment(cashTotal),
+      cardTotal: admin.firestore.FieldValue.increment(cardTotal),
+      lastActivityAt: admin.firestore.Timestamp.fromDate(eventDate),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    }, { merge: true })
+
+    const snapshotRef = db.collection('reportSnapshots').doc(`${storeId}_${bucket}_${key}`)
+    batch.set(snapshotRef, {
+      storeId,
+      bucket,
+      bucketKey: key,
+      source: 'sales',
+      metrics: {
+        salesTotal: admin.firestore.FieldValue.increment(total),
+        salesCount: admin.firestore.FieldValue.increment(1),
+        unitsSold: admin.firestore.FieldValue.increment(unitsSold),
+      },
+      refs: { saleId },
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    }, { merge: true })
+  }
+
+  await batch.commit()
+}
+
+export const onSaleReportingAggregate = functions.firestore
+  .document('sales/{saleId}')
+  .onCreate(async (snapshot, context) => {
+    await writeAggregateForSale(snapshot.data() as SaleRecord, context.params.saleId)
+  })

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -35,4 +35,9 @@
     <priority>0.7</priority>
     <changefreq>weekly</changefreq>
   </url>
+  <url>
+    <loc>https://sedifex.com/docs/how-to-use-sedifex</loc>
+    <priority>0.8</priority>
+    <changefreq>weekly</changefreq>
+  </url>
 </urlset>

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -40,4 +40,9 @@
     <priority>0.7</priority>
     <changefreq>weekly</changefreq>
   </url>
+  <url>
+    <loc>https://sedifex.com/docs/how-to-use-sedifex</loc>
+    <priority>0.8</priority>
+    <changefreq>weekly</changefreq>
+  </url>
 </urlset>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,7 @@ export default function App() {
     '/inventory-management-software-ghana',
     '/pricing',
     '/docs',
+    '/how-to-use-sedifex',
     '/legal/privacy',
     '/legal/cookies',
     '/legal/refund',

--- a/web/src/components/docs/DocsPageLayout.tsx
+++ b/web/src/components/docs/DocsPageLayout.tsx
@@ -15,6 +15,8 @@ export default function DocsPageLayout({ title, subtitle, children }: DocsPageLa
         <nav aria-label="Documentation navigation" className="docs-page__nav">
           <Link to="/account">← Back to account</Link>
           <span>·</span>
+          <Link to="/docs/how-to-use-sedifex">How to use Sedifex</Link>
+          <span>·</span>
           <Link to="/docs/integration-quickstart">Integration quickstart</Link>
           <span>·</span>
           <Link to="/docs/wordpress-install-guide">WordPress install guide</Link>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -52,6 +52,7 @@ import ReturnPolicyPage from './pages/legal/ReturnPolicyPage'
 import IntegrationQuickstartPage from './pages/docs/IntegrationQuickstartPage'
 import WordpressInstallGuidePage from './pages/docs/WordpressInstallGuidePage'
 import BulkEmailGoogleSheetsPage from './pages/docs/BulkEmailGoogleSheetsPage'
+import HowToUseSedifexPage from './pages/docs/HowToUseSedifexPage'
 import PublicBlogPage from './pages/PublicBlogPage'
 
 import { ToastProvider } from './components/ToastProvider'
@@ -133,6 +134,7 @@ const router = createBrowserRouter([
       { path: 'docs/integration-quickstart', element: <IntegrationQuickstartPage /> },
       { path: 'docs/wordpress-install-guide', element: <WordpressInstallGuidePage /> },
       { path: 'docs/bulk-email-google-sheets-guide', element: <BulkEmailGoogleSheetsPage /> },
+      { path: 'docs/how-to-use-sedifex', element: <HowToUseSedifexPage /> },
 
       // Legal pages
       { path: 'legal/privacy', element: <PrivacyPage /> },

--- a/web/src/pages/Onboarding.tsx
+++ b/web/src/pages/Onboarding.tsx
@@ -235,6 +235,9 @@ export default function Onboarding() {
             Let&apos;s confirm your workspace details and walk through your
             contract next steps.
           </p>
+          <p className="page__subtitle">
+            New here? Start with <a href="/docs/how-to-use-sedifex">/docs/how-to-use-sedifex</a> and continue setup from the linked guides.
+          </p>
         </div>
         {hasCompleted && (
           <span

--- a/web/src/pages/docs/HowToUseSedifexPage.tsx
+++ b/web/src/pages/docs/HowToUseSedifexPage.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import DocsPageLayout from '../../components/docs/DocsPageLayout'
+
+export default function HowToUseSedifexPage() {
+  return (
+    <DocsPageLayout
+      title="How to Use Sedifex"
+      subtitle="Fast onboarding for Shop, Travel, NGO, and School workspaces."
+    >
+      <section>
+        <h2>Pick your workspace type</h2>
+        <ul>
+          <li><strong>Shop:</strong> Items, Sell, Customers, Business records, Public page.</li>
+          <li><strong>Travel:</strong> Trips, Travelers, messaging, and business records.</li>
+          <li><strong>NGO:</strong> Donors, campaigns, communication, and records.</li>
+          <li><strong>School:</strong> Classes, students, communication, and records.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Core navigation by role</h2>
+        <p><strong>Owner</strong>: Dashboard, Items/Sell, Customers or industry aliases, Bookings/Trips/Classes, Blog, SMS, Bulk email, Business records, Public page, Account.</p>
+        <p><strong>Staff</strong>: Sell, Customers (or alias), Bookings (or alias), Blog, Business records.</p>
+      </section>
+
+      <section>
+        <h2>Start here in 3 steps</h2>
+        <ol>
+          <li>Confirm workspace in <strong>Account</strong> and verify contract/billing.</li>
+          <li>Load catalog in <strong>Items</strong> and test checkout in <strong>Sell</strong>.</li>
+          <li>Use <strong>Customers</strong> and <strong>Bookings</strong> (or aliases) for daily operations.</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>Related setup docs</h2>
+        <ul>
+          <li><a href="/docs/integration-quickstart">/docs/integration-quickstart</a></li>
+          <li><a href="/docs/wordpress-install-guide">/docs/wordpress-install-guide</a></li>
+          <li><a href="/docs/bulk-email-google-sheets-guide">/docs/bulk-email-google-sheets-guide</a></li>
+        </ul>
+      </section>
+    </DocsPageLayout>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a concise, canonical onboarding doc that covers industry navigation presets and links from the app for faster user setup.
- Expose a server-side reporting aggregation pipeline to support fast read summaries for daily/weekly/monthly reporting.
- Surface the new docs page in site navigation and sitemaps so it is crawlable and accessible from onboarding flows.

### Description
- Replace the long `docs/how-to-use-sedifex.md` content with a concise canonical onboarding doc and add a new React page `web/src/pages/docs/HowToUseSedifexPage.tsx` wired into the router and public paths. 
- Add a link to the new docs page in the docs layout `DocsPageLayout.tsx` and an onboarding hint linking to `/docs/how-to-use-sedifex` in `Onboarding.tsx` and include the path in `App.tsx` publicPaths. 
- Add sitemap entries for `/docs/how-to-use-sedifex` in both `public/sitemap.xml` and `web/public/sitemap.xml`. 
- Implement a reporting Cloud Function `onSaleReportingAggregate` in `functions/src/reporting.ts` and export it from `functions/src/index.ts` to increment per-store daily/weekly/monthly summary documents and denormalized `reportSnapshots`. 
- Add a backfill script `functions/scripts/backfillReportingAggregates.js` and a `backfill-reporting-aggregates` script entry in `functions/package.json`, plus a short docs file `docs/reporting-aggregation-pipeline.md` describing triggers and backfill instructions. 

### Testing
- Ran the existing functions unit test via `npm run test` in `functions` which executed `node test/bookingNormalization.test.js` and completed successfully. 
- Manual local routing verification was performed by visiting `/docs/how-to-use-sedifex` in the dev app to confirm the new page renders and the docs nav link appears. 
- No automated integration tests were added for the new Cloud Function or backfill script in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cc5b4cf48321981865da938cc581)