### PR TITLE
Add structured course item fields

### DIFF
--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -476,7 +476,7 @@ type CheckoutPreviewItem = {
 
 function normalizeCheckoutItemType(value: unknown) {
   const normalized = clean(value, 50).toUpperCase()
-  if (normalized === 'SERVICE') return 'SERVICE'
+  if (normalized === 'SERVICE' || normalized === 'COURSE') return 'SERVICE'
   return 'PRODUCT'
 }
 

--- a/functions/src/publicCatalogSync.ts
+++ b/functions/src/publicCatalogSync.ts
@@ -11,6 +11,35 @@ function text(value: unknown): string | null {
   return trimmed || null
 }
 
+function itemType(value: unknown): 'product' | 'service' | 'course' {
+  return value === 'course' ? 'course' : value === 'service' ? 'service' : 'product'
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function boolOrNull(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null
+}
+
+function timestampOrIso(value: unknown): string | null {
+  try {
+    if (typeof (value as { toDate?: unknown })?.toDate === 'function') {
+      const date = (value as { toDate: () => Date }).toDate()
+      return Number.isNaN(date.getTime()) ? null : date.toISOString()
+    }
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.toISOString()
+    if (typeof value === 'string' && value.trim()) {
+      const date = new Date(value)
+      return Number.isNaN(date.getTime()) ? value.trim() : date.toISOString()
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
 function toArray(value: unknown): string[] {
   if (!Array.isArray(value)) return []
   const out: string[] = []
@@ -41,6 +70,7 @@ function buildStoreMeta(store: StoreData): Record<string, unknown> {
 }
 
 function publicPayload(productId: string, data: ProductData, storeMeta: Record<string, unknown>): Record<string, unknown> {
+  const normalizedItemType = itemType(data.itemType)
   return {
     sourceProductId: productId,
     storeId: text(data.storeId),
@@ -52,11 +82,24 @@ function publicPayload(productId: string, data: ProductData, storeMeta: Record<s
     imageUrl: text(data.imageUrl),
     imageUrls: toArray(data.imageUrls),
     imageAlt: text(data.imageAlt),
-    itemType: data.itemType === 'service' ? 'service' : 'product',
+    itemType: normalizedItemType,
     isPublished: true,
     publishedAt: resolvePublicationTimestampCandidate(data.publishedAt, data.createdAt, data.updatedAt),
     unpublishedAt: admin.firestore.FieldValue.delete(),
     sourceUpdatedAt: data.updatedAt ?? null,
+    listingType: normalizedItemType === 'course' ? 'course' : text(data.listingType),
+    serviceKind: text(data.serviceKind),
+    duration: text(data.duration),
+    branch: text(data.branch) ?? text(data.location),
+    preferredTimes: text(data.preferredTimes) ?? text(data.classTimes),
+    startDate: timestampOrIso(data.startDate),
+    registrationFee: numberOrNull(data.registrationFee),
+    fullFee: numberOrNull(data.fullFee) ?? numberOrNull(data.price),
+    capacity: numberOrNull(data.capacity),
+    requirements: text(data.requirements),
+    starterItems: text(data.starterItems),
+    certificateIncluded: boolOrNull(data.certificateIncluded),
+    Agreement: text(data.Agreement),
     updatedAt: admin.firestore.FieldValue.serverTimestamp(),
   }
 }
@@ -120,9 +163,9 @@ export async function syncStorePublicCatalog(storeId: string): Promise<void> {
 
   for (const productDoc of productsSnap.docs) {
     const data = (productDoc.data() ?? {}) as ProductData
-    const itemType = data.itemType === 'service' ? 'service' : 'product'
-    const targetCollection = itemType === 'service' ? 'publicServices' : 'publicProducts'
-    const oppositeCollection = itemType === 'service' ? 'publicProducts' : 'publicServices'
+    const normalizedItemType = itemType(data.itemType)
+    const targetCollection = normalizedItemType === 'product' ? 'publicProducts' : 'publicServices'
+    const oppositeCollection = normalizedItemType === 'product' ? 'publicServices' : 'publicProducts'
     const payload = publicPayload(productDoc.id, data, storeMeta)
 
     batch.set(db.collection(targetCollection).doc(productDoc.id), payload, { merge: true })
@@ -130,7 +173,7 @@ export async function syncStorePublicCatalog(storeId: string): Promise<void> {
     writes += 2
     removed += 1
 
-    if (itemType === 'service') writtenServices += 1
+    if (normalizedItemType !== 'product') writtenServices += 1
     else writtenProducts += 1
 
     if (writes >= 450) {
@@ -234,9 +277,10 @@ export const syncPublicCatalogOnProductWrite = functions.firestore
     }
 
     const payload = publicPayload(productId, afterData, buildStoreMeta(storeData))
-    const isService = afterData.itemType === 'service'
-    const target = isService ? 'publicServices' : 'publicProducts'
-    const opposite = isService ? 'publicProducts' : 'publicServices'
+    const normalizedItemType = itemType(afterData.itemType)
+    const isPublicProduct = normalizedItemType === 'product'
+    const target = isPublicProduct ? 'publicProducts' : 'publicServices'
+    const opposite = isPublicProduct ? 'publicServices' : 'publicProducts'
 
     await Promise.all([
       db.collection(target).doc(productId).set(payload, { merge: true }),
@@ -246,8 +290,8 @@ export const syncPublicCatalogOnProductWrite = functions.firestore
     functions.logger.info('product synced to public catalog', {
       storeId,
       productId,
-      publicProductsWritten: isService ? 0 : 1,
-      publicServicesWritten: isService ? 1 : 0,
+      publicProductsWritten: isPublicProduct ? 1 : 0,
+      publicServicesWritten: isPublicProduct ? 0 : 1,
       publicDocsRemoved: 1,
     })
   })

--- a/functions/src/types/product.ts
+++ b/functions/src/types/product.ts
@@ -1,4 +1,4 @@
-export type ProductItemType = 'product' | 'service' | 'made_to_order'
+export type ProductItemType = 'product' | 'service' | 'course' | 'made_to_order'
 
 export type ProductReadModel = {
   id: string
@@ -13,4 +13,17 @@ export type ProductReadModel = {
   imageUrls: string[]
   imageAlt: string | null
   updatedAt: FirebaseFirestore.Timestamp | null
+  listingType?: 'product' | 'service' | 'course' | null
+  serviceKind?: string | null
+  duration?: string | null
+  branch?: string | null
+  preferredTimes?: string | null
+  startDate?: FirebaseFirestore.Timestamp | string | null
+  registrationFee?: number | null
+  fullFee?: number | null
+  capacity?: number | null
+  requirements?: string | null
+  starterItems?: string | null
+  certificateIncluded?: boolean | null
+  Agreement?: string | null
 }

--- a/shared/integrationTypes.ts
+++ b/shared/integrationTypes.ts
@@ -10,11 +10,24 @@ export interface IntegrationProduct {
   description: string | null
   price: number | null
   stockCount: number | null
-  itemType: 'product' | 'service'
+  itemType: 'product' | 'service' | 'course'
   imageUrl: string | null
   imageUrls: string[]
   imageAlt: string | null
   updatedAt: string | null
+  listingType?: 'product' | 'service' | 'course' | null
+  serviceKind?: string | null
+  duration?: string | null
+  branch?: string | null
+  preferredTimes?: string | null
+  startDate?: string | null
+  registrationFee?: number | null
+  fullFee?: number | null
+  capacity?: number | null
+  requirements?: string | null
+  starterItems?: string | null
+  certificateIncluded?: boolean | null
+  Agreement?: string | null
 }
 
 export interface IntegrationPromo {

--- a/web/src/api/socialPost.ts
+++ b/web/src/api/socialPost.ts
@@ -12,7 +12,7 @@ export type SocialPostProductPayload = {
   description?: string | null
   price?: number | null
   imageUrl?: string | null
-  itemType?: 'product' | 'service' | 'made_to_order'
+  itemType?: 'product' | 'service' | 'course' | 'made_to_order'
 }
 
 export type GenerateSocialPostPayload = {
@@ -100,7 +100,7 @@ async function requestSocialPostFallback(payload: GenerateSocialPostPayload): Pr
       description: typeof product.description === 'string' ? product.description : null,
       price: typeof product.price === 'number' ? product.price : null,
       imageUrl: typeof product.imageUrl === 'string' ? product.imageUrl : null,
-      itemType: product.itemType === 'service' || product.itemType === 'made_to_order' ? product.itemType : 'product',
+      itemType: product.itemType === 'service' || product.itemType === 'course' || product.itemType === 'made_to_order' ? product.itemType : 'product',
     },
     post: {
       platform:

--- a/web/src/pages/BlogPage.tsx
+++ b/web/src/pages/BlogPage.tsx
@@ -23,7 +23,7 @@ import { requestAiAdvisor } from '../api/aiAdvisor'
 type CatalogItem = {
   id: string
   name: string
-  itemType: 'product' | 'service'
+  itemType: 'product' | 'service' | 'course'
   price: number | null
   description: string | null
   imageUrl: string | null
@@ -172,7 +172,7 @@ export default function BlogPage() {
         return {
           id: docSnap.id,
           name: typeof data.name === 'string' && data.name.trim() ? data.name.trim() : 'Untitled item',
-          itemType: data.itemType === 'service' ? 'service' : 'product',
+          itemType: data.itemType === 'course' ? 'course' : data.itemType === 'service' ? 'service' : 'product',
           price: typeof data.price === 'number' && Number.isFinite(data.price) ? data.price : null,
           description: typeof data.description === 'string' && data.description.trim() ? data.description.trim() : null,
           imageUrl: getCatalogImageUrl(data),

--- a/web/src/pages/BookingsAvailability.tsx
+++ b/web/src/pages/BookingsAvailability.tsx
@@ -8,7 +8,7 @@ import './BookingsAvailability.css'
 type ServiceRecord = {
   id: string
   name: string
-  itemType?: 'product' | 'service' | 'programme'
+  itemType?: 'product' | 'service' | 'course' | 'programme'
   imageUrl?: string | null
   imageAlt?: string | null
   source?: string
@@ -114,7 +114,7 @@ export default function BookingsAvailability() {
       map.set(docId, {
         id: docId,
         name: nameCandidate.trim(),
-        itemType: data.itemType === 'programme' ? 'programme' : data.itemType === 'service' ? 'service' : fallbackType,
+        itemType: data.itemType === 'course' ? 'course' : data.itemType === 'programme' ? 'programme' : data.itemType === 'service' ? 'service' : fallbackType,
         imageUrl: typeof data.imageUrl === 'string' ? data.imageUrl : null,
         imageAlt: typeof data.imageAlt === 'string' ? data.imageAlt : null,
         source,

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -112,7 +112,7 @@ export default function Dashboard() {
   const todayBlogPosts = blogPosts.filter(item => isToday(item.createdAtServer ?? item.createdAt))
 
   const inventory = useMemo(() => {
-    const inventoryItems = products.filter(item => item.itemType !== 'service')
+    const inventoryItems = products.filter(item => item.itemType === 'product')
     const totalStock = inventoryItems.reduce((sum, item) => sum + asNumber(item.stockCount, 0), 0)
     const stockValue = inventoryItems.reduce((sum, item) => sum + (asNumber(item.stockCount, 0) * asNumber(item.price, 0)), 0)
     const lowStock = inventoryItems.filter(item => {

--- a/web/src/pages/DataTransfer.tsx
+++ b/web/src/pages/DataTransfer.tsx
@@ -49,7 +49,7 @@ const ITEM_OPTIONAL_HEADERS: HeaderSpec[] = [
   { key: 'barcode', description: 'Barcode for scanning (letters + digits are supported).' },
   { key: 'stock_count', description: 'Current stock quantity.' },
   { key: 'reorder_point', description: 'Restock alert level.' },
-  { key: 'item_type', description: 'product, service, or made_to_order.' },
+  { key: 'item_type', description: 'product, service, course, or made_to_order.' },
   { key: 'tax_rate', description: 'Tax rate as 7.5 or 0.075.' },
   { key: 'expiry_date', description: 'Use YYYY-MM-DD.' },
   { key: 'manufacturer_name', description: 'Brand or manufacturer name.' },
@@ -450,7 +450,9 @@ export default function DataTransfer() {
         const itemType =
           data.itemType === 'service'
             ? 'service'
-            : data.itemType === 'made_to_order'
+            : data.itemType === 'course'
+              ? 'course'
+              : data.itemType === 'made_to_order'
               ? 'made_to_order'
               : 'product'
         const taxRate = formatTaxRate(data.taxRate)
@@ -698,7 +700,9 @@ export default function DataTransfer() {
         const itemType =
           rawItemType === 'service'
             ? 'service'
-            : rawItemType === 'made_to_order'
+            : rawItemType === 'course'
+              ? 'course'
+              : rawItemType === 'made_to_order'
               ? 'made_to_order'
               : 'product'
         const sku = normalizeText(getRowValue(row, headerIndex, 'sku'))

--- a/web/src/pages/ProductsServiceFirst.tsx
+++ b/web/src/pages/ProductsServiceFirst.tsx
@@ -47,6 +47,15 @@ type Draft = {
   courseLevel: string
   registrationFee: string
   duration: string
+  branch: string
+  preferredTimes: string
+  startDate: string
+  fullFee: string
+  capacity: string
+  requirements: string
+  starterItems: string
+  certificateIncluded: boolean
+  Agreement: string
   courseMode: CourseMode
   classTimes: string
 }
@@ -112,6 +121,15 @@ const blankDraft: Draft = {
   courseLevel: '',
   registrationFee: '',
   duration: '',
+  branch: '',
+  preferredTimes: '',
+  startDate: '',
+  fullFee: '',
+  capacity: '',
+  requirements: '',
+  starterItems: '',
+  certificateIncluded: false,
+  Agreement: '',
   courseMode: 'in_person',
   classTimes: '',
 }
@@ -124,6 +142,10 @@ function cleanNumber(value: unknown): number | null {
   const parsed = Number(value)
   if (!Number.isFinite(parsed) || parsed < 0) return null
   return parsed
+}
+
+function cleanText(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
 function toDate(value: unknown): Date | null {
@@ -179,10 +201,10 @@ function generateItemDescription(draft: Draft): string {
     const level = draft.courseLevel.trim() || 'all levels'
     const duration = draft.duration.trim()
     const mode = draft.courseMode === 'online' ? 'online' : draft.courseMode === 'hybrid' ? 'in online and in-person formats' : 'in person'
-    const classTimes = draft.classTimes.trim()
+    const classTimes = draft.preferredTimes.trim() || draft.classTimes.trim()
     const fee = cleanNumber(draft.price)
     const feeText = fee !== null ? ` The course fee is GHS ${fee.toFixed(2)}.` : ''
-    return `${itemName} is a ${level} ${category.toLowerCase()} programme designed for learners who want practical and structured progress. It includes guided lessons and class support to help students build confidence step by step${duration ? ` over ${duration}` : ''}. Classes are offered ${mode}${locationText ? ` at ${locationText}` : ''}${classTimes ? `, with sessions scheduled ${classTimes}` : ''}.${feeText}`.replace(/\s+/g, ' ').trim()
+    return `${itemName} is a ${level} ${category.toLowerCase()} programme designed for learners who want practical and structured progress. It includes guided lessons and class support to help students build confidence step by step${duration ? ` over ${duration}` : ''}. Classes are offered ${mode}${(draft.branch.trim() || locationText) ? ` at ${draft.branch.trim() || locationText}` : ''}${classTimes ? `, with sessions scheduled ${classTimes}` : ''}.${feeText}`.replace(/\s+/g, ' ').trim()
   }
 
   if (draft.itemType === 'service') {
@@ -215,8 +237,8 @@ function improveDescription(text: string): string {
 }
 
 function normalizeProduct(id: string, data: Record<string, unknown>): Product {
-  const itemType: ItemType = data.itemType === 'service' ? 'service' : 'product'
-  const itemFormType: ItemFormType = itemType === 'service' && data.listingType === 'course' ? 'course' : itemType
+  const itemType: ItemType = data.itemType === 'course' ? 'course' : data.itemType === 'service' ? 'service' : 'product'
+  const itemFormType: ItemFormType = itemType === 'course' || (itemType === 'service' && data.listingType === 'course') ? 'course' : itemType
   const name = typeof data.name === 'string' && data.name.trim() ? titleCase(data.name) : 'Untitled item'
   const imageUrl = typeof data.imageUrl === 'string' && data.imageUrl.trim() ? data.imageUrl.trim() : null
   return {
@@ -240,6 +262,21 @@ function normalizeProduct(id: string, data: Record<string, unknown>): Product {
     imageUrl,
     imageUrls: Array.isArray(data.imageUrls) ? data.imageUrls.filter((item): item is string => typeof item === 'string') : imageUrl ? [imageUrl] : [],
     imageAlt: typeof data.imageAlt === 'string' && data.imageAlt.trim() ? data.imageAlt.trim() : name,
+    listingType: cleanText(data.listingType) as Product['listingType'],
+    serviceKind: cleanText(data.serviceKind),
+    duration: cleanText(data.duration),
+    branch: cleanText(data.branch ?? data.location),
+    preferredTimes: cleanText(data.preferredTimes ?? data.classTimes),
+    startDate: toDate(data.startDate),
+    registrationFee: cleanNumber(data.registrationFee),
+    fullFee: cleanNumber(data.fullFee),
+    capacity: cleanNumber(data.capacity),
+    requirements: cleanText(data.requirements),
+    starterItems: cleanText(data.starterItems),
+    certificateIncluded: typeof data.certificateIncluded === 'boolean' ? data.certificateIncluded : null,
+    Agreement: cleanText(data.Agreement),
+    courseLevel: cleanText(data.courseLevel),
+    courseMode: cleanText(data.courseMode),
     lastReceiptAt: data.lastReceiptAt,
     createdAt: data.createdAt,
     updatedAt: data.updatedAt,
@@ -263,7 +300,7 @@ function buildSavePayload(draft: Draft, storeId: string) {
   return {
     storeId,
     name,
-    itemType: behavesLikeService ? 'service' : 'product',
+    itemType: isCourse ? 'course' : isService ? 'service' : 'product',
     listingType: isCourse ? 'course' : behavesLikeService ? 'service' : 'product',
     serviceKind: isCourse ? 'course_enrollment' : serviceKind,
     salesMode,
@@ -278,7 +315,8 @@ function buildSavePayload(draft: Draft, storeId: string) {
     reorderPoint: behavesLikeService ? null : cleanNumber(draft.reorderPoint),
     expiryDate: behavesLikeService || !draft.expiryDate ? null : new Date(draft.expiryDate),
     durationMinutes: isService ? cleanNumber(draft.durationMinutes) : null,
-    location: behavesLikeService ? draft.location.trim() || null : null,
+    location: behavesLikeService ? (draft.branch.trim() || draft.location.trim() || null) : null,
+    branch: isCourse ? draft.branch.trim() || null : null,
     requiresDateTime: isService ? draft.requiresDateTime : null,
     requiresNotes: isService ? draft.requiresNotes : null,
     requiresDestinationOrTopic: isService ? draft.requiresDestinationOrTopic : null,
@@ -287,8 +325,16 @@ function buildSavePayload(draft: Draft, storeId: string) {
     courseLevel: isCourse ? draft.courseLevel.trim() || null : null,
     registrationFee: isCourse ? cleanNumber(draft.registrationFee) : null,
     duration: isCourse ? draft.duration.trim() || null : null,
+    preferredTimes: isCourse ? draft.preferredTimes.trim() || null : null,
+    startDate: isCourse && draft.startDate ? new Date(draft.startDate) : null,
+    fullFee: isCourse ? cleanNumber(draft.fullFee) ?? price : null,
+    capacity: isCourse ? cleanNumber(draft.capacity) : null,
+    requirements: isCourse ? draft.requirements.trim() || null : null,
+    starterItems: isCourse ? draft.starterItems.trim() || null : null,
+    certificateIncluded: isCourse ? draft.certificateIncluded : null,
+    Agreement: isCourse ? draft.Agreement.trim() || null : null,
     courseMode: isCourse ? draft.courseMode : null,
-    classTimes: isCourse ? draft.classTimes.trim() || null : null,
+    classTimes: isCourse ? draft.preferredTimes.trim() || draft.classTimes.trim() || null : null,
     productionDate: null,
     manufacturerName: null,
     batchNumber: null,
@@ -352,9 +398,12 @@ export default function ProductsServiceFirst() {
           openingStock: nextItemType === 'product' ? current.openingStock : '',
           reorderPoint: nextItemType === 'product' ? current.reorderPoint : '',
           expiryDate: nextItemType === 'product' ? current.expiryDate : '',
+          branch: nextItemType === 'course' ? current.branch || current.location : current.branch,
+          preferredTimes: nextItemType === 'course' ? current.preferredTimes || current.classTimes : current.preferredTimes,
           costPrice: nextItemType === 'product' ? current.costPrice : '',
         }
       }
+      if (key === 'certificateIncluded') return { ...current, certificateIncluded: value === 'true' }
       return { ...current, [key]: value }
     })
   }
@@ -366,7 +415,7 @@ export default function ProductsServiceFirst() {
   }
 
   function editItem(item: Product) {
-    const itemType: ItemFormType = item.itemType === 'service' ? ((item as any).listingType === 'course' ? 'course' : 'service') : 'product'
+    const itemType: ItemFormType = item.itemType === 'course' || (item.itemType === 'service' && item.listingType === 'course') ? 'course' : item.itemType === 'service' ? 'service' : 'product'
     setEditingId(item.id)
     setDraft({
       name: item.name,
@@ -390,10 +439,19 @@ export default function ProductsServiceFirst() {
       allowDepositPayment: (item as any).allowDepositPayment === true,
       depositAmount: typeof (item as any).depositAmount === 'number' ? String((item as any).depositAmount) : '',
       courseLevel: typeof (item as any).courseLevel === 'string' ? (item as any).courseLevel : '',
-      registrationFee: typeof (item as any).registrationFee === 'number' ? String((item as any).registrationFee) : '',
-      duration: typeof (item as any).duration === 'string' ? (item as any).duration : '',
+      registrationFee: typeof item.registrationFee === 'number' ? String(item.registrationFee) : '',
+      duration: typeof item.duration === 'string' ? item.duration : '',
+      branch: item.branch ?? (typeof (item as any).location === 'string' ? (item as any).location : ''),
+      preferredTimes: item.preferredTimes ?? (typeof (item as any).classTimes === 'string' ? (item as any).classTimes : ''),
+      startDate: formatDateInput(item.startDate),
+      fullFee: typeof item.fullFee === 'number' ? String(item.fullFee) : typeof item.price === 'number' ? String(item.price) : '',
+      capacity: typeof item.capacity === 'number' ? String(item.capacity) : '',
+      requirements: item.requirements ?? '',
+      starterItems: item.starterItems ?? '',
+      certificateIncluded: item.certificateIncluded === true,
+      Agreement: item.Agreement ?? '',
       courseMode: ((item as any).courseMode as CourseMode) ?? 'in_person',
-      classTimes: typeof (item as any).classTimes === 'string' ? (item as any).classTimes : '',
+      classTimes: item.preferredTimes ?? (typeof (item as any).classTimes === 'string' ? (item as any).classTimes : ''),
     })
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
@@ -408,14 +466,14 @@ export default function ProductsServiceFirst() {
       const payload = buildSavePayload(draft as any, storeId)
       if (editingId) {
         await updateDoc(doc(db, 'products', editingId), payload)
-        setMessage(`${draft.itemType === 'service' ? 'Service' : 'Product'} updated.`)
+        setMessage(`${draft.itemType === 'course' ? 'Course' : draft.itemType === 'service' ? 'Service' : 'Product'} updated.`)
       } else {
         await setDoc(doc(collection(db, 'products')), {
           ...payload,
           createdAt: serverTimestamp(),
           sortOrder: items.length + 1,
         })
-        setMessage(`${draft.itemType === 'service' ? 'Service' : 'Product'} added.`)
+        setMessage(`${draft.itemType === 'course' ? 'Course' : draft.itemType === 'service' ? 'Service' : 'Product'} added.`)
       }
       resetForm()
     } catch (err) {
@@ -429,7 +487,7 @@ export default function ProductsServiceFirst() {
     if (!canManage) return
     if (!window.confirm(`Delete ${item.name}?`)) return
     await deleteDoc(doc(db, 'products', item.id))
-    setMessage(`${item.itemType === 'service' ? 'Service' : 'Product'} deleted.`)
+    setMessage(`${item.itemType === 'course' ? 'Course' : item.itemType === 'service' ? 'Service' : 'Product'} deleted.`)
   }
 
   const visibleItems = useMemo(() => {
@@ -522,12 +580,24 @@ export default function ProductsServiceFirst() {
 
             {isService ? <div className="field"><label className="field__label" htmlFor="service-kind">Service kind</label><select id="service-kind" value={draft.serviceKind} onChange={event => updateDraft('serviceKind', event.target.value)}><option value="appointment">Appointment</option><option value="consultation">Consultation</option><option value="quote_request">Quote request</option></select></div> : null}
             {isService ? <div className="field"><label className="field__label" htmlFor="service-duration">Duration minutes</label><input id="service-duration" type="number" min="0" step="1" value={draft.durationMinutes} onChange={event => updateDraft('durationMinutes', event.target.value)} /></div> : null}
-            {behavesLikeService ? <div className="field"><label className="field__label" htmlFor="service-location">Branch / location</label><input id="service-location" value={draft.location} onChange={event => updateDraft('location', event.target.value)} /></div> : null}
-            {isCourse ? <div className="field"><label className="field__label" htmlFor="course-level">Course level</label><input id="course-level" value={draft.courseLevel} onChange={event => updateDraft('courseLevel', event.target.value)} /></div> : null}
-            {isCourse ? <div className="field"><label className="field__label" htmlFor="course-regfee">Registration fee / deposit</label><input id="course-regfee" type="number" min="0" step="0.01" value={draft.registrationFee} onChange={event => updateDraft('registrationFee', event.target.value)} /></div> : null}
-            {isCourse ? <div className="field"><label className="field__label" htmlFor="course-duration">Duration</label><input id="course-duration" value={draft.duration} onChange={event => updateDraft('duration', event.target.value)} /></div> : null}
-            {isCourse ? <div className="field"><label className="field__label" htmlFor="course-mode">Mode</label><select id="course-mode" value={draft.courseMode} onChange={event => updateDraft('courseMode', event.target.value)}><option value="online">Online</option><option value="in_person">In person</option><option value="hybrid">Hybrid</option></select></div> : null}
-            {isCourse ? <div className="field"><label className="field__label" htmlFor="course-times">Class times</label><input id="course-times" value={draft.classTimes} onChange={event => updateDraft('classTimes', event.target.value)} /></div> : null}
+            {behavesLikeService && !isCourse ? <div className="field"><label className="field__label" htmlFor="service-location">Branch / location</label><input id="service-location" value={draft.location} onChange={event => updateDraft('location', event.target.value)} /></div> : null}
+            {isCourse ? (
+              <>
+                <div className="field"><label className="field__label" htmlFor="course-branch">Branch</label><input id="course-branch" value={draft.branch} onChange={event => updateDraft('branch', event.target.value)} placeholder="e.g. Accra campus or Online" /></div>
+                <div className="field"><label className="field__label" htmlFor="course-times">Preferred times</label><input id="course-times" value={draft.preferredTimes} onChange={event => updateDraft('preferredTimes', event.target.value)} placeholder="e.g. Weekdays 6pm, Saturdays 10am" /></div>
+                <div className="field"><label className="field__label" htmlFor="course-start-date">Start date</label><input id="course-start-date" type="date" value={draft.startDate} onChange={event => updateDraft('startDate', event.target.value)} /></div>
+                <div className="field"><label className="field__label" htmlFor="course-regfee">Registration fee</label><input id="course-regfee" type="number" min="0" step="0.01" value={draft.registrationFee} onChange={event => updateDraft('registrationFee', event.target.value)} /></div>
+                <div className="field"><label className="field__label" htmlFor="course-fullfee">Full fee</label><input id="course-fullfee" type="number" min="0" step="0.01" value={draft.fullFee} onChange={event => updateDraft('fullFee', event.target.value)} placeholder="Defaults to Fee when blank" /></div>
+                <div className="field"><label className="field__label" htmlFor="course-duration">Duration</label><input id="course-duration" value={draft.duration} onChange={event => updateDraft('duration', event.target.value)} placeholder="e.g. 8 weeks" /></div>
+                <div className="field"><label className="field__label" htmlFor="course-capacity">Capacity</label><input id="course-capacity" type="number" min="0" step="1" value={draft.capacity} onChange={event => updateDraft('capacity', event.target.value)} /></div>
+                <div className="field"><label className="field__label" htmlFor="course-requirements">Requirements</label><textarea id="course-requirements" rows={3} value={draft.requirements} onChange={event => updateDraft('requirements', event.target.value)} /></div>
+                <div className="field"><label className="field__label" htmlFor="course-starter-items">Starter items</label><textarea id="course-starter-items" rows={3} value={draft.starterItems} onChange={event => updateDraft('starterItems', event.target.value)} /></div>
+                <label className="checkbox"><input type="checkbox" checked={draft.certificateIncluded} onChange={event => updateDraft('certificateIncluded', event.target.checked ? 'true' : '')} /><span>Certificate included</span></label>
+                <div className="field"><label className="field__label" htmlFor="course-agreement">Agreement</label><textarea id="course-agreement" rows={3} value={draft.Agreement} onChange={event => updateDraft('Agreement', event.target.value)} /></div>
+                <div className="field"><label className="field__label" htmlFor="course-level">Course level</label><input id="course-level" value={draft.courseLevel} onChange={event => updateDraft('courseLevel', event.target.value)} /></div>
+                <div className="field"><label className="field__label" htmlFor="course-mode">Mode</label><select id="course-mode" value={draft.courseMode} onChange={event => updateDraft('courseMode', event.target.value)}><option value="online">Online</option><option value="in_person">In person</option><option value="hybrid">Hybrid</option></select></div>
+              </>
+            ) : null}
             <div className="field">
               <div className="products-page__label-row">
                 <label className="field__label" htmlFor="item-description">{behavesLikeService ? 'Description' : 'Product description'}</label>
@@ -606,7 +676,9 @@ export default function ProductsServiceFirst() {
 
           <div className="products-page__list" aria-live="polite">
             {visibleItems.map(item => {
+              const itemIsCourse = item.itemType === 'course' || item.listingType === 'course'
               const itemIsService = item.itemType === 'service'
+              const itemIsServiceLike = itemIsService || itemIsCourse
               return (
                 <article key={item.id} className="products-page__list-card">
                   <header className="products-page__list-card__header">
@@ -615,7 +687,7 @@ export default function ProductsServiceFirst() {
                     </div>
                     <div className="products-page__list-title">
                       <h4>{item.name}</h4>
-                      <span className="products-page__badge products-page__badge--muted">{itemIsService ? 'Service' : 'Product'}</span>
+                      <span className="products-page__badge products-page__badge--muted">{itemIsCourse ? 'Course' : itemIsService ? 'Service' : 'Product'}</span>
                       <span className="products-page__list-value">{normalizeCategory(item.category, item.itemType)}</span>
                     </div>
                     <div className="products-page__list-meta">
@@ -625,10 +697,21 @@ export default function ProductsServiceFirst() {
                   </header>
 
                   <div className="products-page__list-grid">
-                    {itemIsService ? (
+                    {itemIsServiceLike ? (
                       <>
-                        <div className="products-page__list-field"><label className="field__label">Service category</label><p className="products-page__list-value">{normalizeCategory(item.category, item.itemType)}</p></div>
-                        <div className="products-page__list-field"><label className="field__label">Booking / service item</label><p className="products-page__list-value">No stock tracking</p></div>
+                        <div className="products-page__list-field"><label className="field__label">{itemIsCourse ? 'Course category' : 'Service category'}</label><p className="products-page__list-value">{normalizeCategory(item.category, itemIsCourse ? 'course' : item.itemType)}</p></div>
+                        <div className="products-page__list-field"><label className="field__label">{itemIsCourse ? 'Course item' : 'Booking / service item'}</label><p className="products-page__list-value">No stock tracking</p></div>
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Duration</label><p className="products-page__list-value">{item.duration || '—'}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Branch</label><p className="products-page__list-value">{item.branch || '—'}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Preferred times</label><p className="products-page__list-value">{item.preferredTimes || '—'}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Start date</label><p className="products-page__list-value">{item.startDate ? item.startDate.toLocaleDateString() : '—'}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Registration fee</label><p className="products-page__list-value">{formatMoney(item.registrationFee)}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Full fee</label><p className="products-page__list-value">{formatMoney(item.fullFee ?? item.price)}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Capacity</label><p className="products-page__list-value">{item.capacity ?? '—'}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Certificate</label><p className="products-page__list-value">{item.certificateIncluded ? 'Included' : '—'}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Requirements</label><p className="products-page__list-value">{item.requirements || '—'}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Starter items</label><p className="products-page__list-value">{item.starterItems || '—'}</p></div> : null}
+                        {itemIsCourse ? <div className="products-page__list-field"><label className="field__label">Agreement</label><p className="products-page__list-value">{item.Agreement || '—'}</p></div> : null}
                       </>
                     ) : (
                       <>

--- a/web/src/pages/PromoLandingPage.tsx
+++ b/web/src/pages/PromoLandingPage.tsx
@@ -84,7 +84,7 @@ type CatalogItem = {
   price: number | null
   imageUrl: string | null
   imageAlt: string | null
-  itemType: 'product' | 'service' | 'made_to_order'
+  itemType: 'product' | 'service' | 'course' | 'made_to_order'
 }
 
 type CatalogApiResponse = {
@@ -96,7 +96,7 @@ type CatalogApiResponse = {
     price?: number | null
     imageUrl?: string | null
     imageAlt?: string | null
-    itemType?: 'product' | 'service' | 'made_to_order'
+    itemType?: 'product' | 'service' | 'course' | 'made_to_order'
   }>
 }
 
@@ -362,7 +362,9 @@ export default function PromoLandingPage() {
               itemType:
                 item.itemType === 'service'
                   ? 'service'
-                  : item.itemType === 'made_to_order'
+                  : item.itemType === 'course'
+                    ? 'course'
+                    : item.itemType === 'made_to_order'
                     ? 'made_to_order'
                     : 'product',
             } satisfies CatalogItem
@@ -812,11 +814,11 @@ export default function PromoLandingPage() {
                         </>
                       ) : (
                         <p className="promo-summary">
-                          {`${item.itemType === 'service' ? 'Service' : 'Product'} available`}
+                          {`${item.itemType === 'course' ? 'Course' : item.itemType === 'service' ? 'Service' : 'Product'} available`}
                         </p>
                       )}
                       <p className="promo-meta">
-                        {item.category || 'General'} · {item.itemType === 'service' ? 'Service' : 'Product'}
+                        {item.category || 'General'} · {item.itemType === 'course' ? 'Course' : item.itemType === 'service' ? 'Service' : 'Product'}
                         {typeof item.price === 'number' ? ` · ${item.price.toFixed(2)}` : ''}
                       </p>
                       <p className="promo-meta">Part #: {item.id}</p>

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -183,7 +183,7 @@ function mapFirestoreProduct(id: string, data: any): Product {
     barcode: normalizeBarcode(barcodeSource) || null,
     price: typeof data.price === 'number' && Number.isFinite(data.price) ? data.price : null,
     taxRate: typeof data.taxRate === 'number' && Number.isFinite(data.taxRate) ? data.taxRate : null,
-    itemType: data.itemType === 'service' ? 'service' : 'product',
+    itemType: data.itemType === 'course' ? 'course' : data.itemType === 'service' ? 'service' : 'product',
     manufacturerName:
       typeof data.manufacturerName === 'string' && data.manufacturerName.trim()
         ? data.manufacturerName.trim()
@@ -1380,7 +1380,7 @@ export default function Sell() {
     const labels = items.map(item => {
       const product = products.find(p => p.id === item.productId)
       const typeLabel =
-        item.itemType === 'service' ? 'service' : product?.itemType === 'service' ? 'service' : 'product'
+        item.itemType === 'service' || item.itemType === 'course' ? 'service' : product?.itemType === 'service' || product?.itemType === 'course' ? 'service' : 'product'
       const name = item.name || product?.name || 'Item'
       return typeLabel === 'service' ? `${name} (service)` : name
     })

--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -164,7 +164,7 @@ function mapProduct(id: string, raw: Record<string, unknown>): ProductOption {
     description: typeof raw.description === 'string' ? raw.description.trim() : null,
     price: typeof raw.price === 'number' && Number.isFinite(raw.price) ? raw.price : null,
     imageUrl: typeof raw.imageUrl === 'string' && raw.imageUrl.trim() ? raw.imageUrl.trim() : null,
-    itemType: raw.itemType === 'service' || raw.itemType === 'made_to_order' ? raw.itemType : 'product',
+    itemType: raw.itemType === 'service' || raw.itemType === 'course' || raw.itemType === 'made_to_order' ? raw.itemType : 'product',
   }
 }
 

--- a/web/src/types/product.ts
+++ b/web/src/types/product.ts
@@ -1,4 +1,4 @@
-export type ItemType = 'product' | 'service' | 'made_to_order'
+export type ItemType = 'product' | 'service' | 'course' | 'made_to_order'
 
 export type Product = {
   id: string
@@ -25,4 +25,19 @@ export type Product = {
   createdAt?: unknown
   updatedAt?: unknown
   sortOrder?: number | null
+  listingType?: 'product' | 'service' | 'course' | null
+  serviceKind?: string | null
+  duration?: string | null
+  branch?: string | null
+  preferredTimes?: string | null
+  startDate?: Date | null
+  registrationFee?: number | null
+  fullFee?: number | null
+  capacity?: number | null
+  requirements?: string | null
+  starterItems?: string | null
+  certificateIncluded?: boolean | null
+  Agreement?: string | null
+  courseLevel?: string | null
+  courseMode?: string | null
 }


### PR DESCRIPTION
### Motivation

- Make `course` a first-class item type so course listings expose structured metadata instead of relying on ad-hoc fields.
- Provide clear fields (branch, preferred times, start date, fees, capacity, requirements, starter items, certificate, Agreement, etc.) so storefronts and integrations can display and sync course data reliably.

### Description

- Add `course` to `ItemType` and extend the product/read models with structured course fields such as `listingType`, `serviceKind`, `duration`, `branch`, `preferredTimes`, `startDate`, `registrationFee`, `fullFee`, `capacity`, `requirements`, `starterItems`, `certificateIncluded`, and `Agreement` across `web/src/types/product.ts`, `functions/src/types/product.ts`, and `shared/integrationTypes.ts`.
- Update the item editor `ProductsServiceFirst` to collect the new course fields in the `Draft` and include them in the save payload with `itemType: 'course'` and `listingType: 'course'`, and normalize course display/description generation to use `branch`/`preferredTimes`/`startDate` where appropriate.
- Extend public catalog sync (`functions/src/publicCatalogSync.ts`) to include the structured course fields in published payloads and route course items into the published service bucket for compatibility while surfacing course-specific attributes.
- Treat `course` items as service-like in flows where appropriate by normalizing checkout/resolve code and UI (checkout integration helpers, `Sell` page, `Dashboard` inventory filtering, `BookingsAvailability`, `Promo`/social/blog pages, and data import/export), and update rendering to surface course metadata in listings.

### Testing

- Ran `npx tsc --noEmit` in `functions/` and it passed (type-check of updated functions code succeeded).
- Built the functions package with `npm run build` in `functions/` and the build completed successfully.
- Ran `git diff --check` (code style / whitespace checks) and it passed with no warnings.
- Attempted to run the web build with `npm run build` in `web/` but it could not complete in this environment because local web dependencies/types are not installed (errors for missing `vite/client` and `vitest/globals`).
- Attempted `npm ci` in `web/` to install dependencies but it was blocked by the environment/package registry (HTTP 403 for `@azure/msal-browser`), so automated web build/tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b9b826db08321b42f7d05c5fd0e89)