### PR TITLE
Add donations intake/confirmation/dispatch APIs and Funds Ledger UI with navigation integration

### DIFF
--- a/web/api/donations-communications-dispatch.ts
+++ b/web/api/donations-communications-dispatch.ts
@@ -1,0 +1,61 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { FieldValue } from 'firebase-admin/firestore'
+import { db } from './_firebase-admin.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed.' })
+
+  const token = typeof req.headers.authorization === 'string' ? req.headers.authorization.replace('Bearer ', '') : ''
+  if (!process.env.CRON_SECRET || token !== process.env.CRON_SECRET) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+
+  const firestore = db()
+  const queueSnap = await firestore.collection('communications_queue').where('status', '==', 'queued').limit(25).get()
+  let processed = 0
+
+  for (const job of queueSnap.docs) {
+    const data = job.data() as { storeId?: string; fundTransactionId?: string; event?: string }
+    if (!data.storeId || !data.fundTransactionId) continue
+
+    const txRef = firestore.collection('fund_transactions').doc(data.fundTransactionId)
+    const txSnap = await txRef.get()
+    if (!txSnap.exists) {
+      await job.ref.set({ status: 'failed', failureReason: 'transaction_missing', updatedAt: FieldValue.serverTimestamp() }, { merge: true })
+      continue
+    }
+
+    const tx = txSnap.data() as { donorId?: string; amount?: number; currency?: string; reference?: string }
+    const receiptRef = await firestore.collection('donation_receipts').add({
+      storeId: data.storeId,
+      fundTransactionId: data.fundTransactionId,
+      donorId: tx.donorId || null,
+      amount: tx.amount || 0,
+      currency: tx.currency || 'GHS',
+      reference: tx.reference || null,
+      event: data.event || 'donation.captured',
+      generatedAt: FieldValue.serverTimestamp(),
+      deliveryStatus: 'queued',
+    })
+
+    await firestore.collection('donor_comms').add({
+      storeId: data.storeId,
+      donorId: tx.donorId || null,
+      channel: 'email',
+      template: 'donation-receipt-v1',
+      payload: {
+        receiptId: receiptRef.id,
+        amount: tx.amount || 0,
+        currency: tx.currency || 'GHS',
+        reference: tx.reference || null,
+      },
+      status: 'queued',
+      createdAt: FieldValue.serverTimestamp(),
+    })
+
+    await job.ref.set({ status: 'processed', processedAt: FieldValue.serverTimestamp() }, { merge: true })
+    processed += 1
+  }
+
+  return res.status(200).json({ ok: true, processed })
+}

