### PR TITLE
Add website integration guidance and editable logo upload to Social Links settings

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -236,6 +236,69 @@ Recommended field mapping:
 
 This keeps promo content focused while ensuring all website surfaces pull the same brand/contact values from one shared profile.
 
+### Website integration pattern for social links (recommended)
+
+For website integrations, treat the store `publicProfile` as the single source for contact/social/footer/header data.
+
+#### 1) Pull core page data from promo endpoint
+
+Use promo endpoint for campaign content and basic identity:
+
+- `GET /v1IntegrationPromo?slug=<promoSlug>` (public), or
+- `GET /v1IntegrationPromo?storeId=<storeId>` (authenticated with `x-api-key`).
+
+This gives campaign fields (`title`, `summary`, dates, media) and `storeName`.
+
+#### 2) Pull/merge public contact profile into website model
+
+Your integration backend should also resolve the store profile payload and map:
+
+- `publicProfile.logoUrl` as the **official logo URL** across invoice/receipt templates, website header, and favicon/logo surfaces.
+- `publicProfile.publicPhone`, `publicProfile.whatsappNumber`, `publicProfile.telegramNumber`, `publicProfile.publicEmail`.
+- `publicProfile.websiteUrl`, `publicProfile.instagramHandle`, `publicProfile.facebookUrl`, `publicProfile.tiktokHandle`, `publicProfile.youtubeUrl`, `publicProfile.xHandle`, `publicProfile.linkedinUrl`.
+
+Always keep legacy fallbacks for backward compatibility (example: `logoUrl`, `phoneNumber`, `whatsappNumber`, `telegramNumber`, `websiteUrl`) using the priority mapping above.
+
+#### 3) Render once, reuse everywhere
+
+To avoid drift between pages:
+
+- Build one `contactLinks` object in your website codebase from mapped fields.
+- Reuse that same object in:
+  - website header,
+  - footer,
+  - contact page,
+  - promo landing CTA blocks,
+  - invoice/receipt logo surfaces.
+
+#### Example normalized object
+
+```json
+{
+  "brand": {
+    "name": "Sedifex Store",
+    "logoUrl": "https://cdn.example.com/stores/store_123/assets/logo.jpg"
+  },
+  "contact": {
+    "phone": "+233...",
+    "whatsapp": "+233...",
+    "telegram": "@storehandle",
+    "email": "hello@store.com",
+    "website": "https://store.com"
+  },
+  "social": {
+    "instagram": "@store",
+    "facebook": "https://facebook.com/store",
+    "tiktok": "@store",
+    "youtube": "https://youtube.com/@store",
+    "x": "@store",
+    "linkedin": "https://linkedin.com/company/store"
+  }
+}
+```
+
+This normalization allows sites to update once in Sedifex **Social links** and automatically stay consistent across Sedifex-generated documents and external websites.
+
 ### `GET /v1IntegrationAvailability?storeId=<storeId>&serviceId=<serviceId>&from=<ISO>&to=<ISO>` (authenticated)
 
 - Returns session/class slots for service-type offerings.

