### PR TITLE
Fix Firebase functions deploy filter to include only deployable handlers

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build and list functions to deploy
         run: |
           npm --prefix functions run build
-          FUNCTIONS_LIST=$(node -e "const exportsMap = require('./functions/lib/index.js'); const deployable = Object.keys(exportsMap).filter((name) => !name.startsWith('__')); process.stdout.write(deployable.join(','));")
+          FUNCTIONS_LIST=$(node -e "const exportsMap = require('./functions/lib/index.js'); const deployable = Object.entries(exportsMap).filter(([name, value]) => !name.startsWith('__') && value && typeof value === 'function' && (value.__endpoint || value.__trigger)).map(([name]) => name); process.stdout.write(deployable.join(','));")
           if [ -z "$FUNCTIONS_LIST" ]; then
             echo "No deployable function exports found in functions/lib/index.js"
             exit 1


### PR DESCRIPTION
### Motivation
- Deploys failed with `No function matches the filter: default:removeStorePublicCatalog` because the workflow treated every export from `functions/lib/index.js` as a deploy target instead of actual Cloud Function handlers. 
- The change ensures the workflow only selects real Firebase function handlers for the `--only` filter to avoid invalid deploy targets.

### Description
- Updated `.github/workflows/deploy-functions.yml` to change the Node one-liner that builds `FUNCTIONS_LIST` to filter `Object.entries(exportsMap)` for values that are functions and expose Firebase trigger metadata (`__endpoint` or `__trigger`).
- This replaces the previous `Object.keys` approach which inadvertently included helper/non-deployable exports like `removeStorePublicCatalog` in the deploy filter.
- The workflow still runs `npm --prefix functions run build` and produces `FUNCTIONS_ONLY` in the same format for the `firebase deploy --only` call.

### Testing
- Verified the updated line appears in the workflow using `rg -n "FUNCTIONS_LIST|deployable" .github/workflows/deploy-functions.yml` which returned the new filtered discovery command and `git diff` showed the single-line change (success). 
- Committed the change with `git commit` and created the PR metadata via the `make_pr` step (both succeeded). 
- No full CI deploy run was executed in this change; the modification is limited to the workflow script and is intended to prevent the previously observed deploy-time error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb8c03dc08321a21aaa8cd78883ca)