### PR TITLE
Split website API keys into product and booking tabs

### DIFF
--- a/web/src/components/WebsiteApiKeysPanel.tsx
+++ b/web/src/components/WebsiteApiKeysPanel.tsx
@@ -1,0 +1,175 @@
+import React, { useMemo, useState } from 'react'
+import { httpsCallable } from 'firebase/functions'
+import { serverTimestamp, type Timestamp } from 'firebase/firestore'
+import { functions } from '../firebase'
+import { useToast } from './ToastProvider'
+
+type KeyPurpose = 'product' | 'booking'
+type KeyRow = { id: string; name: string; status: string; keyPreview: string; createdAt: Timestamp | null; purpose?: KeyPurpose }
+
+type Props = {
+  storeId: string
+  keys: KeyRow[]
+  keysLoading: boolean
+  isSaving: boolean
+  setIsSaving: (value: boolean) => void
+  refreshKeys: () => Promise<void>
+  saveKeyPreview: (payload: Record<string, unknown>) => Promise<void>
+  envBlock: string
+}
+
+const DEFAULT_NAMES: Record<KeyPurpose, string> = {
+  product: 'Website product/integration key',
+  booking: 'Website booking/checkout key',
+}
+
+function labelFor(purpose: KeyPurpose) {
+  return purpose === 'product' ? 'Product / Integration key' : 'Booking / Checkout key'
+}
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value : ''
+}
+
+function formatTimestamp(timestamp: Timestamp | null) {
+  if (!timestamp) return '—'
+  try {
+    return timestamp.toDate().toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+  } catch {
+    return '—'
+  }
+}
+
+function inferPurpose(key: KeyRow): KeyPurpose {
+  if (key.purpose) return key.purpose
+  const name = key.name.toLowerCase()
+  if (name.includes('booking') || name.includes('checkout') || name.includes('payment')) return 'booking'
+  return 'product'
+}
+
+export function WebsiteApiKeysPanel({ storeId, keys, keysLoading, isSaving, setIsSaving, refreshKeys, saveKeyPreview, envBlock }: Props) {
+  const { publish } = useToast()
+  const [purpose, setPurpose] = useState<KeyPurpose>('product')
+  const [keyName, setKeyName] = useState(DEFAULT_NAMES.product)
+  const [latestProductToken, setLatestProductToken] = useState('')
+  const [latestBookingToken, setLatestBookingToken] = useState('')
+
+  const currentToken = purpose === 'product' ? latestProductToken : latestBookingToken
+  const visibleKeys = useMemo(() => keys.filter(key => inferPurpose(key) === purpose), [keys, purpose])
+
+  async function copy(value: string, label: string) {
+    await navigator.clipboard.writeText(value)
+    publish({ message: `${label} copied.`, tone: 'success' })
+  }
+
+  function selectPurpose(nextPurpose: KeyPurpose) {
+    setPurpose(nextPurpose)
+    setKeyName(DEFAULT_NAMES[nextPurpose])
+  }
+
+  async function createKey() {
+    if (!keyName.trim()) {
+      publish({ message: 'Enter a key name first.', tone: 'error' })
+      return
+    }
+
+    try {
+      setIsSaving(true)
+      const callable = httpsCallable(functions, 'createIntegrationApiKey')
+      const response = await callable({
+        name: keyName.trim(),
+        storeId,
+        purpose,
+        keyPurpose: purpose,
+        keyType: purpose === 'product' ? 'product_read' : 'booking_checkout',
+        scopes: purpose === 'product'
+          ? ['products:read', 'services:read', 'promo:read', 'gallery:read']
+          : ['bookings:write', 'checkout:create'],
+      })
+      const token = text((response.data as Record<string, unknown> | undefined)?.token)
+      const keyPreview = token ? `${token.slice(0, 4)}••••${token.slice(-4)}` : 'masked preview only'
+
+      await saveKeyPreview({
+        integrationApi: {
+          keyName: keyName.trim(),
+          keyPreview,
+          latestProductKeyPreview: purpose === 'product' ? keyPreview : undefined,
+          latestBookingKeyPreview: purpose === 'booking' ? keyPreview : undefined,
+          updatedAt: serverTimestamp(),
+        },
+        latestIntegrationApiKeyPreview: keyPreview,
+        latestProductIntegrationKeyPreview: purpose === 'product' ? keyPreview : undefined,
+        latestBookingCheckoutKeyPreview: purpose === 'booking' ? keyPreview : undefined,
+        updatedAt: serverTimestamp(),
+      })
+
+      if (token) {
+        if (purpose === 'product') setLatestProductToken(token)
+        else setLatestBookingToken(token)
+        await copy(token, labelFor(purpose))
+        publish({ message: `${labelFor(purpose)} copied.`, tone: 'success' })
+      }
+
+      await refreshKeys()
+    } catch (err) {
+      console.error('[integrations] failed to create key', err)
+      publish({ message: 'Unable to create API key.', tone: 'error' })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div className="account-overview__website-sync">
+      <h2>Website API keys</h2>
+      <p className="account-overview__hint">Create two separate website keys. Use the product key for product/service/promo/gallery reads, and the booking key for bookings and checkout.</p>
+
+      <nav className="account-overview__tabs" aria-label="Website API key types">
+        {(['product', 'booking'] as KeyPurpose[]).map(item => (
+          <button key={item} type="button" className={`account-overview__tab ${purpose === item ? 'is-active' : ''}`} onClick={() => selectPurpose(item)}>
+            {labelFor(item)}
+          </button>
+        ))}
+      </nav>
+
+      <div className="account-overview__integration-token-notice">
+        <p><strong>{labelFor(purpose)}</strong></p>
+        {purpose === 'product' ? (
+          <p className="account-overview__hint">Put this key on the client website as <code>SEDIFEX_INTEGRATION_API_KEY</code>. It pulls products, services, courses, promo, and gallery.</p>
+        ) : (
+          <p className="account-overview__hint">Put this key on the client website as <code>SEDIFEX_BOOKING_API_KEY</code> and <code>SEDIFEX_CHECKOUT_API_KEY</code>. It creates bookings and checkout links.</p>
+        )}
+      </div>
+
+      <div className="account-overview__website-sync-test">
+        <label><span>New key name</span><input value={keyName} onChange={event => setKeyName(event.target.value)} placeholder={DEFAULT_NAMES[purpose]} /></label>
+        <button type="button" className="button" onClick={createKey} disabled={isSaving}>{isSaving ? 'Creating…' : 'Create and copy key'}</button>
+      </div>
+
+      {currentToken ? (
+        <div className="account-overview__integration-token-notice">
+          <p><strong>Save this key now. It is shown once.</strong></p>
+          <code className="account-overview__integration-token-value">{currentToken}</code>
+          <div className="account-overview__website-sync-actions">
+            <button type="button" className="button button--secondary" onClick={() => copy(currentToken, labelFor(purpose))}>Copy this key</button>
+            <button type="button" className="button button--secondary" onClick={() => copy(envBlock, 'Developer env block')}>Copy developer env block</button>
+          </div>
+        </div>
+      ) : null}
+
+      {keysLoading ? <p>Loading keys…</p> : (
+        <ul className="account-overview__integration-key-list">
+          {visibleKeys.map(item => (
+            <li key={item.id} className="account-overview__integration-key-item">
+              <div>
+                <strong>{item.name}</strong>
+                <p className="account-overview__hint">{labelFor(inferPurpose(item))} · {item.keyPreview} · {item.status} · Created {formatTimestamp(item.createdAt)}</p>
+              </div>
+            </li>
+          ))}
+          {!visibleKeys.length ? <li className="account-overview__integration-key-item"><p className="account-overview__hint">No {purpose === 'product' ? 'product/integration' : 'booking/checkout'} keys yet.</p></li> : null}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/IntegrationSettingsHub.tsx
+++ b/web/src/pages/IntegrationSettingsHub.tsx
@@ -5,11 +5,13 @@ import { db, functions } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useAuthUser } from '../hooks/useAuthUser'
 import { useToast } from '../components/ToastProvider'
+import { WebsiteApiKeysPanel } from '../components/WebsiteApiKeysPanel'
 import './AccountOverview.css'
 
 type IntegrationTab = 'website' | 'booking' | 'email' | 'keys'
+type KeyPurpose = 'product' | 'booking'
 type Props = { defaultTab?: IntegrationTab }
-type KeyRow = { id: string; name: string; status: string; keyPreview: string; createdAt: Timestamp | null }
+type KeyRow = { id: string; name: string; status: string; keyPreview: string; createdAt: Timestamp | null; purpose?: KeyPurpose }
 
 type Draft = {
   websiteDomain: string
@@ -30,7 +32,8 @@ type Draft = {
 const DEFAULT_BASE_URL = 'https://us-central1-sedifex-web.cloudfunctions.net'
 const DEFAULT_CHECKOUT_CREATE_URL = 'https://us-central1-sedifex-web.cloudfunctions.net/integrationCheckoutCreate'
 const DEFAULT_CONTRACT_VERSION = '2026-04-13'
-const API_KEY_PLACEHOLDER = 'PASTE_CREATED_SEDIFEX_API_KEY_HERE'
+const PRODUCT_KEY_PLACEHOLDER = 'PASTE_PRODUCT_INTEGRATION_KEY_HERE'
+const BOOKING_KEY_PLACEHOLDER = 'PASTE_BOOKING_CHECKOUT_KEY_HERE'
 
 function text(value: unknown) {
   return typeof value === 'string' ? value : ''
@@ -40,18 +43,15 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
 }
 
-function formatTimestamp(timestamp: Timestamp | null) {
-  if (!timestamp) return '—'
-  try {
-    return timestamp.toDate().toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
-  } catch {
-    return '—'
-  }
-}
-
 function normalize(value: string) {
   const trimmed = value.trim()
   return trimmed || null
+}
+
+function deriveKeyPurpose(item: Record<string, unknown>): KeyPurpose {
+  const combined = `${text(item.purpose)} ${text(item.keyPurpose)} ${text(item.keyType)} ${text(item.type)} ${text(item.name)}`.toLowerCase()
+  if (combined.includes('booking') || combined.includes('checkout') || combined.includes('payment')) return 'booking'
+  return 'product'
 }
 
 export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props) {
@@ -77,14 +77,11 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
   const [isSaving, setIsSaving] = useState(false)
   const [keys, setKeys] = useState<KeyRow[]>([])
   const [keysLoading, setKeysLoading] = useState(false)
-  const [keyName, setKeyName] = useState('Website production key')
-  const [latestToken, setLatestToken] = useState('')
 
   const canSave = Boolean(storeId && user)
 
   const envBlock = useMemo(() => {
     if (!storeId) return ''
-    const apiKeyValue = latestToken || API_KEY_PLACEHOLDER
     const apiBaseUrl = draft.apiBaseUrl || DEFAULT_BASE_URL
     const checkoutCreateUrl = draft.checkoutCreateUrl || DEFAULT_CHECKOUT_CREATE_URL
     const returnUrl = draft.checkoutReturnUrl || 'https://yourwebsite.com/payment/return'
@@ -94,13 +91,14 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
       `SEDIFEX_INTEGRATION_CHECKOUT_CREATE_URL=${checkoutCreateUrl}`,
       `SEDIFEX_BOOKING_TARGET_STORE_ID=${storeId}`,
       `SEDIFEX_STORE_ID=${storeId}`,
-      `SEDIFEX_BOOKING_API_KEY=${apiKeyValue}`,
-      `SEDIFEX_CHECKOUT_API_KEY=${apiKeyValue}`,
+      `SEDIFEX_INTEGRATION_API_KEY=${PRODUCT_KEY_PLACEHOLDER}`,
+      `SEDIFEX_BOOKING_API_KEY=${BOOKING_KEY_PLACEHOLDER}`,
+      `SEDIFEX_CHECKOUT_API_KEY=${BOOKING_KEY_PLACEHOLDER}`,
       `SEDIFEX_CONTRACT_VERSION=${draft.contractVersion || DEFAULT_CONTRACT_VERSION}`,
       `SEDIFEX_CHECKOUT_RETURN_URL=${returnUrl}`,
       `NEXT_PUBLIC_SEDIFEX_STORE_ID=${storeId}`,
     ].join('\n')
-  }, [draft.apiBaseUrl, draft.checkoutCreateUrl, draft.checkoutReturnUrl, draft.contractVersion, latestToken, storeId])
+  }, [draft.apiBaseUrl, draft.checkoutCreateUrl, draft.checkoutReturnUrl, draft.contractVersion, storeId])
 
   function update(key: keyof Draft, value: string | boolean) {
     setDraft(current => ({ ...current, [key]: value }))
@@ -123,6 +121,7 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
         status: text(item.status) || 'active',
         keyPreview: text(item.keyPreview) || 'sedx••••',
         createdAt: item.createdAt && typeof item.createdAt === 'object' && typeof (item.createdAt as Timestamp).toDate === 'function' ? item.createdAt as Timestamp : null,
+        purpose: deriveKeyPurpose(item),
       })).filter(item => item.id))
     } catch (err) {
       console.error('[integrations] failed to load keys', err)
@@ -131,6 +130,14 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
     } finally {
       setKeysLoading(false)
     }
