### PR TITLE
Redact API keys in logs and make auth lookup fallback more robust

### DIFF
--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -283,6 +283,12 @@ function getRequestApiKey(req: functions.https.Request) {
   return clean(req.get('x-api-key'), 1000) || bearer
 }
 
+function redactApiKey(apiKey: string) {
+  if (!apiKey) return null
+  if (apiKey.length <= 8) return `${apiKey.slice(0, 2)}***${apiKey.slice(-2)}`
+  return `${apiKey.slice(0, 4)}***${apiKey.slice(-4)}`
+}
+
 
 function getSedifexMarketMerchantTokenMap(): Record<string, string> {
   const raw =
@@ -386,6 +392,8 @@ async function isAuthorized(req: functions.https.Request, storeId: string) {
     return true
   }
 
+  let authLookupFailed = false
+
   try {
     const storeSnap = await defaultDb.collection('stores').doc(storeId).get()
     const storeData = (storeSnap.data() ?? {}) as Record<string, unknown>
@@ -416,9 +424,16 @@ async function isAuthorized(req: functions.https.Request, storeId: string) {
       if (!snapshot.empty) return true
     }
 
-    if (await isAuthorizedByExistingProductEndpoint(req, storeId, apiKey)) return true
   } catch (error) {
+    authLookupFailed = true
     functions.logger.warn('integration order status auth lookup failed', { storeId, error })
+  }
+
+  if (await isAuthorizedByExistingProductEndpoint(req, storeId, apiKey)) {
+    if (authLookupFailed) {
+      functions.logger.info('integration checkout authorized via product endpoint fallback after auth lookup failure', { storeId })
+    }
+    return true
   }
 
   return false
@@ -626,9 +641,12 @@ export const integrationCheckoutPreview = functions.https.onRequest(async (req, 
 
     const authorized = await isAuthorized(req, storeId)
     if (!authorized) {
+      const requestApiKey = getRequestApiKey(req)
       functions.logger.warn('integrationCheckoutPreview auth failed', {
         storeId,
-        hasApiKey: Boolean(getRequestApiKey(req)),
+        hasApiKey: Boolean(requestApiKey),
+        apiKeyHint: redactApiKey(requestApiKey),
+        hasAuthorizationHeader: Boolean(clean(req.get('authorization'), 1000)),
       })
       res.status(401).json({ error: 'invalid-api-key' })
       return
@@ -874,6 +892,14 @@ export const integrationOrderStatus = functions.https.onRequest(async (req, res)
 
     const authorized = await isAuthorized(req, storeId)
     if (!authorized) {
+      const requestApiKey = getRequestApiKey(req)
+      functions.logger.warn('integrationOrderStatus auth failed', {
+        storeId,
+        reference,
+        hasApiKey: Boolean(requestApiKey),
+        apiKeyHint: redactApiKey(requestApiKey),
+        hasAuthorizationHeader: Boolean(clean(req.get('authorization'), 1000)),
+      })
       res.status(401).json({ error: 'unauthorized' })
       return
     }


### PR DESCRIPTION
### Motivation

- Avoid logging full API keys while improving diagnostics when auth lookups fail. 
- Ensure the existing-product-endpoint fallback is honored even if the primary Firestore lookup throws an error. 

### Description

- Add a `redactApiKey` helper to expose only a short hint of API keys instead of full values in logs. 
- Capture `getRequestApiKey(req)` in a local variable and log `apiKeyHint` and `hasAuthorizationHeader` in `integrationCheckoutPreview` and `integrationOrderStatus` when auth fails. 
- Introduce an `authLookupFailed` flag in `isAuthorized` and move the `isAuthorizedByExistingProductEndpoint` fallback to run after the Firestore try/catch, logging an info message if the fallback authorizes after a lookup failure. 
- Minor refactor to avoid repeated `getRequestApiKey` calls and improve diagnostic messages. 

### Testing

- Ran TypeScript compilation (`tsc`) to validate types and build; compilation succeeded. 
- Ran lint checks and unit tests where present; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb752f6348321a637cc6ad7ae6ea4)