--- a/web/api/donations-intake.ts
+++ b/web/api/donations-intake.ts
@@ -1,0 +1,137 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createHash, timingSafeEqual } from 'node:crypto'
+import { FieldValue } from 'firebase-admin/firestore'
+import { db } from './_firebase-admin.js'
+
+type IntakeMode = 'lead' | 'donation'
+
+function sanitizeString(value: unknown, max = 200) {
+  return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+
+function normalizeEmail(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function normalizePhone(value: string) {
+  const raw = value.trim()
+  if (!raw) return ''
+  const digits = raw.replace(/\D/g, '')
+  return raw.startsWith('+') ? `+${digits}` : `+${digits}`
+}
+
+function isValidEmail(value: string) {
+  if (!value) return true
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+}
+
+function hash(value: string) {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24)
+}
+
+function verifyApiKey(req: VercelRequest, expected: string) {
+  const supplied = sanitizeString(req.headers['x-api-key'], 200)
+  if (!supplied || !expected) return false
+  const a = Buffer.from(supplied)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed.' })
+
+  const storeId = sanitizeString(req.headers['x-store-id'], 120)
+  const apiKey = process.env.DONATIONS_INTAKE_API_KEY || ''
+  if (!storeId) return res.status(400).json({ error: 'Missing x-store-id header.' })
+  if (!verifyApiKey(req, apiKey)) return res.status(401).json({ error: 'Unauthorized.' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const donorInput = (body.donor ?? {}) as Record<string, unknown>
+
+  const mode = sanitizeString(body.mode, 20) === 'donation' ? 'donation' : 'lead'
+  const donorName = sanitizeString(donorInput.name, 120)
+  const email = normalizeEmail(sanitizeString(donorInput.email, 120))
+  const phone = normalizePhone(sanitizeString(donorInput.phone, 40))
+  const amount = Number(body.amount)
+  const currency = sanitizeString(body.currency, 12) || 'GHS'
+  const fundId = sanitizeString(body.fundId, 120)
+  const project = sanitizeString(body.project, 160)
+  const message = sanitizeString(body.message, 500)
+  const reference = sanitizeString(body.reference, 140)
+  const idempotencyKey = sanitizeString(req.headers['idempotency-key'], 140)
+
+  if (!donorName) return res.status(400).json({ error: 'Donor name is required.' })
+  if (!email && !phone) return res.status(400).json({ error: 'Provide donor email or phone.' })
+  if (!isValidEmail(email)) return res.status(400).json({ error: 'Invalid donor email.' })
+  if (mode === 'donation' && (!Number.isFinite(amount) || amount <= 0 || !fundId)) {
+    return res.status(400).json({ error: 'For donation mode, amount and fundId are required.' })
+  }
+  if (!idempotencyKey) return res.status(400).json({ error: 'Missing idempotency-key header.' })
+
+  const firestore = db()
+  const dedupeRef = firestore.collection('integration_idempotency').doc(`${storeId}_${idempotencyKey}`)
+  const dedupeSnap = await dedupeRef.get()
+  if (dedupeSnap.exists) return res.status(200).json({ ok: true, duplicate: true })
+
+  const donorLookup = email
+    ? await firestore.collection('customers').where('storeId', '==', storeId).where('email', '==', email).limit(1).get()
+    : phone
+      ? await firestore.collection('customers').where('storeId', '==', storeId).where('phone', '==', phone).limit(1).get()
+      : null
+
+  let donorId: string
+  if (donorLookup && !donorLookup.empty) {
+    donorId = donorLookup.docs[0].id
+    await donorLookup.docs[0].ref.set({
+      name: donorName,
+      displayName: donorName,
+      email: email || null,
+      phone: phone || null,
+      source: 'website-donation-intake',
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true })
+  } else {
+    const donorRef = await firestore.collection('customers').add({
+      storeId,
+      name: donorName,
+      displayName: donorName,
+      email: email || null,
+      phone: phone || null,
+      source: 'website-donation-intake',
+      tags: ['Donor'],
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    })
+    donorId = donorRef.id
+  }
+
+  if (mode === 'donation') {
+    await firestore.collection('fund_transactions').add({
+      storeId,
+      fundId,
+      donorId,
+      direction: 'inflow',
+      amount,
+      currency,
+      project,
+      description: message,
+      date: new Date().toISOString().slice(0, 10),
+      source: 'api',
+      status: 'pending_confirmation',
+      reference: reference || null,
+      createdAt: FieldValue.serverTimestamp(),
+    })
+  }
+
+  await dedupeRef.set({
+    storeId,
+    idempotencyKey,
+    donorId,
+    mode: mode as IntakeMode,
+    bodyHash: hash(JSON.stringify(body)),
+    createdAt: FieldValue.serverTimestamp(),
+  })
+
+  return res.status(200).json({ ok: true, donorId, mode })
+}

--- a/web/api/donations-payment-confirmation.ts
+++ b/web/api/donations-payment-confirmation.ts
@@ -1,0 +1,61 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { FieldValue } from 'firebase-admin/firestore'
+import { db } from './_firebase-admin.js'
+
+function sanitizeString(value: unknown, max = 140) {
+  return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed.' })
+
+  const storeId = sanitizeString(req.body?.storeId, 120)
+  const reference = sanitizeString(req.body?.reference, 140)
+  const provider = sanitizeString(req.body?.provider, 40) || 'paystack'
+  const status = sanitizeString(req.body?.status, 40)
+  const amount = Number(req.body?.amount)
+  const transactionId = sanitizeString(req.body?.transactionId, 140)
+
+  if (!storeId || !reference || !status) {
+    return res.status(400).json({ error: 'storeId, reference and status are required.' })
+  }
+
+  const firestore = db()
+  const txSnap = await firestore
+    .collection('fund_transactions')
+    .where('storeId', '==', storeId)
+    .where('reference', '==', reference)
+    .limit(1)
+    .get()
+
+  if (txSnap.empty) {
+    return res.status(404).json({ error: 'Matching donation transaction not found.' })
+  }
+
+  const txDoc = txSnap.docs[0]
+  const success = status === 'success' || status === 'captured' || status === 'paid'
+
+  await txDoc.ref.set({
+    status: success ? 'captured' : 'failed',
+    provider,
+    providerReference: reference,
+    providerTransactionId: transactionId || null,
+    confirmedAmount: Number.isFinite(amount) ? amount : null,
+    confirmedAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  }, { merge: true })
+
+  if (success) {
+    await firestore.collection('communications_queue').add({
+      storeId,
+      event: 'donation.captured',
+      fundTransactionId: txDoc.id,
+      provider,
+      reference,
+      status: 'queued',
+      createdAt: FieldValue.serverTimestamp(),
+    })
+  }
+
+  return res.status(200).json({ ok: true, status: success ? 'captured' : 'failed', fundTransactionId: txDoc.id })
+}

--- a/web/src/components/NavigationSettingsSection.tsx
+++ b/web/src/components/NavigationSettingsSection.tsx
@@ -108,6 +108,7 @@ export default function NavigationSettingsSection({ preferences, onSave, canEdit
       Only access levels are editable here. Labels, routes, and link types use site defaults.
     </p>
     <div className="account-overview__custom-nav-list">
+      {draft.customNavItems.length === 0 ? <p className="account-overview__help-text">No custom navigation links are configured yet.</p> : null}
       {draft.customNavItems.map((item) => <div key={item.id}>
         <strong>{item.label || item.target || 'Custom navigation item'}</strong>
         <label><input type="checkbox" checked={item.roles_allowed.includes('owner')} disabled={!canEdit} onChange={() => updateItem(item.id, { roles_allowed: item.roles_allowed.includes('owner') ? item.roles_allowed.filter(r => r !== 'owner') as NavRole[] : [...item.roles_allowed, 'owner'] })} />Owner</label>

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -62,6 +62,7 @@ export const NAV_ITEMS: NavItem[] = [
     sortOrder: 90,
   },
   { id: 'public-page', label: 'Public page', type: 'module', target: '/public-page', rolesAllowed: ['owner'], sortOrder: 100 },
+  { id: 'funds-ledger', label: 'Funds ledger', type: 'module', target: '/funds-ledger', rolesAllowed: ['owner', 'staff'], sortOrder: 105 },
   { id: 'account', label: 'Account', type: 'module', target: '/account', rolesAllowed: ['owner'], sortOrder: 110 },
 ]
 
@@ -102,7 +103,7 @@ export type NavigationSettings = {
 export const INDUSTRY_ENABLED_MODULE_PRESETS: Record<Industry, string[]> = {
   shop: ['dashboard', 'products', 'sell', 'customers', 'expenses', 'public-page'],
   travel: ['dashboard', 'bookings', 'customers', 'bulk-messaging', 'bulk-email', 'expenses'],
-  ngo: ['dashboard', 'customers', 'bulk-messaging', 'bulk-email', 'expenses', 'public-page'],
+  ngo: ['dashboard', 'customers', 'bulk-messaging', 'bulk-email', 'expenses', 'funds-ledger', 'public-page'],
   school: ['dashboard', 'bookings', 'customers', 'bulk-messaging', 'bulk-email', 'expenses'],
 }
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -23,6 +23,7 @@ import StaffManagement from './pages/StaffManagement'
 import { BillingVerifyPage } from './pages/BillingVerifyPage'
 import Support from './pages/Support'
 import Expenses from './pages/Expenses'
+import FundsLedger from './pages/FundsLedger'
 import DocumentsGenerator from './pages/DocumentsGenerator'
 import ResetPassword from './pages/ResetPassword'
 import VerifyEmail from './pages/VerifyEmail'
@@ -102,6 +103,7 @@ const router = createBrowserRouter([
           { path: 'finance', element: <Navigate to="/sell/invoice" replace /> },
           { path: 'finance/documents', element: <Navigate to="/sell/invoice" replace /> },
           { path: 'expenses', element: <Expenses /> },
+          { path: 'funds-ledger', element: <FundsLedger /> },
 
           // Close day
           { path: 'sell/close-day', element: <CloseDay /> },

--- a/web/src/pages/FundsLedger.tsx
+++ b/web/src/pages/FundsLedger.tsx
@@ -1,0 +1,244 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { addDoc, collection, onSnapshot, orderBy, query, serverTimestamp, where } from 'firebase/firestore'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import { useAuthUser } from '../hooks/useAuthUser'
+
+type Fund = {
+  id: string
+  storeId: string
+  fundName: string
+  sourceName: string
+  restrictionType: 'restricted' | 'unrestricted'
+  openingBalance: number
+  endDate?: string
+  reportDueDate?: string
+  status: 'active' | 'closed'
+}
+
+type FundTransaction = {
+  id: string
+  storeId: string
+  fundId: string
+  direction: 'inflow' | 'outflow'
+  amount: number
+  date: string
+  project: string
+  category: string
+  description: string
+}
+
+export default function FundsLedger() {
+  const { storeId } = useActiveStore()
+  const user = useAuthUser()
+
+  const [funds, setFunds] = useState<Fund[]>([])
+  const [transactions, setTransactions] = useState<FundTransaction[]>([])
+
+  const [fundName, setFundName] = useState('')
+  const [sourceName, setSourceName] = useState('')
+  const [restrictionType, setRestrictionType] = useState<'restricted' | 'unrestricted'>('restricted')
+  const [openingBalance, setOpeningBalance] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [reportDueDate, setReportDueDate] = useState('')
+
+  const [fundId, setFundId] = useState('')
+  const [direction, setDirection] = useState<'inflow' | 'outflow'>('inflow')
+  const [amount, setAmount] = useState('')
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [project, setProject] = useState('')
+  const [category, setCategory] = useState('')
+  const [description, setDescription] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!storeId) return
+    const fundsQuery = query(collection(db, 'funds'), where('storeId', '==', storeId), orderBy('createdAt', 'desc'))
+    const txQuery = query(
+      collection(db, 'fund_transactions'),
+      where('storeId', '==', storeId),
+      orderBy('date', 'desc'),
+      orderBy('createdAt', 'desc'),
+    )
+
+    const unsubFunds = onSnapshot(fundsQuery, snapshot => {
+      setFunds(
+        snapshot.docs.map(docSnap => {
+          const data = docSnap.data() as any
+          return {
+            id: docSnap.id,
+            storeId: data.storeId,
+            fundName: data.fundName || '',
+            sourceName: data.sourceName || '',
+            restrictionType: data.restrictionType === 'unrestricted' ? 'unrestricted' : 'restricted',
+            openingBalance: Number(data.openingBalance) || 0,
+            endDate: data.endDate || '',
+            reportDueDate: data.reportDueDate || '',
+            status: data.status === 'closed' ? 'closed' : 'active',
+          }
+        }),
+      )
+    })
+
+    const unsubTx = onSnapshot(txQuery, snapshot => {
+      setTransactions(
+        snapshot.docs.map(docSnap => {
+          const data = docSnap.data() as any
+          return {
+            id: docSnap.id,
+            storeId: data.storeId,
+            fundId: data.fundId,
+            direction: data.direction === 'outflow' ? 'outflow' : 'inflow',
+            amount: Number(data.amount) || 0,
+            date: data.date || '',
+            project: data.project || '',
+            category: data.category || '',
+            description: data.description || '',
+          }
+        }),
+      )
+    })
+
+    return () => {
+      unsubFunds()
+      unsubTx()
+    }
+  }, [storeId])
+
+  const stats = useMemo(() => {
+    const byFund = new Map<string, { inflows: number; outflows: number }>()
+    transactions.forEach(tx => {
+      const current = byFund.get(tx.fundId) || { inflows: 0, outflows: 0 }
+      if (tx.direction === 'inflow') current.inflows += tx.amount
+      else current.outflows += tx.amount
+      byFund.set(tx.fundId, current)
+    })
+    return byFund
+  }, [transactions])
+
+  async function createFund(e: React.FormEvent) {
+    e.preventDefault()
+    if (!storeId || !user) return
+    if (!fundName.trim() || !sourceName.trim()) return
+
+    await addDoc(collection(db, 'funds'), {
+      storeId,
+      fundName: fundName.trim(),
+      sourceName: sourceName.trim(),
+      restrictionType,
+      openingBalance: Number(openingBalance) || 0,
+      endDate: endDate || null,
+      reportDueDate: reportDueDate || null,
+      status: 'active',
+      createdAt: serverTimestamp(),
+      createdBy: user.uid,
+    })
+
+    setFundName('')
+    setSourceName('')
+    setOpeningBalance('')
+    setEndDate('')
+    setReportDueDate('')
+  }
+
+  async function addTransaction(e: React.FormEvent) {
+    e.preventDefault()
+    if (!storeId || !user || !fundId || Number(amount) <= 0) return
+
+    const targetFund = funds.find(item => item.id === fundId)
+    if (!targetFund) return
+
+    const fundTotals = stats.get(fundId) || { inflows: 0, outflows: 0 }
+    const remainingBefore = targetFund.openingBalance + fundTotals.inflows - fundTotals.outflows
+    if (direction === 'outflow' && Number(amount) > remainingBefore) {
+      setError('Outflow exceeds remaining fund balance.')
+      return
+    }
+
+    setError(null)
+    await addDoc(collection(db, 'fund_transactions'), {
+      storeId,
+      fundId,
+      direction,
+      amount: Number(amount),
+      date,
+      project: project.trim(),
+      category: category.trim(),
+      description: description.trim(),
+      source: 'manual',
+      createdAt: serverTimestamp(),
+      createdBy: user.uid,
+    })
+
+    setAmount('')
+    setProject('')
+    setCategory('')
+    setDescription('')
+  }
+
+  return (
+    <main className="page-shell">
+      <header className="page-header">
+        <h1>Funds & Grants Ledger</h1>
+        <p className="form__hint">Track donor funds, tranches, outflows, and remaining balances.</p>
+      </header>
+
+      <section className="card" style={{ padding: 16, marginBottom: 16 }}>
+        <h2>Create fund bucket</h2>
+        <form onSubmit={createFund} className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+          <input value={fundName} onChange={e => setFundName(e.target.value)} placeholder="Fund name" required />
+          <input value={sourceName} onChange={e => setSourceName(e.target.value)} placeholder="Source / donor" required />
+          <select value={restrictionType} onChange={e => setRestrictionType(e.target.value as 'restricted' | 'unrestricted')}>
+            <option value="restricted">Restricted</option>
+            <option value="unrestricted">Unrestricted</option>
+          </select>
+          <input value={openingBalance} onChange={e => setOpeningBalance(e.target.value)} placeholder="Opening balance" type="number" min="0" step="0.01" />
+          <input value={endDate} onChange={e => setEndDate(e.target.value)} type="date" />
+          <input value={reportDueDate} onChange={e => setReportDueDate(e.target.value)} type="date" />
+          <button className="button button--primary" type="submit">Save fund</button>
+        </form>
+      </section>
+
+      <section className="card" style={{ padding: 16, marginBottom: 16 }}>
+        <h2>Add transaction</h2>
+        {error ? <p style={{ color: 'crimson' }}>{error}</p> : null}
+        <form onSubmit={addTransaction} className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+          <select value={fundId} onChange={e => setFundId(e.target.value)} required>
+            <option value="">Select fund</option>
+            {funds.map(fund => <option key={fund.id} value={fund.id}>{fund.fundName}</option>)}
+          </select>
+          <select value={direction} onChange={e => setDirection(e.target.value as 'inflow' | 'outflow')}>
+            <option value="inflow">Inflow</option>
+            <option value="outflow">Outflow</option>
+          </select>
+          <input value={amount} onChange={e => setAmount(e.target.value)} type="number" min="0.01" step="0.01" placeholder="Amount" required />
+          <input value={date} onChange={e => setDate(e.target.value)} type="date" required />
+          <input value={project} onChange={e => setProject(e.target.value)} placeholder="Project / campaign" />
+          <input value={category} onChange={e => setCategory(e.target.value)} placeholder="Category" />
+          <input value={description} onChange={e => setDescription(e.target.value)} placeholder="Description" />
+          <button className="button button--primary" type="submit">Save transaction</button>
+        </form>
+      </section>
+
+      <section className="card" style={{ padding: 16 }}>
+        <h2>Funds summary</h2>
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Fund</th><th>Source</th><th>Type</th><th>Opening</th><th>Inflows</th><th>Outflows</th><th>Remaining</th><th>End</th><th>Report due</th>
+              </tr>
+            </thead>
+            <tbody>
+              {funds.map(fund => {
+                const totals = stats.get(fund.id) || { inflows: 0, outflows: 0 }
+                const remaining = fund.openingBalance + totals.inflows - totals.outflows
+                return <tr key={fund.id}><td>{fund.fundName}</td><td>{fund.sourceName}</td><td>{fund.restrictionType}</td><td>{fund.openingBalance.toFixed(2)}</td><td>{totals.inflows.toFixed(2)}</td><td>{totals.outflows.toFixed(2)}</td><td>{remaining.toFixed(2)}</td><td>{fund.endDate || '-'}</td><td>{fund.reportDueDate || '-'}</td></tr>
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a simple ingestion path for donor leads and donations with idempotency and donor record creation.  
- Accept and confirm payment provider callbacks to mark donation transactions and enqueue downstream work.  
- Process queued communication jobs to generate donation receipts and queue donor communications.  
- Expose a Funds Ledger UI so workspaces can create funds and record inflows/outflows, and surface the feature in the app navigation.

### Description
- Added three serverless API endpoints: `donations-intake` (donor/donation intake with idempotency and donor lookup/creation), `donations-payment-confirmation` (map provider status to transaction status and enqueue `donation.captured` events), and `donations-communications-dispatch` (process `communications_queue`, create `donation_receipts` and `donor_comms`).
- Implemented a new React page `FundsLedger` with live Firestore listeners for `funds` and `fund_transactions`, forms to create funds and transactions, balance checks to prevent overdrawing, and summary table rendering.
- Wired the Funds Ledger into the app by importing the page in `main.tsx`, adding a route at `/funds-ledger`, adding `funds-ledger` to `NAV_ITEMS` and the NGO industry enabled modules preset in `web/src/config/navigation.ts`.
- Small UI improvement in `NavigationSettingsSection` to show a help message when no custom navigation links are configured.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0737ac07708321a5481ad9f37fa2e8)