### PR TITLE
Allow adminBackfillPublicListings to run in emulator without auth

### DIFF
--- a/functions/src/publicCatalogSync.ts
+++ b/functions/src/publicCatalogSync.ts
@@ -202,12 +202,15 @@ export const syncPublicCatalogOnProductWrite = functions.firestore.document('pro
 })
 
 export const adminBackfillPublicListings = functions.https.onCall(async (data: BackfillPayload, context) => {
-  if (!context.auth) {
-    throw new functions.https.HttpsError('unauthenticated', 'Authentication required.')
-  }
-  const isAdmin = context.auth.token.admin === true
-  if (!isAdmin) {
-    throw new functions.https.HttpsError('permission-denied', 'Admin access required.')
+  const runningInEmulator = process.env.FUNCTIONS_EMULATOR === 'true'
+  if (!runningInEmulator) {
+    if (!context.auth) {
+      throw new functions.https.HttpsError('unauthenticated', 'Authentication required.')
+    }
+    const isAdmin = context.auth.token?.admin === true
+    if (!isAdmin) {
+      throw new functions.https.HttpsError('permission-denied', 'Admin access required.')
+    }
   }
 
   const dryRun = data?.dryRun === true


### PR DESCRIPTION
### Motivation
- Allow `adminBackfillPublicListings` to be executed from `firebase functions:shell` (emulator) where `context.auth` is not provided, while keeping production access restricted to admin users.

### Description
- Detect emulator runtime with `process.env.FUNCTIONS_EMULATOR === 'true'` and skip the `context.auth` / `context.auth.token?.admin === true` checks only when running in the emulator, leaving `dryRun` behavior unchanged.

### Testing
- Ran `npm --prefix functions run build` and the TypeScript build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd98395508321bdd1ffd838be75df)