### PR TITLE
Add admin backfill callable for publicListings sync

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.sendBrandedNotificationPreview = exports.notifyDonationCaptured = exports.notifySupportRequestCreated = exports.notifyVolunteerApplicationCreated = exports.notifyStudentRegistrationCreated = exports.notifyIntegrationOrderStatus = exports.initializeStoreNotificationDefaults = exports.supportRequestIntake = exports.volunteerIntake = exports.v1IntegrationBookings = exports.v1IntegrationAvailability = exports.integrationOrderStatus = exports.integrationCheckoutPreview = exports.integrationCheckoutCreate = exports.fetchPaystackSettlementBanks = exports.fetchPaystackMerchantSubaccount = exports.createPaystackMerchantSubaccount = exports.handlePaystackWebhook = exports.paystackWebhook = exports.createCheckout = exports.checkSignupUnlock = void 0;
+exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.sendBrandedNotificationPreview = exports.notifyDonationCaptured = exports.notifySupportRequestCreated = exports.notifyVolunteerApplicationCreated = exports.notifyStudentRegistrationCreated = exports.notifyIntegrationOrderStatus = exports.initializeStoreNotificationDefaults = exports.supportRequestIntake = exports.volunteerIntake = exports.v1IntegrationStudentRegistrations = exports.v1IntegrationBookings = exports.v1IntegrationAvailability = exports.integrationOrderStatus = exports.integrationCheckoutPreview = exports.integrationCheckoutCreate = exports.fetchPaystackSettlementBanks = exports.fetchPaystackMerchantSubaccount = exports.createPaystackMerchantSubaccount = exports.handlePaystackWebhook = exports.paystackWebhook = exports.createCheckout = exports.checkSignupUnlock = void 0;
 const params_1 = require("firebase-functions/params");
 var paystack_1 = require("./paystack");
 Object.defineProperty(exports, "checkSignupUnlock", { enumerable: true, get: function () { return paystack_1.checkSignupUnlock; } });
@@ -34,6 +34,8 @@ var integrationAvailability_1 = require("./integrationAvailability");
 Object.defineProperty(exports, "v1IntegrationAvailability", { enumerable: true, get: function () { return integrationAvailability_1.v1IntegrationAvailability; } });
 var integrationBookings_1 = require("./integrationBookings");
 Object.defineProperty(exports, "v1IntegrationBookings", { enumerable: true, get: function () { return integrationBookings_1.v1IntegrationBookings; } });
+var integrationStudentRegistrations_1 = require("./integrationStudentRegistrations");
+Object.defineProperty(exports, "v1IntegrationStudentRegistrations", { enumerable: true, get: function () { return integrationStudentRegistrations_1.v1IntegrationStudentRegistrations; } });
 var ngoIntake_1 = require("./ngoIntake");
 Object.defineProperty(exports, "volunteerIntake", { enumerable: true, get: function () { return ngoIntake_1.volunteerIntake; } });
 Object.defineProperty(exports, "supportRequestIntake", { enumerable: true, get: function () { return ngoIntake_1.supportRequestIntake; } });
@@ -52,6 +54,8 @@ Object.defineProperty(exports, "googleAdsCampaign", { enumerable: true, get: fun
 Object.defineProperty(exports, "googleAdsMetricsSync", { enumerable: true, get: function () { return googleAds_1.googleAdsMetricsSync; } });
 __exportStar(require("./googleShopping"), exports);
 __exportStar(require("./reporting"), exports);
+__exportStar(require("./publicCatalogSync"), exports);
+__exportStar(require("./blogAutomation"), exports);
 const VALID_ROLES = new Set(['owner', 'staff']);
 const GRACE_DAYS = 7;
 const MILLIS_PER_DAY = 1000 * 60 * 60 * 24;

--- a/functions/src/publicCatalogSync.ts
+++ b/functions/src/publicCatalogSync.ts
@@ -163,6 +163,53 @@ export async function syncStorePublicCatalog(storeId: string): Promise<void> {
   }, { merge: true })
 }
 
+
+export const adminBackfillPublicListings = functions.https.onCall(async (_data, context) => {
+  if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Login required')
+  if (context.auth.token?.admin !== true) {
+    throw new functions.https.HttpsError('permission-denied', 'Admin access required')
+  }
+
+  const productsSnap = await db.collection('products')
+    .where('isPublished', '==', true)
+    .where('isMarketplaceVisible', '==', true)
+    .get()
+
+  const storeCache = new Map<string, StoreData>()
+  let batch = db.batch()
+  let writes = 0
+  let synced = 0
+
+  for (const productDoc of productsSnap.docs) {
+    const data = (productDoc.data() ?? {}) as ProductData
+    const storeId = text(data.storeId)
+    if (!storeId) continue
+
+    let storeData = storeCache.get(storeId)
+    if (!storeData) {
+      const storeSnap = await db.collection('stores').doc(storeId).get()
+      storeData = (storeSnap.data() ?? {}) as StoreData
+      storeCache.set(storeId, storeData)
+    }
+
+    if (!isStoreEligible(storeData)) continue
+
+    batch.set(db.collection('publicListings').doc(productDoc.id), publicPayload(productDoc.id, data, buildStoreMeta(storeData)), { merge: true })
+    writes += 1
+    synced += 1
+
+    if (writes >= 450) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+
+  if (writes > 0) await batch.commit()
+
+  return { ok: true as const, synced }
+})
+
 export const syncPublicCatalogOnStoreEligibilityUpdate = functions.firestore.document('stores/{storeId}').onUpdate(async (change, context) => {
   const before = (change.before.data() ?? {}) as StoreData
   const after = (change.after.data() ?? {}) as StoreData


### PR DESCRIPTION
### Motivation
- Provide an admin-only backfill to force-create and repopulate `publicListings` when entries are missing or out of sync. 
- Ensure all published, marketplace-visible products/services/courses are materialized into the public read model using the same eligibility and normalization rules as the real-time sync.

### Description
- Added a new callable `adminBackfillPublicListings` in `functions/src/publicCatalogSync.ts` that queries `products` where `isPublished === true` and `isMarketplaceVisible === true` and writes each eligible item to `publicListings/{productId}`.
- The callable requires authentication and an `admin === true` custom claim guard and skips products without a valid `storeId` or stores that fail `isStoreEligible`.
- Reuses existing normalization via `publicPayload` and `buildStoreMeta`, caches store lookups, and performs batched writes with commit chunking to handle large backfills.
- Updated the functions exports to include the public catalog sync module so the callable is deployed (`functions/lib/index.js` updated via build output).

### Testing
- Ran `cd functions && npm run -s build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db3d3326883218cd8d7e758ad146d)