### PR TITLE
Normalize signup full name and business name casing

### DIFF
--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -41,6 +41,13 @@ function sanitizePhone(value: string): string {
   return normalizeGhanaPhoneE164(value)
 }
 
+function toTitleCase(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\b([a-z])/g, match => match.toUpperCase())
+}
+
 function evaluatePasswordStrength(password: string): PasswordStrength {
   return {
     isLongEnough: password.length >= PASSWORD_MIN_LENGTH,
@@ -189,8 +196,8 @@ export default function AuthPage() {
     const sanitizedPassword = password.trim()
     const sanitizedConfirmPassword = confirmPassword.trim()
     const sanitizedPhone = sanitizePhone(phone)
-    const sanitizedFullName = fullName.trim()
-    const sanitizedBusinessName = businessName.trim()
+    const sanitizedFullName = toTitleCase(fullName)
+    const sanitizedBusinessName = toTitleCase(businessName)
     const sanitizedCountry = country.trim()
     const sanitizedTown = town.trim()
     const sanitizedAddress = address.trim()


### PR DESCRIPTION
### Motivation
- Prevent all-caps or inconsistent casing (e.g. `# MAKEUP and MORE school of cosmetology`) from being stored when users sign up by normalizing `Full name` and `Business name` to a readable title case.

### Description
- Added a `toTitleCase` helper in `web/src/pages/AuthPage.tsx` and use it to normalize `fullName` and `businessName` during signup before calling `initializeStore` and persisting customer/store profile fields.

### Testing
- Attempted to run the frontend test for the modified page with `npm --prefix web test -- AuthPage --runInBand`, which failed in this environment because the `vitest` binary is not installed (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a080b301a608321a4f365beb19b841f)