### PR TITLE
Improve item creation payloads for product/service/course and prevent duplicates

### DIFF
--- a/web/src/pages/ProductsServiceFirst.tsx
+++ b/web/src/pages/ProductsServiceFirst.tsx
@@ -60,6 +60,9 @@ type Draft = {
   classTimes: string
 }
 
+type ListingType = 'product' | 'service' | 'course'
+type SalesMode = 'buy_now' | 'book_now' | 'register' | 'request_quote'
+
 const PRODUCT_CATEGORY = 'General Products'
 const SERVICE_CATEGORY = 'General Services'
 const EDUCATION_CATEGORY = 'Education'
@@ -295,19 +298,35 @@ function buildSavePayload(draft: Draft, storeId: string) {
   if (price === null) throw new Error('Price is required.')
 
   const serviceKind: ServiceKind = isCourse ? 'consultation' : draft.serviceKind
-  const salesMode = isCourse ? 'register' : serviceKind === 'quote_request' ? 'request_quote' : 'book_now'
+  const listingType: ListingType = isCourse ? 'course' : isService ? 'service' : 'product'
+  const salesMode: SalesMode = isCourse
+    ? 'register'
+    : isService
+    ? serviceKind === 'quote_request'
+      ? 'request_quote'
+      : 'book_now'
+    : 'buy_now'
+  const trimmedImageUrl = draft.imageUrl.trim()
+  const imageUrls = trimmedImageUrl ? [trimmedImageUrl] : []
+  const currency = 'GHS'
+  const categoryName = category
+  const categoryKey = category.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
 
   return {
     storeId,
+    storeName: null,
     name,
     itemType: isCourse ? 'course' : isService ? 'service' : 'product',
-    listingType: isCourse ? 'course' : behavesLikeService ? 'service' : 'product',
+    listingType,
     serviceKind: isCourse ? 'course_enrollment' : serviceKind,
     salesMode,
     enrollmentMode: isCourse ? 'always_open' : null,
     category,
+    categoryKey,
+    categoryName,
     description: draft.description.trim() || null,
     price,
+    currency,
     costPrice: behavesLikeService ? null : cleanNumber(draft.costPrice),
     sku: behavesLikeService ? null : draft.sku.trim() || null,
     barcode: behavesLikeService ? null : draft.sku.trim() || null,
@@ -339,11 +358,19 @@ function buildSavePayload(draft: Draft, storeId: string) {
     manufacturerName: null,
     batchNumber: null,
     showOnReceipt: false,
-    imageUrl: draft.imageUrl.trim() || null,
-    imageUrls: draft.imageUrl.trim() ? [draft.imageUrl.trim()] : [],
+    imageUrl: trimmedImageUrl || null,
+    imageUrls,
     imageAlt: draft.imageAlt.trim() || name,
+    isPublished: false,
+    isMarketplaceVisible: false,
+    featuredRank: null,
+    rankingScore: null,
     updatedAt: serverTimestamp(),
   }
+}
+
+function normalizeName(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
 export default function ProductsServiceFirst() {
@@ -469,20 +496,47 @@ export default function ProductsServiceFirst() {
     setError('')
     try {
       const payload = buildSavePayload(draft as any, storeId)
+      if (payload.imageUrls.length > 0 && !payload.imageUrls.every(url => /^https?:\/\/\S+/i.test(url))) {
+        throw new Error('Image upload did not return a valid image URL.')
+      }
+      if (!editingId) {
+        const possibleDuplicate = items.find(item => {
+          const existingStoreId = typeof (item as Product & { storeId?: unknown }).storeId === 'string'
+            ? ((item as Product & { storeId?: string }).storeId as string)
+            : storeId
+          if (existingStoreId !== storeId) return false
+          const existingListingType = item.listingType ?? item.itemType
+          return (
+            normalizeName(item.name) === normalizeName(payload.name) &&
+            existingListingType === payload.listingType &&
+            normalizeName(item.category ?? '') === normalizeName(payload.categoryName ?? '') &&
+            Number(item.price ?? -1) === Number(payload.price)
+          )
+        })
+        if (possibleDuplicate) {
+          const shouldCreateAnyway = window.confirm(
+            'Possible duplicate found: this store already has a similar product/course/service. Review before creating another one.\n\nClick OK to "Create anyway", or Cancel to edit the existing item.',
+          )
+          if (!shouldCreateAnyway) {
+            editItem(possibleDuplicate)
+            throw new Error('Duplicate prevented. You can edit the existing item instead.')
+          }
+        }
+      }
       if (editingId) {
         await updateDoc(doc(db, 'products', editingId), payload)
-        setMessage(`${draft.itemType === 'course' ? 'Course' : draft.itemType === 'service' ? 'Service' : 'Product'} updated.`)
+        setMessage('Item saved successfully.')
       } else {
         await setDoc(doc(collection(db, 'products')), {
           ...payload,
           createdAt: serverTimestamp(),
           sortOrder: items.length + 1,
         })
-        setMessage(`${draft.itemType === 'course' ? 'Course' : draft.itemType === 'service' ? 'Service' : 'Product'} added.`)
+        setMessage('Item saved successfully.')
       }
       resetForm()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unable to save item.')
+      setError(err instanceof Error ? err.message : 'Could not save item. Please check the details and try again.')
     } finally {
       setSaving(false)
     }


### PR DESCRIPTION
### Motivation
- Ensure marketplace items are recorded with an explicit `listingType` and `salesMode` so SedifexMarket can unambiguously treat entries as `product`, `service`, or `course`. 
- Prevent accidental duplicate listings inside the same store by checking normalized name, listing type, category, and price before creating a new item. 
- Harden image handling so invalid/missing image URLs block saves and surface clear user-facing messages.

### Description
- Updated `web/src/pages/ProductsServiceFirst.tsx` to add `ListingType` and `SalesMode` types and always populate `listingType` and `salesMode` in the save payload with the requested defaults for product/service/course. 
- Extended the save payload with marketplace-oriented fields: `categoryKey`, `categoryName`, `currency`, `imageUrls`, `storeName` (initially `null`), `isPublished`, `isMarketplaceVisible`, and placeholders `featuredRank`/`rankingScore` for future use. 
- Added image URL validation that throws `Image upload did not return a valid image URL.` if a provided image URL is missing or invalid, and changed success/failure messages to `Item saved successfully.` and `Could not save item. Please check the details and try again.` respectively. 
- Implemented duplicate-detection before creating an item using a `normalizeName` helper and a comparison of normalized name, listing type (fallback to `itemType`), category, and price; if a possible duplicate is found the user is prompted to `Edit existing` or `Create anyway` (OK to confirm). 

### Testing
- Attempted a local web build with `npm -C web run -s build`, but the build failed in this environment due to missing TypeScript type definition files `vite/client` and `vitest/globals`, so full compile validation could not be completed. 
- No other automated test runs were executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7e751ae08321bbc014bf7a335b46)