### PR TITLE
Export marketplace Paystack webhook handler from functions index

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,7 @@ import { normalizePublicSlugValue } from './utils/publicSlug'
 import type { ProductReadModel } from './types/product'
 import { normalizeCatalogPublicationFields, resolvePublicationTimestampCandidate } from './catalogPublication'
 export { checkSignupUnlock, createCheckout, paystackWebhook } from './paystack'
+export { handlePaystackWebhook } from './marketplacePaystackWebhook'
 export {
   createPaystackMerchantSubaccount,
   fetchPaystackMerchantSubaccount,


### PR DESCRIPTION
### Motivation
- Add a marketplace webhook handler so the existing Paystack webhook URL continues to handle legacy Sedifex payments while allowing references starting with `market_` to be processed by marketplace logic.

### Description
- Added `export { handlePaystackWebhook } from './marketplacePaystackWebhook'` to `functions/src/index.ts` while leaving the existing `paystackWebhook` export unchanged so non-market references continue to use the existing logic.

### Testing
- Ran `cd functions && npm run build` which completed successfully.
- Attempted `cd functions && firebase deploy --project sedifex-web --only functions:handlePaystackWebhook` which failed in this environment due to the Firebase CLI not being installed (`firebase: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09923130348321aaad1d8fe32cd676)