### PR TITLE
Expose Product photos upload UI in Add/Edit item forms

### DIFF
--- a/web/src/pages/Products.css
+++ b/web/src/pages/Products.css
@@ -612,6 +612,57 @@
   margin-top: 8px;
 }
 
+.products-page__photo-section {
+  border: 1px solid #dbe3ef;
+  border-radius: 12px;
+  padding: 14px;
+  background: #f8fbff;
+}
+
+.products-page__photo-section h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+}
+
+.products-page__photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+  margin: 10px 0 12px;
+}
+
+.products-page__photo-preview {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  background: #fff;
+  padding: 8px;
+}
+
+.products-page__photo-preview img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 8px;
+  display: block;
+}
+
+.products-page__photo-preview p {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #4b5563;
+}
+
+.products-page__photo-placeholder {
+  border: 1px dashed #94a3b8;
+  border-radius: 10px;
+  background: #fff;
+  min-height: 84px;
+  display: grid;
+  place-items: center;
+  color: #64748b;
+  font-size: 13px;
+}
+
 .products-page__upload-error {
   color: #b91c1c;
   font-size: 14px;

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -653,6 +653,14 @@ export default function Products() {
     [activeStoreId, products, workspaceName],
   )
 
+  const addPhotoPreviewUrls = useMemo(
+    () =>
+      [imageUrlInput, imageUrlInput2, imageUrlInput3]
+        .map(url => normalizeImageUrl(url))
+        .filter((url): url is string => Boolean(url)),
+    [imageUrlInput, imageUrlInput2, imageUrlInput3],
+  )
+
   /**
    * Load products for the active store
    */
@@ -1892,6 +1900,127 @@ export default function Products() {
               />
             </div>
 
+            <section className="products-page__photo-section" aria-label="Product photos">
+              <h3>Product photos</h3>
+              <p className="field__hint">
+                Upload up to 3 images. The first image is used as the main product photo.
+              </p>
+
+              <div className="products-page__photo-grid">
+                {addPhotoPreviewUrls.length ? (
+                  addPhotoPreviewUrls.map((url, index) => (
+                    <article key={`${url}-${index}`} className="products-page__photo-preview">
+                      <img src={url} alt={index === 0 ? 'Main image preview' : `Image ${index + 1} preview`} />
+                      <p>{index === 0 ? 'Main image' : `Image ${index + 1}`}</p>
+                    </article>
+                  ))
+                ) : (
+                  <article className="products-page__photo-placeholder">No image yet</article>
+                )}
+              </div>
+
+              <div className="field">
+                <label className="field__label" htmlFor="add-image-file">
+                  Upload image <span className="field__optional">(optional)</span>
+                </label>
+                <input
+                  id="add-image-file"
+                  type="file"
+                  accept="image/*"
+                  onChange={event => {
+                    const file = event.target.files?.[0] ?? null
+                    setImageFileInput(file)
+                    setImageUploadError(null)
+                  }}
+                />
+                <div className="products-page__upload-actions">
+                  <button
+                    type="button"
+                    className="button button--secondary"
+                    disabled={!imageFileInput || isUploadingImage}
+                    onClick={() => {
+                      void handleImageUpload()
+                    }}
+                  >
+                    {isUploadingImage ? 'Uploading…' : 'Upload and use URL'}
+                  </button>
+                  {imageUploadError ? (
+                    <p className="products-page__upload-error">{imageUploadError}</p>
+                  ) : null}
+                </div>
+                <p className="field__hint">
+                  Uploads to your backend and auto-fills the next empty image URL slot (up to 3).
+                </p>
+              </div>
+
+              <div className="field">
+                <label className="field__label" htmlFor="add-image-url">
+                  Image URL 1 <span className="field__optional">(optional)</span>
+                </label>
+                <div className="products-page__field-inline">
+                  <input
+                    id="add-image-url"
+                    type="url"
+                    placeholder="https://example.com/product-image.jpg"
+                    value={imageUrlInput}
+                    onChange={e => setImageUrlInput(e.target.value)}
+                  />
+                  <button type="button" className="button button--ghost" onClick={() => setImageUrlInput('')}>
+                    Clear
+                  </button>
+                </div>
+              </div>
+
+              <div className="field">
+                <label className="field__label" htmlFor="add-image-url-2">
+                  Image URL 2 <span className="field__optional">(optional)</span>
+                </label>
+                <div className="products-page__field-inline">
+                  <input
+                    id="add-image-url-2"
+                    type="url"
+                    placeholder="https://example.com/product-image-side.jpg"
+                    value={imageUrlInput2}
+                    onChange={e => setImageUrlInput2(e.target.value)}
+                  />
+                  <button type="button" className="button button--ghost" onClick={() => setImageUrlInput2('')}>
+                    Clear
+                  </button>
+                </div>
+              </div>
+
+              <div className="field">
+                <label className="field__label" htmlFor="add-image-url-3">
+                  Image URL 3 <span className="field__optional">(optional)</span>
+                </label>
+                <div className="products-page__field-inline">
+                  <input
+                    id="add-image-url-3"
+                    type="url"
+                    placeholder="https://example.com/product-image-back.jpg"
+                    value={imageUrlInput3}
+                    onChange={e => setImageUrlInput3(e.target.value)}
+                  />
+                  <button type="button" className="button button--ghost" onClick={() => setImageUrlInput3('')}>
+                    Clear
+                  </button>
+                </div>
+              </div>
+
+              <div className="field">
+                <label className="field__label" htmlFor="add-image-alt">
+                  Image alt text <span className="field__optional">(optional)</span>
+                </label>
+                <input
+                  id="add-image-alt"
+                  type="text"
+                  value={imageAltInput}
+                  onChange={e => setImageAltInput(e.target.value)}
+                />
+                <p className="field__hint">Defaults to the item name when left empty.</p>
+              </div>
+            </section>
+
             <details className="products-page__optional-expander">
               <summary>Optional item details</summary>
 
@@ -1994,108 +2123,6 @@ export default function Products() {
                   </label>
                 </>
               )}
-
-              <div className="field">
-                <label className="field__label" htmlFor="add-image-file">
-                  Upload image <span className="field__optional">(optional)</span>
-                </label>
-                <input
-                  id="add-image-file"
-                  type="file"
-                  accept="image/*"
-                  onChange={event => {
-                    const file = event.target.files?.[0] ?? null
-                    setImageFileInput(file)
-                    setImageUploadError(null)
-                  }}
-                />
-                <div className="products-page__upload-actions">
-                  <button
-                    type="button"
-                    className="button button--secondary"
-                    disabled={!imageFileInput || isUploadingImage}
-                    onClick={() => {
-                      void handleImageUpload()
-                    }}
-                  >
-                    {isUploadingImage ? 'Uploading…' : 'Upload and use URL'}
-                  </button>
-                  {imageUploadError ? (
-                    <p className="products-page__upload-error">{imageUploadError}</p>
-                  ) : null}
-                </div>
-                <p className="field__hint">
-                  Uploads to your backend and auto-fills the next empty image URL slot (up to 3).
-                </p>
-              </div>
-
-              <div className="field">
-                <label className="field__label" htmlFor="add-image-url">
-                  Image URL 1 <span className="field__optional">(optional)</span>
-                </label>
-                <div className="products-page__field-inline">
-                  <input
-                    id="add-image-url"
-                    type="url"
-                    placeholder="https://example.com/product-image.jpg"
-                    value={imageUrlInput}
-                    onChange={e => setImageUrlInput(e.target.value)}
-                  />
-                  <button type="button" className="button button--ghost" onClick={() => setImageUrlInput('')}>
-                    Clear
-                  </button>
-                </div>
-              </div>
-
-              <div className="field">
-                <label className="field__label" htmlFor="add-image-url-2">
-                  Image URL 2 <span className="field__optional">(optional)</span>
-                </label>
-                <div className="products-page__field-inline">
-                  <input
-                    id="add-image-url-2"
-                    type="url"
-                    placeholder="https://example.com/product-image-side.jpg"
-                    value={imageUrlInput2}
-                    onChange={e => setImageUrlInput2(e.target.value)}
-                  />
-                  <button type="button" className="button button--ghost" onClick={() => setImageUrlInput2('')}>
-                    Clear
-                  </button>
-                </div>
-              </div>
-
-              <div className="field">
-                <label className="field__label" htmlFor="add-image-url-3">
-                  Image URL 3 <span className="field__optional">(optional)</span>
-                </label>
-                <div className="products-page__field-inline">
-                  <input
-                    id="add-image-url-3"
-                    type="url"
-                    placeholder="https://example.com/product-image-back.jpg"
-                    value={imageUrlInput3}
-                    onChange={e => setImageUrlInput3(e.target.value)}
-                  />
-                  <button type="button" className="button button--ghost" onClick={() => setImageUrlInput3('')}>
-                    Clear
-                  </button>
-                </div>
-                <p className="field__hint">Add up to 3 photos for website galleries.</p>
-              </div>
-
-              <div className="field">
-                <label className="field__label" htmlFor="add-image-alt">
-                  Image alt text <span className="field__optional">(optional)</span>
-                </label>
-                <input
-                  id="add-image-alt"
-                  type="text"
-                  value={imageAltInput}
-                  onChange={e => setImageAltInput(e.target.value)}
-                />
-                <p className="field__hint">Defaults to the item name when left empty.</p>
-              </div>
             </details>
 
             <button
@@ -2353,10 +2380,27 @@ export default function Products() {
                         </div>
                       )}
 