--- a/web/src/pages/SocialLinksSettings.tsx
+++ b/web/src/pages/SocialLinksSettings.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Timestamp, doc, getDoc, setDoc } from 'firebase/firestore'
+import { uploadProductImage } from '../api/productImageUpload'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useMemberships } from '../hooks/useMemberships'
@@ -33,7 +34,10 @@ export default function SocialLinksSettings() {
   const [profile, setProfile] = useState<PublicProfile>({})
   const [loadingProfile, setLoadingProfile] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [logoFile, setLogoFile] = useState<File | null>(null)
+  const [uploadingLogo, setUploadingLogo] = useState(false)
   const [message, setMessage] = useState('')
+  const [isEditing, setIsEditing] = useState(false)
   const activeMembership = useMemo(() => storeId ? memberships.find(member => member.storeId === storeId) ?? null : null, [memberships, storeId])
   const canEdit = activeMembership?.role === 'owner' || activeMembership?.role === 'staff'
 
@@ -50,6 +54,7 @@ export default function SocialLinksSettings() {
         const socialLinks = data?.socialLinks ?? {}
         setStoreName(text(data?.displayName) || text(data?.name))
         setProfile(Object.fromEntries(fields.map(([key]) => [key, text(publicProfile[key]) || text(socialLinks[key])])) as PublicProfile)
+        setIsEditing(false)
       } catch (loadError) {
         console.error('[social-links] load failed', loadError)
         if (!cancelled) setMessage('Unable to load social links.')
@@ -63,6 +68,16 @@ export default function SocialLinksSettings() {
 
   function updateField(key: string, value: string) {
     setProfile(current => ({ ...current, [key]: value }))
+  }
+
+  function beginEditing() {
+    setMessage('')
+    setIsEditing(true)
+  }
+
+  function cancelEditing() {
+    setMessage('')
+    setIsEditing(false)
   }
 
   async function saveSocialLinks(event: React.FormEvent) {
@@ -85,11 +100,36 @@ export default function SocialLinksSettings() {
         updatedAt: Timestamp.now(),
       }, { merge: true })
       publish({ message: 'Social links saved.', tone: 'success' })
+      setIsEditing(false)
     } catch (saveError) {
       console.error('[social-links] save failed', saveError)
       setMessage('Unable to save social links.')
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function uploadLogoFile() {
+    if (!storeId || !canEdit) return
+    if (!logoFile) {
+      setMessage('Choose a logo image first.')
+      return
+    }
+    setUploadingLogo(true)
+    setMessage('')
+    try {
+      const uploadedUrl = await uploadProductImage(logoFile, {
+        storagePath: `stores/${storeId}/assets/logo.jpg`,
+      })
+      setProfile(current => ({ ...current, logoUrl: uploadedUrl }))
+      setLogoFile(null)
+      setIsEditing(true)
+      publish({ tone: 'success', message: 'Logo uploaded. Click Save public profile to apply everywhere.' })
+    } catch (uploadError) {
+      console.error('[social-links] logo upload failed', uploadError)
+      setMessage('Unable to upload logo.')
+    } finally {
+      setUploadingLogo(false)
     }
   }
 
@@ -103,7 +143,7 @@ export default function SocialLinksSettings() {
       {!storeId && !isLoading ? <p>Select a workspace first.</p> : null}
       {storeId && !canEdit ? <p className="account-overview__error">You do not have permission to edit social links.</p> : null}
       {message ? <p className="account-overview__error" role="alert">{message}</p> : null}
-      {storeId && canEdit ? <form className="account-overview__profile-form" onSubmit={saveSocialLinks}><section className="account-overview__card"><h2>{storeName || 'Public profile'}</h2><div className="account-overview__form-grid">{fields.map(([key, label]) => <label key={key}><span>{label}</span><input value={text(profile[key])} onChange={event => updateField(key, event.target.value)} /></label>)}</div></section><button className="button button--primary" type="submit" disabled={saving}>{saving ? 'Saving…' : 'Save public profile'}</button></form> : null}
+      {storeId && canEdit ? <form className="account-overview__profile-form" onSubmit={saveSocialLinks}><section className="account-overview__card"><h2>{storeName || 'Public profile'}</h2><div className="account-overview__form-grid">{fields.map(([key, label]) => <label key={key}><span>{label}</span><input value={text(profile[key])} onChange={event => updateField(key, event.target.value)} disabled={!isEditing || saving || uploadingLogo} /></label>)}</div><div style={{ marginTop: '0.75rem', display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}><label><span>Logo upload</span><input type="file" accept="image/*" onChange={event => setLogoFile(event.target.files?.[0] ?? null)} disabled={!isEditing || saving || uploadingLogo} /></label><button className="button" type="button" onClick={uploadLogoFile} disabled={!isEditing || !logoFile || saving || uploadingLogo}>{uploadingLogo ? 'Uploading…' : 'Browse & upload logo'}</button></div></section>{isEditing ? <div style={{ display: 'flex', gap: '0.75rem' }}><button className="button" type="button" onClick={cancelEditing} disabled={saving || uploadingLogo}>Cancel</button><button className="button button--primary" type="submit" disabled={saving || uploadingLogo}>{saving ? 'Saving…' : 'Save public profile'}</button></div> : <button className="button button--primary" type="button" onClick={beginEditing}>Edit public profile</button>}</form> : null}
     </main>
   )
 }


### PR DESCRIPTION
### Motivation

- Document a recommended website integration pattern for using `publicProfile` as the single source of contact/social/footer/header data to avoid drift. 
- Provide a smoother admin UX for updating public-facing contact data by adding explicit edit state and an inline logo upload to the Social Links settings page. 
- Preserve backward compatibility by continuing to write legacy fallback fields when saving the public profile.

### Description

- Adds a new "Website integration pattern for social links (recommended)" section to `docs/integration-api-guide.md` that describes pulling promo content from the promo endpoint, merging `publicProfile` into the website model, and reusing a normalized `contactLinks` object; includes an example JSON object. 
- Enhances `web/src/pages/SocialLinksSettings.tsx` to support editable mode by introducing `isEditing`, `beginEditing`, and `cancelEditing`, disabling inputs when not editing, and showing an "Edit/Cancel/Save" flow. 
- Adds inline logo upload support by importing `uploadProductImage`, adding `logoFile` and `uploadingLogo` state, implementing `uploadLogoFile` to upload to `stores/<storeId>/assets/logo.jpg`, and populating `profile.logoUrl` with the uploaded URL; saving still writes `publicProfile` and legacy fallback fields and timestamps. 

### Testing

- No automated unit tests were added or modified for this change. 
- Performed a TypeScript type-check (`tsc --noEmit`) and a local frontend build to validate types and compilation, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ad3146a0832196b331677463d0b8)