### PR TITLE
Prevent product ID collisions and strengthen AI description prompt

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -96,13 +96,18 @@ function buildDescriptionPrompt(input: {
     'General product'
 
   return [
-    'Write one product description for a store listing.',
+    'Write one creative, customer-facing product description for a store listing.',
     `Template: ${templateLabel}.`,
     `Product name: ${input.itemName || 'Not provided'}.`,
     `Item type: ${input.itemType}.`,
     `Category: ${input.category || 'Not provided'}.`,
-    `Keep it concise, engaging, and under ${MAX_DESCRIPTION_WORDS} words.`,
-    'Include key benefits, best use case, and a short call-to-action.',
+    'Use natural, simple English with a Ghana-friendly tone.',
+    'Format exactly as:',
+    '- One short opening paragraph.',
+    '- Three benefit bullets, each starting with "-".',
+    '- One line that starts with "Best for:".',
+    '- One short call-to-action line.',
+    `Keep it under ${MAX_DESCRIPTION_WORDS} words.`,
     'Return plain text only.',
   ].join(' ')
 }
@@ -1051,6 +1056,7 @@ export default function Products() {
    */
   async function handleAddItem(event: React.FormEvent) {
     event.preventDefault()
+    if (isSaving || isUploadingImage) return
     if (!activeStoreId) return
 
     setFormStatus('idle')
@@ -1167,9 +1173,11 @@ export default function Products() {
 
     setIsSaving(true)
     try {
-      const productRef = doc(collection(db, 'products'), draftProductKey)
+      const productRef = doc(collection(db, 'products'))
+      const productId = productRef.id
 
       await setDoc(productRef, {
+        productKey: productId,
         storeId: activeStoreId,
         storeName: productStoreMeta.storeName,
         storePhone: productStoreMeta.storePhone,


### PR DESCRIPTION
### Motivation
- Prevent accidental overwrites when a reused `draftProductKey` is used as the Firestore document ID. 
- Avoid duplicate submits while a save or image upload is already in progress. 
- Make AI-generated product descriptions more customer-facing and Ghana-friendly with a stricter plain-text format.

### Description
- Return early in `handleAddItem` after `event.preventDefault()` when `isSaving || isUploadingImage` to prevent concurrent submissions. 
- Create Firestore product documents with an auto-generated ID by replacing `doc(collection(db, 'products'), draftProductKey)` with `doc(collection(db, 'products'))`, capture the generated ID in `productId`, and add `productKey: productId` to the `setDoc` payload while keeping `draftProductKey` available for temporary upload paths. 
- Update `buildDescriptionPrompt` to request a creative, customer-facing description in natural simple English with a Ghana-friendly tone and exact format: one short opening paragraph, three benefit bullets each starting with `-`, one `Best for:` line, one short call-to-action line, plain text only, and under `MAX_DESCRIPTION_WORDS`. 
- Preserve all existing validation and UI behavior outside these targeted changes.

### Testing
- Ran the TypeScript build with `npm --prefix web run build`, which failed due to missing type definition files for `vite/client` and `vitest/globals` reported by `tsc`. 
- No additional automated tests were run in this environment due to the type-definition build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7741a8a08321af0e85762725fc42)