### PR TITLE
Add Google Sheets sync fallback for notification outbox

### DIFF
--- a/functions/src/googleSheets.ts
+++ b/functions/src/googleSheets.ts
@@ -15,6 +15,7 @@ const EMAIL_HEADER_MATCHERS = new Set([
 const SHEETS_SERVICE_ACCOUNT = defineString('SHEETS_SERVICE_ACCOUNT', { default: '' })
 const SHEETS_SPREADSHEET_ID = defineString('SHEETS_SPREADSHEET_ID', { default: '' })
 const SHEETS_RANGE = defineString('SHEETS_RANGE', { default: '' })
+const NOTIFICATION_OUTBOX_SHEET_RANGE = defineString('NOTIFICATION_OUTBOX_SHEET_RANGE', { default: 'NotificationOutbox!A:Z' })
 
 type SheetsClient = sheets_v4.Sheets
 
@@ -94,7 +95,7 @@ async function getSheetsClient() {
 
     const auth = new google.auth.GoogleAuth({
       credentials,
-      scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+      scopes: ['https://www.googleapis.com/auth/spreadsheets'],
     })
 
     const authClientPromise = auth.getClient()
@@ -215,3 +216,22 @@ export function getDefaultSpreadsheetId() {
 }
 
 export type FetchClientRowResult = Awaited<ReturnType<typeof fetchClientRowByEmail>>
+
+export function getNotificationOutboxRange() {
+  const configured = NOTIFICATION_OUTBOX_SHEET_RANGE.value()?.trim()
+  return configured || 'NotificationOutbox!A:Z'
+}
+
+export async function appendNotificationOutboxRow(row: Array<string | number | null | undefined>, spreadsheetId?: string | null) {
+  const config = readConfig()
+  const resolvedSpreadsheetId = resolveSpreadsheetId(config, spreadsheetId ?? null)
+  const sheets = await getSheetsClient()
+  await sheets.spreadsheets.values.append({
+    spreadsheetId: resolvedSpreadsheetId,
+    range: getNotificationOutboxRange(),
+    valueInputOption: 'RAW',
+    requestBody: {
+      values: [row.map(value => (value === null || value === undefined ? '' : String(value)))],
+    },
+  })
+}

--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions/v1'
 import { defineString } from 'firebase-functions/params'
 import { admin, defaultDb } from './firestore'
+import { appendNotificationOutboxRow, getDefaultSpreadsheetId } from './googleSheets'
 
 const SEDIFEX_NOTIFICATION_WEBHOOK_URL = defineString('SEDIFEX_NOTIFICATION_WEBHOOK_URL', { default: '' })
 const SEDIFEX_NOTIFICATION_SHARED_SECRET = defineString('SEDIFEX_NOTIFICATION_SHARED_SECRET', { default: '' })
@@ -130,12 +131,37 @@ async function createDelivery(args: { payload: NotificationPayload; brand: Store
     return true
   })
   if (!created) return { created: false, webhook: null }
+  let sheetSyncStatus: 'synced_to_sheet' | 'sheet_sync_failed' | 'sheet_sync_skipped' = 'sheet_sync_skipped'
+  try {
+    await appendNotificationOutboxRow([
+      new Date().toISOString(),
+      args.payload.storeId,
+      args.brand.storeName,
+      args.payload.eventType,
+      reference,
+      args.recipientType,
+      args.to,
+      args.subject,
+      text(args.payload.payment?.status, 80) || '',
+      formatMoney(args.payload.payment) || '',
+      text(args.payload.payment?.method, 80) || '',
+      email(args.payload.customer?.email) || '',
+      text(args.payload.customer?.phone, 80) || '',
+      text(args.payload.data?.itemName, 220) || '',
+      getDefaultSpreadsheetId(),
+    ])
+    sheetSyncStatus = 'synced_to_sheet'
+  } catch (error) {
+    sheetSyncStatus = 'sheet_sync_failed'
+    await outboxRef.set({ sheetSyncError: error instanceof Error ? error.message : 'sheet-sync-error', updatedAt: now }, { merge: true })
+  }
   try {
     const webhook = await postToWebhook({ storeId: args.payload.storeId, eventType: args.payload.eventType, reference, recipientType: args.recipientType, to: args.to, subject: args.subject, html: args.html, text: args.text, brand: args.brand, customer: args.payload.customer ?? null, payment: args.payload.payment ?? null, data: args.payload.data ?? null }, args.settings)
-    if (webhook.attempted) await outboxRef.set({ status: webhook.ok ? 'sent_to_webhook' : 'webhook_failed', webhookStatus: webhook.status, sentToWebhookAt: now, updatedAt: now }, { merge: true })
+    if (webhook.attempted) await outboxRef.set({ status: webhook.ok ? 'sent_to_webhook' : 'webhook_failed', webhookStatus: webhook.status, sentToWebhookAt: now, sheetSyncStatus, updatedAt: now }, { merge: true })
+    if (!webhook.attempted) await outboxRef.set({ status: sheetSyncStatus, sheetSyncStatus, updatedAt: now }, { merge: true })
     return { created: true, webhook }
   } catch (error) {
-    await outboxRef.set({ status: 'webhook_error', errorMessage: error instanceof Error ? error.message : 'webhook-error', updatedAt: now }, { merge: true })
+    await outboxRef.set({ status: 'webhook_error', errorMessage: error instanceof Error ? error.message : 'webhook-error', sheetSyncStatus, updatedAt: now }, { merge: true })
     return { created: true, webhook: { attempted: true, ok: false, status: null } }
   }
 }


### PR DESCRIPTION
### Motivation
- Some deliveries are recorded as `sent_to_webhook` but downstream email processing can be unreliable, so we need a secondary persistent sink for notification deliveries that spreadsheet-based workflows can consume.

### Description
- Added a configurable `NOTIFICATION_OUTBOX_SHEET_RANGE` and new helpers `getNotificationOutboxRange` and `appendNotificationOutboxRow` in `functions/src/googleSheets.ts` to append outbox rows to a sheet.
- Upgraded the Google Sheets OAuth scope from read-only to full spreadsheets access so the function can append rows as well as read client rows.
- Wired `createDelivery` in `functions/src/notifications.ts` to append each queued delivery to the configured sheet, track `sheetSyncStatus`, and persist `sheetSyncError` to the `notification_outbox` document on failures.
- Updated outbox document writes so status and metadata include `sheetSyncStatus` when webhooks are attempted or when no webhook is configured.

### Testing
- Built the functions package with `npm --prefix functions run build` and the TypeScript compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a219c33c88321b93d0c9cbb9c88ca)