### PR TITLE
Improve text contrast on Expenses page helper copy

### DIFF
--- a/web/src/layout/Workspace.css
+++ b/web/src/layout/Workspace.css
@@ -350,3 +350,10 @@
     justify-content: space-between;
   }
 }
+
+/* Expenses page contrast adjustments */
+.expenses-page .page__subtitle,
+.expenses-page .card__subtitle,
+.expenses-page .form__hint {
+  color: #334155;
+}

--- a/web/src/pages/Expenses.tsx
+++ b/web/src/pages/Expenses.tsx
@@ -538,7 +538,7 @@ export default function Expenses({ embedded = false }: ExpensesProps) {
 
   if (embedded) {
     return (
-      <section className="card" style={{ marginTop: 24 }} aria-label="Business records">
+      <section className="card expenses-page" style={{ marginTop: 24 }} aria-label="Business records">
         <div className="page__header" style={{ padding: 0, marginBottom: 12 }}>
           <div>
             <h3 className="card__title">Business records</h3>
@@ -553,7 +553,7 @@ export default function Expenses({ embedded = false }: ExpensesProps) {
   }
 
   return (
-    <div className="page">
+    <div className="page expenses-page">
       <header className="page__header">
         <div>
           <h2 className="page__title">Business records</h2>


### PR DESCRIPTION
### Motivation
- The helper and summary text on the Expenses screen was too light and needed stronger contrast for readability and accessibility.  
- The change ensures consistent, higher-contrast helper copy in both standalone and embedded render paths.

### Description
- Added an `expenses-page` wrapper class to the root containers in `web/src/pages/Expenses.tsx` for both standalone and embedded views.  
- Added scoped CSS in `web/src/layout/Workspace.css` to set a darker color (`#334155`) for `.expenses-page .page__subtitle`, `.expenses-page .card__subtitle`, and `.expenses-page .form__hint`.  
- No application logic was changed; this is a visual/accessibility-only update.

### Testing
- Located affected strings with `rg` and validated the modified lines with `nl`/`sed` commands, which completed successfully.  
- Verified the visual change by inspecting the `git diff` output for `web/src/pages/Expenses.tsx` and `web/src/layout/Workspace.css`, which showed the intended edits.  
- Committed the change with `git commit`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0736ccafa483219ee9cdbed50171ac)