### PR TITLE
Simplify booking action workflow

### DIFF
--- a/web/src/pages/BookingEditor.tsx
+++ b/web/src/pages/BookingEditor.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { Timestamp, doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore'
 import { db } from '../firebase'
+import { buildCancelBookingPayload, buildCompleteBookingPayload, buildConfirmBookingPayload, hasAppScriptBookingSyncConfigured } from '../utils/bookingActions'
 import { useActiveStore } from '../hooks/useActiveStore'
 import './BookingEditor.css'
 
@@ -144,6 +145,9 @@ export default function BookingEditor() {
   const [loading, setLoading] = useState(!isCreateMode)
   const [saving, setSaving] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [existingPayment, setExistingPayment] = useState<Record<string, unknown>>({})
+  const [shouldQueueBookingSync, setShouldQueueBookingSync] = useState(false)
 
   useEffect(() => {
     if (!storeId || isCreateMode) {
@@ -156,6 +160,8 @@ export default function BookingEditor() {
       setLoading(true)
       setErrorMessage(null)
       try {
+        const storeDocSnap = await getDoc(doc(db, 'stores', storeId))
+        setShouldQueueBookingSync(hasAppScriptBookingSyncConfigured(storeDocSnap.data() as Record<string, unknown> | undefined))
         const storeBookingRef = doc(db, 'stores', storeId, 'integrationBookings', bookingId)
         const storeSnap = await getDoc(storeBookingRef)
         let data: Record<string, unknown> | null = null
@@ -180,6 +186,7 @@ export default function BookingEditor() {
 
         if (cancelled) return
         setForm(normalizeBookingForm(data))
+        setExistingPayment(recordValue(data.payment))
       } catch (error) {
         console.error('[booking-editor] Failed to load booking', error)
         if (!cancelled) {
@@ -194,6 +201,27 @@ export default function BookingEditor() {
       cancelled = true
     }
   }, [bookingId, isCreateMode, storeId])
+
+
+  useEffect(() => {
+    if (!storeId || !isCreateMode) return
+    let cancelled = false
+    async function loadStoreSyncConfig() {
+      try {
+        const storeDocSnap = await getDoc(doc(db, 'stores', storeId))
+        if (!cancelled) {
+          setShouldQueueBookingSync(hasAppScriptBookingSyncConfigured(storeDocSnap.data() as Record<string, unknown> | undefined))
+        }
+      } catch (error) {
+        console.error('[booking-editor] Failed to load booking sync config', error)
+        if (!cancelled) setShouldQueueBookingSync(false)
+      }
+    }
+    void loadStoreSyncConfig()
+    return () => {
+      cancelled = true
+    }
+  }, [isCreateMode, storeId])
 
   const quantityValue = useMemo(() => {
     const parsed = Number.parseInt(form.quantity, 10)
@@ -212,13 +240,11 @@ export default function BookingEditor() {
 
     setSaving(true)
     setErrorMessage(null)
+    setSuccessMessage(null)
     const targetId = isCreateMode ? doc(db, 'stores', storeId, 'integrationBookings').id : bookingId
 
     try {
-      const now = Timestamp.now()
       const normalizedStatus = (form.status.trim() || 'pending_approval').toLowerCase()
-      const isConfirmed = normalizedStatus === 'confirmed'
-      const syncReason = normalizedStatus === 'rescheduled' ? 'booking_rescheduled' : normalizedStatus === 'cancelled' ? 'booking_cancelled' : isConfirmed ? 'booking_confirmed' : null
       const payload = {
           name: form.fullName.trim(),
           fullName: form.fullName.trim(),
@@ -263,26 +289,21 @@ export default function BookingEditor() {
           },
           bookingId: targetId,
           booking_id: targetId,
-          source: isCreateMode ? 'manual_admin' : 'manual-edit',
-          sourceChannel: 'manual_admin',
-          source_channel: 'manual_admin',
-          syncStatus: syncReason ? 'pending' : 'not_ready',
-          syncReason,
-          syncRequestedAt: syncReason ? now : null,
-          confirmedAt: isConfirmed ? now : null,
-          confirmedBy: isConfirmed ? 'staff_admin' : null,
-          rescheduledAt: normalizedStatus === 'rescheduled' ? now : null,
-          cancelledAt: normalizedStatus === 'cancelled' ? now : null,
-          completedAt: normalizedStatus === 'completed' ? now : null,
           updatedAt: serverTimestamp(),
-          ...(isCreateMode ? { createdAt: serverTimestamp() } : {}),
+          ...(isCreateMode ? {
+            createdAt: serverTimestamp(),
+            source: 'manual_admin',
+            sourceChannel: 'manual_admin',
+            source_channel: 'manual_admin',
+          } : {}),
         }
       await Promise.all([
         setDoc(doc(db, 'stores', storeId, 'integrationBookings', targetId), payload, { merge: true }),
         setDoc(doc(db, 'integrationBookings', targetId), payload, { merge: true }),
       ])
 
-      navigate('/bookings')
+      setSuccessMessage('Changes saved.')
+      if (isCreateMode) navigate('/bookings')
     } catch (error) {
       console.error('[booking-editor] Failed to save booking', error)
       setErrorMessage('Unable to save booking right now.')
@@ -291,11 +312,12 @@ export default function BookingEditor() {
     }
   }
 
-  async function updateExistingBooking(payload: Record<string, unknown>, failureMessage: string) {
+  async function updateExistingBooking(payload: Record<string, unknown>, failureMessage: string, successMessageText: string) {
     if (!storeId || isCreateMode) return
 
     setSaving(true)
     setErrorMessage(null)
+    setSuccessMessage(null)
     try {
       await Promise.all([
         setDoc(doc(db, 'stores', storeId, 'integrationBookings', bookingId), payload, { merge: true }),
@@ -306,6 +328,10 @@ export default function BookingEditor() {
         status: typeof payload.status === 'string' ? payload.status : prev.status,
         paymentStatus: typeof payload.paymentStatus === 'string' ? payload.paymentStatus : prev.paymentStatus,
       }))
+      if (payload.payment && typeof payload.payment === 'object') {
+        setExistingPayment(payload.payment as Record<string, unknown>)
+      }
+      setSuccessMessage(successMessageText)
     } catch (error) {
       console.error('[booking-editor] Failed to update booking', error)
       setErrorMessage(failureMessage)
@@ -315,50 +341,29 @@ export default function BookingEditor() {
   }
 
   function handleConfirmBooking() {
-    const now = Timestamp.now()
-    return updateExistingBooking({
-      bookingStatus: 'confirmed',
-      status: 'confirmed',
-      confirmedAt: now,
-      confirmedBy: 'staff_admin',
-      syncStatus: 'pending',
-      syncReason: 'booking_confirmed',
-      syncRequestedAt: now,
-      updatedAt: serverTimestamp(),
-    }, 'Unable to confirm booking right now.')
-  }
-
-  function handleConfirmPayment() {
-    const now = Timestamp.now()
-    return updateExistingBooking({
-      paymentStatus: 'paid',
-      paymentConfirmedAt: now,
-      paymentVerifiedAt: now,
-      paymentVerifiedBy: 'staff_admin',
-      updatedAt: serverTimestamp(),
-    }, 'Unable to confirm payment right now.')
+    return updateExistingBooking(
+      buildConfirmBookingPayload(existingPayment, shouldQueueBookingSync),
+      'Unable to confirm booking right now.',
+      shouldQueueBookingSync
+        ? 'Booking confirmed, payment marked paid, and sync queued.'
+        : 'Booking confirmed and payment marked paid. App Script sync is not configured.',
+    )
   }
 
   function handleCancelBooking() {
-    const now = Timestamp.now()
-    return updateExistingBooking({
-      bookingStatus: 'cancelled',
-      status: 'cancelled',
-      cancelledAt: now,
-      syncStatus: 'pending',
-      syncReason: 'booking_cancelled',
-      syncRequestedAt: now,
-      updatedAt: serverTimestamp(),
-    }, 'Unable to cancel booking right now.')
+    return updateExistingBooking(
+      buildCancelBookingPayload(shouldQueueBookingSync),
+      'Unable to cancel booking right now.',
+      shouldQueueBookingSync ? 'Booking cancelled and sync queued.' : 'Booking cancelled. App Script sync is not configured.',
+    )
   }
 
   function handleCompleteBooking() {
-    return updateExistingBooking({
-      bookingStatus: 'completed',
-      status: 'completed',
-      completedAt: Timestamp.now(),
-      updatedAt: serverTimestamp(),
-    }, 'Unable to complete booking right now.')
+    return updateExistingBooking(
+      buildCompleteBookingPayload(shouldQueueBookingSync),
+      'Unable to complete booking right now.',
+      shouldQueueBookingSync ? 'Booking completed and sync queued.' : 'Booking completed. App Script sync is not configured.',
+    )
   }
 
 
@@ -370,11 +375,12 @@ export default function BookingEditor() {
             <Link to="/bookings">← Back to bookings</Link>
           </p>
           <h1>{isCreateMode ? 'Add booking' : 'Edit booking'}</h1>
-          <p className="form__hint">Save changes to update this booking and queue sync back to your sheet.</p>
+          <p className="form__hint">Use action buttons to immediately confirm, cancel, or complete bookings. Save changes only updates edited fields.</p>
         </header>
 
         {loading && <p className="form__hint">Loading booking…</p>}
         {errorMessage && <p className="form__error">{errorMessage}</p>}
+        {successMessage && <p className="form__success">{successMessage}</p>}
 
         {!loading && (
           <form
@@ -426,9 +432,6 @@ export default function BookingEditor() {
                   <button type="button" className="btn btn-secondary" disabled={saving} onClick={() => void handleConfirmBooking()}>
                     Confirm booking
                   </button>
-                  <button type="button" className="btn btn-secondary" disabled={saving} onClick={() => void handleConfirmPayment()}>
-                    Confirm payment / Mark paid
-                  </button>
                   <button type="button" className="btn btn-secondary" disabled={saving} onClick={() => void handleCancelBooking()}>
                     Cancel booking
                   </button>
@@ -438,7 +441,7 @@ export default function BookingEditor() {
                 </>
               )}
               <button type="submit" className="button button--primary" disabled={saving}>
-                {saving ? 'Saving…' : 'Save and sync'}
+                {saving ? 'Saving…' : 'Save changes'}
               </button>
             </div>
           </form>

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { collection, doc, getDocs, query, setDoc, Timestamp, where } from 'firebase/firestore'
+import { collection, doc, getDoc, getDocs, query, serverTimestamp, setDoc, Timestamp, where } from 'firebase/firestore'
 import { Link } from 'react-router-dom'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
+import { buildCancelBookingPayload, buildCompleteBookingPayload, buildConfirmBookingPayload, hasAppScriptBookingSyncConfigured } from '../utils/bookingActions'
 import './Bookings.css'
 
 type BookingRecord = {
@@ -29,6 +30,7 @@ type BookingRecord = {
   paymentReference: string | null
   duplicateMerged: boolean
   sourcePath: 'store' | 'root'
+  payment: Record<string, unknown>
 }
 
 function pickString(data: Record<string, unknown>, keys: string[]): string | null {
@@ -94,6 +96,7 @@ export default function Bookings() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'needs_action' | 'today' | 'upcoming' | 'all' | 'cancelled'>('needs_action')
   const [updatingBookingId, setUpdatingBookingId] = useState<string | null>(null)
+  const [shouldQueueBookingSync, setShouldQueueBookingSync] = useState(false)
 
   const hydrateBooking = useCallback((id: string, data: Record<string, unknown>, serviceMap: Map<string, string>, sourcePath: 'store' | 'root') => {
     const nestedData = data.data && typeof data.data === 'object' ? (data.data as Record<string, unknown>) : {}
@@ -142,6 +145,7 @@ export default function Bookings() {
       paymentReference: pickString(data, ['paymentReference']) ?? pickString(payment, ['reference']),
       duplicateMerged: false,
       sourcePath,
+      payment,
     } satisfies BookingRecord
   }, [])
 
@@ -150,6 +154,9 @@ export default function Bookings() {
     setLoading(true)
     setErrorMessage(null)
     try {
+      const storeDocSnap = await getDoc(doc(db, 'stores', storeId))
+      setShouldQueueBookingSync(hasAppScriptBookingSyncConfigured(storeDocSnap.data() as Record<string, unknown> | undefined))
+
       const serviceMap = new Map<string, string>()
       for (const collectionName of ['services', 'integrationServices']) {
         const servicesSnapshot = await getDocs(collection(db, 'stores', storeId, collectionName))
@@ -200,9 +207,11 @@ export default function Bookings() {
     if (!storeId) return
     setUpdatingBookingId(booking.id)
     try {
-      const payload = { ...updates, updatedAt: Timestamp.now() }
-      await setDoc(doc(db, 'stores', storeId, 'integrationBookings', booking.id), payload, { merge: true })
-      await setDoc(doc(db, 'integrationBookings', booking.id), payload, { merge: true })
+      const payload = { ...updates, updatedAt: updates.updatedAt ?? serverTimestamp() }
+      await Promise.all([
+        setDoc(doc(db, 'stores', storeId, 'integrationBookings', booking.id), payload, { merge: true }),
+        setDoc(doc(db, 'integrationBookings', booking.id), payload, { merge: true }),
+      ])
       setBookings(prev => prev.map(b => (b.id === booking.id ? { ...b, ...updates } as BookingRecord : b)))
     } finally {
       setUpdatingBookingId(null)
@@ -234,8 +243,7 @@ export default function Bookings() {
     if (['completed', 'cancelled', 'deleted'].includes(b.status)) return ['open']
     const actions = ['open']
     if (['pending', 'pending_approval', 'manual_review'].includes(b.status) || b.bookingStatus === 'pending_approval') actions.push('confirm', 'cancel')
-    if (b.status === 'confirmed') actions.push('reschedule', 'complete', 'cancel')
-    if (['pending', 'payment_pending', 'manual_review'].includes(b.paymentStatus)) actions.push('mark_paid')
+    if (b.status === 'confirmed') actions.push('complete', 'cancel')
     return actions
   }
 
@@ -262,7 +270,7 @@ export default function Bookings() {
 
     {loading ? <p>Loading bookings…</p> : errorMessage ? <p className="form__error">{errorMessage}</p> : <div className="bookings-table-wrap"><table className="table bookings-table"><thead><tr><th>Booking</th><th>Customer</th><th>Schedule</th><th>Source</th><th>Payment</th><th>Status</th><th>Actions</th></tr></thead><tbody>{visible.map(b => {
       const acts = actionsFor(b)
-      return <tr key={b.id}><td><strong>{b.serviceName}</strong><small>{b.reference || b.bookingId || 'No reference'}</small>{b.serviceName === 'Service not named' ? <small className="muted">Service ID: {b.serviceId}</small> : null}{b.duplicateMerged ? <span className="bookings-badge">Duplicate records merged</span> : null}</td><td><strong>{b.customerName || 'Customer'}</strong><small>{b.customerPhone || b.customerEmail || 'No contact'}</small></td><td><strong>{b.bookingDate || 'Date not set'}</strong><small>{b.bookingTime || 'Time not set'}</small><small>{b.preferredBranch || 'Main branch'}</small></td><td><span className="bookings-badge">{b.sourceLabel}</span><small>{b.sourcePath === 'root' ? 'Root booking' : 'Store booking'}</small></td><td><strong>{b.paymentAmount || '—'}</strong><small>{paymentLabel(b.paymentStatus)}</small><small>{b.paymentMethod || 'Method not set'}</small></td><td><span className={`bookings-page__status bookings-page__status--${b.bookingStatus}`}>{statusLabel(b.bookingStatus)}</span><small>{b.paymentStatus === 'paid' && b.bookingStatus !== 'confirmed' ? 'Paid - waiting for store confirmation' : ''}</small><small>{b.syncStatus === 'pending' ? 'Sync pending' : b.syncStatus === 'synced' ? 'Synced' : ''}</small></td><td><div className="bookings-page__row-actions"><Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link>{acts.includes('confirm') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{bookingStatus:'confirmed',status:'confirmed',confirmedAt:Timestamp.now(),confirmedBy:'staff_admin',syncStatus:'pending',syncReason:'booking_confirmed',syncRequestedAt:Timestamp.now()})} disabled={updatingBookingId===b.id}>Confirm</button>}{acts.includes('mark_paid') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{paymentStatus:'paid'})} disabled={updatingBookingId===b.id}>Mark paid</button>}{acts.includes('reschedule') && <Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Reschedule</Link>}{acts.includes('complete') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{bookingStatus:'completed',status:'completed',completedAt:Timestamp.now()})} disabled={updatingBookingId===b.id}>Complete</button>}{acts.includes('cancel') && <button className="btn btn-secondary" onClick={() => void updateBooking(b,{bookingStatus:'cancelled',status:'cancelled',cancelledAt:Timestamp.now(),syncStatus:'pending',syncReason:'booking_cancelled',syncRequestedAt:Timestamp.now()})} disabled={updatingBookingId===b.id}>Cancel</button>}</div></td></tr>
+      return <tr key={b.id}><td><strong>{b.serviceName}</strong><small>{b.reference || b.bookingId || 'No reference'}</small>{b.serviceName === 'Service not named' ? <small className="muted">Service ID: {b.serviceId}</small> : null}{b.duplicateMerged ? <span className="bookings-badge">Duplicate records merged</span> : null}</td><td><strong>{b.customerName || 'Customer'}</strong><small>{b.customerPhone || b.customerEmail || 'No contact'}</small></td><td><strong>{b.bookingDate || 'Date not set'}</strong><small>{b.bookingTime || 'Time not set'}</small><small>{b.preferredBranch || 'Main branch'}</small></td><td><span className="bookings-badge">{b.sourceLabel}</span><small>{b.sourcePath === 'root' ? 'Root booking' : 'Store booking'}</small></td><td><strong>{b.paymentAmount || '—'}</strong><small>{paymentLabel(b.paymentStatus)}</small><small>{b.paymentMethod || 'Method not set'}</small></td><td><span className={`bookings-page__status bookings-page__status--${b.bookingStatus}`}>{statusLabel(b.bookingStatus)}</span><small>{b.paymentStatus === 'paid' && b.bookingStatus !== 'confirmed' ? 'Paid - waiting for store confirmation' : ''}</small><small>{b.syncStatus === 'pending' ? 'Sync pending' : b.syncStatus === 'synced' ? 'Synced' : ''}</small></td><td><div className="bookings-page__row-actions">{acts.includes('confirm') && <button className="btn btn-secondary" onClick={() => void updateBooking(b, buildConfirmBookingPayload(b.payment, shouldQueueBookingSync))} disabled={updatingBookingId===b.id}>Confirm booking</button>}{acts.includes('cancel') && <button className="btn btn-secondary" onClick={() => void updateBooking(b, buildCancelBookingPayload(shouldQueueBookingSync))} disabled={updatingBookingId===b.id}>Cancel booking</button>}{acts.includes('complete') && <button className="btn btn-secondary" onClick={() => void updateBooking(b, buildCompleteBookingPayload(shouldQueueBookingSync))} disabled={updatingBookingId===b.id}>Complete</button>}<Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link></div></td></tr>
     })}</tbody></table><div className="bookings-cards">{visible.map(b => <article key={`${b.id}-card`} className="bookings-card"><h3>{b.serviceName}</h3><p>{b.customerName || 'Customer'} • {b.bookingDate || 'Date not set'} {b.bookingTime || ''}</p><p>{statusLabel(b.status)} • {paymentLabel(b.paymentStatus)}</p><Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link></article>)}</div></div>}
   </section></main>
 }

--- a/web/src/utils/bookingActions.ts
+++ b/web/src/utils/bookingActions.ts
@@ -1,0 +1,105 @@
+import { Timestamp, serverTimestamp } from 'firebase/firestore'
+
+export type BookingActionType = 'confirm' | 'cancel' | 'complete'
+
+export function hasAppScriptBookingSyncConfigured(storeData: Record<string, unknown> | null | undefined): boolean {
+  if (!storeData) return false
+
+  const hasText = (value: unknown) => typeof value === 'string' && value.trim().length > 0
+  const hasEnabledFlag = (value: unknown) => value === true || value === 'enabled' || value === 'active'
+  const asRecord = (value: unknown): Record<string, unknown> | null =>
+    value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+
+  const configCandidates = [
+    storeData.integrationBookingConfig,
+    storeData.bookingSync,
+    storeData.bookingAppsScript,
+    storeData.appsScriptBookingSync,
+    storeData.websiteBookingSync,
+    asRecord(storeData.integrations)?.bookingSync,
+    asRecord(storeData.integrations)?.bookingAppsScript,
+    asRecord(storeData.integrations)?.appsScriptBookingSync,
+  ]
+
+  for (const candidate of configCandidates) {
+    const config = asRecord(candidate)
+    if (!config) continue
+
+    if (
+      hasText(config.webAppUrl) ||
+      hasText(config.appsScriptUrl) ||
+      hasText(config.appScriptUrl) ||
+      hasText(config.scriptUrl) ||
+      hasText(config.webhookUrl) ||
+      hasText(config.endpointUrl) ||
+      hasText(config.url)
+    ) {
+      return config.enabled !== false && config.status !== 'disabled'
+    }
+
+    if (hasEnabledFlag(config.enabled) || hasEnabledFlag(config.status)) return true
+  }
+
+  if (hasEnabledFlag(storeData.bookingSyncEnabled) || hasEnabledFlag(storeData.appScriptBookingSyncEnabled)) return true
+
+  const endpoints = Array.isArray(storeData.webhookEndpoints) ? storeData.webhookEndpoints : []
+  return endpoints.some(endpoint => {
+    const config = asRecord(endpoint)
+    if (!config || config.status === 'revoked' || config.enabled === false) return false
+    const events = Array.isArray(config.events) ? config.events : []
+    const acceptsBookingEvents = events.length === 0 || events.some(event => typeof event === 'string' && event.startsWith('booking.'))
+    return acceptsBookingEvents && (hasText(config.url) || hasText(config.webAppUrl) || hasText(config.endpointUrl))
+  })
+}
+
+function syncPayload(syncReason: string, now: Timestamp, shouldQueueSync: boolean) {
+  if (!shouldQueueSync) return {}
+  return {
+    syncStatus: 'pending',
+    syncReason,
+    syncRequestedAt: now,
+  }
+}
+
+export function buildConfirmBookingPayload(existingPayment: Record<string, unknown>, shouldQueueSync: boolean) {
+  const now = Timestamp.now()
+  return {
+    bookingStatus: 'confirmed',
+    status: 'confirmed',
+    paymentStatus: 'paid',
+    confirmedAt: now,
+    confirmedBy: 'staff_admin',
+    paymentConfirmedAt: now,
+    paymentVerifiedAt: now,
+    paymentVerifiedBy: 'staff_admin',
+    payment: {
+      ...existingPayment,
+      status: 'paid',
+      confirmed: true,
+    },
+    ...syncPayload('booking_confirmed', now, shouldQueueSync),
+    updatedAt: serverTimestamp(),
+  }
+}
+
+export function buildCancelBookingPayload(shouldQueueSync: boolean) {
+  const now = Timestamp.now()
+  return {
+    bookingStatus: 'cancelled',
+    status: 'cancelled',
+    cancelledAt: now,
+    ...syncPayload('booking_cancelled', now, shouldQueueSync),
+    updatedAt: serverTimestamp(),
+  }
+}
+
+export function buildCompleteBookingPayload(shouldQueueSync: boolean) {
+  const now = Timestamp.now()
+  return {
+    bookingStatus: 'completed',
+    status: 'completed',
+    completedAt: now,
+    ...syncPayload('booking_completed', now, shouldQueueSync),
+    updatedAt: serverTimestamp(),
+  }
+}


### PR DESCRIPTION
### Motivation
- Reduce confusion by consolidating booking/payment actions into a small set of immediate action buttons and keep `Save changes` only for editing fields.
- Ensure business semantics: Confirming a booking also marks payment as paid and queues App Script sync only when the store has an Apps Script sync configured.

### Description
- Add a new helper module `web/src/utils/bookingActions.ts` that exposes `hasAppScriptBookingSyncConfigured()` and payload builders `buildConfirmBookingPayload()`, `buildCancelBookingPayload()`, and `buildCompleteBookingPayload()` which produce the required fields, timestamps, nested `payment` updates, conditional `syncStatus: 'pending'` entries, and `updatedAt: serverTimestamp()`.
- Update `BookingEditor` to use those builders, preserve the existing `payment` object when confirming, detect store sync configuration, write action payloads immediately to both `stores/{storeId}/integrationBookings/{bookingId}` and `integrationBookings/{bookingId}` using `setDoc(..., { merge: true })`, show action-specific success messages, remove the separate “Confirm payment / Mark paid” button, and rename the save button to `Save changes` that only persists edited form fields.
- Update `Bookings.tsx` row actions to remove `Mark paid` and show row buttons: `Confirm booking`, `Cancel booking`, `Complete`, and `Open`; those buttons call the same payload builders and write to both Firestore paths with `merge: true` and set `updatedAt` appropriately.
- Action messaging: Confirm booking → "Booking confirmed, payment marked paid, and sync queued." (or fallback message when sync not configured), Cancel → "Booking cancelled and sync queued." (or fallback), Complete → "Booking completed and sync queued.", Save changes → "Changes saved.".

### Testing
- Ran `git diff --check` which produced no whitespace errors (success).
- Attempted `npm ci` but it failed due to registry access/security (observed `403 Forbidden` for `@azure/msal-browser`) so full local dependency install was blocked.
- Attempted `npm run build` but TypeScript/Vite build was blocked because dependencies/type packages were not installed locally (`vite/client` and `vitest/globals` resolution errors) so a full compile could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b9e9309748321b50c08c26c3f1a29)