### PR TITLE
Add automatic public catalog sync when store eligibility changes

### DIFF
--- a/functions/scripts/backfillPublicProducts.js
+++ b/functions/scripts/backfillPublicProducts.js
@@ -89,8 +89,6 @@ function pickStoreCity(storeData) {
 
 function buildStorePublicMeta(storeData) {
   const promoSlug = toTrimmedStringOrNull(storeData.promoSlug)
-  const publication = normalizePublicationFields(data, { fallbackCreatedAt: existingDocData?.createdAt, fallbackUpdatedAt: existingDocData?.updatedAt })
-
   return {
     storeName: toTrimmedStringOrNull(storeData.displayName) || toTrimmedStringOrNull(storeData.name),
     storeCity: pickStoreCity(storeData),
@@ -209,8 +207,6 @@ function toPublicProduct(productDoc, storeMetaByStoreId, existingDocData = null)
   }
 
   const category = normalizeCategory(data.category)
-
-  const publication = normalizePublicationFields(data, { fallbackCreatedAt: existingDocData?.createdAt, fallbackUpdatedAt: existingDocData?.updatedAt })
 
   return {
     sourceProductId: productDoc.id,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -39,6 +39,7 @@ export {
 } from './googleAds'
 export * from './googleShopping'
 export * from './reporting'
+export * from './publicCatalogSync'
 
 /**
  * SINGLE FIRESTORE INSTANCE

--- a/functions/src/publicCatalogSync.ts
+++ b/functions/src/publicCatalogSync.ts
@@ -1,0 +1,253 @@
+import * as functions from 'firebase-functions/v1'
+import { admin, defaultDb as db } from './firestore'
+import { resolvePublicationTimestampCandidate } from './catalogPublication'
+
+type StoreData = Record<string, unknown>
+type ProductData = Record<string, unknown>
+
+function text(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+function toArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const out: string[] = []
+  for (const v of value) {
+    const t = text(v)
+    if (t) out.push(t)
+  }
+  return [...new Set(out)]
+}
+
+function isStoreEligible(store: StoreData | undefined): boolean {
+  if (!store) return false
+  return (
+    store.verified === true &&
+    store.eligibleForBuy === true &&
+    store.buyOptOut !== true &&
+    store.status === 'active'
+  )
+}
+
+function buildStoreMeta(store: StoreData): Record<string, unknown> {
+  return {
+    storeName: text(store.displayName) ?? text(store.name),
+    storeCity: text(store.city) ?? text(store.town),
+    storePhone: text(store.phone) ?? text(store.phoneNumber) ?? text(store.contactPhone),
+    websiteLink: text(store.websiteLink) ?? text(store.promoWebsiteUrl),
+  }
+}
+
+function publicPayload(productId: string, data: ProductData, storeMeta: Record<string, unknown>): Record<string, unknown> {
+  return {
+    sourceProductId: productId,
+    storeId: text(data.storeId),
+    ...storeMeta,
+    name: text(data.name),
+    description: text(data.description),
+    category: text(data.category),
+    price: typeof data.price === 'number' ? data.price : null,
+    imageUrl: text(data.imageUrl),
+    imageUrls: toArray(data.imageUrls),
+    imageAlt: text(data.imageAlt),
+    itemType: data.itemType === 'service' ? 'service' : 'product',
+    isPublished: true,
+    publishedAt: resolvePublicationTimestampCandidate(data.publishedAt, data.createdAt, data.updatedAt),
+    unpublishedAt: admin.firestore.FieldValue.delete(),
+    sourceUpdatedAt: data.updatedAt ?? null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }
+}
+
+async function flush(batch: FirebaseFirestore.WriteBatch, count: number): Promise<void> {
+  if (count > 0) await batch.commit()
+}
+
+export async function removeStorePublicCatalog(storeId: string): Promise<void> {
+  const [publicProducts, publicServices] = await Promise.all([
+    db.collection('publicProducts').where('storeId', '==', storeId).get(),
+    db.collection('publicServices').where('storeId', '==', storeId).get(),
+  ])
+
+  let batch = db.batch()
+  let writes = 0
+  let removed = 0
+
+  for (const doc of [...publicProducts.docs, ...publicServices.docs]) {
+    batch.delete(doc.ref)
+    writes += 1
+    removed += 1
+    if (writes >= 450) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+  await flush(batch, writes)
+
+  await db.collection('stores').doc(storeId).set(
+    {
+      publicCatalogLastSyncedAt: admin.firestore.FieldValue.serverTimestamp(),
+      publicCatalogDocCount: { products: 0, services: 0 },
+    },
+    { merge: true },
+  )
+
+  functions.logger.info('removeStorePublicCatalog complete', { storeId, publicDocsRemoved: removed })
+}
+
+export async function syncStorePublicCatalog(storeId: string): Promise<void> {
+  const storeRef = db.collection('stores').doc(storeId)
+  const storeSnap = await storeRef.get()
+  const storeData = (storeSnap.data() ?? {}) as StoreData
+  const eligible = isStoreEligible(storeData)
+
+  if (!eligible) {
+    await removeStorePublicCatalog(storeId)
+    return
+  }
+
+  const storeMeta = buildStoreMeta(storeData)
+  const productsSnap = await db.collection('products').where('storeId', '==', storeId).where('isPublished', '==', true).get()
+
+  let batch = db.batch()
+  let writes = 0
+  let writtenProducts = 0
+  let writtenServices = 0
+  let removed = 0
+
+  for (const productDoc of productsSnap.docs) {
+    const data = (productDoc.data() ?? {}) as ProductData
+    const itemType = data.itemType === 'service' ? 'service' : 'product'
+    const targetCollection = itemType === 'service' ? 'publicServices' : 'publicProducts'
+    const oppositeCollection = itemType === 'service' ? 'publicProducts' : 'publicServices'
+    const payload = publicPayload(productDoc.id, data, storeMeta)
+
+    batch.set(db.collection(targetCollection).doc(productDoc.id), payload, { merge: true })
+    batch.delete(db.collection(oppositeCollection).doc(productDoc.id))
+    writes += 2
+    removed += 1
+
+    if (itemType === 'service') writtenServices += 1
+    else writtenProducts += 1
+
+    if (writes >= 450) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+
+  await flush(batch, writes)
+
+  await storeRef.set(
+    {
+      publicCatalogLastSyncedAt: admin.firestore.FieldValue.serverTimestamp(),
+      publicCatalogDocCount: {
+        products: writtenProducts,
+        services: writtenServices,
+      },
+      publicCatalogOutOfSyncCount: 0,
+    },
+    { merge: true },
+  )
+
+  functions.logger.info('syncStorePublicCatalog complete', {
+    storeId,
+    productsScanned: productsSnap.size,
+    publicProductsWritten: writtenProducts,
+    publicServicesWritten: writtenServices,
+    publicDocsRemoved: removed,
+  })
+}
+
+export const syncPublicCatalogOnStoreEligibilityUpdate = functions.firestore
+  .document('stores/{storeId}')
+  .onUpdate(async (change, context) => {
+    const before = (change.before.data() ?? {}) as StoreData
+    const after = (change.after.data() ?? {}) as StoreData
+    const storeId = String(context.params.storeId || '')
+
+    const watched: Array<keyof StoreData> = [
+      'verified',
+      'verified_product',
+      'eligibleForBuy',
+      'buyOptOut',
+      'status',
+      'paymentStatus',
+      'contractStatus',
+    ]
+
+    const changed = watched.some((field) => before[field] !== after[field])
+    if (!changed) return
+
+    const beforeEligible = isStoreEligible(before)
+    const afterEligible = isStoreEligible(after)
+
+    functions.logger.info('store eligibility changed', { storeId, beforeEligible, afterEligible })
+
+    if (afterEligible) {
+      await syncStorePublicCatalog(storeId)
+      return
+    }
+
+    if (beforeEligible && !afterEligible) {
+      await removeStorePublicCatalog(storeId)
+    }
+  })
+
+export const syncPublicCatalogOnProductWrite = functions.firestore
+  .document('products/{productId}')
+  .onWrite(async (change, context) => {
+    const productId = String(context.params.productId || '')
+    const afterExists = change.after.exists
+
+    if (!afterExists) {
+      await Promise.all([
+        db.collection('publicProducts').doc(productId).delete(),
+        db.collection('publicServices').doc(productId).delete(),
+      ])
+      functions.logger.info('product removed from public catalog', { productId })
+      return
+    }
+
+    const afterData = (change.after.data() ?? {}) as ProductData
+    const storeId = text(afterData.storeId)
+    if (!storeId || afterData.isPublished !== true) {
+      await Promise.all([
+        db.collection('publicProducts').doc(productId).delete(),
+        db.collection('publicServices').doc(productId).delete(),
+      ])
+      return
+    }
+
+    const storeSnap = await db.collection('stores').doc(storeId).get()
+    const storeData = (storeSnap.data() ?? {}) as StoreData
+    if (!isStoreEligible(storeData)) {
+      await Promise.all([
+        db.collection('publicProducts').doc(productId).delete(),
+        db.collection('publicServices').doc(productId).delete(),
+      ])
+      return
+    }
+
+    const payload = publicPayload(productId, afterData, buildStoreMeta(storeData))
+    const isService = afterData.itemType === 'service'
+    const target = isService ? 'publicServices' : 'publicProducts'
+    const opposite = isService ? 'publicProducts' : 'publicServices'
+
+    await Promise.all([
+      db.collection(target).doc(productId).set(payload, { merge: true }),
+      db.collection(opposite).doc(productId).delete(),
+    ])
+
+    functions.logger.info('product synced to public catalog', {
+      storeId,
+      productId,
+      publicProductsWritten: isService ? 0 : 1,
+      publicServicesWritten: isService ? 1 : 0,
+      publicDocsRemoved: 1,
+    })
+  })


### PR DESCRIPTION
### Motivation
- Ensure published products/services from a store appear on the public market automatically when the store becomes verified/marketplace-eligible without manual backfill.
- Ensure products/services are removed automatically when a store becomes ineligible or opts out.
- Provide a reusable helper so both store-level and product-level triggers can keep public catalog collections consistent.

### Description
- Added a new helper module `functions/src/publicCatalogSync.ts` exporting `syncStorePublicCatalog(storeId)` and `removeStorePublicCatalog(storeId)` that syncs/removes a store's published products into `publicProducts`/`publicServices` with required metadata and counters.
- Implemented a Firestore trigger `stores/{storeId}` update that watches `verified`, `verified_product`, `eligibleForBuy`, `buyOptOut`, `status`, `paymentStatus`, and `contractStatus`, and calls the sync or remove helper on eligibility transitions.
- Implemented a Firestore trigger `products/{productId}` onWrite that syncs a single published product into the appropriate public collection if its store is eligible, or deletes it from both public collections on unpublish/delete/ineligible store.
- Updated the Functions entrypoint to export the new module and added structured logging (storeId, eligibility before/after, products scanned, public docs written/removed) and updates `stores/{storeId}` with `publicCatalogLastSyncedAt`, `publicCatalogDocCount`, and `publicCatalogOutOfSyncCount`.
- Fixed a bug in `functions/scripts/backfillPublicProducts.js` by removing an invalid reference line that used undefined variables inside `buildStorePublicMeta`, preserving the manual backfill/reconcile script.

### Testing
- Ran TypeScript build for functions with `npm --prefix functions run build`, which completed successfully.  
- Verified the Functions entrypoint now exports the new sync module and lint/compile steps pass during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5008d9fc832186fa9111b6832df3)