### PR TITLE
fix(web): enable Firestore multi-tab persistence

### DIFF
--- a/web/src/firebase.ts
+++ b/web/src/firebase.ts
@@ -3,7 +3,7 @@ import { initializeApp } from 'firebase/app'
 import { getAuth, RecaptchaVerifier } from 'firebase/auth'
 import {
   initializeFirestore,
-  enableIndexedDbPersistence,
+  enableMultiTabIndexedDbPersistence,
   type Firestore,
 } from 'firebase/firestore'
 import { getFunctions } from 'firebase/functions'
@@ -74,8 +74,8 @@ export const db: Firestore = initializeFirestore(app, FIRESTORE_SETTINGS)
 
 // ----- Offline persistence (browser only) -----
 if (typeof window !== 'undefined') {
-  enableIndexedDbPersistence(db).catch(() => {
-    // Multi-tab or unsupported browser; safe to ignore.
+  enableMultiTabIndexedDbPersistence(db).catch(() => {
+    // Persistence may be unsupported in this browser; safe to ignore.
   })
 }
 


### PR DESCRIPTION
### Motivation
- Resolve Firestore `INTERNAL ASSERTION FAILED` (ID: b815) caused by exclusive IndexedDB locks when multiple dashboard tabs are open by enabling shared multi-tab persistence.

### Description
- In `web/src/firebase.ts` replaced the single-tab API `enableIndexedDbPersistence` with `enableMultiTabIndexedDbPersistence` and kept the `typeof window` guard and the graceful `.catch()` for unsupported environments.

### Testing
- Attempted to run `cd web && npm test -- --run src/firebase.test.ts` but the test runner binary `vitest` was not available in this environment, so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bc4641c4832189fd69adfb14712a)