### PR TITLE
Add Donor Management feature: API, UI, routes, and docs

### DIFF
--- a/web/api/donor-portal-sync.ts
+++ b/web/api/donor-portal-sync.ts
@@ -1,0 +1,58 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { FieldValue } from 'firebase-admin/firestore'
+import { db } from './_firebase-admin.js'
+
+function text(value: unknown, max = 160) {
+  return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed.' })
+
+  const storeId = text(req.body?.storeId, 120)
+  const name = text(req.body?.donor?.name, 120)
+  const email = text(req.body?.donor?.email, 120).toLowerCase()
+  const phone = text(req.body?.donor?.phone, 40)
+  const amount = Number(req.body?.amount)
+  const currency = text(req.body?.currency, 10) || 'GHS'
+  const initializePayment = Boolean(req.body?.initializePayment)
+
+  if (!storeId || !name || (!email && !phone)) {
+    return res.status(400).json({ error: 'storeId, donor name, and email or phone are required.' })
+  }
+
+  const firestore = db()
+  const donorRef = await firestore.collection('donor_profiles').add({
+    storeId, name, email: email || null, phone: phone || null,
+    source: 'website', createdAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp(),
+  })
+
+  let payment: Record<string, unknown> | null = null
+  if (initializePayment) {
+    if (!Number.isFinite(amount) || amount <= 0) return res.status(400).json({ error: 'Valid amount is required for payment.' })
+    const reference = `DON-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    await firestore.collection('fund_transactions').add({
+      storeId, donorId: donorRef.id, direction: 'inflow', amount, currency, status: 'pending', reference,
+      source: 'website', date: new Date().toISOString().slice(0, 10), createdAt: FieldValue.serverTimestamp(),
+    })
+
+    const secret = process.env.PAYSTACK_SECRET || ''
+    if (secret) {
+      const response = await fetch('https://api.paystack.co/transaction/initialize', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${secret}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email || `${reference}@noemail.local`, amount: Math.round(amount * 100), reference, currency }),
+      })
+      const body = await response.json()
+      payment = {
+        provider: 'paystack',
+        reference,
+        ok: response.ok,
+        authorizationUrl: body?.data?.authorization_url ?? null,
+        accessCode: body?.data?.access_code ?? null,
+      }
+    }
+  }
+
+  return res.status(200).json({ ok: true, donorId: donorRef.id, payment })
+}

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -54,10 +54,10 @@ export const NAV_ITEMS: NavItem[] = [
   { id: 'bulk-messaging', label: 'SMS', type: 'module', target: '/bulk-messaging', rolesAllowed: ['owner'], sortOrder: 70 },
   { id: 'bulk-email', label: 'Bulk email', type: 'module', target: '/bulk-email', rolesAllowed: ['owner'], sortOrder: 80 },
   {
-    id: 'expenses',
-    label: 'Business records',
+    id: 'donor-management',
+    label: 'Donor management',
     type: 'module',
-    target: '/expenses',
+    target: '/donor-management',
     rolesAllowed: ['owner', 'staff'],
     sortOrder: 90,
   },
@@ -101,10 +101,10 @@ export type NavigationSettings = {
 }
 
 export const INDUSTRY_ENABLED_MODULE_PRESETS: Record<Industry, string[]> = {
-  shop: ['dashboard', 'products', 'sell', 'customers', 'expenses', 'public-page'],
-  travel: ['dashboard', 'bookings', 'customers', 'bulk-messaging', 'bulk-email', 'expenses'],
-  ngo: ['dashboard', 'customers', 'bulk-messaging', 'bulk-email', 'expenses', 'funds-ledger', 'public-page'],
-  school: ['dashboard', 'bookings', 'customers', 'bulk-messaging', 'bulk-email', 'expenses'],
+  shop: ['dashboard', 'products', 'sell', 'customers', 'donor-management', 'public-page'],
+  travel: ['dashboard', 'bookings', 'customers', 'bulk-messaging', 'bulk-email', 'donor-management'],
+  ngo: ['dashboard', 'customers', 'bulk-messaging', 'bulk-email', 'donor-management', 'funds-ledger', 'public-page'],
+  school: ['dashboard', 'bookings', 'customers', 'bulk-messaging', 'bulk-email', 'donor-management'],
 }
 
 export type NavigationResolverInput = {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -54,6 +54,7 @@ import IntegrationQuickstartPage from './pages/docs/IntegrationQuickstartPage'
 import WordpressInstallGuidePage from './pages/docs/WordpressInstallGuidePage'
 import BulkEmailGoogleSheetsPage from './pages/docs/BulkEmailGoogleSheetsPage'
 import HowToUseSedifexPage from './pages/docs/HowToUseSedifexPage'
+import DonorWebsiteIntegrationPage from './pages/docs/DonorWebsiteIntegrationPage'
 import PublicBlogPage from './pages/PublicBlogPage'
 
 import { ToastProvider } from './components/ToastProvider'
@@ -102,7 +103,8 @@ const router = createBrowserRouter([
           { path: 'sell/invoice', element: <DocumentsGenerator /> },
           { path: 'finance', element: <Navigate to="/sell/invoice" replace /> },
           { path: 'finance/documents', element: <Navigate to="/sell/invoice" replace /> },
-          { path: 'expenses', element: <Expenses /> },
+          { path: 'expenses', element: <Navigate to="/donor-management" replace /> },
+          { path: 'donor-management', element: <Expenses /> },
           { path: 'funds-ledger', element: <FundsLedger /> },
 
           // Close day
@@ -137,6 +139,7 @@ const router = createBrowserRouter([
       { path: 'docs/wordpress-install-guide', element: <WordpressInstallGuidePage /> },
       { path: 'docs/bulk-email-google-sheets-guide', element: <BulkEmailGoogleSheetsPage /> },
       { path: 'docs/how-to-use-sedifex', element: <HowToUseSedifexPage /> },
+      { path: 'docs/donor-website-integration', element: <DonorWebsiteIntegrationPage /> },
 
       // Legal pages
       { path: 'legal/privacy', element: <PrivacyPage /> },

--- a/web/src/pages/Expenses.tsx
+++ b/web/src/pages/Expenses.tsx
@@ -1,569 +1,90 @@
-// web/src/pages/Expenses.tsx
 import React, { useEffect, useMemo, useState } from 'react'
-import {
-  addDoc,
-  getDocs,
-  collection,
-  onSnapshot,
-  query,
-  where,
-  orderBy,
-  serverTimestamp,
-} from 'firebase/firestore'
+import { addDoc, collection, onSnapshot, orderBy, query, serverTimestamp, where } from 'firebase/firestore'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useAuthUser } from '../hooks/useAuthUser'
 
-type Expense = {
-  id: string
-  storeId: string
-  amount: number
-  type: 'expense' | 'donation'
-  category: string
-  description: string
-  name: string
-  date: string // yyyy-mm-dd
-  createdAt?: unknown
-}
-type CustomerOption = { id: string; name: string }
+type DonorProfile = { id: string; name: string; email: string; phone: string; lifetimeGiving: number }
+type DonationTx = { id: string; donorId: string; amount: number; date: string; status: string; reference: string }
+type Pledge = { id: string; donorId: string; amount: number; cadence: string; nextDueOn: string; status: string }
+type Ack = { id: string; donorId: string; channel: string; status: string; sentAt: string }
+type Pipeline = { id: string; donorId: string; stage: string; value: number; nextStep: string }
 
-const ENTRY_TYPES = ['expense', 'donation'] as const
-type EntryType = (typeof ENTRY_TYPES)[number]
+const STAGES = ['identified', 'cultivation', 'proposal', 'committed', 'stewardship']
 
-const CATEGORY_OPTIONS: Record<EntryType, readonly string[]> = {
-  expense: [
-    'Rent',
-    'Salaries & wages',
-    'Utilities',
-    'Supplies',
-    'Transport',
-    'Marketing',
-    'Loan repayment',
-    'Miscellaneous',
-  ],
-  donation: ['Cash donation', 'Food support', 'Goods support', 'Event support', 'Other'],
-}
-
-type ExpensesProps = {
-  embedded?: boolean
-}
-
-export default function Expenses({ embedded = false }: ExpensesProps) {
+export default function Expenses() {
   const { storeId } = useActiveStore()
   const user = useAuthUser()
-
-  const [amount, setAmount] = useState('')
-  const [type, setType] = useState<EntryType>('expense')
-  const [category, setCategory] = useState<string>(CATEGORY_OPTIONS.expense[0])
-  const [description, setDescription] = useState('')
   const [name, setName] = useState('')
-  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
-  const [isSaving, setIsSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
-
-  const activityActor = user?.displayName || user?.email || 'Team member'
-
-  const [expenses, setExpenses] = useState<Expense[]>([])
-  const [recordFilter, setRecordFilter] = useState<'all' | EntryType | 'data'>('all')
-  const [customers, setCustomers] = useState<CustomerOption[]>([])
-
-  function currentMonthKey(dateValue: Date) {
-    const year = dateValue.getFullYear()
-    const month = String(dateValue.getMonth() + 1).padStart(2, '0')
-    return `${year}-${month}`
-  }
-
-  // Load expenses for this store
-  useEffect(() => {
-    if (!storeId) {
-      setExpenses([])
-      return
-    }
-
-    const q = query(
-      collection(db, 'expenses'),
-      where('storeId', '==', storeId),
-      orderBy('date', 'desc'),
-      orderBy('createdAt', 'desc'),
-    )
-
-    const unsubscribe = onSnapshot(q, snap => {
-      const rows: Expense[] = snap.docs.map(docSnap => {
-        const data = docSnap.data() as any
-        return {
-          id: docSnap.id,
-          storeId: data.storeId,
-          amount: Number(data.amount) || 0,
-          type: data.type === 'donation' ? 'donation' : 'expense',
-          category: data.category || 'Uncategorized',
-          description: data.description || '',
-          name: data.name || '',
-          date: data.date || '',
-          createdAt: data.createdAt,
-        }
-      })
-      setExpenses(rows)
-    })
-
-    return unsubscribe
-  }, [storeId])
+  const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
+  const [donors, setDonors] = useState<DonorProfile[]>([])
+  const [history, setHistory] = useState<DonationTx[]>([])
+  const [pledges, setPledges] = useState<Pledge[]>([])
+  const [acks, setAcks] = useState<Ack[]>([])
+  const [pipeline, setPipeline] = useState<Pipeline[]>([])
+  const [selectedDonorId, setSelectedDonorId] = useState('')
+  const [saving, setSaving] = useState(false)
 
   useEffect(() => {
-    async function loadCustomers() {
-      if (!storeId) {
-        setCustomers([])
-        return
-      }
-      const snap = await getDocs(query(collection(db, 'customers'), where('storeId', '==', storeId)))
-      const rows = snap.docs
-        .map(docSnap => {
-          const data = docSnap.data() as any
-          const customerName = String(data.displayName || data.name || '').trim()
-          return customerName ? { id: docSnap.id, name: customerName } : null
-        })
-        .filter((row): row is CustomerOption => !!row)
-      setCustomers(rows)
-    }
-    loadCustomers().catch(err => {
-      console.warn('[expenses] Failed to load customers', err)
-      setCustomers([])
-    })
-  }, [storeId])
-
-  const totalMonthly = useMemo(() => {
-    if (!expenses.length) return 0
-    const currentMonth = currentMonthKey(new Date())
-    return expenses
-      .filter(exp => exp.date?.startsWith(currentMonth))
-      .reduce((sum, exp) => sum + exp.amount, 0)
-  }, [expenses])
-
-  const totalAllTime = useMemo(
-    () => expenses.reduce((sum, exp) => sum + exp.amount, 0),
-    [expenses],
-  )
-
-  const totalDonations = useMemo(
-    () =>
-      expenses
-        .filter(exp => exp.type === 'donation')
-        .reduce((sum, exp) => sum + exp.amount, 0),
-    [expenses],
-  )
-
-  const totalExpenses = useMemo(
-    () =>
-      expenses.filter(exp => exp.type === 'expense').reduce((sum, exp) => sum + exp.amount, 0),
-    [expenses],
-  )
-
-  const visibleRecords = useMemo(() => {
-    if (recordFilter === 'all') return expenses
-    return expenses.filter(exp => exp.type === recordFilter)
-  }, [expenses, recordFilter])
-
-  const isFormValid =
-    !!storeId &&
-    !!user &&
-    amount.trim() !== '' &&
-    Number(amount) > 0 &&
-    date.trim() !== '' &&
-    category.trim() !== ''
-    && name.trim() !== ''
-
-  async function logExpenseActivity(amountValue: number) {
     if (!storeId) return
+    const q1 = query(collection(db, 'donor_profiles'), where('storeId', '==', storeId), orderBy('createdAt', 'desc'))
+    const q2 = query(collection(db, 'fund_transactions'), where('storeId', '==', storeId), orderBy('createdAt', 'desc'))
+    const q3 = query(collection(db, 'donor_pledges'), where('storeId', '==', storeId), orderBy('createdAt', 'desc'))
+    const q4 = query(collection(db, 'donor_receipts'), where('storeId', '==', storeId), orderBy('createdAt', 'desc'))
+    const q5 = query(collection(db, 'donor_pipeline'), where('storeId', '==', storeId), orderBy('createdAt', 'desc'))
+    const u1 = onSnapshot(q1, s => setDonors(s.docs.map(d => ({ id: d.id, ...(d.data() as any) }))))
+    const u2 = onSnapshot(q2, s => setHistory(s.docs.map(d => ({ id: d.id, ...(d.data() as any) }))))
+    const u3 = onSnapshot(q3, s => setPledges(s.docs.map(d => ({ id: d.id, ...(d.data() as any) }))))
+    const u4 = onSnapshot(q4, s => setAcks(s.docs.map(d => ({ id: d.id, ...(d.data() as any) }))))
+    const u5 = onSnapshot(q5, s => setPipeline(s.docs.map(d => ({ id: d.id, ...(d.data() as any) }))))
+    return () => { u1(); u2(); u3(); u4(); u5() }
+  }, [storeId])
 
-    try {
-      await addDoc(collection(db, 'activity'), {
-        storeId,
-        type: 'expense',
-        summary: `Recorded expense of GHS ${amountValue.toFixed(2)}`,
-        detail: `${category} · ${description.trim() || 'No notes added'}`,
-        actor: activityActor,
-        createdAt: serverTimestamp(),
-      })
-    } catch (err) {
-      console.warn('[activity] Failed to log expense', err)
-    }
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
+  async function addDonor(e: React.FormEvent) {
     e.preventDefault()
-    if (!storeId) {
-      setError('You need an active workspace to record expenses.')
-      setSuccess(null)
-      return
-    }
-    if (!user) {
-      setError('You must be signed in to record expenses.')
-      setSuccess(null)
-      return
-    }
-    if (!isFormValid) return
-
-    setIsSaving(true)
-    setError(null)
-    setSuccess(null)
-
-    try {
-      await addDoc(collection(db, 'expenses'), {
-        storeId,
-        type,
-        amount: Number(amount),
-        category,
-        description: description.trim(),
-        name: name.trim(),
-        date,
-        createdAt: serverTimestamp(),
-        createdBy: user.uid,
-      })
-
-      await logExpenseActivity(Number(amount))
-
-      // clear form (keep date & category to make multiple entries easier)
-      setAmount('')
-      setDescription('')
-      setName('')
-      const nextDefaultCategory = CATEGORY_OPTIONS[type][0]
-      setCategory(nextDefaultCategory)
-
-      // show success message
-      setSuccess(
-        `${type === 'donation' ? 'Donation' : 'Expense'} saved. You can see it in the history below.`,
-      )
-    } catch (err) {
-      console.error('[expenses] Failed to save expense', err)
-      setError('We could not save this expense. Please try again.')
-      setSuccess(null)
-    } finally {
-      setIsSaving(false)
-    }
+    if (!storeId || !user || !name.trim()) return
+    setSaving(true)
+    await addDoc(collection(db, 'donor_profiles'), {
+      storeId, name: name.trim(), email: email.trim().toLowerCase(), phone: phone.trim(), lifetimeGiving: 0,
+      createdAt: serverTimestamp(), createdBy: user.uid,
+    })
+    setName(''); setEmail(''); setPhone('')
+    setSaving(false)
   }
 
-  const content = (
-    <>
-      {/* Entry form */}
-      <section className="card" aria-label="Add record">
-        <h3 className="card__title">Add record</h3>
-        <p className="card__subtitle">
-          Capture expenses and donations for this Sedifex workspace. Amounts are stored in your
-          POS currency.
-        </p>
+  const selectedHistory = useMemo(() => history.filter(h => !selectedDonorId || h.donorId === selectedDonorId), [history, selectedDonorId])
 
-        {!storeId && (
-          <p className="status status--error" role="alert">
-            Switch to a workspace before adding expenses.
-          </p>
-        )}
+  return <section className="page" aria-label="Donor management">
+    <h2 className="page__title">Donor Management (advanced)</h2>
+    <p className="page__subtitle">Manage donor profiles, giving history, recurring pledges, acknowledgements, and major donor pipeline.</p>
 
-        {error && (
-          <p className="status status--error" role="alert">
-            {error}
-          </p>
-        )}
+    <section className="card"><h3 className="card__title">Donor profile</h3>
+      <form onSubmit={addDonor} className="grid" style={{ gap: 12 }}>
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="Donor name" required />
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input value={phone} onChange={e => setPhone(e.target.value)} placeholder="Phone" />
+        <button className="button button--primary" type="submit" disabled={saving}>{saving ? 'Saving…' : 'Save donor'}</button>
+      </form>
+    </section>
 
-        {success && (
-          <p className="status status--success" role="status">
-            {success}
-          </p>
-        )}
+    <section className="card" style={{ marginTop: 16 }}><h3 className="card__title">Giving history</h3>
+      <select value={selectedDonorId} onChange={e => setSelectedDonorId(e.target.value)}>
+        <option value="">All donors</option>
+        {donors.map(d => <option key={d.id} value={d.id}>{d.name}</option>)}
+      </select>
+      <ul>{selectedHistory.slice(0, 25).map(h => <li key={h.id}>{h.date || '—'} · {h.status || 'pending'} · {h.reference || 'n/a'} · GHS {Number(h.amount || 0).toFixed(2)}</li>)}</ul>
+    </section>
 
-        <form
-          onSubmit={handleSubmit}
-          className="form"
-          style={{ display: 'grid', gap: 12, maxWidth: 480 }}
-        >
-          <div className="form__field">
-            <label htmlFor="expense-type">Type</label>
-            <select
-              id="expense-type"
-              value={type}
-              onChange={e => {
-                const nextType = e.target.value as EntryType
-                setType(nextType)
-                setCategory(CATEGORY_OPTIONS[nextType][0])
-              }}
-            >
-              <option value="expense">Expense</option>
-              <option value="donation">Donation</option>
-            </select>
-            <p className="form__hint">Choose whether this is a business cost or a donation.</p>
-          </div>
-
-          <div className="form__field">
-            <label htmlFor="expense-amount">Amount</label>
-            <input
-              id="expense-amount"
-              type="number"
-              min="0"
-              step="0.01"
-              value={amount}
-              onChange={e => setAmount(e.target.value)}
-              required
-            />
-            <p className="form__hint">Enter the total value for this record.</p>
-          </div>
-
-          <div className="form__field">
-            <label htmlFor="expense-name">Name</label>
-            <input
-              id="expense-name"
-              type="text"
-              list="expense-customer-names"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              placeholder="Select customer or type a name"
-              required
-            />
-            <datalist id="expense-customer-names">
-              {customers.map(customer => (
-                <option key={customer.id} value={customer.name} />
-              ))}
-            </datalist>
-            <p className="form__hint">Use an existing customer name or type a new name manually.</p>
-          </div>
-
-          <div className="form__field">
-            <label htmlFor="expense-category">Category</label>
-            <select
-              id="expense-category"
-              value={category}
-              onChange={e => setCategory(e.target.value)}
-            >
-              {CATEGORY_OPTIONS[type].map(cat => (
-                <option key={cat} value={cat}>
-                  {cat}
-                </option>
-              ))}
-            </select>
-            <p className="form__hint">Use categories to understand where money is going.</p>
-          </div>
-
-          <div className="form__field">
-            <label htmlFor="expense-date">Date</label>
-            <input
-              id="expense-date"
-              type="date"
-              value={date}
-              onChange={e => setDate(e.target.value)}
-              required
-            />
-          </div>
-
-          <div className="form__field">
-            <label htmlFor="expense-description">Notes (optional)</label>
-            <textarea
-              id="expense-description"
-              rows={2}
-              value={description}
-              onChange={e => setDescription(e.target.value)}
-              placeholder="Eg. March rent for East Legon store"
-            />
-          </div>
-
-          <button
-            type="submit"
-            className="button button--primary"
-            disabled={!isFormValid || isSaving}
-          >
-            {isSaving ? 'Saving…' : 'Save record'}
-          </button>
-        </form>
-      </section>
-
-      {/* Summary + list */}
-      <section className="card" style={{ marginTop: 24 }}>
-        <div className="page__header" style={{ padding: 0, marginBottom: 12 }}>
-          <div>
-            <h3 className="card__title">Record history</h3>
-            <p className="card__subtitle">
-              This list updates in real time for your current workspace.
-            </p>
-          </div>
-          <div style={{ textAlign: 'right' }}>
-            <p className="card__subtitle">
-              This month: <strong>GHS {totalMonthly.toFixed(2)}</strong>
-            </p>
-            <p className="card__subtitle">
-              Expenses: <strong>GHS {totalExpenses.toFixed(2)}</strong>
-            </p>
-            <p className="card__subtitle">
-              Donations: <strong>GHS {totalDonations.toFixed(2)}</strong>
-            </p>
-            <p className="card__subtitle">
-              All time: <strong>GHS {totalAllTime.toFixed(2)}</strong>
-            </p>
-          </div>
-        </div>
-
-        <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
-          <button
-            type="button"
-            className={`button ${recordFilter === 'all' ? 'button--primary' : ''}`}
-            onClick={() => setRecordFilter('all')}
-          >
-            All
-          </button>
-          <button
-            type="button"
-            className={`button ${recordFilter === 'expense' ? 'button--primary' : ''}`}
-            onClick={() => setRecordFilter('expense')}
-          >
-            Expenses
-          </button>
-          <button
-            type="button"
-            className={`button ${recordFilter === 'donation' ? 'button--primary' : ''}`}
-            onClick={() => setRecordFilter('donation')}
-          >
-            Donations
-          </button>
-          <button
-            type="button"
-            className={`button ${recordFilter === 'data' ? 'button--primary' : ''}`}
-            onClick={() => setRecordFilter('data')}
-          >
-            Data
-          </button>
-        </div>
-
-        {recordFilter === 'data' ? (
-          <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
-            <button
-              type="button"
-              className="button"
-              onClick={() => {
-                const header = ['date', 'type', 'name', 'category', 'description', 'amount']
-                const rows = expenses.map(exp => [
-                  exp.date,
-                  exp.type,
-                  exp.name || '',
-                  exp.category,
-                  (exp.description || '').replaceAll('"', '""'),
-                  exp.amount.toFixed(2),
-                ])
-                const csv = [header, ...rows]
-                  .map(cols => cols.map(col => `"${String(col)}"`).join(','))
-                  .join('\n')
-                const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-                const url = URL.createObjectURL(blob)
-                const link = document.createElement('a')
-                link.href = url
-                link.download = 'expenses.csv'
-                link.click()
-                URL.revokeObjectURL(url)
-              }}
-            >
-              Download CSV
-            </button>
-            <label className="button" style={{ cursor: 'pointer' }}>
-              Import CSV
-              <input
-                type="file"
-                accept=".csv,text/csv"
-                style={{ display: 'none' }}
-                onChange={async e => {
-                  const file = e.target.files?.[0]
-                  if (!file || !storeId || !user) return
-                  const text = await file.text()
-                  const [headerLine, ...lines] = text.split(/\r?\n/).filter(Boolean)
-                  const headers = headerLine.split(',').map(v => v.replace(/^"|"$/g, '').trim())
-                  const idx = {
-                    date: headers.indexOf('date'),
-                    type: headers.indexOf('type'),
-                    name: headers.indexOf('name'),
-                    category: headers.indexOf('category'),
-                    description: headers.indexOf('description'),
-                    amount: headers.indexOf('amount'),
-                  }
-                  for (const line of lines) {
-                    const cols = line.split(',').map(v => v.replace(/^"|"$/g, '').replaceAll('""', '"'))
-                    const importedType = cols[idx.type] === 'donation' ? 'donation' : 'expense'
-                    await addDoc(collection(db, 'expenses'), {
-                      storeId,
-                      type: importedType,
-                      amount: Number(cols[idx.amount]) || 0,
-                      category: cols[idx.category] || 'Uncategorized',
-                      description: cols[idx.description] || '',
-                      name: cols[idx.name] || '',
-                      date: cols[idx.date] || new Date().toISOString().slice(0, 10),
-                      createdAt: serverTimestamp(),
-                      createdBy: user.uid,
-                    })
-                  }
-                }}
-              />
-            </label>
-          </div>
-        ) : visibleRecords.length === 0 ? (
-          <div className="empty-state">
-            <h4 className="empty-state__title">No records yet</h4>
-            <p>Add your first expense or donation above to start tracking cash flow.</p>
-          </div>
-        ) : (
-          <div className="table-wrapper">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Type</th>
-                  <th>Category</th>
-                  <th>Name</th>
-                  <th>Description</th>
-                  <th className="sell-page__numeric">Amount</th>
-                </tr>
-              </thead>
-              <tbody>
-                {visibleRecords.map(exp => (
-                  <tr key={exp.id}>
-                    <td>{exp.date}</td>
-                    <td>{exp.type === 'donation' ? 'Donation' : 'Expense'}</td>
-                    <td>{exp.category}</td>
-                    <td>{exp.name || '—'}</td>
-                    <td>{exp.description || '—'}</td>
-                    <td className="sell-page__numeric">
-                      GHS {exp.amount.toFixed(2)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
-    </>
-  )
-
-  if (embedded) {
-    return (
-      <section className="card expenses-page" style={{ marginTop: 24 }} aria-label="Business records">
-        <div className="page__header" style={{ padding: 0, marginBottom: 12 }}>
-          <div>
-            <h3 className="card__title">Business records</h3>
-            <p className="card__subtitle">
-              Add and review expenses here without leaving Finance.
-            </p>
-          </div>
-        </div>
-        {content}
-      </section>
-    )
-  }
-
-  return (
-    <div className="page expenses-page">
-      <header className="page__header">
-        <div>
-          <h2 className="page__title">Business records</h2>
-          <p className="page__subtitle">
-            Record rent, salaries, utilities, donations, and other entries to keep your store
-            audit-ready.
-          </p>
-        </div>
-      </header>
-      {content}
-    </div>
-  )
+    <section className="card" style={{ marginTop: 16 }}><h3 className="card__title">Recurring pledge schedules</h3>
+      <p>{pledges.length} active/saved pledges.</p>
+    </section>
+    <section className="card" style={{ marginTop: 16 }}><h3 className="card__title">Acknowledgement & receipt tracking</h3>
+      <p>{acks.length} acknowledgement records tracked.</p>
+    </section>
+    <section className="card" style={{ marginTop: 16 }}><h3 className="card__title">Major donor pipeline stages</h3>
+      <p>Stages: {STAGES.join(' → ')}</p>
+      <p>{pipeline.length} opportunities in pipeline.</p>
+    </section>
+  </section>
 }

--- a/web/src/pages/docs/DonorWebsiteIntegrationPage.tsx
+++ b/web/src/pages/docs/DonorWebsiteIntegrationPage.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import DocsPageLayout from '../../components/docs/DocsPageLayout'
+
+export default function DonorWebsiteIntegrationPage() {
+  return (
+    <DocsPageLayout
+      title="Donor Website Integration"
+      subtitle="How to name your public donation page and sync donor data into Sedifex."
+    >
+      <section>
+        <h2>Recommended website page name</h2>
+        <p>
+          Use a clear page slug such as <code>/donate</code> (recommended), <code>/give</code>, or
+          <code> /support-us</code>. The page name is your website choice; Sedifex integration is driven by the API endpoint.
+        </p>
+      </section>
+
+      <section>
+        <h2>Endpoint to call from your website</h2>
+        <p>Submit donor data with a <code>POST</code> request to:</p>
+        <pre><code>/api/donor-portal-sync</code></pre>
+        <p>Minimum JSON payload:</p>
+        <pre><code>{`{
+  "storeId": "your_store_id",
+  "donor": {
+    "name": "Jane Doe",
+    "email": "jane@example.com"
+  }
+}`}</code></pre>
+        <p>
+          You can also send <code>donor.phone</code>. At least one contact field (email or phone) is required.
+        </p>
+      </section>
+
+      <section>
+        <h2>Accepting payment from the same page</h2>
+        <p>
+          Include <code>initializePayment: true</code> plus <code>amount</code> to create a pending donation and request a Paystack checkout URL.
+        </p>
+        <pre><code>{`{
+  "storeId": "your_store_id",
+  "donor": {
+    "name": "Jane Doe",
+    "email": "jane@example.com"
+  },
+  "amount": 150,
+  "currency": "GHS",
+  "initializePayment": true
+}`}</code></pre>
+        <p>
+          If Paystack is configured, the API response includes <code>payment.authorizationUrl</code>; redirect the donor there to complete payment.
+        </p>
+      </section>
+
+      <section>
+        <h2>What syncs into Sedifex</h2>
+        <ul>
+          <li>A donor profile is created in <strong>Donor management</strong>.</li>
+          <li>When payment is requested, a donation transaction is stored in <code>fund_transactions</code>.</li>
+          <li>You can continue confirmation/communications flows using existing donation APIs.</li>
+        </ul>
+      </section>
+    </DocsPageLayout>
+  )
+}

--- a/web/src/pages/docs/HowToUseSedifexPage.tsx
+++ b/web/src/pages/docs/HowToUseSedifexPage.tsx
@@ -10,7 +10,7 @@ export default function HowToUseSedifexPage() {
       <section>
         <h2>Pick your workspace type</h2>
         <ul>
-          <li><strong>Shop:</strong> Items, Sell, Customers, Business records, Public page.</li>
+          <li><strong>Shop:</strong> Items, Sell, Customers, Donor management, Public page.</li>
           <li><strong>Travel:</strong> Trips, Travelers, messaging, and business records.</li>
           <li><strong>NGO:</strong> Donors, campaigns, communication, and records.</li>
           <li><strong>School:</strong> Classes, students, communication, and records.</li>
@@ -19,8 +19,8 @@ export default function HowToUseSedifexPage() {
 
       <section>
         <h2>Core navigation by role</h2>
-        <p><strong>Owner</strong>: Dashboard, Items/Sell, Customers or industry aliases, Bookings/Trips/Classes, Blog, SMS, Bulk email, Business records, Public page, Account.</p>
-        <p><strong>Staff</strong>: Sell, Customers (or alias), Bookings (or alias), Blog, Business records.</p>
+        <p><strong>Owner</strong>: Dashboard, Items/Sell, Customers or industry aliases, Bookings/Trips/Classes, Blog, SMS, Bulk email, Donor management, Public page, Account.</p>
+        <p><strong>Staff</strong>: Sell, Customers (or alias), Bookings (or alias), Blog, Donor management.</p>
       </section>
 
       <section>
@@ -38,6 +38,7 @@ export default function HowToUseSedifexPage() {
           <li><a href="/docs/integration-quickstart">/docs/integration-quickstart</a></li>
           <li><a href="/docs/wordpress-install-guide">/docs/wordpress-install-guide</a></li>
           <li><a href="/docs/bulk-email-google-sheets-guide">/docs/bulk-email-google-sheets-guide</a></li>
+          <li><a href="/docs/donor-website-integration">/docs/donor-website-integration</a></li>
         </ul>
       </section>
     </DocsPageLayout>


### PR DESCRIPTION
### Motivation
- Introduce a first-class Donor management area to replace the previous Expenses/business-records surface and support public website donation flows. 
- Provide a simple website integration endpoint to create donor profiles and optionally initialize Paystack payments for donations. 
- Update navigation, routing, and documentation so workspaces can enable and use donor workflows across Shop/Travel/NGO/School presets.

### Description
- Added a serverless endpoint `web/api/donor-portal-sync.ts` that creates `donor_profiles`, optionally creates a pending `fund_transactions` record, and initializes Paystack transactions when `initializePayment` is true. 
- Reworked the Expenses page (`web/src/pages/Expenses.tsx`) into a Donor Management UI that subscribes to `donor_profiles`, `fund_transactions`, `donor_pledges`, `donor_receipts`, and `donor_pipeline` collections and provides donor creation and giving-history views. 
- Updated navigation config (`web/src/config/navigation.ts`) to replace `expenses` with `donor-management` and updated the `INDUSTRY_ENABLED_MODULE_PRESETS` to include `donor-management` for relevant industries. 
- Updated routing in `web/src/main.tsx` to redirect `/expenses` to `/donor-management`, add the `donor-management` route (rendering the updated `Expenses` component), and register a new docs route for donor integration. 
- Added a new docs page `web/src/pages/docs/DonorWebsiteIntegrationPage.tsx` describing the `POST /api/donor-portal-sync` payload and payment flow, and updated `HowToUseSedifexPage.tsx` to reference `Donor management` in core product guidance.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074992f34c832197350dbac95a151e)