### PR TITLE
Add SettlementReport import and route entry

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -26,6 +26,7 @@ import VolunteersReport from './pages/reports/VolunteersReport'
 import DonorsReport from './pages/reports/DonorsReport'
 import FundsReport from './pages/reports/FundsReport'
 import BlogReport from './pages/reports/BlogReport'
+import SettlementReport from './pages/reports/SettlementReport'
 import Logi from './pages/Logi'
 import Onboarding from './pages/Onboarding'
 import CleanAccountOverview from './pages/CleanAccountOverview'
@@ -88,6 +89,7 @@ const router = createBrowserRouter([
       { path: 'reports/inventory', element: <InventoryReport /> },
       { path: 'reports/pos-sales', element: <PosSalesReport /> },
       { path: 'reports/website-sales', element: <WebsiteSalesReport /> },
+      { path: 'reports/settlement', element: <SettlementReport /> },
       { path: 'reports/bookings', element: <BookingsReport /> },
       { path: 'reports/student-registrations', element: <StudentRegistrationsReport /> },
       { path: 'reports/volunteers', element: <VolunteersReport /> },


### PR DESCRIPTION
### Motivation
- Enable navigation to the new Settlement report page by wiring the component into the router so users can access `/reports/settlement` from the app.

### Description
- Added `import SettlementReport from './pages/reports/SettlementReport'` and registered the route `{ path: 'reports/settlement', element: <SettlementReport /> }` in `web/src/main.tsx` immediately after the `website-sales` route.

### Testing
- No automated tests were run for this routing-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c2a513808321a22ab03b47ebe3de)