### PR TITLE
Backfill and stabilize publicListings marketplace sync

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.sendBrandedNotificationPreview = exports.notifyDonationCaptured = exports.notifySupportRequestCreated = exports.notifyVolunteerApplicationCreated = exports.notifyStudentRegistrationCreated = exports.notifyIntegrationOrderStatus = exports.initializeStoreNotificationDefaults = exports.supportRequestIntake = exports.volunteerIntake = exports.v1IntegrationBookings = exports.v1IntegrationAvailability = exports.integrationOrderStatus = exports.integrationCheckoutPreview = exports.integrationCheckoutCreate = exports.fetchPaystackSettlementBanks = exports.fetchPaystackMerchantSubaccount = exports.createPaystackMerchantSubaccount = exports.handlePaystackWebhook = exports.paystackWebhook = exports.createCheckout = exports.checkSignupUnlock = void 0;
+exports.googleAdsMetricsSync = exports.googleAdsCampaign = exports.googleAdsOAuthCallback = exports.googleAdsOAuthStart = exports.sendBrandedNotificationPreview = exports.notifyDonationCaptured = exports.notifySupportRequestCreated = exports.notifyVolunteerApplicationCreated = exports.notifyStudentRegistrationCreated = exports.notifyIntegrationOrderStatus = exports.initializeStoreNotificationDefaults = exports.supportRequestIntake = exports.volunteerIntake = exports.v1IntegrationStudentRegistrations = exports.v1IntegrationBookings = exports.v1IntegrationAvailability = exports.integrationOrderStatus = exports.integrationCheckoutPreview = exports.integrationCheckoutCreate = exports.fetchPaystackSettlementBanks = exports.fetchPaystackMerchantSubaccount = exports.createPaystackMerchantSubaccount = exports.handlePaystackWebhook = exports.paystackWebhook = exports.createCheckout = exports.checkSignupUnlock = void 0;
 const params_1 = require("firebase-functions/params");
 var paystack_1 = require("./paystack");
 Object.defineProperty(exports, "checkSignupUnlock", { enumerable: true, get: function () { return paystack_1.checkSignupUnlock; } });
@@ -34,6 +34,8 @@ var integrationAvailability_1 = require("./integrationAvailability");
 Object.defineProperty(exports, "v1IntegrationAvailability", { enumerable: true, get: function () { return integrationAvailability_1.v1IntegrationAvailability; } });
 var integrationBookings_1 = require("./integrationBookings");
 Object.defineProperty(exports, "v1IntegrationBookings", { enumerable: true, get: function () { return integrationBookings_1.v1IntegrationBookings; } });
+var integrationStudentRegistrations_1 = require("./integrationStudentRegistrations");
+Object.defineProperty(exports, "v1IntegrationStudentRegistrations", { enumerable: true, get: function () { return integrationStudentRegistrations_1.v1IntegrationStudentRegistrations; } });
 var ngoIntake_1 = require("./ngoIntake");
 Object.defineProperty(exports, "volunteerIntake", { enumerable: true, get: function () { return ngoIntake_1.volunteerIntake; } });
 Object.defineProperty(exports, "supportRequestIntake", { enumerable: true, get: function () { return ngoIntake_1.supportRequestIntake; } });
