### PR TITLE
Add per-merchant integration token lookup and broaden integration auth context

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -54,6 +54,7 @@ Object.defineProperty(exports, "googleAdsOAuthCallback", { enumerable: true, get
 Object.defineProperty(exports, "googleAdsCampaign", { enumerable: true, get: function () { return googleAds_1.googleAdsCampaign; } });
 Object.defineProperty(exports, "googleAdsMetricsSync", { enumerable: true, get: function () { return googleAds_1.googleAdsMetricsSync; } });
 __exportStar(require("./googleShopping"), exports);
+__exportStar(require("./reporting"), exports);
 var googleBusinessProfile_1 = require("./googleBusinessProfile");
 Object.defineProperty(exports, "googleBusinessLocations", { enumerable: true, get: function () { return googleBusinessProfile_1.googleBusinessLocations; } });
 Object.defineProperty(exports, "googleBusinessUploadLocationMedia", { enumerable: true, get: function () { return googleBusinessProfile_1.googleBusinessUploadLocationMedia; } });
@@ -2350,6 +2351,33 @@ exports.deleteWebhookEndpoint = functions.https.onCall(async (data, context) => 
 function getOptionalEnvString(name) {
     const value = process.env[name];
     return typeof value === 'string' ? value.trim() : '';
+}
+function normalizeMerchantIdForEnvSuffix(merchantId) {
+    return merchantId.trim().toUpperCase().replace(/[^A-Z0-9_]/g, '_');
+}
+function getMerchantTokenFromJsonMap(raw, merchantId) {
+    if (!raw)
+        return '';
+    try {
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object')
+            return '';
+        const token = parsed[merchantId];
+        return typeof token === 'string' ? token.trim() : '';
+    }
+    catch {
+        return '';
+    }
+}
+function getMerchantIntegrationToken(merchantId) {
+    const normalizedMerchantId = merchantId.trim();
+    if (!normalizedMerchantId)
+        return '';
+    const tokenFromJsonMap = getMerchantTokenFromJsonMap(getOptionalEnvString('SEDIFEX_MERCHANT_TOKENS_JSON'), normalizedMerchantId);
+    if (tokenFromJsonMap)
+        return tokenFromJsonMap;
+    const legacyNormalizedKey = `SEDIFEX_MERCHANT_TOKEN_${normalizeMerchantIdForEnvSuffix(normalizedMerchantId)}`;
+    return getOptionalEnvString(legacyNormalizedKey);
 }
 const TIKTOK_CLIENT_KEY = getOptionalEnvString('TIKTOK_CLIENT_KEY');
 const TIKTOK_CLIENT_SECRET = getOptionalEnvString('TIKTOK_CLIENT_SECRET');
@@ -7968,6 +7996,9 @@ exports.__testing = {
     sanitizeBookingAttributes,
     normalizeBookingDateForSheet,
     normalizeBookingTimeForSheet,
+    normalizeMerchantIdForEnvSuffix,
+    getMerchantTokenFromJsonMap,
+    getMerchantIntegrationToken,
 };
 exports.publishDailyFeaturedProductBlogPost = functions.pubsub
     .schedule('every day 09:00')

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3108,6 +3108,36 @@ function getOptionalEnvString(name: string) {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+function normalizeMerchantIdForEnvSuffix(merchantId: string): string {
+  return merchantId.trim().toUpperCase().replace(/[^A-Z0-9_]/g, '_')
+}
+
+function getMerchantTokenFromJsonMap(raw: string, merchantId: string): string {
+  if (!raw) return ''
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return ''
+    const token = (parsed as Record<string, unknown>)[merchantId]
+    return typeof token === 'string' ? token.trim() : ''
+  } catch {
+    return ''
+  }
+}
+
+function getMerchantIntegrationToken(merchantId: string): string {
+  const normalizedMerchantId = merchantId.trim()
+  if (!normalizedMerchantId) return ''
+
+  const tokenFromJsonMap = getMerchantTokenFromJsonMap(
+    getOptionalEnvString('SEDIFEX_MERCHANT_TOKENS_JSON'),
+    normalizedMerchantId,
+  )
+  if (tokenFromJsonMap) return tokenFromJsonMap
+
+  const legacyNormalizedKey = `SEDIFEX_MERCHANT_TOKEN_${normalizeMerchantIdForEnvSuffix(normalizedMerchantId)}`
+  return getOptionalEnvString(legacyNormalizedKey)
+}
+
 const TIKTOK_CLIENT_KEY = getOptionalEnvString('TIKTOK_CLIENT_KEY')
 const TIKTOK_CLIENT_SECRET = getOptionalEnvString('TIKTOK_CLIENT_SECRET')
 const TIKTOK_REDIRECT_URI = getOptionalEnvString('TIKTOK_REDIRECT_URI')
@@ -3438,7 +3468,16 @@ function getIntegrationAuthContext(req: functions.https.Request) {
       : Array.isArray(apiKeyHeader) && typeof apiKeyHeader[0] === 'string'
         ? apiKeyHeader[0].trim()
         : ''
-  const storeId = typeof req.query.storeId === 'string' ? req.query.storeId.trim() : ''
+  const queryStoreId =
+    typeof req.query.storeId === 'string'
+      ? req.query.storeId.trim()
+      : typeof req.query.store_id === 'string'
+        ? req.query.store_id.trim()
+        : ''
+  const headerStoreId = typeof req.headers['x-store-id'] === 'string' ? req.headers['x-store-id'].trim() : ''
+  const payload = toPlainObject(req.body)
+  const bodyMerchantId = toTrimmedStringOrNull(payload.merchant_id) ?? toTrimmedStringOrNull(payload.store_id) ?? ''
+  const storeId = queryStoreId || headerStoreId || bodyMerchantId
   return { apiKey, storeId }
 }
 
@@ -4734,6 +4773,11 @@ async function validateIntegrationTokenOrReply(
   if (!storeId) {
     res.status(400).json({ error: 'missing-store-id' })
     return null
+  }
+
+  const merchantIntegrationToken = getMerchantIntegrationToken(storeId)
+  if (merchantIntegrationToken && apiKey === merchantIntegrationToken) {
+    return { storeId, isMasterKey: false }
   }
 
   const tokenHash = hashIntegrationSecret(apiKey)
@@ -9828,6 +9872,9 @@ export const __testing = {
   sanitizeBookingAttributes,
   normalizeBookingDateForSheet,
   normalizeBookingTimeForSheet,
+  normalizeMerchantIdForEnvSuffix,
+  getMerchantTokenFromJsonMap,
+  getMerchantIntegrationToken,
 }
 
 export const publishDailyFeaturedProductBlogPost = functions.pubsub

--- a/functions/test/bookingNormalization.test.js
+++ b/functions/test/bookingNormalization.test.js
@@ -97,6 +97,29 @@ function runTimeFormattingTests(testing) {
   assert.strictEqual(testing.normalizeBookingTimeForSheet(''), null)
 }
 
+function runMerchantTokenLookupTests(testing) {
+  assert.strictEqual(
+    testing.normalizeMerchantIdForEnvSuffix('37mJqg20MjOriggaIaOOuahDsgj1'),
+    '37MJQG20MJORIGGAIAOOUAHDSGJ1',
+  )
+  assert.strictEqual(testing.normalizeMerchantIdForEnvSuffix('store-abc.123'), 'STORE_ABC_123')
+
+  const json = JSON.stringify({
+    rQYE4FQGVZPcUpdptdgeRo5A80G2: 'sdfx_a',
+    '37mJqg20MjOriggaIaOOuahDsgj1': 'sdfx_b',
+  })
+  assert.strictEqual(testing.getMerchantTokenFromJsonMap(json, 'rQYE4FQGVZPcUpdptdgeRo5A80G2'), 'sdfx_a')
+  assert.strictEqual(testing.getMerchantTokenFromJsonMap('not-json', 'merchant'), '')
+
+  process.env.SEDIFEX_MERCHANT_TOKENS_JSON = json
+  process.env.SEDIFEX_MERCHANT_TOKEN_STORE_ABC = 'legacy_token'
+  assert.strictEqual(testing.getMerchantIntegrationToken('37mJqg20MjOriggaIaOOuahDsgj1'), 'sdfx_b')
+  assert.strictEqual(testing.getMerchantIntegrationToken('store-abc'), 'legacy_token')
+
+  delete process.env.SEDIFEX_MERCHANT_TOKENS_JSON
+  delete process.env.SEDIFEX_MERCHANT_TOKEN_STORE_ABC
+}
+
 function run() {
   const module = loadFunctionsModule()
   assert.ok(module.__testing, 'Expected __testing exports')
@@ -106,6 +129,7 @@ function run() {
   runSanitizeTests(module.__testing)
   runDateFormattingTests(module.__testing)
   runTimeFormattingTests(module.__testing)
+  runMerchantTokenLookupTests(module.__testing)
 }
 
 run()


### PR DESCRIPTION
### Motivation

- Provide support for merchant-specific integration tokens (legacy env keys or a JSON map) so integrations can authenticate using a store/merchant identifier without creating DB API keys.
- Make integration authentication more flexible by accepting `storeId` from query, header, or body payload fields to accommodate different clients.
- Expose the `reporting` exports from the functions entrypoint.

### Description

- Added helper functions `normalizeMerchantIdForEnvSuffix`, `getMerchantTokenFromJsonMap`, and `getMerchantIntegrationToken` to read per-merchant tokens from `SEDIFEX_MERCHANT_TOKENS_JSON` or legacy `SEDIFEX_MERCHANT_TOKEN_<NORMALIZED>` env vars.  
- Integrated merchant token lookup into the integration auth flow by checking the merchant token before falling back to DB-stored API keys in `validateIntegrationTokenOrReply`.  
- Enhanced `getIntegrationAuthContext` to accept `storeId` from `req.query.storeId` or `req.query.store_id`, `x-store-id` header, or the request body `merchant_id`/`store_id`.  
- Re-exported `./reporting` from the compiled entrypoint by adding `__exportStar(require("./reporting"), exports);`.  
- Exposed the new helpers on `__testing` for unit testing.  
- Added unit tests in `functions/test/bookingNormalization.test.js` covering the merchant token normalization and lookup behaviors.

### Testing

- Ran the updated unit test file `functions/test/bookingNormalization.test.js`, which includes `runMerchantTokenLookupTests`; the tests completed successfully.  
- Existing booking normalization tests (`normalizeBookingDateForSheet`, `normalizeBookingTimeForSheet`, etc.) were executed as part of the same test run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07593674dc8321a475a14362ff3de3)