### PR TITLE
Fix integration receipt item/service names from checkout payload and snapshots

### DIFF
--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -73,6 +73,61 @@ function getSubaccount(body: CheckoutBody) {
   )
 }
 
+
+function getRecord(value: unknown) {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : {}
+}
+
+function getFirstText(record: Record<string, unknown>, keys: string[], max = 220) {
+  for (const key of keys) {
+    const value = clean(record[key], max)
+    if (value) return value
+  }
+  return ''
+}
+
+function getSnapshotItems(body: CheckoutBody) {
+  const snapshot = getRecord(body.pricing_snapshot)
+  return Array.isArray(snapshot.items) ? snapshot.items : []
+}
+
+function enrichCheckoutItems(body: CheckoutBody) {
+  const rawItems = Array.isArray(body.items) ? body.items : []
+  const snapshotItems = getSnapshotItems(body).map(getRecord)
+  const metadata = getRecord(body.metadata)
+
+  const enrichedItems = rawItems.map((item) => {
+    const base = getRecord(item)
+    const itemId = clean(base.item_id ?? base.itemId, 220)
+    const snapshotMatch = snapshotItems.find(snapshotItem => clean(snapshotItem.item_id ?? snapshotItem.itemId, 220) === itemId)
+    const name = getFirstText(base, ['name', 'title', 'itemName', 'serviceName', 'productName'])
+      || getFirstText(snapshotMatch ?? {}, ['name', 'title', 'itemName', 'serviceName', 'productName'])
+    const itemName = getFirstText(base, ['itemName']) || getFirstText(snapshotMatch ?? {}, ['itemName'])
+    const productName = getFirstText(base, ['productName']) || getFirstText(snapshotMatch ?? {}, ['productName'])
+    const serviceName = getFirstText(base, ['serviceName']) || getFirstText(snapshotMatch ?? {}, ['serviceName'])
+    return {
+      ...base,
+      ...(name ? { name } : {}),
+      ...(itemName ? { itemName } : {}),
+      ...(productName ? { productName } : {}),
+      ...(serviceName ? { serviceName } : {}),
+    }
+  })
+
+  const firstItem = enrichedItems.length ? getRecord(enrichedItems[0]) : {}
+  const firstSnapshotItem = snapshotItems.length ? snapshotItems[0] : {}
+  const itemName = getFirstText(firstItem, ['itemName', 'name', 'title'])
+    || getFirstText(firstSnapshotItem, ['itemName', 'name', 'title'])
+    || getFirstText(metadata, ['itemName'])
+  const productName = getFirstText(firstItem, ['productName'])
+    || getFirstText(firstSnapshotItem, ['productName'])
+    || getFirstText(metadata, ['productName'])
+  const serviceName = getFirstText(firstItem, ['serviceName'])
+    || getFirstText(firstSnapshotItem, ['serviceName'])
+    || getFirstText(metadata, ['serviceName'])
+
+  return { enrichedItems, itemName, productName, serviceName }
+}
 function getTransactionChargeMinor(body: CheckoutBody) {
   const split = body.splitPayment && typeof body.splitPayment === 'object' ? body.splitPayment as Record<string, unknown> : {}
   const value = numberValue(split.transactionChargeMinor ?? split.transaction_charge ?? split.transactionCharge)
@@ -642,6 +697,7 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
 
     const paystack = await initializePaystack(paystackPayload)
     const authorizationUrl = paystack.data?.authorization_url ?? null
+    const { enrichedItems, itemName, productName, serviceName } = enrichCheckoutItems(body)
     const now = admin.firestore.FieldValue.serverTimestamp()
     const record = {
       storeId,
@@ -656,7 +712,11 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       amount: amountMajor,
       amountMinor: Math.round(amountMajor * 100),
       currency,
-      items: Array.isArray(body.items) ? body.items : [],
+      itemName: itemName || null,
+      productName: productName || null,
+      serviceName: serviceName || null,
+      data: { itemName: itemName || null, productName: productName || null, serviceName: serviceName || null },
+      items: enrichedItems,
       pricingSnapshot: body.pricing_snapshot ?? null,
       marketplaceFees: body.marketplace_fees ?? null,
       paymentProvider: 'paystack',

--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -202,7 +202,33 @@ function isSettled(value: unknown) { const normalized = text(value, 80).toLowerC
 function hasAlreadySettled(before: Record<string, unknown> | null) { if (!before) return false; return isSettled(before.paymentStatus) || isSettled(before.payment_status) || isSettled(before.orderStatus) || isSettled(before.order_status) || isSettled(before.status) }
 function paymentFromOrder(data: Record<string, unknown>): PaymentInfo { return { status: text(data.paymentStatus ?? data.payment_status ?? data.orderStatus ?? data.order_status ?? data.status, 80) || null, amount: numberValue(data.amountPaid ?? data.amount), currency: text(data.currency, 20) || 'GHS', method: text(data.paymentCollectionMode ?? data.paymentMethod ?? data.sourceChannel, 80) || null, reference: text(data.paymentReference ?? data.payment_reference ?? data.paystackReference ?? data.reference, 220) || null } }
 function customerFromRecord(data: Record<string, unknown>): CustomerInfo { const customer = getNestedRecord(data, 'customer'); const person = getNestedRecord(data, 'person'); return { name: text(customer.name ?? person.name ?? data.customerName ?? data.name, 160) || null, email: email(customer.email ?? person.email ?? data.customerEmail ?? data.email) || null, phone: text(customer.phone ?? person.phone ?? data.customerPhone ?? data.phone, 80) || null } }
-function orderData(data: Record<string, unknown>) { const firstItem = Array.isArray(data.items) && data.items.length ? getRecord(data.items[0]) : {}; const nestedData = getNestedRecord(data, 'data'); return { itemName: getFirstText(firstItem, ['name', 'title', 'serviceName', 'productName'], 220) || getFirstText(nestedData, ['itemName', 'serviceName', 'course'], 220) || getFirstText(data, ['itemName', 'serviceName', 'productName', 'sourceLabel'], 220), notes: getFirstText(nestedData, ['notes', 'message'], 1000) || getFirstText(data, ['notes'], 1000) } }
+function isGenericSourceLabel(value: string) {
+  const normalized = value.toLowerCase().trim().replace(/\s+/g, ' ')
+  return ['sedifex checkout', 'sedifex market', 'checkout', 'marketplace checkout'].includes(normalized)
+}
+
+function orderData(data: Record<string, unknown>) {
+  const firstItem = Array.isArray(data.items) && data.items.length ? getRecord(data.items[0]) : {}
+  const pricingSnapshot = getNestedRecord(data, 'pricingSnapshot')
+  const pricingSnapshotLegacy = getNestedRecord(data, 'pricing_snapshot')
+  const snapshotItem = Array.isArray(pricingSnapshot.items) && pricingSnapshot.items.length ? getRecord(pricingSnapshot.items[0]) : {}
+  const snapshotLegacyItem = Array.isArray(pricingSnapshotLegacy.items) && pricingSnapshotLegacy.items.length ? getRecord(pricingSnapshotLegacy.items[0]) : {}
+  const nestedData = getNestedRecord(data, 'data')
+  const directName = getFirstText(firstItem, ['name', 'title', 'serviceName', 'productName', 'itemName'], 220)
+    || getFirstText(snapshotItem, ['name', 'title', 'serviceName', 'productName', 'itemName'], 220)
+    || getFirstText(snapshotLegacyItem, ['name', 'title', 'serviceName', 'productName', 'itemName'], 220)
+    || getFirstText(data, ['itemName', 'serviceName', 'productName'], 220)
+    || getFirstText(nestedData, ['itemName', 'serviceName', 'productName', 'course'], 220)
+
+  const sourceLabel = getFirstText(data, ['sourceLabel', 'source_label'], 220)
+  const sourceFallback = sourceLabel && !isGenericSourceLabel(sourceLabel) ? sourceLabel : ''
+  const finalFallback = getFirstText(data, ['serviceName'], 220) ? 'your service' : 'your item'
+
+  return {
+    itemName: directName || sourceFallback || finalFallback,
+    notes: getFirstText(nestedData, ['notes', 'message'], 1000) || getFirstText(data, ['notes'], 1000),
+  }
+}
 
 export const notifyIntegrationOrderStatus = functions.firestore.document('integrationOrders/{reference}').onWrite(async (change, context) => {
   if (!change.after.exists) return


### PR DESCRIPTION
### Motivation
- Customer receipts were showing generic labels like `Sedifex checkout` because integration checkout payloads often only carried minimal item data and the stored order records did not merge preview names from `pricing_snapshot.items`.
- The notification pipeline read `sourceLabel` as a last-resort item name, which caused the wrong label to appear on receipts instead of the real product or service name.
- The goal is to ensure receipts show the real item/service name (from `items`, `pricing_snapshot.items`, or metadata) and to avoid using generic `sourceLabel` values as the item name.

### Description
- Added helper functions `getRecord`, `getFirstText`, `getSnapshotItems`, and `enrichCheckoutItems` in `functions/src/integrationCheckout.ts` to merge names from `body.items`, `pricing_snapshot.items`, and `metadata` when creating orders.
- Updated `integrationCheckoutCreate` to persist enriched items and explicit name fields by saving `itemName`, `productName`, `serviceName`, `data: { itemName, productName, serviceName }`, and `items` (enriched) on the created `integrationOrders` documents.
- Improved `orderData` in `functions/src/notifications.ts` to prefer names in this order: `items[0]`, `pricingSnapshot.items[0]`, legacy `pricing_snapshot.items[0]`, then top-level/nested `data`; added `isGenericSourceLabel` filtering so `sourceLabel` values like `Sedifex checkout` or `Sedifex Market` are not used as item names and final fallbacks use `your item` or `your service`.
- These changes provide backfill/compatibility for existing orders that have `pricingSnapshot.items` names so notification emails will surface the correct name even for older records.

### Testing
- Ran the TypeScript build with `npm --prefix functions run build`, which completed successfully and produced no compilation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b3839f88883218878c9d19759f04f)