### PR TITLE
Fix marketplace visibility toggle resetting after save

### DIFF
--- a/web/src/pages/ProductsServiceFirst.tsx
+++ b/web/src/pages/ProductsServiceFirst.tsx
@@ -480,6 +480,8 @@ export default function ProductsServiceFirst() {
       itemType: current.itemType === 'service' ? 'service' : current.itemType === 'course' ? 'course' : 'product',
       category: current.itemType === 'service' ? SERVICE_CATEGORY : current.itemType === 'course' ? EDUCATION_CATEGORY : PRODUCT_CATEGORY,
       serviceKind: current.itemType === 'service' ? current.serviceKind : 'consultation',
+      isMarketplaceVisible: current.isMarketplaceVisible,
+      isWebsiteVisible: current.isWebsiteVisible,
     }))
     setError('')
     setImageUploadState('idle')


### PR DESCRIPTION
### Motivation
- Preserve `isMarketplaceVisible` and `isWebsiteVisible` when resetting the items form so the "Show on SedifexMarket" and website visibility checkboxes do not appear to untick after saving.

### Description
- In `web/src/pages/ProductsServiceFirst.tsx` updated `resetForm()` to copy `isMarketplaceVisible` and `isWebsiteVisible` from the current draft into the reset draft so visibility toggles persist across save/edit cycles.

### Testing
- Attempted to run the product tests with `cd web && npm -s run test -- src/pages/__tests__/Products.test.tsx --runInBand` but the test runner failed because `vitest` is not available in the local environment PATH.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0daa555fa88321b4830dcec4a85055)