@@ -52,6 +54,8 @@ Object.defineProperty(exports, "googleAdsCampaign", { enumerable: true, get: fun
 Object.defineProperty(exports, "googleAdsMetricsSync", { enumerable: true, get: function () { return googleAds_1.googleAdsMetricsSync; } });
 __exportStar(require("./googleShopping"), exports);
 __exportStar(require("./reporting"), exports);
+__exportStar(require("./publicCatalogSync"), exports);
+__exportStar(require("./blogAutomation"), exports);
 const VALID_ROLES = new Set(['owner', 'staff']);
 const GRACE_DAYS = 7;
 const MILLIS_PER_DAY = 1000 * 60 * 60 * 24;

--- a/functions/src/publicCatalogSync.ts
+++ b/functions/src/publicCatalogSync.ts
@@ -4,6 +4,9 @@ import { resolvePublicationTimestampCandidate } from './catalogPublication'
 
 type StoreData = Record<string, unknown>
 type ProductData = Record<string, unknown>
+type BackfillPayload = {
+  dryRun?: unknown
+}
 
 function text(value: unknown): string | null {
   if (typeof value !== 'string') return null
@@ -196,4 +199,86 @@ export const syncPublicCatalogOnProductWrite = functions.firestore.document('pro
     return
   }
   await db.collection('publicListings').doc(productId).set(publicPayload(productId, afterData, buildStoreMeta(storeData)), { merge: true })
+})
+
+export const adminBackfillPublicListings = functions.https.onCall(async (data: BackfillPayload, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'Authentication required.')
+  }
+  const isAdmin = context.auth.token.admin === true
+  if (!isAdmin) {
+    throw new functions.https.HttpsError('permission-denied', 'Admin access required.')
+  }
+
+  const dryRun = data?.dryRun === true
+  const productsSnap = await db.collection('products')
+    .where('isPublished', '==', true)
+    .where('isMarketplaceVisible', '==', true)
+    .get()
+
+  const storeCache = new Map<string, StoreData | undefined>()
+  let syncedCount = 0
+  let skippedCount = 0
+  let ineligibleStoreCount = 0
+  let batch = db.batch()
+  let writes = 0
+
+  for (const productDoc of productsSnap.docs) {
+    const productData = (productDoc.data() ?? {}) as ProductData
+    const storeId = text(productData.storeId)
+    if (!storeId) {
+      skippedCount += 1
+      continue
+    }
+
+    let storeData = storeCache.get(storeId)
+    if (!storeCache.has(storeId)) {
+      const storeSnap = await db.collection('stores').doc(storeId).get()
+      storeData = (storeSnap.data() ?? {}) as StoreData
+      storeCache.set(storeId, storeData)
+    }
+
+    if (!storeData || !isStoreEligible(storeData)) {
+      skippedCount += 1
+      ineligibleStoreCount += 1
+      continue
+    }
+
+    syncedCount += 1
+    if (dryRun) continue
+
+    batch.set(
+      db.collection('publicListings').doc(productDoc.id),
+      publicPayload(productDoc.id, productData, buildStoreMeta(storeData)),
+      { merge: true },
+    )
+    writes += 1
+
+    if (writes >= 450) {
+      await batch.commit()
+      batch = db.batch()
+      writes = 0
+    }
+  }
+
+  if (!dryRun && writes > 0) {
+    await batch.commit()
+  }
+
+  functions.logger.info('adminBackfillPublicListings completed', {
+    dryRun,
+    syncedCount,
+    skippedCount,
+    ineligibleStoreCount,
+    scannedCount: productsSnap.size,
+  })
+
+  return {
+    ok: true,
+    dryRun,
+    scannedCount: productsSnap.size,
+    syncedCount,
+    skippedCount,
+    ineligibleStoreCount,
+  }
 })


### PR DESCRIPTION
### Motivation
- Production is missing the new unified `publicListings` read model while legacy `publicProducts`/`publicServices` remain, so a safe backfill path is required to populate `publicListings` from existing published marketplace items. 
- Backfill must reuse existing normalization and eligibility logic and avoid disrupting the current read models during migration.

### Description
- Added an admin-only callable `adminBackfillPublicListings` (HTTPS onCall) which requires `context.auth.token.admin === true` and supports an optional `dryRun` flag. 
- The callable reads `products` filtered by `isPublished === true` and `isMarketplaceVisible === true`, validates store eligibility via the existing `isStoreEligible()` check, and writes normalized documents into `publicListings/{productId}` using `publicPayload()` and `buildStoreMeta()`. 
- Writes are batched and committed in safe chunks (450 writes per batch) with a store-level cache to avoid repeated store lookups, and the function returns and logs `syncedCount`, `skippedCount`, `ineligibleStoreCount`, and `scannedCount`. 
- Existing triggers and legacy `publicProducts`/`publicServices` behavior are left untouched and the compiled export surface was updated so `publicCatalogSync` is exported from the functions entrypoint.

### Testing
- Ran a production build with `npm --prefix functions run build` which completed successfully. 
- Verified the new callable compiles into the functions bundle and the compiled exports include the updated `publicCatalogSync` surface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc7f9b11483219623566d08eda06a)