### PR TITLE
Fix BlogPage runtime crash from missing `useMemo` import

### DIFF
--- a/web/src/pages/BlogPage.tsx
+++ b/web/src/pages/BlogPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import './BlogPage.css'
 import {
   addDoc,


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError: useMemo is not defined` when rendering the blog page by ensuring the hook is available where it is used.

### Description
- Add `useMemo` to the React import in `web/src/pages/BlogPage.tsx` so memoized values (e.g. `selectedCatalogItem`) are evaluated without error.

### Testing
- Ran `cd web && npm run build`, which reproduced an unrelated environment/type-definition failure for `vite/client` and `vitest/globals` and therefore the build did not complete, but the change itself addresses the observed runtime error during page render.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07737338a483218eafc5550bcbf713)