### PR TITLE
Add missing report PDF exports and dashboard customers shortcut

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 // web/src/pages/Dashboard.tsx
 import { useEffect, useMemo, useState } from 'react'
 import { collection, onSnapshot, query, where } from 'firebase/firestore'
+import { Link } from 'react-router-dom'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 
@@ -129,7 +130,7 @@ export default function Dashboard() {
     <div className="workspace-page">
       <section className="workspace-card"><p className="workspace-eyebrow">Dashboard</p><h1>Quick business overview</h1><p className="workspace-muted">This dashboard now shows only quick KPIs. Detailed inventory, website sales, donor reports, exports, and PDF reports live under Reports.</p></section>
       <section aria-label="Primary metrics" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))', gap: 16 }}>{primaryMetrics.map(metric => <article key={metric.id} style={cardStyle(metric.tone)}><p style={{ margin: 0, color: metric.tone, fontWeight: 900, fontSize: 12, letterSpacing: '0.1em', textTransform: 'uppercase' }}>Primary metric</p><h2 style={{ margin: '8px 0 4px', fontSize: 32, letterSpacing: '-0.03em' }}>{metric.value}</h2><p style={{ margin: '0 0 4px', fontWeight: 800, color: '#0f172a' }}>{metric.label}</p><p style={{ margin: 0, color: '#64748b', lineHeight: 1.5 }}>{metric.hint}</p></article>)}</section>
-      <section className="workspace-card"><div className="workspace-section-header"><div><h2>Smart report direction</h2><p className="workspace-muted">Use Reports for rich data. Dashboard stays fast and clean for daily decisions.</p></div></div><div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))', gap: 12 }}>{secondaryMetrics.map(metric => <article key={metric.id} style={{ border: '1px solid #e2e8f0', borderRadius: 18, padding: 16, background: '#f8fafc' }}><strong style={{ display: 'block', fontSize: 22, color: '#0f172a' }}>{metric.value}</strong><span style={{ display: 'block', fontWeight: 800, color: '#334155' }}>{metric.label}</span><small style={{ color: '#64748b' }}>{metric.hint}</small></article>)}</div></section>
+      <section className="workspace-card"><div className="workspace-section-header"><div><h2>Smart report direction</h2><p className="workspace-muted">Use Reports for rich data. Dashboard stays fast and clean for daily decisions.</p></div><Link className="button button--primary" to="/customers">Customers</Link></div><div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))', gap: 12 }}>{secondaryMetrics.map(metric => <article key={metric.id} style={{ border: '1px solid #e2e8f0', borderRadius: 18, padding: 16, background: '#f8fafc' }}><strong style={{ display: 'block', fontSize: 22, color: '#0f172a' }}>{metric.value}</strong><span style={{ display: 'block', fontWeight: 800, color: '#334155' }}>{metric.label}</span><small style={{ color: '#64748b' }}>{metric.hint}</small></article>)}</div></section>
     </div>
   )
 }

--- a/web/src/pages/reports/BookingsReport.tsx
+++ b/web/src/pages/reports/BookingsReport.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { collection, onSnapshot, query, where } from 'firebase/firestore'
 import { db } from '../../firebase'
 import { useActiveStore } from '../../hooks/useActiveStore'
-import { asNumber, asText, downloadCsv, formatDate, formatMoney, getNestedObject, normalizeSourceChannel, toDate } from './reportUtils'
+import { asNumber, asText, downloadCsv, exportReportPdf, formatDate, formatMoney, getNestedObject, normalizeSourceChannel, toDate } from './reportUtils'
 
 type BookingRow = {
   id: string
@@ -82,6 +82,32 @@ export default function BookingsReport() {
     })))
   }
 
