### PR TITLE
Public contact hub copy + simplify Promo settings

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -197,7 +197,6 @@ const items = Array.isArray(payload.items) ? payload.items : []
     "summary": "Promo summary",
     "startDate": "2026-04-01",
     "endDate": "2026-04-30",
-    "websiteUrl": "https://example.com",
     "youtubeUrl": null,
     "youtubeEmbedUrl": null,
     "youtubeChannelId": null,
@@ -210,6 +209,32 @@ const items = Array.isArray(payload.items) ? payload.items : []
   }
 }
 ```
+
+Promo settings are intentionally simplified for core campaign data (`title`, `summary`, `startDate`, `endDate`). Rich social/contact links should come from the store's shared public contact profile (`publicProfile`) so websites can reuse one source across headers, footers, contact sections, and public pages.
+
+### Website pull mapping for shared public contact data
+
+When your integration layer receives store profile data, use this priority order to avoid duplicates and field drift:
+
+1. `publicProfile.<field>` (preferred)
+2. legacy/top-level fallback fields on the store record
+
+Recommended field mapping:
+
+- `logoUrl` → `publicProfile.logoUrl` then fallback `logoUrl`
+- `phone` → `publicProfile.publicPhone` then fallback `phoneNumber`
+- `whatsapp` → `publicProfile.whatsappNumber` then fallback `whatsappNumber`
+- `telegram` → `publicProfile.telegramNumber` then fallback `telegramNumber`
+- `email` → `publicProfile.publicEmail`
+- `website` → `publicProfile.websiteUrl` then fallback `websiteUrl`
+- `instagram` → `publicProfile.instagramHandle`
+- `facebook` → `publicProfile.facebookUrl`
+- `tiktok` → `publicProfile.tiktokHandle`
+- `youtube` → `publicProfile.youtubeUrl`
+- `x` → `publicProfile.xHandle`
+- `linkedin` → `publicProfile.linkedinUrl`
+
+This keeps promo content focused while ensuring all website surfaces pull the same brand/contact values from one shared profile.
 
 ### `GET /v1IntegrationAvailability?storeId=<storeId>&serviceId=<serviceId>&from=<ISO>&to=<ISO>` (authenticated)
 

--- a/docs/integration-quickstart.md
+++ b/docs/integration-quickstart.md
@@ -57,13 +57,39 @@ Promo data fields (store promo profile)
 
     promoSlug
 
-    promoWebsiteUrl
-
 Also used with:
 
     displayName / name (store name fallback shown on promo page).
 
-The same promo field set is defined in the account/store profile typing too, so these are the right canonical keys to use
+The dedicated Promo settings page is intentionally simplified to promo title, promo summary, and promo duration dates.
+
+Public contact hub fields (shared customer-facing profile for websites and public pages)
+
+    logoUrl
+
+    publicPhone
+
+    whatsappNumber
+
+    telegramNumber
+
+    publicEmail
+
+    websiteUrl
+
+    instagramHandle
+
+    facebookUrl
+
+    tiktokHandle
+
+    youtubeUrl
+
+    xHandle
+
+    linkedinUrl
+
+Sedifex stores these in `stores/{storeId}.publicProfile` (and mirrors key fields such as `logoUrl`, `phoneNumber`, `whatsappNumber`, `telegramNumber`, `websiteUrl` at top-level store fields). Treat this as the single source of truth for website/footer/contact blocks.
 
 Promo gallery data fields (stores/{storeId}/promoGallery/{itemId})
 
@@ -137,6 +163,7 @@ Base URL:
    - **Products:** normalize image fields, dedupe products, and filter to service-type products when available.
    - **Promo:** search nested payloads and map flexible key variants (`promoTitle`, `promo_title`, etc.) into a unified promo object.
    - **Gallery:** normalize image/alt fields, keep published items only, and sort by `sortOrder`.
+   - **Store profile/contact hub (if you include it in your integration layer):** map from `publicProfile` first, then fallback to top-level store fields (`logoUrl`, `phoneNumber`, `whatsappNumber`, `telegramNumber`, `websiteUrl`) for backwards compatibility.
 5. **Apply resilience fallback logic**
    - If config is missing, fetch fails, or data is incomplete, fall back to local curated data:
      - `fallbackProducts`

--- a/web/src/pages/PromoSettings.tsx
+++ b/web/src/pages/PromoSettings.tsx
@@ -17,9 +17,6 @@ type StorePromoProfile = {
   promoStartDate?: string | null
   promoEndDate?: string | null
   promoSlug?: string | null
-  promoWebsiteUrl?: string | null
-  promoYoutubeUrl?: string | null
-  promoTiktokUrl?: string | null
   promoImageUrl?: string | null
   promoImageAlt?: string | null
 }
@@ -46,9 +43,6 @@ export default function PromoSettings() {
   const [summary, setSummary] = useState('')
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
-  const [websiteUrl, setWebsiteUrl] = useState('')
-  const [youtubeUrl, setYoutubeUrl] = useState('')
-  const [tiktokUrl, setTiktokUrl] = useState('')
   const [imageUrl, setImageUrl] = useState('')
   const [imageAlt, setImageAlt] = useState('')
   const [imageFile, setImageFile] = useState<File | null>(null)
@@ -87,9 +81,6 @@ export default function PromoSettings() {
         setSummary(text(data?.promoSummary))
         setStartDate(text(data?.promoStartDate))
         setEndDate(text(data?.promoEndDate))
-        setWebsiteUrl(text(data?.promoWebsiteUrl))
-        setYoutubeUrl(text(data?.promoYoutubeUrl))
-        setTiktokUrl(text(data?.promoTiktokUrl))
         setImageUrl(text(data?.promoImageUrl))
         setImageAlt(text(data?.promoImageAlt))
       } catch (loadError) {
@@ -136,9 +127,6 @@ export default function PromoSettings() {
         promoStartDate: nullable(startDate),
         promoEndDate: nullable(endDate),
         promoSlug: slug,
-        promoWebsiteUrl: nullable(websiteUrl),
-        promoYoutubeUrl: nullable(youtubeUrl),
-        promoTiktokUrl: nullable(tiktokUrl),
         promoImageUrl: nullable(imageUrl),
         promoImageAlt: nullable(imageAlt),
         updatedAt: Timestamp.now(),
@@ -161,7 +149,7 @@ export default function PromoSettings() {
       <header className="account-overview__section-header">
         <div>
           <h1>Promo</h1>
-          <p className="account-overview__subtitle">Create the main offer customers should see on your Sedifex public link and connected website.</p>
+          <p className="account-overview__subtitle">Create a simple promo with title, message, and duration for your Sedifex public link.</p>
         </div>
       </header>
 
@@ -186,9 +174,6 @@ export default function PromoSettings() {
                 <label><span>Start date</span><input type="date" value={startDate} onChange={event => setStartDate(event.target.value)} /></label>
                 <label><span>End date</span><input type="date" value={endDate} onChange={event => setEndDate(event.target.value)} /></label>
               </div>
-              <label><span>Website link</span><input type="url" value={websiteUrl} onChange={event => setWebsiteUrl(event.target.value)} placeholder="https://..." /></label>
-              <label><span>YouTube link</span><input type="url" value={youtubeUrl} onChange={event => setYoutubeUrl(event.target.value)} placeholder="https://youtube.com/..." /></label>
-              <label><span>TikTok link</span><input type="url" value={tiktokUrl} onChange={event => setTiktokUrl(event.target.value)} placeholder="https://tiktok.com/..." /></label>
               <button className="button button--primary" type="submit" disabled={saving}>{saving ? 'Saving…' : 'Save promo'}</button>
             </form>
           </section>

--- a/web/src/pages/SocialLinksSettings.tsx
+++ b/web/src/pages/SocialLinksSettings.tsx
@@ -96,8 +96,9 @@ export default function SocialLinksSettings() {
   if (error) return <div role="alert">{error}</div>
   return (
     <main className="account-overview">
-      <header className="account-overview__section-header"><div><h1>Social links</h1><p className="account-overview__subtitle">Save public contact and social data once so your public page and website integrations can reuse it.</p></div></header>
+      <header className="account-overview__section-header"><div><h1>Public contact hub</h1><p className="account-overview__subtitle">Save logo, phone, WhatsApp, Telegram, and social handles once so Sedifex public pages and website integrations can pull the same data everywhere.</p></div></header>
       <div className="account-overview__banner" role="note"><p><strong>Account stays internal.</strong> This page is for customer-facing brand and contact details only.</p></div>
+      <div className="account-overview__banner" role="note"><p><strong>No duplicate account records.</strong> This page only updates your workspace public profile fields and reuses the same source for integrations.</p></div>
       {isLoading || loadingProfile ? <p>Loading social links…</p> : null}
       {!storeId && !isLoading ? <p>Select a workspace first.</p> : null}
       {storeId && !canEdit ? <p className="account-overview__error">You do not have permission to edit social links.</p> : null}


### PR DESCRIPTION
### Motivation
- Provide a single public-facing source of truth for logo, phone, WhatsApp, Telegram and social handles so integrations and public pages reuse the same data.
- Reduce confusion about duplicate account records by clarifying that these fields update a shared public profile on the workspace.
- Simplify the Promo settings to a minimal promo (title, message/summary, start/end dates) because richer media/link integrations will be handled elsewhere.

### Description
- Update `SocialLinksSettings` text to rebrand the page as a `Public contact hub` and add a banner clarifying the data is the shared public-profile source used by integrations (`web/src/pages/SocialLinksSettings.tsx`).
- Keep saving behavior for `publicProfile` and mapped store fields (logo, phone, whatsapp, telegram, email, website, `socialLinks`) so integrations can pull the same values (`web/src/pages/SocialLinksSettings.tsx`).
- Remove website/YouTube/TikTok state, form inputs, and payload fields from the Promo settings and update the subtitle to focus on title, message, and duration while preserving image upload support (`web/src/pages/PromoSettings.tsx`).
- Ensure the change only simplifies the dedicated Promo Settings UI and does not automatically mutate other stored promo link fields unless edited through other flows.

### Testing
- Ran `cd web && npm run lint` which failed in this environment due to a missing ESLint peer dependency (`@eslint/js`).
- Ran `cd web && npm run test -- PromoSettings` which failed because `vitest` is not available in the environment (dependencies are not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a56b2f988321ab841348df004bfe)