+  }
+
+  async function saveDocs(payload: Record<string, unknown>) {
+    if (!storeId) return
+    await Promise.all([
+      setDoc(doc(db, 'stores', storeId), payload, { merge: true }),
+      setDoc(doc(db, 'storeSettings', storeId), payload, { merge: true }),
+    ])
   }
 
   useEffect(() => {
@@ -196,10 +203,7 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
         },
         updatedAt: serverTimestamp(),
       }
-      await Promise.all([
-        setDoc(doc(db, 'stores', storeId), payload, { merge: true }),
-        setDoc(doc(db, 'storeSettings', storeId), payload, { merge: true }),
-      ])
+      await saveDocs(payload)
       publish({ message: 'Website integration settings saved.', tone: 'success' })
     } catch (err) {
       console.error('[integrations] failed to save website settings', err)
@@ -245,10 +249,7 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
         integrationApiEnabled: true,
         updatedAt: serverTimestamp(),
       }
-      await Promise.all([
-        setDoc(doc(db, 'stores', storeId), payload, { merge: true }),
-        setDoc(doc(db, 'storeSettings', storeId), payload, { merge: true }),
-      ])
+      await saveDocs(payload)
       publish({ message: 'Booking/App Script sync saved.', tone: 'success' })
     } catch (err) {
       console.error('[integrations] failed to save booking sync', err)
@@ -272,60 +273,11 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
         fromName: normalize(draft.emailFromName),
         updatedAt: serverTimestamp(),
       }
