### PR TITLE
Add integrationCheckoutPreview Cloud Function

### DIFF
--- a/functions/lib/googleSheets.js
+++ b/functions/lib/googleSheets.js
@@ -36,6 +36,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.normalizeHeader = normalizeHeader;
 exports.fetchClientRowByEmail = fetchClientRowByEmail;
 exports.getDefaultSpreadsheetId = getDefaultSpreadsheetId;
+exports.getNotificationOutboxRange = getNotificationOutboxRange;
+exports.appendNotificationOutboxRow = appendNotificationOutboxRow;
 const params_1 = require("firebase-functions/params");
 const DEFAULT_SPREADSHEET_ID = '1_oqRHePaZnpULD9zRUtxBIHQUaHccGAxSP3SPCJ0o7g';
 const DEFAULT_RANGE = 'Clients!A:ZZ';
@@ -49,6 +51,7 @@ const EMAIL_HEADER_MATCHERS = new Set([
 const SHEETS_SERVICE_ACCOUNT = (0, params_1.defineString)('SHEETS_SERVICE_ACCOUNT', { default: '' });
 const SHEETS_SPREADSHEET_ID = (0, params_1.defineString)('SHEETS_SPREADSHEET_ID', { default: '' });
 const SHEETS_RANGE = (0, params_1.defineString)('SHEETS_RANGE', { default: '' });
+const NOTIFICATION_OUTBOX_SHEET_RANGE = (0, params_1.defineString)('NOTIFICATION_OUTBOX_SHEET_RANGE', { default: 'NotificationOutbox!A:Z' });
 let sheetsClientPromise = null;
 async function loadSheetsClientFactory() {
     // googleapis is large; load it lazily to keep function module import fast.
@@ -108,7 +111,7 @@ async function getSheetsClient() {
         const google = await loadSheetsClientFactory();
         const auth = new google.auth.GoogleAuth({
             credentials,
-            scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+            scopes: ['https://www.googleapis.com/auth/spreadsheets'],
         });
         const authClientPromise = auth.getClient();
         sheetsClientPromise = (async () => {
@@ -210,4 +213,21 @@ async function fetchClientRowByEmail(sheetId, email) {
 function getDefaultSpreadsheetId() {
     const config = readConfig();
     return resolveSpreadsheetId(config, null);
+}
+function getNotificationOutboxRange() {
+    const configured = NOTIFICATION_OUTBOX_SHEET_RANGE.value()?.trim();
+    return configured || 'NotificationOutbox!A:Z';
+}
+async function appendNotificationOutboxRow(row, spreadsheetId) {
+    const config = readConfig();
+    const resolvedSpreadsheetId = resolveSpreadsheetId(config, spreadsheetId ?? null);
+    const sheets = await getSheetsClient();
+    await sheets.spreadsheets.values.append({
+        spreadsheetId: resolvedSpreadsheetId,
+        range: getNotificationOutboxRange(),
+        valueInputOption: 'RAW',
+        requestBody: {
+            values: [row.map(value => (value === null || value === undefined ? '' : String(value)))],
+        },
+    });
 }

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.sendBrandedNotificationPreview = exports.notifyDonationCaptured = exports.notifySupportRequestCreated = exports.notifyVolunteerApplicationCreated = exports.notifyStudentRegistrationCreated = exports.notifyIntegrationOrderStatus = exports.initializeStoreNotificationDefaults = exports.supportRequestIntake = exports.volunteerIntake = exports.v1IntegrationAvailability = exports.integrationOrderStatus = exports.integrationCheckoutCreate = exports.fetchPaystackSettlementBanks = exports.fetchPaystackMerchantSubaccount = exports.createPaystackMerchantSubaccount = exports.handlePaystackWebhook = exports.paystackWebhook = exports.createCheckout = exports.checkSignupUnlock = void 0;
+exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.sendBrandedNotificationPreview = exports.notifyDonationCaptured = exports.notifySupportRequestCreated = exports.notifyVolunteerApplicationCreated = exports.notifyStudentRegistrationCreated = exports.notifyIntegrationOrderStatus = exports.initializeStoreNotificationDefaults = exports.supportRequestIntake = exports.volunteerIntake = exports.v1IntegrationAvailability = exports.integrationOrderStatus = exports.integrationCheckoutPreview = exports.integrationCheckoutCreate = exports.fetchPaystackSettlementBanks = exports.fetchPaystackMerchantSubaccount = exports.createPaystackMerchantSubaccount = exports.handlePaystackWebhook = exports.paystackWebhook = exports.createCheckout = exports.checkSignupUnlock = void 0;
 const params_1 = require("firebase-functions/params");
 var paystack_1 = require("./paystack");
 Object.defineProperty(exports, "checkSignupUnlock", { enumerable: true, get: function () { return paystack_1.checkSignupUnlock; } });
@@ -28,6 +28,7 @@ Object.defineProperty(exports, "fetchPaystackMerchantSubaccount", { enumerable: 
 Object.defineProperty(exports, "fetchPaystackSettlementBanks", { enumerable: true, get: function () { return paystackSubaccounts_1.fetchPaystackSettlementBanks; } });
 var integrationCheckout_1 = require("./integrationCheckout");
 Object.defineProperty(exports, "integrationCheckoutCreate", { enumerable: true, get: function () { return integrationCheckout_1.integrationCheckoutCreate; } });
+Object.defineProperty(exports, "integrationCheckoutPreview", { enumerable: true, get: function () { return integrationCheckout_1.integrationCheckoutPreview; } });
 Object.defineProperty(exports, "integrationOrderStatus", { enumerable: true, get: function () { return integrationCheckout_1.integrationOrderStatus; } });
 var integrationAvailability_1 = require("./integrationAvailability");
 Object.defineProperty(exports, "v1IntegrationAvailability", { enumerable: true, get: function () { return integrationAvailability_1.v1IntegrationAvailability; } });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -14,7 +14,11 @@ export {
   fetchPaystackMerchantSubaccount,
   fetchPaystackSettlementBanks,
 } from './paystackSubaccounts'
-export { integrationCheckoutCreate, integrationOrderStatus } from './integrationCheckout'
+export {
+  integrationCheckoutCreate,
+  integrationCheckoutPreview,
+  integrationOrderStatus,
+} from './integrationCheckout'
 export { v1IntegrationAvailability } from './integrationAvailability'
 export { volunteerIntake, supportRequestIntake } from './ngoIntake'
 export {

--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -406,6 +406,176 @@ async function initializePaystack(payload: Record<string, unknown>) {
   return json
 }
 
+
+
+type CheckoutPreviewItem = {
+  item_id?: unknown
+  itemId?: unknown
+  productId?: unknown
+  serviceId?: unknown
+  qty?: unknown
+  quantity?: unknown
+  type?: unknown
+  item_type?: unknown
+}
+
+function normalizeCheckoutItemType(value: unknown) {
+  const normalized = clean(value, 50).toUpperCase()
+  if (normalized === 'SERVICE') return 'SERVICE'
+  return 'PRODUCT'
+}
+
+function getItemPriceMinor(record: Record<string, unknown>) {
+  const minor = numberValue(record.priceMinor ?? record.amountMinor)
+  if (minor !== null && minor >= 0) return Math.round(minor)
+
+  const major = numberValue(record.price ?? record.sellingPrice ?? record.salePrice ?? record.amount ?? record.fee)
+  if (major === null || major < 0) return null
+  return Math.round(major * 100)
+}
+
+async function resolveCatalogItem(storeId: string, itemId: string, hintedType: string) {
+  const directRefs = [
+    defaultDb.collection('stores').doc(storeId).collection('products').doc(itemId),
+    defaultDb.collection('stores').doc(storeId).collection('services').doc(itemId),
+    defaultDb.collection('products').doc(itemId),
+    defaultDb.collection('services').doc(itemId),
+    defaultDb.collection('publicProducts').doc(itemId),
+    defaultDb.collection('publicServices').doc(itemId),
+  ]
+
+  for (const ref of directRefs) {
+    const snap = await ref.get()
+    if (!snap.exists) continue
+    const data = (snap.data() ?? {}) as Record<string, unknown>
+    return {
+      item: data,
+      type: normalizeCheckoutItemType(data.type ?? data.item_type ?? hintedType ?? (ref.parent.id.toUpperCase().includes('SERVICE') ? 'SERVICE' : 'PRODUCT')),
+    }
+  }
+
+  const queryCollections = ['publicProducts', 'publicServices', 'v1IntegrationProducts']
+  const queryFields = ['id', 'productId', 'sourceProductId']
+
+  for (const collectionName of queryCollections) {
+    for (const field of queryFields) {
+      const snap = await defaultDb
+        .collection(collectionName)
+        .where(field, '==', itemId)
+        .where('storeId', '==', storeId)
+        .limit(1)
+        .get()
+      if (snap.empty) continue
+      const data = (snap.docs[0].data() ?? {}) as Record<string, unknown>
+      return {
+        item: data,
+        type: normalizeCheckoutItemType(data.type ?? data.item_type ?? hintedType),
+      }
+    }
+  }
+
+  return null
+}
+
+export const integrationCheckoutPreview = functions.https.onRequest(async (req, res): Promise<void> => {
+  setCors(res)
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('')
+    return
+  }
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'method-not-allowed' })
+    return
+  }
+  if (!assertContract(req, res)) return
+
+  try {
+    const body = (req.body ?? {}) as CheckoutBody
+    const storeId = getStoreId(body)
+    if (!storeId) {
+      res.status(400).json({ error: 'missing-store-id' })
+      return
+    }
+
+    const authorized = await isAuthorized(req, storeId)
+    if (!authorized) {
+      functions.logger.warn('integrationCheckoutPreview auth failed', {
+        storeId,
+        hasApiKey: Boolean(getRequestApiKey(req)),
+      })
+      res.status(401).json({ error: 'invalid-api-key' })
+      return
+    }
+
+    const items = Array.isArray(body.items) ? body.items as CheckoutPreviewItem[] : []
+    if (!items.length) {
+      res.status(400).json({ error: 'items-required' })
+      return
+    }
+
+    functions.logger.info('integrationCheckoutPreview authorized', { storeId, itemCount: items.length })
+
+    const responseItems: Array<Record<string, unknown>> = []
+    let subtotal = 0
+
+    for (const rawItem of items) {
+      const item = rawItem && typeof rawItem === 'object' ? rawItem as CheckoutPreviewItem : {}
+      const itemId = clean(item.item_id ?? item.itemId ?? item.productId ?? item.serviceId, 220)
+      const qtyRaw = numberValue(item.qty ?? item.quantity)
+      const qty = qtyRaw && qtyRaw > 0 ? Math.round(qtyRaw) : 1
+      const type = normalizeCheckoutItemType(item.type ?? item.item_type ?? (item.serviceId ? 'SERVICE' : 'PRODUCT'))
+
+      if (!itemId) {
+        res.status(404).json({ error: 'checkout-item-not-found', item_id: itemId, storeId })
+        return
+      }
+
+      const resolved = await resolveCatalogItem(storeId, itemId, type)
+      if (!resolved) {
+        res.status(404).json({ error: 'checkout-item-not-found', item_id: itemId, storeId })
+        return
+      }
+
+      const unitPrice = getItemPriceMinor(resolved.item)
+      if (unitPrice === null) {
+        res.status(400).json({ error: 'checkout-item-price-missing', item_id: itemId, storeId })
+        return
+      }
+
+      const lineTotal = unitPrice * qty
+      subtotal += lineTotal
+
+      responseItems.push({
+        item_id: itemId,
+        name: clean(resolved.item.name ?? resolved.item.productName ?? resolved.item.title, 220) || itemId,
+        qty,
+        unit_price: unitPrice,
+        line_total: lineTotal,
+        type: resolved.type,
+      })
+    }
+
+    const payload = {
+      pricing_version: '2026-05-12-v1',
+      currency: 'GHS',
+      subtotal,
+      tax_total: 0,
+      delivery_fee: 0,
+      pre_processing_total: subtotal,
+      processing_fee_to_add: 0,
+      final_total: subtotal,
+      breakdown: [
+        { code: 'SUBTOTAL', amount: subtotal },
+      ],
+      items: responseItems,
+    }
+
+    res.status(200).json(payload)
+  } catch (error) {
+    functions.logger.error('integrationCheckoutPreview failed', { error })
+    res.status(500).json({ error: 'checkout-preview-failed' })
+  }
+})
 export const integrationCheckoutCreate = functions.https.onRequest(async (req, res): Promise<void> => {
   setCors(res)
   if (req.method === 'OPTIONS') {


### PR DESCRIPTION
### Motivation
- Provide a real, current pricing preview endpoint for Sedifex Market so integrations (e.g. BuySedifex) can call a direct function URL instead of the deprecated `/integration/checkout/preview` route.
- Ensure preview requests use the same robust authorization checks as other integration endpoints by reusing the existing `isAuthorized(req, storeId)` logic and not leaking tokens in logs.
- Support resolving products/services across store, public and v1 integration catalogs and return totals in minor currency units for accurate client-side pricing.

### Description
- Added a new `integrationCheckoutPreview` HTTPS Cloud Function in `functions/src/integrationCheckout.ts` that is registered with `functions.https.onRequest` and uses `setCors`, handles `OPTIONS` with `204`, enforces `POST` only, and calls `assertContract(req, res)` and `isAuthorized(req, storeId)`.
- Implemented item normalization, quantity parsing, catalog resolution (`stores/{storeId}/products|services`, `products`, `services`, `publicProducts`, `publicServices`, and fallback queries in `v1IntegrationProducts`/public collections), and price extraction (supports `priceMinor|amountMinor` and major-unit fields `price|sellingPrice|salePrice|amount|fee`, converting majors via `Math.round(price * 100)`).
- Added structured preview response with minor-unit totals and breakdown using the `2026-05-12-v1` pricing version format and GHS currency, and explicit error payloads for missing `storeId`, missing/empty `items`, item not found, and missing/invalid price.
- Added safe logs on auth success and failure using `functions.logger.info` and `functions.logger.warn` (includes `hasApiKey: Boolean(getRequestApiKey(req))` on failures); reused helpers `clean`, `numberValue`, `getStoreId`, `getRequestApiKey`, and other existing utilities.
- Exported `integrationCheckoutPreview` from `functions/src/index.ts` so the function is discoverable by Firebase, and built the Functions code with the project `build` script.

### Testing
- Ran `npm --prefix functions run build`, which runs `tsc` as part of the functions build, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2b8509dc8321ba6c73890cb6613f)