### PR TITLE
Fix timestamp parsing and per-item resilience in public listings backfill

### DIFF
--- a/functions/src/catalogPublication.ts
+++ b/functions/src/catalogPublication.ts
@@ -1,17 +1,50 @@
 import * as admin from 'firebase-admin'
 
 function isTimestampLike(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as {
+    toDate?: unknown
+    seconds?: unknown
+    nanoseconds?: unknown
+    _seconds?: unknown
+    _nanoseconds?: unknown
+  }
+
   return (
-    value instanceof admin.firestore.Timestamp ||
-    (typeof value === 'object' && value !== null && 'toDate' in value && typeof (value as { toDate?: unknown }).toDate === 'function')
+    typeof candidate.toDate === 'function'
+    || (typeof candidate.seconds === 'number' && typeof candidate.nanoseconds === 'number')
+    || (typeof candidate._seconds === 'number' && typeof candidate._nanoseconds === 'number')
   )
 }
 
 export function resolvePublicationTimestampCandidate(...candidates: unknown[]): unknown {
   for (const candidate of candidates) {
-    if (isTimestampLike(candidate) || typeof candidate === 'string') return candidate
+    if (candidate === null || candidate === undefined) continue
+
+    if (isTimestampLike(candidate)) return candidate
+
+    if (candidate instanceof Date) {
+      if (!Number.isNaN(candidate.getTime())) return candidate
+      continue
+    }
+
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim()
+      if (!trimmed) continue
+      const parsed = new Date(trimmed)
+      if (!Number.isNaN(parsed.getTime())) return trimmed
+    }
   }
-  return admin.firestore.FieldValue.serverTimestamp()
+
+  try {
+    if (admin?.firestore?.FieldValue?.serverTimestamp) {
+      return admin.firestore.FieldValue.serverTimestamp()
+    }
+  } catch {
+    return null
+  }
+
+  return null
 }
 
 export function normalizeCatalogPublicationFields(

--- a/functions/src/publicCatalogSync.ts
+++ b/functions/src/publicCatalogSync.ts
@@ -296,12 +296,22 @@ export const adminBackfillPublicListings = functions.https.onCall(async (data: B
       writes += 1
     }
 
-    batch.set(
-      db.collection('publicListings').doc(productDoc.id),
-      publicPayload(productDoc.id, productData, buildStoreMeta(eligibleStoreData)),
-      { merge: true },
-    )
-    writes += 1
+    try {
+      batch.set(
+        db.collection('publicListings').doc(productDoc.id),
+        publicPayload(productDoc.id, productData, buildStoreMeta(eligibleStoreData)),
+        { merge: true },
+      )
+      writes += 1
+    } catch (error) {
+      skippedCount += 1
+      syncedCount -= 1
+      functions.logger.error('adminBackfillPublicListings failed to build public payload', {
+        productId: productDoc.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
 
     if (writes >= 450) {
       await batch.commit()


### PR DESCRIPTION
### Motivation
- Backfill runs could crash when `admin.firestore.Timestamp` is undefined and code used `instanceof`, causing `TypeError` in emulator/runtime. 
- The change is intended to make timestamp detection and parsing robust across environments and data shapes. 
- The backfill should continue processing other products even if one product has malformed timestamp fields. 

### Description
- Replaced unsafe `instanceof admin.firestore.Timestamp` checks with shape-based detection in `isTimestampLike` by checking `toDate()`, `seconds`/`nanoseconds`, or `_seconds`/`_nanoseconds`.
- Updated `resolvePublicationTimestampCandidate` to accept Firestore-like timestamps, valid `Date` objects, valid ISO date strings, and to skip `null`/`undefined`/invalid values before falling back.
- Added a safe fallback that returns `admin.firestore.FieldValue.serverTimestamp()` when available, otherwise returns `null` without throwing.
- Wrapped `publicPayload` generation inside `adminBackfillPublicListings` in a `try/catch` so a single bad product increments `skippedCount`, decrements `syncedCount`, logs `productId` and error, and continues processing the rest while keeping `dryRun` behavior unchanged. 

### Testing
- Built the `functions` package with `npm --prefix functions run build`, which completed successfully.
- Ran `npm --prefix functions test`, which failed due to an unrelated test assertion (`Expected __testing exports` in `test/bookingNormalization.test.js`) and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de30cdca88321bcac2b23778062b7)