### PR TITLE
Expand public catalog product inclusion rules

### DIFF
--- a/functions/src/publicCatalogSync.ts
+++ b/functions/src/publicCatalogSync.ts
@@ -58,6 +58,30 @@ function isStoreEligible(store: StoreData | undefined): boolean {
   return store.verified === true && store.eligibleForBuy === true && store.buyOptOut !== true && store.status === 'active'
 }
 
+function isDraftStatus(status: unknown): boolean {
+  return text(status)?.toLowerCase() === 'draft'
+}
+
+function isPublishedStatus(status: unknown): boolean {
+  return text(status)?.toLowerCase() === 'published'
+}
+
+function hasLegacyPublicationFields(data: ProductData): boolean {
+  return data.isPublished === null
+    || data.isPublished === undefined
+    || data.status === null
+    || data.status === undefined
+}
+
+function shouldIncludeProduct(data: ProductData, eligibleStore: boolean): boolean {
+  if (data.isMarketplaceVisible === false) return false
+  if (data.isPublished === false) return false
+  if (isDraftStatus(data.status)) return false
+  if (data.isPublished === true) return true
+  if (isPublishedStatus(data.status)) return true
+  return eligibleStore && hasLegacyPublicationFields(data)
+}
+
 function buildStoreMeta(store: StoreData): Record<string, unknown> {
   return {
     storeName: text(store.displayName) ?? text(store.name),
@@ -141,13 +165,13 @@ export async function syncStorePublicCatalog(storeId: string): Promise<void> {
   }
 
   const storeMeta = buildStoreMeta(storeData)
-  const productsSnap = await db.collection('products').where('storeId', '==', storeId).where('isPublished', '==', true).get()
+  const productsSnap = await db.collection('products').where('storeId', '==', storeId).get()
   let batch = db.batch()
   let writes = 0
   let writtenListings = 0
   for (const productDoc of productsSnap.docs) {
     const data = (productDoc.data() ?? {}) as ProductData
-    if (data.isMarketplaceVisible !== true) continue
+    if (!shouldIncludeProduct(data, true)) continue
     batch.set(db.collection('publicListings').doc(productDoc.id), publicPayload(productDoc.id, data, storeMeta), { merge: true })
     writes += 1
     writtenListings += 1
@@ -184,17 +208,18 @@ export const syncPublicCatalogOnProductWrite = functions.firestore.document('pro
   }
   const afterData = (change.after.data() ?? {}) as ProductData
   const storeId = text(afterData.storeId)
-  if (!storeId || afterData.isPublished !== true) {
-    await db.collection('publicListings').doc(productId).delete()
-    return
-  }
-  if (afterData.isMarketplaceVisible !== true) {
+  if (!storeId) {
     await db.collection('publicListings').doc(productId).delete()
     return
   }
   const storeSnap = await db.collection('stores').doc(storeId).get()
   const storeData = (storeSnap.data() ?? {}) as StoreData
-  if (!isStoreEligible(storeData)) {
+  const eligibleStore = isStoreEligible(storeData)
+  if (!eligibleStore) {
+    await db.collection('publicListings').doc(productId).delete()
+    return
+  }
+  if (!shouldIncludeProduct(afterData, eligibleStore)) {
     await db.collection('publicListings').doc(productId).delete()
     return
   }
@@ -214,9 +239,7 @@ export const adminBackfillPublicListings = functions.https.onCall(async (data: B
   }
 
   const dryRun = data?.dryRun === true
-  const productsSnap = await db.collection('products')
-    .where('isPublished', '==', true)
-    .get()
+  const productsSnap = await db.collection('products').get()
 
   const storeCache = new Map<string, StoreData | undefined>()
   let scannedCount = 0
@@ -236,12 +259,6 @@ export const adminBackfillPublicListings = functions.https.onCall(async (data: B
       continue
     }
 
-    if (productData.isMarketplaceVisible === false) {
-      skippedCount += 1
-      explicitHiddenCount += 1
-      continue
-    }
-
     let storeData = storeCache.get(storeId)
     if (!storeCache.has(storeId)) {
       const storeSnap = await db.collection('stores').doc(storeId).get()
@@ -250,23 +267,23 @@ export const adminBackfillPublicListings = functions.https.onCall(async (data: B
     }
 
     const eligibleStore = !!storeData && isStoreEligible(storeData)
-    const isExplicitVisible = productData.isMarketplaceVisible === true
-    const isLegacyCandidate = productData.isMarketplaceVisible === null || productData.isMarketplaceVisible === undefined
-    const includeExplicit = isExplicitVisible && eligibleStore
-    const includeLegacy = isLegacyCandidate && eligibleStore
-    if (!includeExplicit && !includeLegacy) {
+    const includeProduct = shouldIncludeProduct(productData, eligibleStore)
+    if (!includeProduct) {
       skippedCount += 1
+      if (productData.isMarketplaceVisible === false || productData.isPublished === false || isDraftStatus(productData.status)) {
+        explicitHiddenCount += 1
+      }
       continue
     }
     const eligibleStoreData = storeData as StoreData
 
     syncedCount += 1
-    if (includeLegacy) {
+    if (hasLegacyPublicationFields(productData)) {
       legacyIncludedCount += 1
     }
     if (dryRun) continue
 
-    if (includeLegacy) {
+    if (hasLegacyPublicationFields(productData) && productData.isMarketplaceVisible !== true) {
       batch.set(
         db.collection('products').doc(productDoc.id),
         {


### PR DESCRIPTION
### Motivation
- Make public catalog sync include legacy and status-driven products rather than only `isPublished === true` entries to surface older services/products and items with `status === "published"`.
- Exclude only explicit negatives (`isPublished === false`, `status === "draft"`, or `isMarketplaceVisible === false`) while still preserving legacy migration behavior for verified, eligible stores.

### Description
- Added helper predicates in `functions/src/publicCatalogSync.ts`: `isDraftStatus`, `isPublishedStatus`, `hasLegacyPublicationFields`, and `shouldIncludeProduct` to centralize inclusion/exclusion logic.
- Changed store-level sync (`syncStorePublicCatalog`) and admin backfill to query the full `products` set instead of filtering by `isPublished == true`, and apply `shouldIncludeProduct` per item before writing `publicListings`.
- Updated product write trigger (`syncPublicCatalogOnProductWrite`) to require an eligible store and use `shouldIncludeProduct` instead of requiring `isPublished === true` and `isMarketplaceVisible === true` in code.
- Preserved legacy migration behavior by marking legacy-included products with `isMarketplaceVisible: true`, `migratedMarketplaceVisible: true`, and `marketplaceVisibilitySource: 'legacy_verified_store'` when applicable.

### Testing
- Ran `cd functions && npm test -- --runInBand`, which failed due to a pre-existing repo bootstrap issue where `functions/lib/index.js` requires a missing module `./marketplacePaystackWebhook`; the new logic itself was exercised where possible but full test suite could not run because of that missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ddf63c7a883218496de0acd30f2c5)