### PR TITLE
Refactor listing save flow: draft-first saves, non-blocking image uploads, and unified publicListings export

### DIFF
--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -366,9 +366,8 @@ async function isAuthorizedByExistingProductEndpoint(req: functions.https.Reques
     if (payloadStoreId && payloadStoreId !== storeId) return false
 
     const products = Array.isArray(payload.products) ? payload.products : []
-    const publicProducts = Array.isArray(payload.publicProducts) ? payload.publicProducts : []
-    const publicServices = Array.isArray(payload.publicServices) ? payload.publicServices : []
-    const sampledItems = [...products, ...publicProducts, ...publicServices].slice(0, 10)
+    const publicListings = Array.isArray(payload.publicListings) ? payload.publicListings : []
+    const sampledItems = [...products, ...publicListings].slice(0, 10)
 
     for (const item of sampledItems) {
       if (!item || typeof item !== 'object') continue
@@ -587,8 +586,7 @@ async function resolveCatalogItem(storeId: string, itemId: string, hintedType: s
     defaultDb.collection('stores').doc(storeId).collection('services').doc(itemId),
     defaultDb.collection('products').doc(itemId),
     defaultDb.collection('services').doc(itemId),
-    defaultDb.collection('publicProducts').doc(itemId),
-    defaultDb.collection('publicServices').doc(itemId),
+    defaultDb.collection('publicListings').doc(itemId),
   ]
 
   for (const ref of directRefs) {
@@ -601,7 +599,7 @@ async function resolveCatalogItem(storeId: string, itemId: string, hintedType: s
     }
   }
 
-  const queryCollections = ['publicProducts', 'publicServices', 'v1IntegrationProducts']
+  const queryCollections = ['publicListings', 'v1IntegrationProducts']
   const queryFields = ['id', 'productId', 'sourceProductId']
 
   for (const collectionName of queryCollections) {

--- a/functions/src/publicCatalogSync.ts
+++ b/functions/src/publicCatalogSync.ts
@@ -52,12 +52,7 @@ function toArray(value: unknown): string[] {
 
 function isStoreEligible(store: StoreData | undefined): boolean {
   if (!store) return false
-  return (
-    store.verified === true &&
-    store.eligibleForBuy === true &&
-    store.buyOptOut !== true &&
-    store.status === 'active'
-  )
+  return store.verified === true && store.eligibleForBuy === true && store.buyOptOut !== true && store.status === 'active'
 }
 
 function buildStoreMeta(store: StoreData): Record<string, unknown> {
@@ -83,11 +78,11 @@ function publicPayload(productId: string, data: ProductData, storeMeta: Record<s
     imageUrls: toArray(data.imageUrls),
     imageAlt: text(data.imageAlt),
     itemType: normalizedItemType,
+    listingType: normalizedItemType,
     isPublished: true,
     publishedAt: resolvePublicationTimestampCandidate(data.publishedAt, data.createdAt, data.updatedAt),
     unpublishedAt: admin.firestore.FieldValue.delete(),
     sourceUpdatedAt: data.updatedAt ?? null,
-    listingType: normalizedItemType === 'course' ? 'course' : text(data.listingType),
     serviceKind: text(data.serviceKind),
     duration: text(data.duration),
     branch: text(data.branch) ?? text(data.location),
@@ -104,194 +99,88 @@ function publicPayload(productId: string, data: ProductData, storeMeta: Record<s
   }
 }
 
-async function flush(batch: FirebaseFirestore.WriteBatch, count: number): Promise<void> {
-  if (count > 0) await batch.commit()
-}
-
 export async function removeStorePublicCatalog(storeId: string): Promise<void> {
-  const [publicProducts, publicServices] = await Promise.all([
-    db.collection('publicProducts').where('storeId', '==', storeId).get(),
-    db.collection('publicServices').where('storeId', '==', storeId).get(),
-  ])
-
+  const listings = await db.collection('publicListings').where('storeId', '==', storeId).get()
   let batch = db.batch()
   let writes = 0
-  let removed = 0
-
-  for (const doc of [...publicProducts.docs, ...publicServices.docs]) {
-    batch.delete(doc.ref)
+  for (const listing of listings.docs) {
+    batch.delete(listing.ref)
     writes += 1
-    removed += 1
     if (writes >= 450) {
       await batch.commit()
       batch = db.batch()
       writes = 0
     }
   }
-  await flush(batch, writes)
+  if (writes > 0) await batch.commit()
 
-  await db.collection('stores').doc(storeId).set(
-    {
-      publicCatalogLastSyncedAt: admin.firestore.FieldValue.serverTimestamp(),
-      publicCatalogDocCount: { products: 0, services: 0 },
-    },
-    { merge: true },
-  )
-
-  functions.logger.info('removeStorePublicCatalog complete', { storeId, publicDocsRemoved: removed })
+  await db.collection('stores').doc(storeId).set({
+    publicCatalogLastSyncedAt: admin.firestore.FieldValue.serverTimestamp(),
+    publicCatalogDocCount: { listings: 0 },
+  }, { merge: true })
 }
 
 export async function syncStorePublicCatalog(storeId: string): Promise<void> {
   const storeRef = db.collection('stores').doc(storeId)
   const storeSnap = await storeRef.get()
   const storeData = (storeSnap.data() ?? {}) as StoreData
-  const eligible = isStoreEligible(storeData)
-
-  if (!eligible) {
+  if (!isStoreEligible(storeData)) {
     await removeStorePublicCatalog(storeId)
     return
   }
 
   const storeMeta = buildStoreMeta(storeData)
   const productsSnap = await db.collection('products').where('storeId', '==', storeId).where('isPublished', '==', true).get()
-
   let batch = db.batch()
   let writes = 0
-  let writtenProducts = 0
-  let writtenServices = 0
-  let removed = 0
-
+  let writtenListings = 0
   for (const productDoc of productsSnap.docs) {
     const data = (productDoc.data() ?? {}) as ProductData
-    const normalizedItemType = itemType(data.itemType)
-    const targetCollection = normalizedItemType === 'product' ? 'publicProducts' : 'publicServices'
-    const oppositeCollection = normalizedItemType === 'product' ? 'publicServices' : 'publicProducts'
-    const payload = publicPayload(productDoc.id, data, storeMeta)
-
-    batch.set(db.collection(targetCollection).doc(productDoc.id), payload, { merge: true })
-    batch.delete(db.collection(oppositeCollection).doc(productDoc.id))
-    writes += 2
-    removed += 1
-
-    if (normalizedItemType !== 'product') writtenServices += 1
-    else writtenProducts += 1
-
+    batch.set(db.collection('publicListings').doc(productDoc.id), publicPayload(productDoc.id, data, storeMeta), { merge: true })
+    writes += 1
+    writtenListings += 1
     if (writes >= 450) {
       await batch.commit()
       batch = db.batch()
       writes = 0
     }
   }
+  if (writes > 0) await batch.commit()
 
-  await flush(batch, writes)
-
-  await storeRef.set(
-    {
-      publicCatalogLastSyncedAt: admin.firestore.FieldValue.serverTimestamp(),
-      publicCatalogDocCount: {
-        products: writtenProducts,
-        services: writtenServices,
-      },
-      publicCatalogOutOfSyncCount: 0,
-    },
-    { merge: true },
-  )
-
-  functions.logger.info('syncStorePublicCatalog complete', {
-    storeId,
-    productsScanned: productsSnap.size,
-    publicProductsWritten: writtenProducts,
-    publicServicesWritten: writtenServices,
-    publicDocsRemoved: removed,
-  })
+  await storeRef.set({
+    publicCatalogLastSyncedAt: admin.firestore.FieldValue.serverTimestamp(),
+    publicCatalogDocCount: { listings: writtenListings },
+    publicCatalogOutOfSyncCount: 0,
+  }, { merge: true })
 }
 
-export const syncPublicCatalogOnStoreEligibilityUpdate = functions.firestore
-  .document('stores/{storeId}')
-  .onUpdate(async (change, context) => {
-    const before = (change.before.data() ?? {}) as StoreData
-    const after = (change.after.data() ?? {}) as StoreData
-    const storeId = String(context.params.storeId || '')
+export const syncPublicCatalogOnStoreEligibilityUpdate = functions.firestore.document('stores/{storeId}').onUpdate(async (change, context) => {
+  const before = (change.before.data() ?? {}) as StoreData
+  const after = (change.after.data() ?? {}) as StoreData
+  const storeId = String(context.params.storeId || '')
+  const watched: Array<keyof StoreData> = ['verified', 'verified_product', 'eligibleForBuy', 'buyOptOut', 'status', 'paymentStatus', 'contractStatus']
+  if (!watched.some((field) => before[field] !== after[field])) return
+  if (isStoreEligible(after)) return syncStorePublicCatalog(storeId)
+  if (isStoreEligible(before)) return removeStorePublicCatalog(storeId)
+})
 
-    const watched: Array<keyof StoreData> = [
-      'verified',
-      'verified_product',
-      'eligibleForBuy',
-      'buyOptOut',
-      'status',
-      'paymentStatus',
-      'contractStatus',
-    ]
-
-    const changed = watched.some((field) => before[field] !== after[field])
-    if (!changed) return
-
-    const beforeEligible = isStoreEligible(before)
-    const afterEligible = isStoreEligible(after)
-
-    functions.logger.info('store eligibility changed', { storeId, beforeEligible, afterEligible })
-
-    if (afterEligible) {
-      await syncStorePublicCatalog(storeId)
-      return
-    }
-
-    if (beforeEligible && !afterEligible) {
-      await removeStorePublicCatalog(storeId)
-    }
-  })
-
-export const syncPublicCatalogOnProductWrite = functions.firestore
-  .document('products/{productId}')
-  .onWrite(async (change, context) => {
-    const productId = String(context.params.productId || '')
-    const afterExists = change.after.exists
-
-    if (!afterExists) {
-      await Promise.all([
-        db.collection('publicProducts').doc(productId).delete(),
-        db.collection('publicServices').doc(productId).delete(),
-      ])
-      functions.logger.info('product removed from public catalog', { productId })
-      return
-    }
-
-    const afterData = (change.after.data() ?? {}) as ProductData
-    const storeId = text(afterData.storeId)
-    if (!storeId || afterData.isPublished !== true) {
-      await Promise.all([
-        db.collection('publicProducts').doc(productId).delete(),
-        db.collection('publicServices').doc(productId).delete(),
-      ])
-      return
-    }
-
-    const storeSnap = await db.collection('stores').doc(storeId).get()
-    const storeData = (storeSnap.data() ?? {}) as StoreData
-    if (!isStoreEligible(storeData)) {
-      await Promise.all([
-        db.collection('publicProducts').doc(productId).delete(),
-        db.collection('publicServices').doc(productId).delete(),
-      ])
-      return
-    }
-
-    const payload = publicPayload(productId, afterData, buildStoreMeta(storeData))
-    const normalizedItemType = itemType(afterData.itemType)
-    const isPublicProduct = normalizedItemType === 'product'
-    const target = isPublicProduct ? 'publicProducts' : 'publicServices'
-    const opposite = isPublicProduct ? 'publicServices' : 'publicProducts'
-
-    await Promise.all([
-      db.collection(target).doc(productId).set(payload, { merge: true }),
-      db.collection(opposite).doc(productId).delete(),
-    ])
-
-    functions.logger.info('product synced to public catalog', {
-      storeId,
-      productId,
-      publicProductsWritten: isPublicProduct ? 1 : 0,
-      publicServicesWritten: isPublicProduct ? 0 : 1,
-      publicDocsRemoved: 1,
-    })
-  })
+export const syncPublicCatalogOnProductWrite = functions.firestore.document('products/{productId}').onWrite(async (change, context) => {
+  const productId = String(context.params.productId || '')
+  if (!change.after.exists) {
+    await db.collection('publicListings').doc(productId).delete()
+    return
+  }
+  const afterData = (change.after.data() ?? {}) as ProductData
+  const storeId = text(afterData.storeId)
+  if (!storeId || afterData.isPublished !== true) {
+    await db.collection('publicListings').doc(productId).delete()
+    return
+  }
+  const storeSnap = await db.collection('stores').doc(storeId).get()
+  const storeData = (storeSnap.data() ?? {}) as StoreData
+  if (!isStoreEligible(storeData)) {
+    await db.collection('publicListings').doc(productId).delete()
+    return
+  }
+  await db.collection('publicListings').doc(productId).set(publicPayload(productId, afterData, buildStoreMeta(storeData)), { merge: true })
+})

--- a/web/src/pages/ProductsServiceFirst.tsx
+++ b/web/src/pages/ProductsServiceFirst.tsx
@@ -138,7 +138,7 @@ const blankDraft: Draft = {
   Agreement: '',
   courseMode: 'in_person',
   classTimes: '',
-  isPublished: true,
+  isPublished: false,
   isMarketplaceVisible: false,
 }
 
@@ -518,9 +518,6 @@ export default function ProductsServiceFirst() {
     setMessage('')
     setError('')
     try {
-      if (draft.imageUrl.startsWith('data:image/')) {
-        throw new Error('Image is still local. Please upload again or paste an image URL.')
-      }
       const payload = buildSavePayload(draft as any, storeId)
       if (!editingId) {
         const possibleDuplicate = items.find(item => {
@@ -546,24 +543,55 @@ export default function ProductsServiceFirst() {
           }
         }
       }
-      if (editingId) {
-        await withTimeout(
-          updateDoc(doc(db, 'products', editingId), payload),
-          20_000,
-          'Save timed out. Please check your internet and try again.',
-        )
-        setMessage('Item saved successfully.')
-      } else {
-        await withTimeout(
-          setDoc(doc(collection(db, 'products')), {
+      const imageUploadPending = draft.imageUrl.startsWith('data:image/')
+      const draftPayload = {
+        ...payload,
+        status: 'draft',
+        isPublished: false,
+      }
+      const publishPayload = payload.isPublished
+        ? {
             ...payload,
-            createdAt: serverTimestamp(),
-            sortOrder: items.length + 1,
-          }),
-          20_000,
-          'Save timed out. Please check your internet and try again.',
-        )
-        setMessage('Item saved successfully.')
+            status: 'published',
+            publishedAt: serverTimestamp(),
+          }
+        : null
+
+      if (editingId) {
+        const itemRef = doc(db, 'products', editingId)
+        await withTimeout(updateDoc(itemRef, draftPayload), 20_000, 'Save timed out. Please check your internet and try again.')
+        if (publishPayload) {
+          try {
+            await withTimeout(updateDoc(itemRef, publishPayload), 20_000, 'Publish timed out. Please try again.')
+            setMessage(imageUploadPending ? 'Item saved. Image upload is pending — you can retry later.' : 'Item saved successfully.')
+          } catch (_publishError) {
+            setMessage('Draft saved but publishing was incomplete.')
+            setError('Draft saved but publishing was incomplete.')
+          }
+        } else {
+          setMessage(imageUploadPending ? 'Draft saved. Image upload is pending — you can retry later.' : 'Draft saved successfully.')
+        }
+      } else {
+        const itemRef = doc(collection(db, 'products'))
+        await withTimeout(setDoc(itemRef, {
+          ...draftPayload,
+          createdAt: serverTimestamp(),
+          sortOrder: items.length + 1,
+        }), 20_000, 'Save timed out. Please check your internet and try again.')
+        if (publishPayload) {
+          try {
+            await withTimeout(updateDoc(itemRef, publishPayload), 20_000, 'Publish timed out. Please try again.')
+            setMessage(imageUploadPending ? 'Item saved. Image upload is pending — you can retry later.' : 'Item saved successfully.')
+          } catch (_publishError) {
+            setMessage('Draft saved but publishing was incomplete.')
+            setError('Draft saved but publishing was incomplete.')
+          }
+        } else {
+          setMessage(imageUploadPending ? 'Draft saved. Image upload is pending — you can retry later.' : 'Draft saved successfully.')
+        }
+      }
+      if (imageUploadPending) {
+        setError('Image upload failed or is incomplete. Item was still saved; retry upload later.')
       }
       resetForm()
     } catch (err) {
@@ -813,7 +841,7 @@ export default function ProductsServiceFirst() {
                       <h4>{item.name}</h4>
                       <span className="products-page__badge products-page__badge--muted">{itemIsCourse ? 'Course' : itemIsService ? 'Service' : 'Product'}</span>
                       <span className={`products-page__badge ${(item as any).isPublished === false ? 'products-page__badge--draft' : 'products-page__badge--published'}`}>{(item as any).isPublished === false ? 'Draft' : 'Published'}</span>
-                      {(item as any).isMarketplaceVisible ? <span className="products-page__badge products-page__badge--market">Visible on Market</span> : null}
+                      {(item as any).isMarketplaceVisible ? <span className="products-page__badge products-page__badge--market">Marketplace Visible</span> : null}
                       <span className="products-page__list-value">{normalizeCategory(item.category, item.itemType)}</span>
                     </div>
                     <div className="products-page__list-meta">


### PR DESCRIPTION
### Motivation
- Fix broken partial saves where items were saved as `draft-*` and the UI stayed stuck on “Saving…”.
- Ensure image uploads do not block saving and that failed uploads do not discard saved drafts.
- Unify public catalog export from two collections into a single `publicListings` collection with an explicit `listingType`.
- Provide clear recovery messaging when publish fails after a draft save.

### Description
- Reworked the save flow in `web/src/pages/ProductsServiceFirst.tsx` to always write a draft first (`status: 'draft'`, `isPublished: false`) and then perform a separate publish update when `isPublished` is requested, so publish is a distinct step.  (new draft-first flow and publish retry/recovery messaging).
- Removed the blocking check that threw when `draft.imageUrl` was a local data URL so image upload state no longer prevents saving, and added non-blocking image handling that sets a warning if image upload is pending or failed so users can retry later.
- Ensured `setSaving(false)` is always called in the `finally` block so the UI button is no longer stuck on `Saving…`.
- Added user-facing recovery text `"Draft saved but publishing was incomplete."` when publish fails after a successful draft save and surface an error/warning instead of rolling back the draft.
- Updated UI badge text to show `Marketplace Visible` and preserved Draft/Published badges based on saved item state.
- Replaced split `publicProducts` / `publicServices` handling in `functions/src/publicCatalogSync.ts` with a unified `publicListings` collection and set `listingType` in the public payload to `product | service | course`.
- Updated `functions/src/integrationCheckout.ts` to consume `publicListings` (payload sampling and query fallbacks) and to resolve items against the new `publicListings` collection.
- Changes committed include `web/src/pages/ProductsServiceFirst.tsx`, `functions/src/publicCatalogSync.ts`, and `functions/src/integrationCheckout.ts` implementing the above behaviors.

### Testing
- Ran `npm -C web run -s lint`; it did not complete successfully due to a missing local dependency (`@eslint/js`) in the environment, so lint failed and reported the module not found error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d92b147dc8321a4684e97c22e87c2)