### PR TITLE
Remove invoice tab from Sell page

### DIFF
--- a/web/src/pages/Sell.test.tsx
+++ b/web/src/pages/Sell.test.tsx
@@ -196,6 +196,18 @@ describe('Sell page', () => {
     onSnapshotMock.mockClear()
   })
 
+  it('does not show the invoice page in the sell workspace tabs', async () => {
+    renderWithProviders(<Sell />)
+
+    await screen.findByRole('link', { name: /^sell$/i })
+
+    expect(screen.getByRole('link', { name: /close day/i })).toHaveAttribute(
+      'href',
+      '/sell/close-day',
+    )
+    expect(screen.queryByRole('link', { name: /invoice/i })).not.toBeInTheDocument()
+  })
+
   it('records a cash sale and shows a success message', async () => {
     const user = userEvent.setup()
 

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -1745,9 +1745,6 @@ export default function Sell() {
         <Link to="/sell/close-day" className="sell-page__workspace-tab">
           Close day
         </Link>
-        <Link to="/sell/invoice" className="sell-page__workspace-tab">
-          Invoice
-        </Link>
       </nav>
 
       {reachedDailySalesLimit && (


### PR DESCRIPTION
### Motivation
- Remove the "Invoice" workspace tab from the Sell page so invoices are not accessible from the Sell workspace.

### Description
- Deleted the `<Link to="/sell/invoice">Invoice</Link>` entry in `web/src/pages/Sell.tsx` and added a regression test in `web/src/pages/Sell.test.tsx` asserting the invoice link is not present while `Close day` remains.

### Testing
- Ran `npm test -- --run web/src/pages/Sell.test.tsx` from the repo root (failed: no root `package.json`).
- Ran `npm test -- --run src/pages/Sell.test.tsx` from `web` (failed: `vitest` not found before installing dependencies).
- Ran `npm ci` in `web` to install dependencies (failed: registry `403` for `@azure/msal-browser`), so unit tests could not be executed in this environment; `git diff --check` passed and the commit was created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8f219a788321a379290b62834085)