### PR TITLE
Restrict custom navigation edits to access roles and add robust preferences parsing

### DIFF
--- a/web/src/components/NavigationSettingsSection.tsx
+++ b/web/src/components/NavigationSettingsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { INDUSTRY_ENABLED_MODULE_PRESETS, NAV_ITEMS, type CustomNavItem, type Industry, type NavItemType, type NavRole } from '../config/navigation'
+import { INDUSTRY_ENABLED_MODULE_PRESETS, NAV_ITEMS, type CustomNavItem, type Industry, type NavRole } from '../config/navigation'
 import type { StorePreferences } from '../hooks/useStorePreferences'
 
 type Props = {
@@ -17,7 +17,6 @@ const INDUSTRY_OPTIONS: Array<{ value: Industry; label: string }> = [
   { value: 'school', label: 'School' },
 ]
 
-function makeId() { return `custom-${Date.now()}-${Math.random().toString(36).slice(2, 8)}` }
 function isValidExternalUrl(url: string) {
   try {
     const parsed = new URL(url)
@@ -33,7 +32,6 @@ export default function NavigationSettingsSection({ preferences, onSave, canEdit
   })
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<ValidationError>(null)
-  const [dragId, setDragId] = useState<string | null>(null)
 
   useEffect(() => {
     setDraft({
@@ -105,27 +103,15 @@ export default function NavigationSettingsSection({ preferences, onSave, canEdit
         <label key={item.id}><input type="checkbox" disabled={!canEdit} checked={draft.enabledModules.length === 0 || draft.enabledModules.includes(item.id)} onChange={() => toggleModule(item.id)} /> {item.label}</label>
       ))}
     </div>
-    <h3>Custom navigation</h3>
-    <button type="button" className="button button--secondary" disabled={!canEdit} onClick={() => setDraft(c => ({ ...c, customNavItems: [...c.customNavItems, { id: makeId(), label: '', type: 'internal', target: '', roles_allowed: ['owner'], sort_order: c.customNavItems.length + 1 }] }))}>Add item</button>
+    <h3>Custom navigation access</h3>
+    <p className="account-overview__help-text">
+      Only access levels are editable here. Labels, routes, and link types use site defaults.
+    </p>
     <div className="account-overview__custom-nav-list">
-      {draft.customNavItems.map((item) => <div key={item.id} draggable={canEdit} onDragStart={() => setDragId(item.id)} onDragOver={e => e.preventDefault()} onDrop={() => {
-        if (!dragId || dragId === item.id) return
-        setDraft(c => {
-          const items = [...c.customNavItems]
-          const from = items.findIndex(i => i.id === dragId)
-          const to = items.findIndex(i => i.id === item.id)
-          const [moved] = items.splice(from, 1)
-          items.splice(to, 0, moved)
-          return { ...c, customNavItems: items.map((it, idx) => ({ ...it, sort_order: idx + 1 })) }
-        })
-      }}>
-        <input placeholder="Label" value={item.label} disabled={!canEdit} onChange={e => updateItem(item.id, { label: e.target.value })} />
-        <select value={item.type} disabled={!canEdit} onChange={e => updateItem(item.id, { type: e.target.value as NavItemType })}><option value="module">module</option><option value="internal">internal</option><option value="external">external</option></select>
-        <input placeholder={item.type === 'external' ? 'https://example.com' : '/route'} value={item.target} disabled={!canEdit} onChange={e => updateItem(item.id, { target: e.target.value })} />
-        <input placeholder="Icon (optional)" disabled />
+      {draft.customNavItems.map((item) => <div key={item.id}>
+        <strong>{item.label || item.target || 'Custom navigation item'}</strong>
         <label><input type="checkbox" checked={item.roles_allowed.includes('owner')} disabled={!canEdit} onChange={() => updateItem(item.id, { roles_allowed: item.roles_allowed.includes('owner') ? item.roles_allowed.filter(r => r !== 'owner') as NavRole[] : [...item.roles_allowed, 'owner'] })} />Owner</label>
         <label><input type="checkbox" checked={item.roles_allowed.includes('staff')} disabled={!canEdit} onChange={() => updateItem(item.id, { roles_allowed: item.roles_allowed.includes('staff') ? item.roles_allowed.filter(r => r !== 'staff') as NavRole[] : [...item.roles_allowed, 'staff'] })} />Staff</label>
-        <button type="button" className="button button--ghost" disabled={!canEdit} onClick={() => setDraft(c => ({ ...c, customNavItems: c.customNavItems.filter(nav => nav.id !== item.id) }))}>Remove</button>
       </div>)}
     </div>
     {error && <p className="account-overview__error-text">{error}</p>}

--- a/web/src/hooks/useStorePreferences.ts
+++ b/web/src/hooks/useStorePreferences.ts
@@ -95,29 +95,47 @@ function mergePreferences(raw: Record<string, unknown> | undefined | null): Stor
       : DEFAULT_PREFERENCES.navigation.customLabels
 
 
-  const enabledModules =
+  const enabledModulesSource =
     navigation && Array.isArray(navigation.enabled_modules)
-      ? (navigation.enabled_modules as unknown[]).reduce<string[]>((acc, value) => {
-          if (typeof value === 'string' && value.trim()) acc.push(value.trim())
-          return acc
-        }, [])
+      ? navigation.enabled_modules
+      : navigation && Array.isArray(navigation.enabledModules)
+      ? navigation.enabledModules
       : navigation && Array.isArray(navigation.visible_modules)
-      ? (navigation.visible_modules as unknown[]).reduce<string[]>((acc, value) => {
+      ? navigation.visible_modules
+      : null
+
+  const enabledModules =
+    enabledModulesSource
+      ? (enabledModulesSource as unknown[]).reduce<string[]>((acc, value) => {
           if (typeof value === 'string' && value.trim()) acc.push(value.trim())
           return acc
         }, [])
       : INDUSTRY_ENABLED_MODULE_PRESETS[industry]
 
-  const customNavItems =
+  const customNavItemsSource =
     navigation && Array.isArray(navigation.custom_nav_items)
-      ? (navigation.custom_nav_items as Record<string, unknown>[]).reduce<CustomNavItem[]>((acc, item) => {
+      ? navigation.custom_nav_items
+      : navigation && Array.isArray(navigation.customNavItems)
+      ? navigation.customNavItems
+      : null
+
+  const customNavItems =
+    customNavItemsSource
+      ? (customNavItemsSource as Record<string, unknown>[]).reduce<CustomNavItem[]>((acc, item) => {
           const id = typeof item.id === 'string' ? item.id.trim() : ''
           const label = typeof item.label === 'string' ? item.label.trim() : ''
           const type = item.type
           const target = typeof item.target === 'string' ? item.target.trim() : ''
-          const sortOrder = typeof item.sort_order === 'number' ? item.sort_order : 0
+          const sortOrder =
+            typeof item.sort_order === 'number'
+              ? item.sort_order
+              : typeof item.sortOrder === 'number'
+              ? item.sortOrder
+              : 0
           const rolesAllowed = Array.isArray(item.roles_allowed)
             ? item.roles_allowed.filter(role => role === 'owner' || role === 'staff')
+            : Array.isArray(item.rolesAllowed)
+            ? item.rolesAllowed.filter(role => role === 'owner' || role === 'staff')
             : []
 
           if (!id || !label || !target || rolesAllowed.length === 0) return acc


### PR DESCRIPTION
### Motivation
- Prevent editing of labels, routes and link types in the UI while still allowing access-level changes for existing custom navigation items. 
- Remove fragile drag/drop and item creation/removal flows from the settings UI to simplify the editing surface.
- Improve resilience when reading store preferences by supporting multiple legacy and alternate JSON key names for navigation fields.

### Description
- Update `NavigationSettingsSection.tsx` to remove drag/drop, add/remove and direct editing of labels/routes; the UI now only shows access checkboxes and a help text and header indicating that only access levels are editable. 
- Removed `makeId` and `dragId` usage and corresponding event handlers, and simplified the custom nav item rendering to display the existing label/target and role checkboxes. 
- Update `useStorePreferences.ts` to normalize incoming preference payloads by supporting `enabled_modules`, `enabledModules`, or `visible_modules` as sources for enabled modules and by supporting `custom_nav_items` or `customNavItems` for custom items. 
- Normalize property variants for `sort_order`/`sortOrder` and `roles_allowed`/`rolesAllowed` and filter/trim values to produce safe `enabledModules` and `customNavItems` fallbacks to industry presets.

### Testing
- Ran `yarn build` to verify TypeScript compilation and bundling, and the build completed successfully. 
- Ran unit tests with `yarn test` and all tests passed. 
- Ran `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0730a7e55483218a20981d26501dec)