### PR TITLE
Sync donations intake into donor_profiles for donor management

### DIFF
--- a/web/api/donations-intake.ts
+++ b/web/api/donations-intake.ts
@@ -81,6 +81,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       : null
 
   let donorId: string
+  let donorProfileId: string
   if (donorLookup && !donorLookup.empty) {
     donorId = donorLookup.docs[0].id
     await donorLookup.docs[0].ref.set({
@@ -106,22 +107,62 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     donorId = donorRef.id
   }
 
+  const donorProfileLookup = email
+    ? await firestore.collection('donor_profiles').where('storeId', '==', storeId).where('email', '==', email).limit(1).get()
+    : phone
+      ? await firestore.collection('donor_profiles').where('storeId', '==', storeId).where('phone', '==', phone).limit(1).get()
+      : null
+
+  if (donorProfileLookup && !donorProfileLookup.empty) {
+    donorProfileId = donorProfileLookup.docs[0].id
+    await donorProfileLookup.docs[0].ref.set({
+      name: donorName,
+      email: email || null,
+      phone: phone || null,
+      source: 'website-donation-intake',
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true })
+  } else {
+    const donorProfileRef = await firestore.collection('donor_profiles').add({
+      storeId,
+      name: donorName,
+      email: email || null,
+      phone: phone || null,
+      source: 'website-donation-intake',
+      status: 'active',
+      lifetimeGiving: 0,
+      lastGiftAmount: 0,
+      lastGiftDate: null,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    })
+    donorProfileId = donorProfileRef.id
+  }
+
   if (mode === 'donation') {
+    const today = new Date().toISOString().slice(0, 10)
     await firestore.collection('fund_transactions').add({
       storeId,
       fundId,
-      donorId,
+      donorId: donorProfileId,
       direction: 'inflow',
       amount,
       currency,
       project,
       description: message,
-      date: new Date().toISOString().slice(0, 10),
+      date: today,
       source: 'api',
       status: 'pending_confirmation',
       reference: reference || null,
       createdAt: FieldValue.serverTimestamp(),
     })
+
+    await firestore.collection('donor_profiles').doc(donorProfileId).set({
+      lifetimeGiving: FieldValue.increment(amount),
+      lastGiftAmount: amount,
+      lastGiftDate: today,
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true })
   }
 
   await dedupeRef.set({


### PR DESCRIPTION
### Motivation
- Website donation integrations were creating/updating `customers` and fund transactions but donor management UI and donor reports read from `donor_profiles`, so integration donors were not appearing in `/donor-management` and donor reports.

### Description
- Updated `web/api/donations-intake.ts` to upsert a `donor_profiles` record (lookup by `storeId` + email or phone, merge/update if found or create if missing).
- For `mode === 'donation'`, the created `fund_transactions` now use the `donor_profiles` id for `donorId` and the donor profile is updated with `lifetimeGiving`, `lastGiftAmount`, and `lastGiftDate` (using a computed `today` string and `FieldValue.increment`).
- Kept the existing `customers` creation/update and idempotency (`integration_idempotency`) logic intact so existing integrations and dedupe behavior remain unchanged.

### Testing
- Attempted to run the build with `npm -C web run build`, but the build failed in this environment due to missing type definition packages (`vite/client` and `vitest/globals`), so a full TypeScript build/test run could not be completed here.
- No automated tests were changed; existing test suite was not executed because the environment build errors prevented running `tsc`/`vite`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a12e7547c83218e39bf938072ac98)