+  function exportPdf() {
+    exportReportPdf({
+      title: 'Bookings report',
+      subtitle: 'Service, class, appointment, and website bookings with payment and schedule details.',
+      summary: [
+        { label: 'Total bookings', value: totals.count },
+        { label: 'Paid/confirmed', value: totals.paid },
+        { label: 'Pending', value: totals.pending },
+        { label: 'Booking value', value: formatMoney(totals.value) },
+      ],
+      rows: filtered.map(booking => ({
+        reference: booking.reference,
+        serviceName: booking.serviceName,
+        customer: booking.customerName,
+        contact: booking.customerPhone,
+        source: booking.sourceChannel,
+        bookingDate: booking.bookingDate,
+        bookingTime: booking.bookingTime,
+        paymentStatus: booking.paymentStatus,
+        bookingStatus: booking.bookingStatus,
+        amount: booking.amount,
+        createdAt: formatDate(booking.createdAt),
+      })),
+    })
+  }
+
   return (
     <div className="workspace-page">
       <section className="workspace-card">
@@ -96,7 +122,7 @@ export default function BookingsReport() {
         <article className="workspace-card"><strong>{formatMoney(totals.value)}</strong><span>Booking value</span></article>
       </section>
       <section className="workspace-card">
-        <div className="workspace-section-header"><div><h2>Booking details</h2><p className="workspace-muted">Filter status and export data.</p></div><button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button></div>
+        <div className="workspace-section-header"><div><h2>Booking details</h2><p className="workspace-muted">Filter status and export data.</p></div><div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}><button type="button" className="button button--secondary" onClick={exportPdf} disabled={!filtered.length}>Export PDF</button><button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button></div></div>
         <div className="workspace-toolbar"><select value={status} onChange={event => setStatus(event.target.value)}><option value="all">All statuses</option><option value="pending">Pending</option><option value="confirmed">Confirmed</option><option value="success">Paid</option><option value="completed">Completed</option></select></div>
         <div className="workspace-table-wrap"><table className="workspace-table"><thead><tr><th>Reference</th><th>Service</th><th>Customer</th><th>Schedule</th><th>Status</th><th>Amount</th><th>Date</th></tr></thead><tbody>{filtered.map(booking => <tr key={booking.id}><td>{booking.reference}</td><td>{booking.serviceName}</td><td><strong>{booking.customerName}</strong><br /><small>{booking.customerPhone || 'No contact'}</small></td><td>{booking.bookingDate}<br /><small>{booking.bookingTime}</small></td><td>{booking.bookingStatus}<br /><small>{booking.paymentStatus}</small></td><td>{formatMoney(booking.amount)}</td><td>{formatDate(booking.createdAt)}</td></tr>)}</tbody></table></div>
       </section>

--- a/web/src/pages/reports/PosSalesReport.tsx
+++ b/web/src/pages/reports/PosSalesReport.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { collection, onSnapshot, query, where } from 'firebase/firestore'
 import { db } from '../../firebase'
 import { useActiveStore } from '../../hooks/useActiveStore'
-import { asNumber, asText, downloadCsv, formatDate, formatMoney, getNestedObject, toDate } from './reportUtils'
+import { asNumber, asText, downloadCsv, exportReportPdf, formatDate, formatMoney, getNestedObject, toDate } from './reportUtils'
 
 type SaleRow = {
   id: string
@@ -93,6 +93,30 @@ export default function PosSalesReport() {
     })))
   }
 
+  function exportPdf() {
+    exportReportPdf({
+      title: 'POS sales report',
+      subtitle: 'Detailed POS sales with receipts, payment split, units sold, and totals.',
+      summary: [
+        { label: 'Sales', value: totals.count },
+        { label: 'Sales value', value: formatMoney(totals.revenue) },
+        { label: 'Units sold', value: totals.units },
+        { label: 'Cash collected', value: formatMoney(totals.cash) },
+      ],
+      rows: filtered.map(sale => ({
+        receiptNo: sale.receiptNo,
+        customer: sale.customerName,
+        total: sale.total,
+        cash: sale.cashTotal,
+        card: sale.cardTotal,
+        momo: sale.momoTotal,
+        unitsSold: sale.unitsSold,
+        paymentSummary: sale.paymentSummary,
+        createdAt: formatDate(sale.createdAt),
+      })),
+    })
+  }
+
   return (
     <div className="workspace-page">
       <section className="workspace-card">
@@ -109,7 +133,10 @@ export default function PosSalesReport() {
       <section className="workspace-card">
         <div className="workspace-section-header">
           <div><h2>Sale details</h2><p className="workspace-muted">Filter by period and export sales.</p></div>
-          <button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button type="button" className="button button--secondary" onClick={exportPdf} disabled={!filtered.length}>Export PDF</button>
+            <button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button>
+          </div>
         </div>
         <div className="workspace-toolbar">
           <select value={range} onChange={event => setRange(event.target.value)}>

--- a/web/src/pages/reports/StudentRegistrationsReport.tsx
+++ b/web/src/pages/reports/StudentRegistrationsReport.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { collection, onSnapshot, query, where } from 'firebase/firestore'
 import { db } from '../../firebase'
 import { useActiveStore } from '../../hooks/useActiveStore'
-import { asNumber, asText, downloadCsv, formatDate, formatMoney, getNestedObject, toDate } from './reportUtils'
+import { asNumber, asText, downloadCsv, exportReportPdf, formatDate, formatMoney, getNestedObject, toDate } from './reportUtils'
 
 type RegistrationRow = {
   id: string
@@ -73,11 +73,35 @@ export default function StudentRegistrationsReport() {
     })))
   }
 
