### PR TITLE
refactor: use Firestore FieldValue.serverTimestamp() in publicCatalogRepair

### DIFF
--- a/functions/src/publicCatalogRepair.ts
+++ b/functions/src/publicCatalogRepair.ts
@@ -1,5 +1,6 @@
 import * as functions from 'firebase-functions/v1'
-import { admin, defaultDb as db } from './firestore'
+import { FieldValue } from 'firebase-admin/firestore'
+import { defaultDb as db } from './firestore'
 import { resolvePublicationTimestampCandidate } from './catalogPublication'
 
 type StoreData = Record<string, unknown>
@@ -127,7 +128,7 @@ function toArray(value: unknown): string[] {
 }
 
 function serverTimestamp(): unknown {
-  return admin.firestore.FieldValue.serverTimestamp()
+  return FieldValue.serverTimestamp()
 }
 
 function isStoreEligible(store: StoreData | undefined): boolean {


### PR DESCRIPTION
### Motivation
- Replace the indirect `admin.firestore.FieldValue.serverTimestamp()` usage with the direct `FieldValue` import to avoid depending on the `admin` export and follow the `firebase-admin/firestore` API pattern.

### Description
- Updated `functions/src/publicCatalogRepair.ts` to import `FieldValue` from `firebase-admin/firestore` and removed the `admin` import from `./firestore`.
- Replaced the helper to return `FieldValue.serverTimestamp()` instead of `admin.firestore.FieldValue.serverTimestamp()` so all call sites use the new import via `serverTimestamp()`.

### Testing
- No automated tests were run for this trivial refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0edf26405883218667d31701a10481)