### PR TITLE
Initialize store preferences hook in AccountOverview to fix runtime crash

### DIFF
--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -432,6 +432,7 @@ export default function AccountOverview({
   } = useMemberships()
   const { publish } = useToast()
   const user = useAuthUser()
+  const { preferences, updatePreferences } = useStorePreferences(storeId)
 
   const [profile, setProfile] = useState<StoreProfile | null>(null)
   const [profileLoading, setProfileLoading] = useState(false)


### PR DESCRIPTION
### Motivation
- Prevent the runtime `Can't find variable: preferences` crash on the `/account` page by ensuring `preferences` and `updatePreferences` are defined when rendering navigation settings.

### Description
- Add `const { preferences, updatePreferences } = useStorePreferences(storeId)` to `web/src/pages/AccountOverview.tsx` so `preferences.navigation` and `updatePreferences` are available to the component.

### Testing
- Ran `npm run -s build` in `web/`, which failed due to missing type definition files (`vite/client`, `vitest/globals`).
- Ran `npm ci` in `web/`, which failed with `403 Forbidden` from the npm registry, so no successful build or test artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f8f9ccf48321af5fbd57e6a4f49a)