### PR TITLE
Add event/intake metadata to availability API, types, docs and admin UI

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -127,6 +127,30 @@ Query parameters:
 
 `publicProducts` and `publicServices` are convenience buckets derived from `itemType` so storefronts can render physical products and services in separate sections without extra client-side sorting.
 
+### Listing model guidance (products, services, courses, events)
+
+Use these values to keep catalog and upcoming availability consistent:
+
+- **Products**
+  - `listingType: "product"`
+  - `salesMode: "buy_now"`
+- **Services**
+  - `listingType: "service"`
+  - `serviceKind: "appointment" | "consultation" | "quote_request"`
+  - `salesMode: "book_now" | "request_quote"`
+- **Always-open courses/programmes**
+  - `listingType: "course"`
+  - `serviceKind: "course_enrollment"`
+  - `enrollmentMode: "always_open"`
+  - `salesMode: "register"`
+  - These should not require `startAt/endAt`.
+- **Scheduled intakes/events**
+  - `listingType: "event"`
+  - `enrollmentMode: "scheduled"`
+  - Store schedule rows in `stores/{storeId}/integrationAvailabilitySlots`.
+
+Backward compatibility note: existing `publicProducts` / `publicServices` consumption remains valid; new fields are additive.
+
 #### Which endpoint should other websites use?
 
 1. **Server-to-server (recommended):** `GET /v1IntegrationProducts?storeId=<storeId>` with `x-api-key`.
@@ -301,9 +325,18 @@ This normalization allows sites to update once in Sedifex **Social links** and a
 
 ### `GET /v1IntegrationAvailability?storeId=<storeId>&serviceId=<serviceId>&from=<ISO>&to=<ISO>` (authenticated)
 
-- Returns session/class slots for service-type offerings.
+- Returns scheduled slots/intakes/events from `stores/{storeId}/integrationAvailabilitySlots`.
 - `serviceId`, `from`, and `to` are optional filters.
