### PR TITLE
Add v1IntegrationBookings endpoint for integrations/BuySedifex

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.sendBrandedNotificationPreview = exports.notifyDonationCaptured = exports.notifySupportRequestCreated = exports.notifyVolunteerApplicationCreated = exports.notifyStudentRegistrationCreated = exports.notifyIntegrationOrderStatus = exports.initializeStoreNotificationDefaults = exports.supportRequestIntake = exports.volunteerIntake = exports.v1IntegrationAvailability = exports.integrationOrderStatus = exports.integrationCheckoutPreview = exports.integrationCheckoutCreate = exports.fetchPaystackSettlementBanks = exports.fetchPaystackMerchantSubaccount = exports.createPaystackMerchantSubaccount = exports.handlePaystackWebhook = exports.paystackWebhook = exports.createCheckout = exports.checkSignupUnlock = void 0;
+exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.sendBrandedNotificationPreview = exports.notifyDonationCaptured = exports.notifySupportRequestCreated = exports.notifyVolunteerApplicationCreated = exports.notifyStudentRegistrationCreated = exports.notifyIntegrationOrderStatus = exports.initializeStoreNotificationDefaults = exports.supportRequestIntake = exports.volunteerIntake = exports.v1IntegrationBookings = exports.v1IntegrationAvailability = exports.integrationOrderStatus = exports.integrationCheckoutPreview = exports.integrationCheckoutCreate = exports.fetchPaystackSettlementBanks = exports.fetchPaystackMerchantSubaccount = exports.createPaystackMerchantSubaccount = exports.handlePaystackWebhook = exports.paystackWebhook = exports.createCheckout = exports.checkSignupUnlock = void 0;
 const params_1 = require("firebase-functions/params");
 var paystack_1 = require("./paystack");
 Object.defineProperty(exports, "checkSignupUnlock", { enumerable: true, get: function () { return paystack_1.checkSignupUnlock; } });
