### PR TITLE
Relax integration checkout payload parsing for booking flows

### DIFF
--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -37,6 +37,23 @@ type CheckoutBody = {
   sourceLabel?: unknown
   source_label?: unknown
   metadata?: unknown
+  branchLocationId?: unknown
+  branch_location_id?: unknown
+  selectedBranchStoreId?: unknown
+  selected_branch_store_id?: unknown
+  customerEmail?: unknown
+  customer_email?: unknown
+  customerName?: unknown
+  customer_name?: unknown
+  customerPhone?: unknown
+  customer_phone?: unknown
+  email?: unknown
+  name?: unknown
+  phone?: unknown
+  servicePrice?: unknown
+  service_price?: unknown
+  totalAmount?: unknown
+  total_amount?: unknown
 }
 
 function clean(value: unknown, max = 500) {
@@ -49,16 +66,34 @@ function numberValue(value: unknown) {
 }
 
 function getStoreId(body: CheckoutBody) {
-  return clean(body.store_id ?? body.merchant_id ?? body.storeId ?? body.merchantId, 180)
+  return clean(
+    body.store_id
+      ?? body.merchant_id
+      ?? body.storeId
+      ?? body.merchantId
+      ?? body.selectedBranchStoreId
+      ?? body.selected_branch_store_id
+      ?? body.branchLocationId
+      ?? body.branch_location_id,
+    180,
+  )
 }
 
 function getCustomer(body: CheckoutBody) {
-  return body.customer && typeof body.customer === 'object' ? (body.customer as Record<string, unknown>) : {}
+  const nested = body.customer && typeof body.customer === 'object' ? (body.customer as Record<string, unknown>) : {}
+  return {
+    ...nested,
+    email: nested.email ?? body.customerEmail ?? body.customer_email ?? body.email,
+    name: nested.name ?? body.customerName ?? body.customer_name ?? body.name,
+    phone: nested.phone ?? body.customerPhone ?? body.customer_phone ?? body.phone,
+  }
 }
 
 function getAmountMajor(body: CheckoutBody) {
   const direct = numberValue(body.amount)
   if (direct && direct > 0) return direct
+  const fallbackAmount = numberValue(body.servicePrice ?? body.service_price ?? body.totalAmount ?? body.total_amount)
+  if (fallbackAmount && fallbackAmount > 0) return fallbackAmount
   const snapshot = body.pricing_snapshot && typeof body.pricing_snapshot === 'object' ? body.pricing_snapshot as Record<string, unknown> : {}
   const finalTotalMinor = numberValue(snapshot.final_total)
   return finalTotalMinor && finalTotalMinor > 0 ? finalTotalMinor / 100 : null


### PR DESCRIPTION
### Motivation
- Client website booking payloads often use alternate or mixed snake_case/camelCase field names and booking-specific keys which caused checkout requests to be rejected. 
- The change aims to make `integrationCheckoutCreate` tolerant of these real-world payload shapes so testing and site integration succeed without requiring exact canonical field names. 

### Description
- Added booking-style aliases to the `CheckoutBody` type in `functions/src/integrationCheckout.ts` to accept `branchLocationId`, `selectedBranchStoreId`, customer aliases (`customerEmail`, `customerPhone`, etc.), and amount aliases (`servicePrice`, `totalAmount`).
- Updated `getStoreId` to fallback to `selectedBranchStoreId`, `selected_branch_store_id`, and `branchLocationId` when canonical store fields are absent. 
- Updated `getCustomer` to merge nested `customer` fields with top-level customer aliases and normalized `email`, `name`, and `phone` extraction. 
- Updated `getAmountMajor` to fallback to `servicePrice`/`service_price` and `totalAmount`/`total_amount` when `amount` is missing before using `pricing_snapshot`.

### Testing
- `npm --prefix functions run build` completed successfully. 
- `npm --prefix functions test` failed with an existing test harness error (`Expected __testing exports`) that appears unrelated to the parsing changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca391e07483218a9f8931fd38d35d)