### PR TITLE
Harden checkout auth fallback to product endpoint

### DIFF
--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -386,6 +386,8 @@ async function isAuthorized(req: functions.https.Request, storeId: string) {
     return true
   }
 
+  let authLookupFailed = false
+
   try {
     const storeSnap = await defaultDb.collection('stores').doc(storeId).get()
     const storeData = (storeSnap.data() ?? {}) as Record<string, unknown>
@@ -416,9 +418,16 @@ async function isAuthorized(req: functions.https.Request, storeId: string) {
       if (!snapshot.empty) return true
     }
 
-    if (await isAuthorizedByExistingProductEndpoint(req, storeId, apiKey)) return true
   } catch (error) {
+    authLookupFailed = true
     functions.logger.warn('integration order status auth lookup failed', { storeId, error })
+  }
+
+  if (await isAuthorizedByExistingProductEndpoint(req, storeId, apiKey)) {
+    if (authLookupFailed) {
+      functions.logger.info('integration checkout authorized via product endpoint fallback after auth lookup failure', { storeId })
+    }
+    return true
   }
 
   return false


### PR DESCRIPTION
### Motivation
- Some integrations can successfully fetch products but fail checkout authorization when Firestore-based API key lookups transiently error, causing valid merchant requests to be rejected. 
- Ensure checkout eligibility mirrors product-access capability by always attempting the product-endpoint fallback even after lookup failures.

### Description
- Updated the `isAuthorized` flow in `functions/src/integrationCheckout.ts` to track whether the Firestore key lookup path threw (`authLookupFailed`) and to always call the product-endpoint fallback (`isAuthorizedByExistingProductEndpoint`) after the lookup attempt. 
- When the product-endpoint fallback succeeds after a lookup failure, the code now emits an info log so these fallback authorizations are visible (`integration checkout authorized via product endpoint fallback after auth lookup failure`).
- No other authorization checks or public APIs were changed.

### Testing
- Ran `npm run build` in `functions/` and the TypeScript build completed successfully. 
- Ran `npm test` in `functions/` and the test harness failed with a pre-existing assertion (`Expected __testing exports`), which is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb752f6348321a637cc6ad7ae6ea4)