+  function exportPdf() {
+    exportReportPdf({
+      title: 'Student registrations report',
+      subtitle: 'Admissions and registration data from Sedifex and connected school websites.',
+      summary: [
+        { label: 'Registrations', value: totals.count },
+        { label: 'Paid/confirmed', value: totals.paid },
+        { label: 'Pending', value: totals.pending },
+        { label: 'Registration value', value: formatMoney(totals.value) },
+      ],
+      rows: filtered.map(row => ({
+        fullName: row.fullName,
+        phone: row.phone,
+        email: row.email,
+        course: row.course,
+        startMonth: row.startMonth,
+        paymentStatus: row.paymentStatus,
+        amount: row.amount,
+        reference: row.reference,
+        createdAt: formatDate(row.createdAt),
+      })),
+    })
+  }
+
   return (
     <div className="workspace-page">
       <section className="workspace-card"><p className="workspace-eyebrow">Reports / Student registrations</p><h1>Student registrations report</h1><p className="workspace-muted">Admissions data from Sedifex student registration and connected school websites.</p></section>
       <section className="workspace-grid workspace-grid--four"><article className="workspace-card"><strong>{totals.count}</strong><span>Registrations</span></article><article className="workspace-card"><strong>{totals.paid}</strong><span>Paid/confirmed</span></article><article className="workspace-card"><strong>{totals.pending}</strong><span>Pending</span></article><article className="workspace-card"><strong>{formatMoney(totals.value)}</strong><span>Registration value</span></article></section>
-      <section className="workspace-card"><div className="workspace-section-header"><div><h2>Registration details</h2><p className="workspace-muted">Filter by course and export CSV.</p></div><button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button></div><div className="workspace-toolbar"><select value={course} onChange={event => setCourse(event.target.value)}><option value="all">All courses</option>{courses.map(name => <option key={name} value={name}>{name}</option>)}</select></div><div className="workspace-table-wrap"><table className="workspace-table"><thead><tr><th>Student</th><th>Course</th><th>Start</th><th>Payment</th><th>Amount</th><th>Reference</th><th>Date</th></tr></thead><tbody>{filtered.map(row => <tr key={row.id}><td><strong>{row.fullName}</strong><br /><small>{row.phone || row.email || 'No contact'}</small></td><td>{row.course}</td><td>{row.startMonth}</td><td>{row.paymentStatus}</td><td>{formatMoney(row.amount)}</td><td>{row.reference}</td><td>{formatDate(row.createdAt)}</td></tr>)}</tbody></table></div></section>
+      <section className="workspace-card"><div className="workspace-section-header"><div><h2>Registration details</h2><p className="workspace-muted">Filter by course and export data.</p></div><div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}><button type="button" className="button button--secondary" onClick={exportPdf} disabled={!filtered.length}>Export PDF</button><button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button></div></div><div className="workspace-toolbar"><select value={course} onChange={event => setCourse(event.target.value)}><option value="all">All courses</option>{courses.map(name => <option key={name} value={name}>{name}</option>)}</select></div><div className="workspace-table-wrap"><table className="workspace-table"><thead><tr><th>Student</th><th>Course</th><th>Start</th><th>Payment</th><th>Amount</th><th>Reference</th><th>Date</th></tr></thead><tbody>{filtered.map(row => <tr key={row.id}><td><strong>{row.fullName}</strong><br /><small>{row.phone || row.email || 'No contact'}</small></td><td>{row.course}</td><td>{row.startMonth}</td><td>{row.paymentStatus}</td><td>{formatMoney(row.amount)}</td><td>{row.reference}</td><td>{formatDate(row.createdAt)}</td></tr>)}</tbody></table></div></section>
     </div>
   )
 }

