### PR TITLE
BookingEditor: load root bookings, normalize nested website payloads, and add booking actions

### DIFF
--- a/web/src/pages/BookingEditor.css
+++ b/web/src/pages/BookingEditor.css
@@ -21,5 +21,7 @@
 .booking-editor-page__actions {
   grid-column: 1 / -1;
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-end;
+  gap: 0.5rem;
 }

--- a/web/src/pages/BookingEditor.tsx
+++ b/web/src/pages/BookingEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { Timestamp, deleteDoc, doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore'
+import { Timestamp, doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import './BookingEditor.css'
@@ -21,6 +21,8 @@ type BookingFormState = {
   paymentAmount: string
   depositAmount: string
   paymentMethod: string
+  paymentReference: string
+  paymentStatus: string
 }
 
 const DEFAULT_FORM: BookingFormState = {
@@ -39,14 +41,67 @@ const DEFAULT_FORM: BookingFormState = {
   paymentAmount: '',
   depositAmount: '',
   paymentMethod: '',
+  paymentReference: '',
+  paymentStatus: 'payment_pending',
 }
 
 function stringValue(value: unknown): string {
   if (typeof value === 'string') return value
   if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  if (value instanceof Date) return value.toISOString()
+  if (value && typeof value === 'object' && typeof (value as Timestamp).toDate === 'function') {
+    return (value as Timestamp).toDate().toISOString()
+  }
   return ''
 }
 
+function recordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+function firstStringValue(...values: unknown[]): string {
+  for (const value of values) {
+    const str = stringValue(value).trim()
+    if (str) return str
+  }
+  return ''
+}
+
+function normalizePaymentStatus(data: Record<string, unknown>, payment: Record<string, unknown>): string {
+  if (payment.confirmed === true) return 'paid'
+  const raw = firstStringValue(data.paymentStatus, data.payment_status, payment.status).toLowerCase()
+  if (!raw) return 'payment_pending'
+  if (['paid', 'confirmed', 'success', 'succeeded', 'complete', 'completed'].includes(raw)) return 'paid'
+  if (['pending', 'payment_pending', 'unpaid'].includes(raw)) return 'payment_pending'
+  return raw
+}
+
+function normalizeBookingForm(data: Record<string, unknown>): BookingFormState {
+  const customer = recordValue(data.customer)
+  const booking = recordValue(data.booking)
+  const payment = recordValue(data.payment)
+  const status = firstStringValue(data.bookingStatus, data.status) || 'confirmed'
+
+  return {
+    fullName: firstStringValue(data.fullName, data.name, data.customerName, customer.name),
+    phone: firstStringValue(data.phone, data.customerPhone, customer.phone),
+    email: firstStringValue(data.email, data.customerEmail, customer.email),
+    serviceName: firstStringValue(data.serviceName, data.internalServiceName, booking.serviceName, data.itemName, data.productName),
+    serviceId: firstStringValue(data.serviceId, booking.serviceId),
+    bookingDate: normalizeDateInput(firstStringValue(data.bookingDate, data.date, booking.preferredDate, booking.date, booking.startAt)),
+    bookingTime: normalizeTimeInput(firstStringValue(data.bookingTime, data.time, booking.preferredTime, booking.time, booking.startAt)),
+    preferredBranch: firstStringValue(data.preferredBranch, data.branchName, data.branch, data.location),
+    preferredContactMethod: firstStringValue(data.preferredContactMethod, data.contactMethod),
+    status,
+    quantity: String(typeof data.quantity === 'number' && Number.isFinite(data.quantity) ? data.quantity : 1),
+    notes: firstStringValue(data.notes),
+    paymentAmount: firstStringValue(data.paymentAmount, data.amount, data.total, data.price, payment.amount),
+    depositAmount: firstStringValue(data.depositAmount, data.depositPaid, data.amountPaid, payment.depositAmount, payment.amountPaid),
+    paymentMethod: firstStringValue(data.paymentMethod, payment.method),
+    paymentReference: firstStringValue(data.paymentReference, data.reference, payment.reference),
+    paymentStatus: normalizePaymentStatus(data, payment),
+  }
+}
 
 function normalizeDateInput(value: unknown): string {
   const raw = stringValue(value).trim()
@@ -101,33 +156,30 @@ export default function BookingEditor() {
       setLoading(true)
       setErrorMessage(null)
       try {
-        const bookingRef = doc(db, 'stores', storeId, 'integrationBookings', bookingId)
-        const snap = await getDoc(bookingRef)
-        if (!snap.exists()) {
+        const storeBookingRef = doc(db, 'stores', storeId, 'integrationBookings', bookingId)
+        const storeSnap = await getDoc(storeBookingRef)
+        let data: Record<string, unknown> | null = null
+
+        if (storeSnap.exists()) {
+          data = storeSnap.data() as Record<string, unknown>
+        } else {
+          const rootBookingRef = doc(db, 'integrationBookings', bookingId)
+          const rootSnap = await getDoc(rootBookingRef)
+          if (rootSnap.exists()) {
+            data = rootSnap.data() as Record<string, unknown>
+            await setDoc(storeBookingRef, { ...data, storeId }, { merge: true })
+          }
+        }
+
+        if (!data) {
           if (!cancelled) {
             setErrorMessage('Booking not found.')
           }
           return
         }
-        const data = snap.data() as Record<string, unknown>
+
         if (cancelled) return
-        setForm({
-          fullName: stringValue(data.fullName || data.name || data.customerName),
-          phone: stringValue(data.phone || data.customerPhone),
-          email: stringValue(data.email || data.customerEmail),
-          serviceName: stringValue(data.serviceName || data.internalServiceName),
-          serviceId: stringValue(data.serviceId),
-          bookingDate: normalizeDateInput(data.bookingDate || data.date),
-          bookingTime: normalizeTimeInput(data.bookingTime || data.time),
-          preferredBranch: stringValue(data.preferredBranch || data.branchName),
-          preferredContactMethod: stringValue(data.preferredContactMethod || data.contactMethod),
-          status: stringValue(data.status) || 'confirmed',
-          quantity: String(typeof data.quantity === 'number' ? data.quantity : 1),
-          notes: stringValue(data.notes),
-          paymentAmount: stringValue(data.paymentAmount || data.amount || data.total || data.price),
-          depositAmount: stringValue(data.depositAmount || data.depositPaid || data.amountPaid),
-          paymentMethod: stringValue(data.paymentMethod),
-        })
+        setForm(normalizeBookingForm(data))
       } catch (error) {
         console.error('[booking-editor] Failed to load booking', error)
         if (!cancelled) {
@@ -187,6 +239,23 @@ export default function BookingEditor() {
           paymentAmount: form.paymentAmount.trim(),
           depositAmount: form.depositAmount.trim(),
           paymentMethod: form.paymentMethod.trim(),
+          paymentReference: form.paymentReference.trim(),
+          reference: form.paymentReference.trim(),
+          paymentStatus: form.paymentStatus.trim() || 'payment_pending',
+          payment: {
+            amount: form.paymentAmount.trim(),
+            depositAmount: form.depositAmount.trim(),
+            method: form.paymentMethod.trim(),
+            reference: form.paymentReference.trim(),
+            status: form.paymentStatus.trim() || 'payment_pending',
+            confirmed: ['paid', 'confirmed'].includes((form.paymentStatus.trim() || '').toLowerCase()),
+          },
+          booking: {
+            serviceId: form.serviceId.trim(),
+            serviceName: form.serviceName.trim(),
+            preferredDate: normalizeDateInput(form.bookingDate),
+            preferredTime: normalizeTimeInput(form.bookingTime),
+          },
           customer: {
             name: form.fullName.trim(),
             phone: form.phone.trim(),
@@ -206,7 +275,7 @@ export default function BookingEditor() {
           cancelledAt: normalizedStatus === 'cancelled' ? now : null,
           completedAt: normalizedStatus === 'completed' ? now : null,
           updatedAt: serverTimestamp(),
-          createdAt: isCreateMode ? serverTimestamp() : undefined,
+          ...(isCreateMode ? { createdAt: serverTimestamp() } : {}),
         }
       await Promise.all([
         setDoc(doc(db, 'stores', storeId, 'integrationBookings', targetId), payload, { merge: true }),
@@ -222,34 +291,76 @@ export default function BookingEditor() {
     }
   }
 
-  async function handleConfirmPayment() {
+  async function updateExistingBooking(payload: Record<string, unknown>, failureMessage: string) {
     if (!storeId || isCreateMode) return
 
     setSaving(true)
     setErrorMessage(null)
     try {
-      const now = Timestamp.now()
-      const payload = {
-          paymentStatus: 'confirmed',
-          paymentConfirmedAt: now,
-          paymentVerifiedAt: now,
-          paymentVerifiedBy: 'staff_admin',
-          syncStatus: 'not_ready',
-          syncRequestedAt: null,
-          updatedAt: serverTimestamp(),
-        }
       await Promise.all([
         setDoc(doc(db, 'stores', storeId, 'integrationBookings', bookingId), payload, { merge: true }),
         setDoc(doc(db, 'integrationBookings', bookingId), payload, { merge: true }),
       ])
-      navigate('/bookings')
+      setForm(prev => ({
+        ...prev,
+        status: typeof payload.status === 'string' ? payload.status : prev.status,
+        paymentStatus: typeof payload.paymentStatus === 'string' ? payload.paymentStatus : prev.paymentStatus,
+      }))
     } catch (error) {
-      console.error('[booking-editor] Failed to confirm payment', error)
-      setErrorMessage('Unable to confirm payment right now.')
+      console.error('[booking-editor] Failed to update booking', error)
+      setErrorMessage(failureMessage)
     } finally {
       setSaving(false)
     }
   }
+
+  function handleConfirmBooking() {
+    const now = Timestamp.now()
+    return updateExistingBooking({
+      bookingStatus: 'confirmed',
+      status: 'confirmed',
+      confirmedAt: now,
+      confirmedBy: 'staff_admin',
+      syncStatus: 'pending',
+      syncReason: 'booking_confirmed',
+      syncRequestedAt: now,
+      updatedAt: serverTimestamp(),
+    }, 'Unable to confirm booking right now.')
+  }
+
+  function handleConfirmPayment() {
+    const now = Timestamp.now()
+    return updateExistingBooking({
+      paymentStatus: 'paid',
+      paymentConfirmedAt: now,
+      paymentVerifiedAt: now,
+      paymentVerifiedBy: 'staff_admin',
+      updatedAt: serverTimestamp(),
+    }, 'Unable to confirm payment right now.')
+  }
+
+  function handleCancelBooking() {
+    const now = Timestamp.now()
+    return updateExistingBooking({
+      bookingStatus: 'cancelled',
+      status: 'cancelled',
+      cancelledAt: now,
+      syncStatus: 'pending',
+      syncReason: 'booking_cancelled',
+      syncRequestedAt: now,
+      updatedAt: serverTimestamp(),
+    }, 'Unable to cancel booking right now.')
+  }
+
+  function handleCompleteBooking() {
+    return updateExistingBooking({
+      bookingStatus: 'completed',
+      status: 'completed',
+      completedAt: Timestamp.now(),
+      updatedAt: serverTimestamp(),
+    }, 'Unable to complete booking right now.')
+  }
+
 
   return (
     <main className="page booking-editor-page">
@@ -285,6 +396,8 @@ export default function BookingEditor() {
             <label>
               <span>Status</span>
               <select value={form.status} onChange={event => setForm(prev => ({ ...prev, status: event.target.value }))}>
+                <option value="pending_approval">Pending approval</option>
+                <option value="pending">Pending</option>
                 <option value="confirmed">Confirmed</option>
                 <option value="rescheduled">Rescheduled</option>
                 <option value="completed">Completed</option>
@@ -295,22 +408,38 @@ export default function BookingEditor() {
             <label><span>Payment amount</span><input value={form.paymentAmount} onChange={event => setForm(prev => ({ ...prev, paymentAmount: event.target.value }))} /></label>
             <label><span>Deposit amount</span><input value={form.depositAmount} onChange={event => setForm(prev => ({ ...prev, depositAmount: event.target.value }))} /></label>
             <label><span>Payment method</span><input value={form.paymentMethod} onChange={event => setForm(prev => ({ ...prev, paymentMethod: event.target.value }))} /></label>
+            <label><span>Payment reference</span><input value={form.paymentReference} onChange={event => setForm(prev => ({ ...prev, paymentReference: event.target.value }))} /></label>
+            <label>
+              <span>Payment status</span>
+              <select value={form.paymentStatus} onChange={event => setForm(prev => ({ ...prev, paymentStatus: event.target.value }))}>
+                <option value="payment_pending">Payment pending</option>
+                <option value="paid">Paid</option>
+                <option value="manual_review">Manual review</option>
+                <option value="refunded">Refunded</option>
+              </select>
+            </label>
             <label className="booking-editor-page__notes"><span>Notes</span><textarea value={form.notes} onChange={event => setForm(prev => ({ ...prev, notes: event.target.value }))} rows={4} /></label>
 
             <div className="booking-editor-page__actions">
+              {!isCreateMode && (
+                <>
+                  <button type="button" className="btn btn-secondary" disabled={saving} onClick={() => void handleConfirmBooking()}>
+                    Confirm booking
+                  </button>
+                  <button type="button" className="btn btn-secondary" disabled={saving} onClick={() => void handleConfirmPayment()}>
+                    Confirm payment / Mark paid
+                  </button>
+                  <button type="button" className="btn btn-secondary" disabled={saving} onClick={() => void handleCancelBooking()}>
+                    Cancel booking
+                  </button>
+                  <button type="button" className="btn btn-secondary" disabled={saving} onClick={() => void handleCompleteBooking()}>
+                    Complete booking
+                  </button>
+                </>
+              )}
               <button type="submit" className="button button--primary" disabled={saving}>
                 {saving ? 'Saving…' : 'Save and sync'}
               </button>
-              {!isCreateMode && (
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  disabled={saving}
-                  onClick={() => void handleConfirmPayment()}
-                >
-                  {saving ? 'Saving…' : 'Confirm payment'}
-                </button>
-              )}
             </div>
           </form>
         )}

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -28,12 +28,14 @@ type BookingRecord = {
   bookingId: string | null
   paymentReference: string | null
   duplicateMerged: boolean
+  sourcePath: 'store' | 'root'
 }
 
 function pickString(data: Record<string, unknown>, keys: string[]): string | null {
   for (const key of keys) {
     const value = data[key]
     if (typeof value === 'string' && value.trim()) return value.trim()
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value)
   }
   return null
 }
@@ -93,10 +95,12 @@ export default function Bookings() {
   const [activeTab, setActiveTab] = useState<'needs_action' | 'today' | 'upcoming' | 'all' | 'cancelled'>('needs_action')
   const [updatingBookingId, setUpdatingBookingId] = useState<string | null>(null)
 
-  const hydrateBooking = useCallback((id: string, data: Record<string, unknown>, serviceMap: Map<string, string>) => {
+  const hydrateBooking = useCallback((id: string, data: Record<string, unknown>, serviceMap: Map<string, string>, sourcePath: 'store' | 'root') => {
     const nestedData = data.data && typeof data.data === 'object' ? (data.data as Record<string, unknown>) : {}
     const customer = data.customer && typeof data.customer === 'object' ? (data.customer as Record<string, unknown>) : {}
-    const serviceId = pickString(data, ['serviceId']) ?? '—'
+    const booking = data.booking && typeof data.booking === 'object' ? (data.booking as Record<string, unknown>) : {}
+    const payment = data.payment && typeof data.payment === 'object' ? (data.payment as Record<string, unknown>) : {}
+    const serviceId = pickString(data, ['serviceId']) ?? pickString(booking, ['serviceId']) ?? '—'
     const snapshotA = data.pricingSnapshot && typeof data.pricingSnapshot === 'object' ? (data.pricingSnapshot as Record<string, unknown>) : {}
     const snapshotB = data.pricing_snapshot && typeof data.pricing_snapshot === 'object' ? (data.pricing_snapshot as Record<string, unknown>) : {}
     const pickSnapshotName = (snapshot: Record<string, unknown>) => {
@@ -106,9 +110,9 @@ export default function Bookings() {
       return typeof first.name === 'string' && first.name.trim() ? first.name.trim() : null
     }
     const serviceName =
-      pickString(data, ['serviceName', 'itemName', 'productName']) ??
+      pickString(data, ['serviceName', 'internalServiceName', 'itemName', 'productName']) ??
+      pickString(booking, ['serviceName']) ??
       pickString(nestedData, ['serviceName', 'itemName']) ??
-      pickString(data, ['booking.serviceName']) ??
       pickSnapshotName(snapshotA) ??
       pickSnapshotName(snapshotB) ??
       serviceMap.get(serviceId) ??
@@ -118,25 +122,26 @@ export default function Bookings() {
       id,
       serviceId,
       serviceName,
-      bookingDate: pickString(data, ['bookingDate', 'date']),
-      bookingTime: pickString(data, ['bookingTime', 'time']),
+      bookingDate: pickString(data, ['bookingDate', 'date']) ?? pickString(booking, ['preferredDate', 'date']),
+      bookingTime: pickString(data, ['bookingTime', 'time']) ?? pickString(booking, ['preferredTime', 'time']),
       preferredBranch: pickString(data, ['preferredBranch', 'branch', 'location']),
-      paymentAmount: pickString(data, ['paymentAmount', 'amount', 'total']),
-      paymentMethod: pickString(data, ['paymentMethod']),
+      paymentAmount: pickString(data, ['paymentAmount', 'amount', 'total', 'price']) ?? pickString(payment, ['amount']),
+      paymentMethod: pickString(data, ['paymentMethod']) ?? pickString(payment, ['method']),
       bookingStatus: normalizeStatus(data.bookingStatus ?? data.status),
       status: normalizeStatus(data.status),
       syncStatus: normalizeStatus(data.syncStatus ?? data.sync_status, 'not_ready'),
-      paymentStatus: normalizePaymentStatus(data.paymentStatus),
+      paymentStatus: payment.confirmed === true ? 'paid' : normalizePaymentStatus(data.paymentStatus ?? data.payment_status ?? payment.status),
       customerName: pickString(data, ['customerName', 'name']) ?? pickString(customer, ['name']),
       customerPhone: pickString(data, ['customerPhone', 'phone']) ?? pickString(customer, ['phone']),
       customerEmail: pickString(data, ['customerEmail', 'email']) ?? pickString(customer, ['email']),
       createdAt: pickTimestamp(data, ['createdAt', 'createdAtServer', 'updatedAt', 'syncRequestedAt']),
       updatedAt: pickTimestamp(data, ['updatedAt']),
       sourceLabel: normalizeSource(data.sourceChannel ?? data.source_channel ?? data.source ?? data.channel),
-      reference: pickString(data, ['reference']),
+      reference: pickString(data, ['reference']) ?? pickString(payment, ['reference']),
       bookingId: pickString(data, ['bookingId']),
-      paymentReference: pickString(data, ['paymentReference']),
+      paymentReference: pickString(data, ['paymentReference']) ?? pickString(payment, ['reference']),
       duplicateMerged: false,
+      sourcePath,
     } satisfies BookingRecord
   }, [])
 
@@ -166,11 +171,11 @@ export default function Bookings() {
         `${(b.customerPhone || b.customerEmail || 'unknown').toLowerCase()}|${b.serviceId}|${b.bookingDate || ''}|${b.bookingTime || ''}`
 
       storeSnapshot.forEach(docSnap => {
-        const booking = hydrateBooking(docSnap.id, docSnap.data() as Record<string, unknown>, serviceMap)
+        const booking = hydrateBooking(docSnap.id, docSnap.data() as Record<string, unknown>, serviceMap, 'store')
         merged.set(makeKey(booking), booking)
       })
       rootSnapshot.forEach(docSnap => {
-        const booking = hydrateBooking(docSnap.id, docSnap.data() as Record<string, unknown>, serviceMap)
+        const booking = hydrateBooking(docSnap.id, docSnap.data() as Record<string, unknown>, serviceMap, 'root')
         const key = makeKey(booking)
         if (merged.has(key)) {
           const kept = merged.get(key)
@@ -257,7 +262,7 @@ export default function Bookings() {
 
     {loading ? <p>Loading bookings…</p> : errorMessage ? <p className="form__error">{errorMessage}</p> : <div className="bookings-table-wrap"><table className="table bookings-table"><thead><tr><th>Booking</th><th>Customer</th><th>Schedule</th><th>Source</th><th>Payment</th><th>Status</th><th>Actions</th></tr></thead><tbody>{visible.map(b => {
       const acts = actionsFor(b)
-      return <tr key={b.id}><td><strong>{b.serviceName}</strong><small>{b.reference || b.bookingId || 'No reference'}</small>{b.serviceName === 'Service not named' ? <small className="muted">Service ID: {b.serviceId}</small> : null}{b.duplicateMerged ? <span className="bookings-badge">Duplicate records merged</span> : null}</td><td><strong>{b.customerName || 'Customer'}</strong><small>{b.customerPhone || b.customerEmail || 'No contact'}</small></td><td><strong>{b.bookingDate || 'Date not set'}</strong><small>{b.bookingTime || 'Time not set'}</small><small>{b.preferredBranch || 'Main branch'}</small></td><td><span className="bookings-badge">{b.sourceLabel}</span></td><td><strong>{b.paymentAmount || '—'}</strong><small>{paymentLabel(b.paymentStatus)}</small><small>{b.paymentMethod || 'Method not set'}</small></td><td><span className={`bookings-page__status bookings-page__status--${b.bookingStatus}`}>{statusLabel(b.bookingStatus)}</span><small>{b.paymentStatus === 'paid' && b.bookingStatus !== 'confirmed' ? 'Paid - waiting for store confirmation' : ''}</small><small>{b.syncStatus === 'pending' ? 'Sync pending' : b.syncStatus === 'synced' ? 'Synced' : ''}</small></td><td><div className="bookings-page__row-actions"><Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link>{acts.includes('confirm') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{bookingStatus:'confirmed',status:'confirmed',confirmedAt:Timestamp.now(),confirmedBy:'staff_admin',syncStatus:'pending',syncReason:'booking_confirmed',syncRequestedAt:Timestamp.now()})} disabled={updatingBookingId===b.id}>Confirm</button>}{acts.includes('mark_paid') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{paymentStatus:'paid'})} disabled={updatingBookingId===b.id}>Mark paid</button>}{acts.includes('reschedule') && <Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Reschedule</Link>}{acts.includes('complete') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{bookingStatus:'completed',status:'completed',completedAt:Timestamp.now()})} disabled={updatingBookingId===b.id}>Complete</button>}{acts.includes('cancel') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{bookingStatus:'cancelled',status:'cancelled',cancelledAt:Timestamp.now(),syncStatus:'pending',syncReason:'booking_cancelled',syncRequestedAt:Timestamp.now()})} disabled={updatingBookingId===b.id}>Cancel</button>}</div></td></tr>
+      return <tr key={b.id}><td><strong>{b.serviceName}</strong><small>{b.reference || b.bookingId || 'No reference'}</small>{b.serviceName === 'Service not named' ? <small className="muted">Service ID: {b.serviceId}</small> : null}{b.duplicateMerged ? <span className="bookings-badge">Duplicate records merged</span> : null}</td><td><strong>{b.customerName || 'Customer'}</strong><small>{b.customerPhone || b.customerEmail || 'No contact'}</small></td><td><strong>{b.bookingDate || 'Date not set'}</strong><small>{b.bookingTime || 'Time not set'}</small><small>{b.preferredBranch || 'Main branch'}</small></td><td><span className="bookings-badge">{b.sourceLabel}</span><small>{b.sourcePath === 'root' ? 'Root booking' : 'Store booking'}</small></td><td><strong>{b.paymentAmount || '—'}</strong><small>{paymentLabel(b.paymentStatus)}</small><small>{b.paymentMethod || 'Method not set'}</small></td><td><span className={`bookings-page__status bookings-page__status--${b.bookingStatus}`}>{statusLabel(b.bookingStatus)}</span><small>{b.paymentStatus === 'paid' && b.bookingStatus !== 'confirmed' ? 'Paid - waiting for store confirmation' : ''}</small><small>{b.syncStatus === 'pending' ? 'Sync pending' : b.syncStatus === 'synced' ? 'Synced' : ''}</small></td><td><div className="bookings-page__row-actions"><Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link>{acts.includes('confirm') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{bookingStatus:'confirmed',status:'confirmed',confirmedAt:Timestamp.now(),confirmedBy:'staff_admin',syncStatus:'pending',syncReason:'booking_confirmed',syncRequestedAt:Timestamp.now()})} disabled={updatingBookingId===b.id}>Confirm</button>}{acts.includes('mark_paid') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{paymentStatus:'paid'})} disabled={updatingBookingId===b.id}>Mark paid</button>}{acts.includes('reschedule') && <Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Reschedule</Link>}{acts.includes('complete') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{bookingStatus:'completed',status:'completed',completedAt:Timestamp.now()})} disabled={updatingBookingId===b.id}>Complete</button>}{acts.includes('cancel') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{bookingStatus:'cancelled',status:'cancelled',cancelledAt:Timestamp.now(),syncStatus:'pending',syncReason:'booking_cancelled',syncRequestedAt:Timestamp.now()})} disabled={updatingBookingId===b.id}>Cancel</button>}</div></td></tr>
     })}</tbody></table><div className="bookings-cards">{visible.map(b => <article key={`${b.id}-card`} className="bookings-card"><h3>{b.serviceName}</h3><p>{b.customerName || 'Customer'} • {b.bookingDate || 'Date not set'} {b.bookingTime || ''}</p><p>{statusLabel(b.status)} • {paymentLabel(b.paymentStatus)}</p><Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link></article>)}</div></div>}
   </section></main>
 }


### PR DESCRIPTION
### Motivation
- Fix BookingEditor so bookings listed from the Bookings page (which merges store and root integrationBookings) always load full data when opened. 
- Support website/API booking payloads that use nested shapes for customer, booking and payment so the editor form is populated correctly. 
- Provide store staff visible actions (confirm booking, confirm/mark payment, cancel, complete, save and sync) that update both store and root Firestore locations.

### Description
- BookingEditor: try `stores/{storeId}/integrationBookings/{bookingId}` first, then fall back to `integrationBookings/{bookingId}`, and mirror root-only documents into the store path with `setDoc(..., { merge: true })` when found. (web/src/pages/BookingEditor.tsx)
- BookingEditor: added normalization helpers (`recordValue`, `firstStringValue`, `normalizeBookingForm`, `normalizePaymentStatus`) and expanded the field mapping to read both flat and nested shapes for customer, service, date/time and payment (including `paymentReference` and `paymentStatus`), and to populate nested `payment`, `booking`, and `customer` payloads on save. (web/src/pages/BookingEditor.tsx)
- BookingEditor: added visible action buttons for existing bookings (Confirm booking, Confirm payment / Mark paid, Cancel booking, Complete booking, Save and sync) and `updateExistingBooking` helper that writes updates to both `stores/{storeId}/integrationBookings/{bookingId}` and `integrationBookings/{bookingId}` with `merge: true`. (web/src/pages/BookingEditor.tsx)
- Bookings list: improved `hydrateBooking` to extract nested `booking`/`payment` data, treat `payment.confirmed === true` as paid, add `sourcePath: 'store'|'root'` so source is tracked, and render a small label indicating whether a row came from the root or store path. (web/src/pages/Bookings.tsx)
- UI tweak: adjusted `.booking-editor-page__actions` CSS so the expanded action button set wraps nicely. (web/src/pages/BookingEditor.css)

### Testing
- Ran `git diff --check` to validate whitespace/format issues and it completed without errors. 
- Attempted `npm --prefix web ci` but it failed due to a `403 Forbidden` from the registry for `@azure/msal-browser` so dependencies could not be installed. 
- Attempted `npm --prefix web run build` and `npm --prefix web run lint` but both were blocked because local dependencies were not present (TypeScript/ESLint type definitions and plugins could not be resolved). 
- Manual runtime testing recommended after installing project dependencies so website-origin bookings and action flows can be verified end-to-end (create root-only booking, open editor, confirm fields, run actions and verify both Firestore locations update).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b98ff67e4832192b76742bbdd3479)