@@ -32,6 +32,8 @@ Object.defineProperty(exports, "integrationCheckoutPreview", { enumerable: true,
 Object.defineProperty(exports, "integrationOrderStatus", { enumerable: true, get: function () { return integrationCheckout_1.integrationOrderStatus; } });
 var integrationAvailability_1 = require("./integrationAvailability");
 Object.defineProperty(exports, "v1IntegrationAvailability", { enumerable: true, get: function () { return integrationAvailability_1.v1IntegrationAvailability; } });
+var integrationBookings_1 = require("./integrationBookings");
+Object.defineProperty(exports, "v1IntegrationBookings", { enumerable: true, get: function () { return integrationBookings_1.v1IntegrationBookings; } });
 var ngoIntake_1 = require("./ngoIntake");
 Object.defineProperty(exports, "volunteerIntake", { enumerable: true, get: function () { return ngoIntake_1.volunteerIntake; } });
 Object.defineProperty(exports, "supportRequestIntake", { enumerable: true, get: function () { return ngoIntake_1.supportRequestIntake; } });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -20,6 +20,7 @@ export {
   integrationOrderStatus,
 } from './integrationCheckout'
 export { v1IntegrationAvailability } from './integrationAvailability'
+export { v1IntegrationBookings } from './integrationBookings'
 export { volunteerIntake, supportRequestIntake } from './ngoIntake'
 export {
   initializeStoreNotificationDefaults,

--- a/functions/src/integrationBookings.ts
+++ b/functions/src/integrationBookings.ts
@@ -1,0 +1,268 @@
+import * as functions from 'firebase-functions/v1'
+import { defineString } from 'firebase-functions/params'
+import { admin, defaultDb } from './firestore'
+
+const INTEGRATION_CONTRACT_VERSION = defineString('INTEGRATION_CONTRACT_VERSION', {
+  default: '2026-04-13',
+})
+const SEDIFEX_INTEGRATION_API_KEY = defineString('SEDIFEX_INTEGRATION_API_KEY', { default: '' })
+
+type BookingRequestBody = {
+  serviceId?: unknown
+  slotId?: unknown
+  customer?: unknown
+  quantity?: unknown
+  notes?: unknown
+  bookingDate?: unknown
+  bookingTime?: unknown
+  branchLocationId?: unknown
+  branchLocationName?: unknown
+  paymentMethod?: unknown
+  paymentAmount?: unknown
+  serviceName?: unknown
+  attributes?: unknown
+  status?: unknown
+}
+
+function clean(value: unknown, max = 500) {
+  return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+
+function setCors(res: functions.Response) {
+  res.set('Access-Control-Allow-Origin', '*')
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-api-key, X-Sedifex-Contract-Version')
+  res.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+}
+
+function assertContract(req: functions.https.Request, res: functions.Response) {
+  const expected = INTEGRATION_CONTRACT_VERSION.value() || '2026-04-13'
+  const received = clean(req.get('x-sedifex-contract-version'), 80)
+  res.set('x-sedifex-contract-version', expected)
+  res.set('x-sedifex-request-id', `${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  if (received && received !== expected) {
+    res.status(400).json({ error: 'contract-version-mismatch', expectedVersion: expected, receivedVersion: received })
+    return false
+  }
+  return true
+}
+
+function toNumber(value: unknown, fallback = 0) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+async function queryHasMatch(collectionPath: FirebaseFirestore.CollectionReference, field: string, apiKey: string) {
+  const snapshot = await collectionPath.where(field, '==', apiKey).limit(1).get()
+  return !snapshot.empty
+}
+
+function recordContainsKey(record: Record<string, unknown>, apiKey: string) {
+  const candidates = [record.integrationApiKey, record.integrationKey, record.integrationToken, record.apiKey, record.token, record.key]
+  return candidates.some(value => clean(value, 1000) === apiKey)
+}
+
+async function isAuthorized(req: functions.https.Request, storeId: string) {
+  const bearer = clean(req.get('authorization'), 1000).replace(/^Bearer\s+/i, '')
+  const apiKey = clean(req.get('x-api-key'), 1000) || bearer
+  if (!apiKey) return false
+
+  const master = SEDIFEX_INTEGRATION_API_KEY.value()?.trim() || process.env.SEDIFEX_INTEGRATION_API_KEY?.trim() || ''
+  if (master && apiKey === master) return true
+
+  try {
+    const storeSnap = await defaultDb.collection('stores').doc(storeId).get()
+    const storeData = (storeSnap.data() ?? {}) as Record<string, unknown>
+    if (recordContainsKey(storeData, apiKey)) return true
+
+    const settingsSnap = await defaultDb.collection('storeSettings').doc(storeId).get()
+    const settingsData = (settingsSnap.data() ?? {}) as Record<string, unknown>
+    if (recordContainsKey(settingsData, apiKey)) return true
+
+    const storeKeyCollections = [
+      defaultDb.collection('stores').doc(storeId).collection('integrationApiKeys'),
+      defaultDb.collection('storeSettings').doc(storeId).collection('integrationApiKeys'),
+    ]
+
+    for (const keyCollection of storeKeyCollections) {
+      for (const field of ['token', 'key', 'apiKey', 'value']) {
+        if (await queryHasMatch(keyCollection, field, apiKey)) return true
+      }
+    }
+
+    for (const field of ['token', 'key', 'apiKey', 'value']) {
+      const snapshot = await defaultDb
+        .collection('integrationApiKeys')
+        .where('storeId', '==', storeId)
+        .where(field, '==', apiKey)
+        .limit(1)
+        .get()
+      if (!snapshot.empty) return true
+    }
+  } catch (error) {
+    functions.logger.warn('integration bookings auth lookup failed', { storeId, error })
+  }
+
+  return false
+}
+
+function asObject(value: unknown) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+async function findCustomerDoc(storeId: string, phone: string, email: string) {
+  const customersRef = defaultDb.collection('stores').doc(storeId).collection('customers')
+  if (phone) {
+    const byPhone = await customersRef.where('phone', '==', phone).limit(1).get()
+    if (!byPhone.empty) return byPhone.docs[0]
+  }
+  if (email) {
+    const byEmail = await customersRef.where('email', '==', email).limit(1).get()
+    if (!byEmail.empty) return byEmail.docs[0]
+  }
+  return null
+}
+
+export const v1IntegrationBookings = functions.https.onRequest(async (req, res): Promise<void> => {
+  setCors(res)
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('')
+    return
+  }
+  if (!assertContract(req, res)) return
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    res.status(405).json({ error: 'method-not-allowed' })
+    return
+  }
+
+  const storeId = clean(req.query.storeId, 180)
+  if (!storeId) {
+    res.status(400).json({ error: 'missing-store-id' })
+    return
+  }
+
+  if (!(await isAuthorized(req, storeId))) {
+    res.status(401).json({ error: 'unauthorized' })
+    return
+  }
+
+  try {
+    if (req.method === 'GET') {
+      const status = clean(req.query.status, 80).toLowerCase()
+      const serviceId = clean(req.query.serviceId, 220)
+
+      let query: FirebaseFirestore.Query = defaultDb
+        .collection('stores')
+        .doc(storeId)
+        .collection('integrationBookings')
+        .orderBy('createdAt', 'desc')
+
+      if (status) query = query.where('status', '==', status)
+      if (serviceId) query = query.where('serviceId', '==', serviceId)
+
+      const snapshot = await query.limit(200).get()
+      const bookings = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as Record<string, unknown>) }))
+      res.status(200).json({ ok: true, storeId, status: status || null, serviceId: serviceId || null, bookings })
+      return
+    }
+
+    const body = asObject(req.body) as BookingRequestBody
+    const serviceId = clean(body.serviceId, 220)
+    const slotId = clean(body.slotId, 220)
+    const quantity = Math.max(1, Math.floor(toNumber(body.quantity, 1)))
+    const notes = clean(body.notes, 2000)
+    const bookingDate = clean(body.bookingDate, 80)
+    const bookingTime = clean(body.bookingTime, 80)
+    const branchLocationId = clean(body.branchLocationId, 220)
+    const branchLocationName = clean(body.branchLocationName, 240)
+    const paymentMethod = clean(body.paymentMethod, 120)
+    const serviceName = clean(body.serviceName, 240)
+    const requestedStatus = clean(body.status, 80).toLowerCase()
+    const status = requestedStatus || 'pending'
+    const paymentAmount = toNumber(body.paymentAmount, 0)
+    const attributes = asObject(body.attributes)
+    const customer = asObject(body.customer)
+    const customerName = clean(customer.name, 240)
+    const customerPhone = clean(customer.phone, 80)
+    const customerEmail = clean(customer.email, 240).toLowerCase()
+
+    if (!serviceId && !slotId) {
+      res.status(400).json({ error: 'missing-service-or-slot' })
+      return
+    }
+
+    const now = admin.firestore.FieldValue.serverTimestamp()
+    const storeRef = defaultDb.collection('stores').doc(storeId)
+
+    let resolvedServiceId = serviceId
+    let resolvedServiceName = serviceName
+    if (slotId) {
+      const slotRef = storeRef.collection('integrationAvailabilitySlots').doc(slotId)
+      await defaultDb.runTransaction(async tx => {
+        const slotSnap = await tx.get(slotRef)
+        if (!slotSnap.exists) throw new Error('slot-not-found')
+        const slot = slotSnap.data() as Record<string, unknown>
+        const slotStatus = clean(slot.status, 40).toLowerCase() || 'open'
+        if (slotStatus !== 'open') throw new Error('slot-not-open')
+
+        const capacity = Math.max(0, Math.floor(toNumber(slot.capacity, 0)))
+        const seatsBooked = Math.max(0, Math.floor(toNumber(slot.seatsBooked, 0)))
+        const seatsRemaining = Math.max(0, capacity - seatsBooked)
+        if (capacity > 0 && seatsRemaining < quantity) throw new Error('slot-capacity-exceeded')
+
+        resolvedServiceId = resolvedServiceId || clean(slot.serviceId, 220)
+        resolvedServiceName = resolvedServiceName || clean(slot.serviceName, 240)
+        tx.update(slotRef, { seatsBooked: seatsBooked + quantity, updatedAt: now })
+      })
+    }
+
+    const customerDoc = await findCustomerDoc(storeId, customerPhone, customerEmail)
+    const customerRef = customerDoc ? customerDoc.ref : storeRef.collection('customers').doc()
+    await customerRef.set(
+      {
+        name: customerName || null,
+        phone: customerPhone || null,
+        email: customerEmail || null,
+        updatedAt: now,
+        createdAt: customerDoc ? customerDoc.get('createdAt') || now : now,
+        source: 'integration',
+      },
+      { merge: true },
+    )
+
+    const bookingRef = storeRef.collection('integrationBookings').doc()
+    const reference = `IB-${bookingRef.id.slice(0, 8).toUpperCase()}`
+    const bookingRecord: Record<string, unknown> = {
+      bookingId: bookingRef.id,
+      reference,
+      storeId,
+      customerId: customerRef.id,
+      serviceId: resolvedServiceId,
+      serviceName: resolvedServiceName || null,
+      slotId: slotId || null,
+      customer: { name: customerName || null, phone: customerPhone || null, email: customerEmail || null },
+      quantity,
+      notes: notes || null,
+      bookingDate: bookingDate || null,
+      bookingTime: bookingTime || null,
+      branchLocationId: branchLocationId || null,
+      branchLocationName: branchLocationName || null,
+      paymentMethod: paymentMethod || null,
+      paymentAmount,
+      attributes,
+      status,
+      source: 'integration',
+      channel: 'BuySedifex',
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    await bookingRef.set(bookingRecord, { merge: true })
+    await defaultDb.collection('integrationBookings').doc(bookingRef.id).set(bookingRecord, { merge: true })
+
+    res.status(200).json({ ok: true, bookingId: bookingRef.id, reference, booking: bookingRecord })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'integration-booking-failed'
+    const known = new Set(['slot-not-found', 'slot-not-open', 'slot-capacity-exceeded'])
+    res.status(known.has(message) ? 400 : 500).json({ error: message })
+  }
+})


### PR DESCRIPTION
### Motivation
- Provide a canonical integration bookings endpoint used by BuySedifex so external/manual bookings can create Sedifex bookings for a store and appear in the bookings dashboard. 
- Reuse the existing integration auth/contract pattern to keep behavior consistent with `v1IntegrationAvailability` and other integration endpoints.

### Description
- Added `functions/src/integrationBookings.ts` which implements `v1IntegrationBookings` supporting `GET /v1IntegrationBookings?storeId=<storeId>&status=<status>&serviceId=<serviceId>` and `POST /v1IntegrationBookings?storeId=<storeId>`. 
- Exported `v1IntegrationBookings` from `functions/src/index.ts` so the function is discovered and deployed. 
- Reused the same authentication and contract checks as `v1IntegrationAvailability` (supports `x-api-key`, `Authorization: Bearer`, `X-Sedifex-Contract-Version`, master key plus store key lookups). 
- `POST` accepts the required fields: `serviceId`, `slotId`, `customer { name, phone, email }`, `quantity`, `notes`, `bookingDate`, `bookingTime`, `branchLocationId`, `branchLocationName`, `paymentMethod`, `paymentAmount`, `serviceName`, and `attributes`. 
- When `slotId` is provided the code reads `stores/{storeId}/integrationAvailabilitySlots/{slotId}`, validates slot exists and is `open`, validates capacity / `seatsRemaining` vs requested quantity, and atomically increments `seatsBooked` in a Firestore transaction. 
- Upserts customer into `stores/{storeId}/customers` (search by phone first, then email) and writes/merges the customer document. 
- Creates booking under `stores/{storeId}/integrationBookings/{bookingId}` and mirrors the record in top-level `integrationBookings/{bookingId}`, and tags the booking with `source: 'integration'` and `channel: 'BuySedifex'` to ensure dashboard visibility. 
- `GET` returns a listing for the store with optional `status` and `serviceId` filters and returns `{ ok: true, storeId, status, serviceId, bookings }`. 
- Returns on success: `{ ok: true, bookingId, reference, booking }` and uses `IB-<short>` style booking reference.

### Testing
- Ran TypeScript build with `cd functions && npm run build` which completed successfully. 
- Ran function tests with `cd functions && npm test` which failed due to an existing baseline assertion (`Expected __testing exports`) unrelated to the integration bookings changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b331f259483219ce787f5ea51c81a)