### PR TITLE
Allow public fallback reads for v1IntegrationAvailability

### DIFF
--- a/functions/src/integrationAvailability.ts
+++ b/functions/src/integrationAvailability.ts
@@ -169,8 +169,7 @@ export const v1IntegrationAvailability = functions.https.onRequest(async (req, r
 
     const authorized = await isAuthorized(req, storeId)
     if (!authorized) {
-      res.status(401).json({ error: 'unauthorized' })
-      return
+      functions.logger.info('Availability request using public open-slot fallback', { storeId, serviceId })
     }
 
     const snapshot = await defaultDb
@@ -190,6 +189,12 @@ export const v1IntegrationAvailability = functions.https.onRequest(async (req, r
       const seatsBooked = Math.max(0, Math.floor(toNumber(data.seatsBooked, 0)))
       const resolvedServiceId = clean(data.serviceId, 220)
       const resolvedServiceName = clean(data.serviceName, 240)
+      if (!authorized) {
+        const isClosed = data.status === 'closed'
+        const isPublicBlocked = data.public === false || data.isPublic === false || data.visibleOnWebsite === false
+        if (isClosed || isPublicBlocked) return []
+      }
+
       const slot: SlotResponse = {
         id: slotDoc.id,
         storeId,
@@ -209,10 +214,12 @@ export const v1IntegrationAvailability = functions.https.onRequest(async (req, r
     })
 
     res.status(200).json({
+      ok: true,
       storeId,
       serviceId: serviceId || null,
       from: fromDate?.toISOString() ?? null,
       to: toDateFilter?.toISOString() ?? null,
+      authenticated: authorized,
       slots,
     })
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Public school/booking availability slots are catalog-style and should be readable by `storeId` even when the requester is not authorized, matching how product data is exposed.
- The change preserves existing authorized behavior while providing a safe public fallback for unauthenticated website requests.

### Description
- Kept the `isAuthorized(req, storeId)` check and added an info log when authorization fails to indicate the public open-slot fallback is used via `functions.logger.info`.
- Removed the `401` response for unauthorized requests and continued to read `stores/{storeId}/integrationAvailabilitySlots` for both authorized and unauthorized flows.
- When not authorized, filtered slots to exclude ones where `status === 'closed'` or any of `public === false`, `isPublic === false`, or `visibleOnWebsite === false`, while authorized requests still return all matching slots.
- Added `ok: true` and `authenticated: authorized` to the JSON success response while preserving the `v1IntegrationAvailability` endpoint and request contract handling.

### Testing
- Ran `cd functions && npm run build` which completed successfully (TypeScript compilation via `tsc`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089ab21370832185c53e75c57bb627)