--- a/web/src/pages/reports/VolunteersReport.tsx
+++ b/web/src/pages/reports/VolunteersReport.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { collection, onSnapshot, query, where } from 'firebase/firestore'
 import { db } from '../../firebase'
 import { useActiveStore } from '../../hooks/useActiveStore'
-import { asText, downloadCsv, formatDate, getNestedObject, toDate } from './reportUtils'
+import { asText, downloadCsv, exportReportPdf, formatDate, getNestedObject, toDate } from './reportUtils'
 
 type VolunteerRow = {
   id: string
@@ -54,11 +54,25 @@ export default function VolunteersReport() {
     downloadCsv('sedifex-volunteers-report.csv', filtered.map(row => ({ name: row.name, phone: row.phone, email: row.email, skills: row.skills, availability: row.availability, status: row.status, createdAt: formatDate(row.createdAt) })))
   }
 
+  function exportPdf() {
+    exportReportPdf({
+      title: 'Volunteers report',
+      subtitle: 'Volunteer applications, skills, availability, and status tracking.',
+      summary: [
+        { label: 'Total volunteers', value: totals.count },
+        { label: 'New applications', value: totals.newRows },
+        { label: 'Active/approved', value: totals.active },
+        { label: 'Status groups', value: statuses.length },
+      ],
+      rows: filtered.map(row => ({ name: row.name, phone: row.phone, email: row.email, skills: row.skills, availability: row.availability, status: row.status, createdAt: formatDate(row.createdAt) })),
+    })
+  }
+
   return (
     <div className="workspace-page">
       <section className="workspace-card"><p className="workspace-eyebrow">Reports / Volunteers</p><h1>Volunteers report</h1><p className="workspace-muted">Volunteer applications, skills, availability, status, and CSV export.</p></section>
       <section className="workspace-grid workspace-grid--four"><article className="workspace-card"><strong>{totals.count}</strong><span>Total volunteers</span></article><article className="workspace-card"><strong>{totals.newRows}</strong><span>New applications</span></article><article className="workspace-card"><strong>{totals.active}</strong><span>Active/approved</span></article><article className="workspace-card"><strong>{statuses.length}</strong><span>Status groups</span></article></section>
-      <section className="workspace-card"><div className="workspace-section-header"><div><h2>Volunteer details</h2><p className="workspace-muted">Filter by status and export CSV.</p></div><button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button></div><div className="workspace-toolbar"><select value={status} onChange={event => setStatus(event.target.value)}><option value="all">All statuses</option>{statuses.map(name => <option key={name} value={name}>{name}</option>)}</select></div><div className="workspace-table-wrap"><table className="workspace-table"><thead><tr><th>Volunteer</th><th>Skills</th><th>Availability</th><th>Status</th><th>Date</th></tr></thead><tbody>{filtered.map(row => <tr key={row.id}><td><strong>{row.name}</strong><br /><small>{row.phone || row.email || 'No contact'}</small></td><td>{row.skills || '—'}</td><td>{row.availability}</td><td>{row.status}</td><td>{formatDate(row.createdAt)}</td></tr>)}</tbody></table></div></section>
+      <section className="workspace-card"><div className="workspace-section-header"><div><h2>Volunteer details</h2><p className="workspace-muted">Filter by status and export data.</p></div><div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}><button type="button" className="button button--secondary" onClick={exportPdf} disabled={!filtered.length}>Export PDF</button><button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button></div></div><div className="workspace-toolbar"><select value={status} onChange={event => setStatus(event.target.value)}><option value="all">All statuses</option>{statuses.map(name => <option key={name} value={name}>{name}</option>)}</select></div><div className="workspace-table-wrap"><table className="workspace-table"><thead><tr><th>Volunteer</th><th>Skills</th><th>Availability</th><th>Status</th><th>Date</th></tr></thead><tbody>{filtered.map(row => <tr key={row.id}><td><strong>{row.name}</strong><br /><small>{row.phone || row.email || 'No contact'}</small></td><td>{row.skills || '—'}</td><td>{row.availability}</td><td>{row.status}</td><td>{formatDate(row.createdAt)}</td></tr>)}</tbody></table></div></section>
     </div>
   )
 }