-      await Promise.all([
-        setDoc(doc(db, 'stores', storeId), { bulkEmailIntegration, updatedAt: serverTimestamp() }, { merge: true }),
-        setDoc(doc(db, 'storeSettings', storeId), { bulkEmailIntegration, updatedAt: serverTimestamp() }, { merge: true }),
-      ])
+      await saveDocs({ bulkEmailIntegration, updatedAt: serverTimestamp() })
       publish({ message: 'Email integration saved.', tone: 'success' })
     } catch (err) {
       console.error('[integrations] failed to save email integration', err)
       publish({ message: 'Unable to save email integration.', tone: 'error' })
-    } finally {
-      setIsSaving(false)
-    }
-  }
-
-  async function createKey() {
-    if (!keyName.trim()) {
-      publish({ message: 'Enter a key name first.', tone: 'error' })
-      return
-    }
-    try {
-      setIsSaving(true)
-      const callable = httpsCallable(functions, 'createIntegrationApiKey')
-      const response = await callable({
-        name: keyName.trim(),
-        storeId,
-      })
-      const token = text((response.data as Record<string, unknown> | undefined)?.token)
-      const keyPreview = 'masked preview only'
-      const integrationApiPayload = {
-        integrationApi: {
-          enabled: true,
-          baseUrl: normalize(draft.apiBaseUrl) || DEFAULT_BASE_URL,
-          checkoutCreateUrl: normalize(draft.checkoutCreateUrl) || DEFAULT_CHECKOUT_CREATE_URL,
-          contractVersion: normalize(draft.contractVersion) || DEFAULT_CONTRACT_VERSION,
-          keyName: keyName.trim(),
-          keyPreview,
-          updatedAt: serverTimestamp(),
-        },
-        integrationApiEnabled: true,
-        latestIntegrationApiKeyPreview: keyPreview,
-        updatedAt: serverTimestamp(),
-      }
-      await Promise.all([
-        setDoc(doc(db, 'stores', storeId), integrationApiPayload, { merge: true }),
-        setDoc(doc(db, 'storeSettings', storeId), integrationApiPayload, { merge: true }),
-      ])
-      if (token) {
-        setLatestToken(token)
-        await copy(token, 'New API key')
-        publish({ message: 'New API key copied. The developer env block now includes it.', tone: 'success' })
-      }
-      await refreshKeys()
-    } catch (err) {
-      console.error('[integrations] failed to create key', err)
-      publish({ message: 'Unable to create API key.', tone: 'error' })
     } finally {
       setIsSaving(false)
     }
@@ -356,7 +308,7 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
       {tab === 'website' && (
         <div className="account-overview__website-sync">
           <h2>Website + checkout setup</h2>
-          <p className="account-overview__hint">Use these values on Glittering, Kwaku, Pirus, or any client website that connects to Sedifex. Create an API key in the API keys tab first if you want this block to include the actual key.</p>
+          <p className="account-overview__hint">Use these values on Glittering, Kwaku, Pirus, or any client website that connects to Sedifex. Create separate product/integration and booking/checkout keys in the API keys tab.</p>
           <div className="account-overview__form-grid">
             <label><span>Website domain</span><input value={draft.websiteDomain} onChange={event => update('websiteDomain', event.target.value)} placeholder="https://www.example.com" /></label>
             <label><span>Checkout return URL</span><input value={draft.checkoutReturnUrl} onChange={event => update('checkoutReturnUrl', event.target.value)} placeholder="https://www.example.com/payment/return" /></label>
@@ -372,7 +324,7 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
           </div>
           <div className="account-overview__website-sync-actions">
             <button type="button" className="button button--secondary" onClick={() => copy(storeId, 'Store ID')}>Copy Store ID</button>
-            <button type="button" className="button button--secondary" onClick={() => copy(envBlock, latestToken ? 'Developer env block with key' : 'Developer env block')}>Copy developer env block</button>
+            <button type="button" className="button button--secondary" onClick={() => copy(envBlock, 'Developer env block')}>Copy developer env block</button>
             <button type="button" className="button" onClick={saveWebsite} disabled={isSaving}>{isSaving ? 'Saving…' : 'Save website setup'}</button>
           </div>
         </div>
@@ -405,16 +357,16 @@ export default function IntegrationSettingsHub({ defaultTab = 'website' }: Props
       )}
 
       {tab === 'keys' && (
-        <div className="account-overview__website-sync">
-          <h2>Website API keys</h2>
-          <p className="account-overview__hint">Create a key, copy it once, and put it in the website environment as SEDIFEX_BOOKING_API_KEY and SEDIFEX_CHECKOUT_API_KEY. The full key is shown once only.</p>
-          <div className="account-overview__website-sync-test">
-            <label><span>New key name</span><input value={keyName} onChange={event => setKeyName(event.target.value)} placeholder="Website production key" /></label>
-            <button type="button" className="button" onClick={createKey} disabled={isSaving}>{isSaving ? 'Creating…' : 'Create and copy key'}</button>
-          </div>
-          {latestToken ? <div className="account-overview__integration-token-notice"><p><strong>Save this key now. It is shown once.</strong></p><code className="account-overview__integration-token-value">{latestToken}</code><div className="account-overview__website-sync-actions"><button type="button" className="button button--secondary" onClick={() => copy(envBlock, 'Developer env block with new key')}>Copy full developer env block with key</button></div></div> : null}
-          {keysLoading ? <p>Loading keys…</p> : <ul className="account-overview__integration-key-list">{keys.map(item => <li key={item.id} className="account-overview__integration-key-item"><div><strong>{item.name}</strong><p className="account-overview__hint">{item.keyPreview} · {item.status} · Created {formatTimestamp(item.createdAt)}</p></div></li>)}</ul>}
-        </div>
+        <WebsiteApiKeysPanel
+          storeId={storeId}
+          keys={keys}
+          keysLoading={keysLoading}
+          isSaving={isSaving}
+          setIsSaving={setIsSaving}
+          refreshKeys={refreshKeys}
+          saveKeyPreview={saveDocs}
+          envBlock={envBlock}
+        />
       )}
     </section>
   )


### PR DESCRIPTION
## Summary
- Adds a dedicated website API keys panel with two clear sections:
  - Product / Integration key
  - Booking / Checkout key
- Updates the developer env block to show separate variables:
  - `SEDIFEX_INTEGRATION_API_KEY` for product/service/promo/gallery reads
  - `SEDIFEX_BOOKING_API_KEY` and `SEDIFEX_CHECKOUT_API_KEY` for booking and checkout
- Keeps compatibility with the existing `createIntegrationApiKey` and `listIntegrationApiKeys` functions.
- Sends key purpose metadata (`purpose`, `keyPurpose`, `keyType`, `scopes`) when creating keys so the UI can group them better.
- Keeps old keys visible by inferring their purpose from key name/type.

## Why
The current Integrations UI makes it look like one website key should be used for everything. That caused confusion when the same booking key was used as the integration key. The UI now guides users to create separate keys for product reads and booking/checkout actions.

## Testing
Not run locally in this environment.