### PR TITLE
Add logo upload and inline edit mode to Social Links settings

### DIFF
--- a/web/src/pages/SocialLinksSettings.tsx
+++ b/web/src/pages/SocialLinksSettings.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Timestamp, doc, getDoc, setDoc } from 'firebase/firestore'
+import { uploadProductImage } from '../api/productImageUpload'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useMemberships } from '../hooks/useMemberships'
@@ -33,7 +34,10 @@ export default function SocialLinksSettings() {
   const [profile, setProfile] = useState<PublicProfile>({})
   const [loadingProfile, setLoadingProfile] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [logoFile, setLogoFile] = useState<File | null>(null)
+  const [uploadingLogo, setUploadingLogo] = useState(false)
   const [message, setMessage] = useState('')
+  const [isEditing, setIsEditing] = useState(false)
   const activeMembership = useMemo(() => storeId ? memberships.find(member => member.storeId === storeId) ?? null : null, [memberships, storeId])
   const canEdit = activeMembership?.role === 'owner' || activeMembership?.role === 'staff'
 
@@ -50,6 +54,7 @@ export default function SocialLinksSettings() {
         const socialLinks = data?.socialLinks ?? {}
         setStoreName(text(data?.displayName) || text(data?.name))
         setProfile(Object.fromEntries(fields.map(([key]) => [key, text(publicProfile[key]) || text(socialLinks[key])])) as PublicProfile)
+        setIsEditing(false)
       } catch (loadError) {
         console.error('[social-links] load failed', loadError)
         if (!cancelled) setMessage('Unable to load social links.')
@@ -63,6 +68,16 @@ export default function SocialLinksSettings() {
 
   function updateField(key: string, value: string) {
     setProfile(current => ({ ...current, [key]: value }))
+  }
+
+  function beginEditing() {
+    setMessage('')
+    setIsEditing(true)
+  }
+
+  function cancelEditing() {
+    setMessage('')
+    setIsEditing(false)
   }
 
   async function saveSocialLinks(event: React.FormEvent) {
@@ -85,11 +100,36 @@ export default function SocialLinksSettings() {
         updatedAt: Timestamp.now(),
       }, { merge: true })
       publish({ message: 'Social links saved.', tone: 'success' })
+      setIsEditing(false)
     } catch (saveError) {
       console.error('[social-links] save failed', saveError)
       setMessage('Unable to save social links.')
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function uploadLogoFile() {
+    if (!storeId || !canEdit) return
+    if (!logoFile) {
+      setMessage('Choose a logo image first.')
+      return
+    }
+    setUploadingLogo(true)
+    setMessage('')
+    try {
+      const uploadedUrl = await uploadProductImage(logoFile, {
+        storagePath: `stores/${storeId}/assets/logo.jpg`,
+      })
+      setProfile(current => ({ ...current, logoUrl: uploadedUrl }))
+      setLogoFile(null)
+      setIsEditing(true)
+      publish({ tone: 'success', message: 'Logo uploaded. Click Save public profile to apply everywhere.' })
+    } catch (uploadError) {
+      console.error('[social-links] logo upload failed', uploadError)
+      setMessage('Unable to upload logo.')
+    } finally {
+      setUploadingLogo(false)
     }
   }
 
@@ -103,7 +143,7 @@ export default function SocialLinksSettings() {
       {!storeId && !isLoading ? <p>Select a workspace first.</p> : null}
       {storeId && !canEdit ? <p className="account-overview__error">You do not have permission to edit social links.</p> : null}
       {message ? <p className="account-overview__error" role="alert">{message}</p> : null}
-      {storeId && canEdit ? <form className="account-overview__profile-form" onSubmit={saveSocialLinks}><section className="account-overview__card"><h2>{storeName || 'Public profile'}</h2><div className="account-overview__form-grid">{fields.map(([key, label]) => <label key={key}><span>{label}</span><input value={text(profile[key])} onChange={event => updateField(key, event.target.value)} /></label>)}</div></section><button className="button button--primary" type="submit" disabled={saving}>{saving ? 'Saving…' : 'Save public profile'}</button></form> : null}
+      {storeId && canEdit ? <form className="account-overview__profile-form" onSubmit={saveSocialLinks}><section className="account-overview__card"><h2>{storeName || 'Public profile'}</h2><div className="account-overview__form-grid">{fields.map(([key, label]) => <label key={key}><span>{label}</span><input value={text(profile[key])} onChange={event => updateField(key, event.target.value)} disabled={!isEditing || saving || uploadingLogo} /></label>)}</div><div style={{ marginTop: '0.75rem', display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}><label><span>Logo upload</span><input type="file" accept="image/*" onChange={event => setLogoFile(event.target.files?.[0] ?? null)} disabled={!isEditing || saving || uploadingLogo} /></label><button className="button" type="button" onClick={uploadLogoFile} disabled={!isEditing || !logoFile || saving || uploadingLogo}>{uploadingLogo ? 'Uploading…' : 'Browse & upload logo'}</button></div></section>{isEditing ? <div style={{ display: 'flex', gap: '0.75rem' }}><button className="button" type="button" onClick={cancelEditing} disabled={saving || uploadingLogo}>Cancel</button><button className="button button--primary" type="submit" disabled={saving || uploadingLogo}>{saving ? 'Saving…' : 'Save public profile'}</button></div> : <button className="button button--primary" type="button" onClick={beginEditing}>Edit public profile</button>}</form> : null}
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Provide a more complete public profile editor that supports uploading a logo image and an explicit edit/save flow so changes are not made accidentally. 
- Reuse the same public profile source so integrations and public pages can pull a single consistent set of contact and social fields.

### Description
- Add `uploadProductImage` import and implement `uploadLogoFile` to upload a chosen file to `stores/{storeId}/assets/logo.jpg`, update the local `profile.logoUrl`, and notify the user via toast. 
- Add local state: `logoFile`, `uploadingLogo`, and `isEditing`, and wire `setIsEditing(false)` after loading and on successful save. 
- Implement `beginEditing` and `cancelEditing` helpers and make inputs and upload controls disabled unless editing is active or an upload/save is in progress. 
- Update the form UI to include a file input and upload button, and change the action controls to show either an `Edit public profile` button or `Cancel`/`Save public profile` buttons depending on `isEditing`.

### Testing
- Ran the app build with `yarn build` and it completed successfully. 
- Ran the test suite with `yarn test` and existing tests passed. 
- Ran lint checks with `yarn lint` and there were no lint failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ad3146a0832196b331677463d0b8)