--- a/web/src/pages/reports/WebsiteSalesReport.tsx
+++ b/web/src/pages/reports/WebsiteSalesReport.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { collection, onSnapshot, query, where } from 'firebase/firestore'
 import { db } from '../../firebase'
 import { useActiveStore } from '../../hooks/useActiveStore'
-import { asNumber, asText, downloadCsv, formatDate, formatMoney, getNestedObject, normalizeSourceChannel, toDate } from './reportUtils'
+import { asNumber, asText, downloadCsv, exportReportPdf, formatDate, formatMoney, getNestedObject, normalizeSourceChannel, toDate } from './reportUtils'
 
 type OrderRow = {
   id: string
@@ -94,6 +94,31 @@ export default function WebsiteSalesReport() {
     })))
   }
 
+  function exportPdf() {
+    exportReportPdf({
+      title: 'Website sales report',
+      subtitle: 'Online and website sales from Sedifex Market, client websites, and public pages.',
+      summary: [
+        { label: 'Orders', value: totals.count },
+        { label: 'Order value', value: formatMoney(totals.revenue) },
+        { label: 'Client website orders', value: totals.website },
+        { label: 'Pay on delivery', value: totals.payOnDelivery },
+      ],
+      rows: filtered.map(order => ({
+        reference: order.reference,
+        source: order.sourceLabel,
+        customer: order.customerName,
+        contact: order.customerPhone,
+        amount: order.amount,
+        currency: order.currency,
+        paymentStatus: order.paymentStatus,
+        orderStatus: order.orderStatus,
+        paymentCollectionMode: order.paymentCollectionMode,
+        createdAt: formatDate(order.createdAt),
+      })),
+    })
+  }
+
   return (
     <div className="workspace-page">
       <section className="workspace-card">
@@ -110,7 +135,10 @@ export default function WebsiteSalesReport() {
       <section className="workspace-card">
         <div className="workspace-section-header">
           <div><h2>Order details</h2><p className="workspace-muted">Filter by source or payment mode, then export CSV.</p></div>
-          <button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button type="button" className="button button--secondary" onClick={exportPdf} disabled={!filtered.length}>Export PDF</button>
+            <button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button>
+          </div>
         </div>
         <div className="workspace-toolbar">
           <select value={channel} onChange={event => setChannel(event.target.value)}>


### PR DESCRIPTION
### Motivation
- Provide PDF export actions for the remaining report pages so users can download printable reports in addition to CSVs. 
- Give a quick dashboard shortcut to the Customers page so merchants can add/manage customer records from the dashboard.

### Description
- Added `exportReportPdf` imports and `exportPdf()` functions to the following report pages: `web/src/pages/reports/PosSalesReport.tsx`, `web/src/pages/reports/WebsiteSalesReport.tsx`, `web/src/pages/reports/BookingsReport.tsx`, `web/src/pages/reports/StudentRegistrationsReport.tsx`, and `web/src/pages/reports/VolunteersReport.tsx`.
- Each `exportPdf()` maps the current filtered rows into a `rows` array and includes a small `summary` payload (title/subtitle and summary cards) for `exportReportPdf(...)`.
- Updated the report header action areas to show both an `Export PDF` (secondary) and `Export CSV` (primary) button and wired the PDF buttons to the new `exportPdf()` handlers.
- Added a `Customers` link button on the Dashboard header that navigates to `/customers` (`web/src/pages/Dashboard.tsx`).

### Testing
- Ran a project build with `npm -C web run build`, which invoked TypeScript and Vite; the build failed in this environment due to missing type definition files: `vite/client` and `vitest/globals` (errors from `tsc -b`).
- Changes were committed locally (commit message: `Add PDF export buttons to remaining reports and dashboard customers shortcut`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bace4ae8832182111a9cc045a6c4)