-- `attributes` is a flexible object for industry-specific fields (for example: school grade level or travel pickup point).
+- `attributes` remains a flexible object for industry-specific fields.
+- New optional event metadata is now returned when present:
+  - `linkedCourseId`
+  - `eventKind` (`intake | class | workshop | event | trip`)
+  - `registrationMode` (`free | paid | deposit | enquiry`)
+  - `price`
+  - `depositAmount`
+  - `location`
+  - `description`
+  - `marketplaceEnabled`
 
 ```json
 {
@@ -316,8 +349,16 @@ This normalization allows sites to update once in Sedifex **Social links** and a
       "id": "slot_1",
       "storeId": "store_123",
       "serviceId": "service_abc",
-      "startAt": "2026-04-22T10:00:00.000Z",
-      "endAt": "2026-04-22T11:00:00.000Z",
+      "linkedCourseId": "german-b1-course",
+      "eventKind": "intake",
+      "registrationMode": "paid",
+      "price": 1200,
+      "depositAmount": 300,
+      "location": "East Legon Campus",
+      "description": "German B1 Evening Batch starts 10 June",
+      "marketplaceEnabled": true,
+      "startAt": "2026-06-10T18:00:00.000Z",
+      "endAt": "2026-06-10T20:00:00.000Z",
       "timezone": "Africa/Accra",
       "capacity": 20,
       "seatsBooked": 8,
@@ -326,7 +367,7 @@ This normalization allows sites to update once in Sedifex **Social links** and a
       "attributes": {
         "level": "Beginner"
       },
-      "updatedAt": "2026-04-13T00:00:00.000Z"
+      "updatedAt": "2026-05-17T00:00:00.000Z"
     }
   ]
 }

--- a/docs/integration-quickstart.md
+++ b/docs/integration-quickstart.md
@@ -179,7 +179,7 @@ Base URL:
 
 - `GET /integrationCustomers?storeId=<storeId>`
 - `GET /integrationTopSelling?storeId=<storeId>&days=30&limit=10`
-- `GET /v1IntegrationAvailability?storeId=<storeId>&serviceId=<serviceId>&from=<ISO>&to=<ISO>`
+- `GET /v1IntegrationAvailability?storeId=<storeId>&serviceId=<serviceId>&from=<ISO>&to=<ISO>` (includes optional `linkedCourseId`, `eventKind`, `registrationMode`, `price`, `depositAmount`, `location`, `description`, `marketplaceEnabled`)
 - `GET /v1IntegrationBookings?storeId=<storeId>`
 - `POST /v1IntegrationBookings?storeId=<storeId>`
 

--- a/functions/src/integrationAvailability.ts
+++ b/functions/src/integrationAvailability.ts
@@ -12,6 +12,14 @@ type SlotResponse = {
   storeId: string
   serviceId: string
   serviceName?: string
+  linkedCourseId?: string | null
+  eventKind?: 'intake' | 'class' | 'workshop' | 'event' | 'trip'
+  registrationMode?: 'free' | 'paid' | 'deposit' | 'enquiry'
+  price?: number | null
+  depositAmount?: number | null
+  location?: string | null
+  description?: string | null
+  marketplaceEnabled?: boolean | null
   startAt: string
   endAt: string
   timezone: string
@@ -195,11 +203,28 @@ export const v1IntegrationAvailability = functions.https.onRequest(async (req, r
         if (isClosed || isPublicBlocked) return []
       }
 
+      const rawEventKind = clean(data.eventKind, 40).toLowerCase()
+      const eventKind = ['intake', 'class', 'workshop', 'event', 'trip'].includes(rawEventKind)
+        ? (rawEventKind as SlotResponse['eventKind'])
+        : undefined
+      const rawRegistrationMode = clean(data.registrationMode, 40).toLowerCase()
+      const registrationMode = ['free', 'paid', 'deposit', 'enquiry'].includes(rawRegistrationMode)
+        ? (rawRegistrationMode as SlotResponse['registrationMode'])
+        : undefined
+
       const slot: SlotResponse = {
         id: slotDoc.id,
         storeId,
         serviceId: resolvedServiceId,
         serviceName: resolvedServiceName || undefined,
+        linkedCourseId: clean(data.linkedCourseId, 220) || null,
+        eventKind,
+        registrationMode,
+        price: data.price == null ? null : toNumber(data.price, 0),
+        depositAmount: data.depositAmount == null ? null : toNumber(data.depositAmount, 0),
+        location: clean(data.location, 240) || null,
+        description: clean(data.description, 1200) || null,
+        marketplaceEnabled: typeof data.marketplaceEnabled === 'boolean' ? data.marketplaceEnabled : null,
         startAt,
         endAt,
         timezone: clean(data.timezone, 80) || 'Africa/Accra',

--- a/shared/integrationTypes.ts
+++ b/shared/integrationTypes.ts
@@ -60,6 +60,14 @@ export interface IntegrationAvailabilitySlot {
   id: string
   storeId: string
   serviceId: string
+  linkedCourseId?: string | null
+  eventKind?: 'intake' | 'class' | 'workshop' | 'event' | 'trip'
+  registrationMode?: 'free' | 'paid' | 'deposit' | 'enquiry'
+  price?: number | null
+  depositAmount?: number | null
+  location?: string | null
+  description?: string | null
+  marketplaceEnabled?: boolean | null
   startAt: string
   endAt: string
   timezone: string | null

--- a/web/src/pages/BookingsAvailability.tsx
+++ b/web/src/pages/BookingsAvailability.tsx
@@ -13,10 +13,21 @@ type ServiceRecord = {
   imageAlt?: string | null
   source?: string
 }
+type EventKind = 'intake' | 'class' | 'workshop' | 'event' | 'trip'
+type RegistrationMode = 'free' | 'paid' | 'deposit' | 'enquiry'
+
 type SlotRecord = {
   id: string
   serviceId: string
   serviceName: string
+  linkedCourseId?: string
+  eventKind: EventKind
+  registrationMode: RegistrationMode
+  price?: number
+  depositAmount?: number
+  location?: string
+  description?: string
+  marketplaceEnabled: boolean
   startAt: Date
   endAt: Date
   timezone: string
@@ -69,6 +80,14 @@ export default function BookingsAvailability() {
   const [endAt, setEndAt] = useState(toLocalInputValue(new Date(Date.now() + 2 * 60 * 60 * 1000)))
   const [timezone, setTimezone] = useState(Intl.DateTimeFormat().resolvedOptions().timeZone || 'Africa/Accra')
   const [capacity, setCapacity] = useState('20')
+  const [eventKind, setEventKind] = useState<EventKind>('intake')
+  const [registrationMode, setRegistrationMode] = useState<RegistrationMode>('paid')
+  const [linkedCourseId, setLinkedCourseId] = useState('')
+  const [price, setPrice] = useState('')
+  const [depositAmount, setDepositAmount] = useState('')
+  const [location, setLocation] = useState('')
+  const [description, setDescription] = useState('')
+  const [marketplaceEnabled, setMarketplaceEnabled] = useState(true)
   const [imageUrl, setImageUrl] = useState('')
   const [imageAlt, setImageAlt] = useState('')
   const [photoFile, setPhotoFile] = useState<File | null>(null)
@@ -156,6 +175,14 @@ export default function BookingsAvailability() {
           capacity: typeof data.capacity === 'number' && Number.isFinite(data.capacity) ? Math.max(1, Math.floor(data.capacity)) : 1,
           seatsBooked: typeof data.seatsBooked === 'number' && Number.isFinite(data.seatsBooked) ? Math.max(0, Math.floor(data.seatsBooked)) : 0,
           status: data.status === 'closed' ? 'closed' : 'open',
+          linkedCourseId: typeof data.linkedCourseId === 'string' ? data.linkedCourseId : undefined,
+          eventKind: (typeof data.eventKind === 'string' ? data.eventKind : 'event') as EventKind,
+          registrationMode: (typeof data.registrationMode === 'string' ? data.registrationMode : 'paid') as RegistrationMode,
+          price: typeof data.price === 'number' ? data.price : undefined,
+          depositAmount: typeof data.depositAmount === 'number' ? data.depositAmount : undefined,
+          location: typeof data.location === 'string' ? data.location : undefined,
+          description: typeof data.description === 'string' ? data.description : undefined,
+          marketplaceEnabled: typeof data.marketplaceEnabled === 'boolean' ? data.marketplaceEnabled : true,
           imageUrl: typeof data.imageUrl === 'string' ? data.imageUrl : typeof attributes.imageUrl === 'string' ? attributes.imageUrl : undefined,
           imageAlt: typeof data.imageAlt === 'string' ? data.imageAlt : typeof attributes.imageAlt === 'string' ? attributes.imageAlt : undefined,
         } as SlotRecord
@@ -250,6 +277,16 @@ export default function BookingsAvailability() {
         timezone,
         capacity: nextCapacity,
         seatsBooked: 0,
+        listingType: 'event',
+        enrollmentMode: 'scheduled',
+        eventKind,
+        registrationMode,
+        linkedCourseId: linkedCourseId.trim() || null,
+        price: price.trim() ? Number(price) : null,
+        depositAmount: depositAmount.trim() ? Number(depositAmount) : null,
+        location: location.trim() || null,
+        description: description.trim() || null,
+        marketplaceEnabled,
         status: 'open',
         isPublic: true,
         visibleOnWebsite: true,
@@ -275,7 +312,7 @@ export default function BookingsAvailability() {
     } finally {
       setSaving(false)
     }
-  }, [capacity, endAt, imageAlt, imageUrl, loadSlots, manualServiceName, saving, selectedService, serviceId, serviceMap, serviceMode, startAt, storeId, timezone, uploadPhoto])
+  }, [capacity, depositAmount, description, endAt, eventKind, imageAlt, imageUrl, linkedCourseId, loadSlots, location, manualServiceName, marketplaceEnabled, price, registrationMode, saving, selectedService, serviceId, serviceMap, serviceMode, startAt, storeId, timezone, uploadPhoto])
 
   const toggleStatus = useCallback(async (slot: SlotRecord) => {
     if (!storeId) return
@@ -323,7 +360,15 @@ export default function BookingsAvailability() {
           <label><span>Start</span><input type="datetime-local" value={startAt} onChange={event => setStartAt(event.target.value)} required /></label>
           <label><span>End</span><input type="datetime-local" value={endAt} onChange={event => setEndAt(event.target.value)} required /></label>
           <label><span>Timezone</span><input value={timezone} onChange={event => setTimezone(event.target.value)} required /></label>
+          <label><span>Event kind</span><select value={eventKind} onChange={event => setEventKind(event.target.value as EventKind)}><option value="intake">Intake</option><option value="class">Class</option><option value="workshop">Workshop</option><option value="event">Event</option><option value="trip">Trip</option></select></label>
+          <label><span>Registration mode</span><select value={registrationMode} onChange={event => setRegistrationMode(event.target.value as RegistrationMode)}><option value="paid">Paid</option><option value="free">Free</option><option value="deposit">Deposit</option><option value="enquiry">Enquiry</option></select></label>
+          <label><span>Linked course ID (optional)</span><input value={linkedCourseId} onChange={event => setLinkedCourseId(event.target.value)} placeholder="e.g. german-b1-course" /></label>
           <label><span>Capacity / limit</span><input type="number" min={1} value={capacity} onChange={event => setCapacity(event.target.value)} required /></label>
+          <label><span>Price (optional)</span><input type="number" min={0} step="0.01" value={price} onChange={event => setPrice(event.target.value)} /></label>
+          <label><span>Deposit amount (optional)</span><input type="number" min={0} step="0.01" value={depositAmount} onChange={event => setDepositAmount(event.target.value)} /></label>
+          <label><span>Location (optional)</span><input value={location} onChange={event => setLocation(event.target.value)} /></label>
+          <label><span>Description (optional)</span><input value={description} onChange={event => setDescription(event.target.value)} /></label>
+          <label><span>Marketplace enabled</span><select value={marketplaceEnabled ? 'yes' : 'no'} onChange={event => setMarketplaceEnabled(event.target.value === 'yes')}><option value="yes">Yes</option><option value="no">No</option></select></label>
           <div className="availability-photo-picker">
             <span>Photo upload</span>
             <input ref={fileInputRef} type="file" accept="image/*" style={{ display: 'none' }} onChange={event => setPhotoFile(event.target.files?.[0] ?? null)} />


### PR DESCRIPTION
### Motivation

- Extend the availability model to support scheduled intakes/events with pricing, registration modes, locations and marketplace flags so storefronts and marketplace features can surface richer event data.
- Ensure the backend API, TypeScript types and admin UI are aligned to read/write the new fields from `stores/{storeId}/integrationAvailabilitySlots`.
- Update documentation so integrators know the new optional fields and recommended listing conventions for products, services, courses and events.

### Description

- Add new optional fields to the availability response in `functions/src/integrationAvailability.ts` including `linkedCourseId`, `eventKind`, `registrationMode`, `price`, `depositAmount`, `location`, `description`, and `marketplaceEnabled`, and parse/clean them before returning slots.
- Extend the `SlotResponse`/`IntegrationAvailabilitySlot` types in `shared/integrationTypes.ts` to include the same new fields and preserve backward compatibility.
- Update the admin UI `web/src/pages/BookingsAvailability.tsx` to surface inputs for event kind, registration mode, linked course id, price, deposit amount, location, description and marketplace enabled, to read those fields when loading slots, and to write them on create.
- Update docs (`docs/integration-api-guide.md` and `docs/integration-quickstart.md`) with guidance for listing models (products/services/courses/events) and to document the new optional availability fields returned by `GET /v1IntegrationAvailability`.

### Testing

- Performed a TypeScript type-check with `tsc --noEmit` and a local web build with `npm run build`, and both completed successfully.
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a46ace2648321b324b2a96f86b348)