-                      <div className="products-page__list-field">
-                        <label className="field__label">Image URLs</label>
+                      <div className="products-page__list-field products-page__photo-section">
+                        <label className="field__label">Product photos</label>
                         {isEditing ? (
                           <>
+                            <div className="products-page__photo-grid">
+                              {([editImageUrlInput, editImageUrlInput2, editImageUrlInput3]
+                                .map(url => normalizeImageUrl(url))
+                                .filter((url): url is string => Boolean(url)).length ? (
+                                [editImageUrlInput, editImageUrlInput2, editImageUrlInput3]
+                                  .map(url => normalizeImageUrl(url))
+                                  .filter((url): url is string => Boolean(url))
+                                  .map((url, index) => (
+                                    <article key={`${url}-${index}`} className="products-page__photo-preview">
+                                      <img src={url} alt={index === 0 ? 'Main image preview' : `Image ${index + 1} preview`} />
+                                      <p>{index === 0 ? 'Main image' : `Image ${index + 1}`}</p>
+                                    </article>
+                                  ))
+                              ) : (
+                                <article className="products-page__photo-placeholder">No image yet</article>
+                              ))}
+                            </div>
                             <div className="products-page__upload-actions">
                               <input
                                 type="file"
@@ -2372,12 +2416,15 @@ export default function Products() {
                                 onClick={() => void handleEditImageUpload(product)}
                                 disabled={isUploadingEditImage}
                               >
-                                {isUploadingEditImage ? 'Uploading…' : 'Upload image'}
+                                {isUploadingEditImage ? 'Uploading…' : 'Upload and use URL'}
                               </button>
                             </div>
                             {editImageUploadError ? (
                               <p className="products-page__upload-error">{editImageUploadError}</p>
                             ) : null}
+                            <p className="field__hint">
+                              Upload up to 3 images. The first image is used as the main product photo.
+                            </p>
                             <input
                               type="url"
                               value={editImageUrlInput}


### PR DESCRIPTION
### Motivation
- The image upload controls were hidden inside "Optional item details" or buried in edit details, making uploads hard to find; the goal is to make product photo upload and URL fields clearly visible when adding or editing items.

### Description
- Added a visible "Product photos" section to the add-item form (placed above the optional details) with upload input, "Upload and use URL" button, Image URL 1/2/3, alt text, clear buttons, upload error display and helper text; the UI uses the existing upload handlers.  
- Added preview grid on the add form that shows thumbnails for any filled `imageUrlInput`/`imageUrlInput2`/`imageUrlInput3`, labeling the first thumbnail as "Main image" and showing a "No image yet" placeholder when empty.  
- Made edit-item image controls prominent inside the expanded edit area by adding a "Product photos" area with current previews, file input + upload button, URL inputs with clear buttons, alt text input, upload error feedback and helper text.  
- Implemented UI styling and layout in `web/src/pages/Products.css` and updated `web/src/pages/Products.tsx`; preserved existing functions/behavior (`handleImageUpload`, `handleEditImageUpload`, `uploadProductImage`, `buildProductImagePath`, and image URL slot logic).

### Testing
- Attempted to run lint with `npm --prefix web run lint`, but it failed due to a missing ESLint dependency (`@eslint/js`), so linting could not complete.  
- No automated unit tests were executed; changes were committed after local manual verification of code edits and JSX structure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4361615c832188aa79e80c500f0e)