### PR TITLE
Normalize sedx/sdfx merchant token prefixes for Sedifex Market auth

### DIFF
--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -184,10 +184,20 @@ function getSedifexMarketMerchantTokenMap(): Record<string, string> {
   }
 }
 
+function normalizeMerchantTokenPrefix(token: string) {
+  const trimmed = clean(token, 1000)
+  if (!trimmed) return ''
+  if (trimmed.startsWith('sdfx_')) return `sedx_${trimmed.slice('sdfx_'.length)}`
+  return trimmed
+}
+
 function isAuthorizedBySedifexMarketToken(storeId: string, apiKey: string) {
   const map = getSedifexMarketMerchantTokenMap()
   const expected = map[storeId]
-  return Boolean(expected && apiKey && expected === apiKey)
+  if (!expected || !apiKey) return false
+  const normalizedExpected = normalizeMerchantTokenPrefix(expected)
+  const normalizedApiKey = normalizeMerchantTokenPrefix(apiKey)
+  return normalizedExpected === normalizedApiKey
 }
 
 async function isAuthorizedByExistingProductEndpoint(req: functions.https.Request, storeId: string, apiKey: string) {


### PR DESCRIPTION
### Motivation
- Legacy tokens were issued with the `sdfx_` prefix while newer tokens and UI use `sedx_`, causing valid merchant tokens to fail equality checks during Sedifex Market authorization. 
- The change ensures prefix variants are treated equivalently while preserving strict matching of the secret suffix.

### Description
- Add `normalizeMerchantTokenPrefix(token: string)` to normalize `sdfx_` to `sedx_` and trim values. 
- Update `isAuthorizedBySedifexMarketToken` to normalize both the expected token from `SEDIFEX_MERCHANT_TOKENS_JSON` and the incoming `apiKey` before comparing. 
- Keep early guards to return false when `expected` or `apiKey` are missing. 
- Change made in `functions/src/integrationCheckout.ts`.

### Testing
- Ran `npm run build` in `functions/` which completed successfully. 
- Ran `npm test` in `functions/` which failed in this environment due to a missing compiled module (`./marketplacePaystackWebhook`) imported by `functions/lib/index.js`, and that failure is unrelated to the token normalization change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b038942788321a99fc82cf8fadd70)