### PR TITLE
Refine booking actions and sync feedback

### DIFF
--- a/web/src/pages/BookingEditor.tsx
+++ b/web/src/pages/BookingEditor.tsx
@@ -139,10 +139,6 @@ function normalizeTimeInput(value: unknown): string {
   return ''
 }
 
-function statusLabel(value: string) {
-  return value.replace(/_/g, ' ').replace(/\b\w/g, letter => letter.toUpperCase())
-}
-
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, timeoutMessage: string): Promise<T> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -243,17 +239,6 @@ export default function BookingEditor() {
     const parsed = Number.parseInt(form.quantity, 10)
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 1
   }, [form.quantity])
-
-  function setStatusDraft(nextStatus: string, nextPaymentStatus?: string) {
-    setForm(prev => ({
-      ...prev,
-      status: nextStatus,
-      paymentStatus: nextPaymentStatus ?? prev.paymentStatus,
-    }))
-    const message = `Status set to ${statusLabel(nextStatus)}. Click Save changes to save to reports${shouldQueueBookingSync ? ' and queue sheet sync' : ''}.`
-    setSuccessMessage(message)
-    publish({ tone: 'info', message })
-  }
 
   function buildStatusPayload(normalizedStatus: string, normalizedPaymentStatus: string) {
     if (normalizedStatus === 'confirmed') return buildConfirmBookingPayload({}, shouldQueueBookingSync)
@@ -413,7 +398,7 @@ export default function BookingEditor() {
           <p className="form__hint"><Link to="/bookings">← Back to bookings</Link></p>
           <h1>{isCreateMode ? 'Add booking' : 'Edit booking'}</h1>
           <p className="form__hint">
-            Update the booking, then click <strong>Save changes</strong>. Saved bookings appear in reports. If booking sheet sync is configured, the update is queued for the sheet.
+            Choose the booking status, then click <strong>Save changes</strong>. Saved bookings appear in reports. If booking sheet sync is configured, the update is queued for the sheet.
           </p>
           <p className="form__hint">
             Sheet sync status: <strong>{shouldQueueBookingSync ? 'Configured - updates will be queued' : 'Not configured'}</strong>
@@ -445,16 +430,12 @@ export default function BookingEditor() {
             <label className="booking-editor-page__notes"><span>Notes</span><textarea value={form.notes} onChange={event => setForm(prev => ({ ...prev, notes: event.target.value }))} rows={4} /></label>
 
             {!isCreateMode && (
-              <div className="booking-editor-page__quick-status" aria-label="Quick status shortcuts">
+              <div className="booking-editor-page__quick-status" aria-label="Sheet sync test">
                 <div>
-                  <strong>Booking actions</strong>
-                  <p className="form__hint">Use these buttons, then click Save changes. This saves to reports and queues sheet sync when configured.</p>
+                  <strong>Sheet sync test</strong>
+                  <p className="form__hint">Use only when you want to check if the connected booking sheet/App Script can pick up this booking.</p>
                 </div>
                 <div className="booking-editor-page__quick-status-actions">
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('confirmed')}>Confirm</button>
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('cancelled')}>Cancel</button>
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('completed')}>Complete</button>
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('confirmed', 'paid')}>Confirm + mark paid</button>
                   <button type="button" className="button button--outline" disabled={saving} onClick={() => void trySheetSync()}>Try sheet sync</button>
                 </div>
               </div>

--- a/web/src/pages/BookingEditor.tsx
+++ b/web/src/pages/BookingEditor.tsx
@@ -4,6 +4,7 @@ import { Timestamp, doc, getDoc, serverTimestamp, setDoc } from 'firebase/firest
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useToast } from '../components/ToastProvider'
+import { buildCancelBookingPayload, buildCompleteBookingPayload, buildConfirmBookingPayload, hasAppScriptBookingSyncConfigured } from '../utils/bookingActions'
 import { playSound } from '../utils/sound'
 import './BookingEditor.css'
 
@@ -154,6 +155,17 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, timeoutMes
   }
 }
 
+function saveMessage(isCreateMode: boolean, shouldQueueBookingSync: boolean) {
+  if (shouldQueueBookingSync) {
+    return isCreateMode
+      ? 'Booking created, saved to reports, and queued for sheet sync.'
+      : 'Booking saved to reports and queued for sheet sync.'
+  }
+  return isCreateMode
+    ? 'Booking created and saved to reports. Sheet sync is not configured yet.'
+    : 'Booking saved to reports. Sheet sync is not configured yet.'
+}
+
 export default function BookingEditor() {
   const { storeId } = useActiveStore()
   const { bookingId = 'new' } = useParams()
@@ -164,7 +176,24 @@ export default function BookingEditor() {
   const [saving, setSaving] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [shouldQueueBookingSync, setShouldQueueBookingSync] = useState(false)
   const { publish } = useToast()
+
+  useEffect(() => {
+    if (!storeId) return
+    let cancelled = false
+    async function loadStoreSyncConfig() {
+      try {
+        const storeSnap = await getDoc(doc(db, 'stores', storeId))
+        if (!cancelled) setShouldQueueBookingSync(hasAppScriptBookingSyncConfigured(storeSnap.data() as Record<string, unknown> | undefined))
+      } catch (error) {
+        console.error('[booking-editor] Failed to load booking sync config', error)
+        if (!cancelled) setShouldQueueBookingSync(false)
+      }
+    }
+    void loadStoreSyncConfig()
+    return () => { cancelled = true }
+  }, [storeId])
 
   useEffect(() => {
     if (!storeId || isCreateMode) {
@@ -193,9 +222,7 @@ export default function BookingEditor() {
         }
 
         if (!data) {
-          if (!cancelled) {
-            setErrorMessage('Booking not found.')
-          }
+          if (!cancelled) setErrorMessage('Booking not found.')
           return
         }
 
@@ -203,17 +230,13 @@ export default function BookingEditor() {
         setForm(normalizeBookingForm(data))
       } catch (error) {
         console.error('[booking-editor] Failed to load booking', error)
-        if (!cancelled) {
-          setErrorMessage('Unable to load this booking. Please retry.')
-        }
+        if (!cancelled) setErrorMessage('Unable to load this booking. Please retry.')
       } finally {
         if (!cancelled) setLoading(false)
       }
     }
     void loadBooking()
-    return () => {
-      cancelled = true
-    }
+    return () => { cancelled = true }
   }, [bookingId, isCreateMode, storeId])
 
   const quantityValue = useMemo(() => {
@@ -227,9 +250,36 @@ export default function BookingEditor() {
       status: nextStatus,
       paymentStatus: nextPaymentStatus ?? prev.paymentStatus,
     }))
-    const message = `Status set to ${statusLabel(nextStatus)}. Click Save changes to sync this booking.`
+    const message = `Status set to ${statusLabel(nextStatus)}. Click Save changes to save to reports${shouldQueueBookingSync ? ' and queue sheet sync' : ''}.`
     setSuccessMessage(message)
     publish({ tone: 'info', message })
+  }
+
+  function buildStatusPayload(normalizedStatus: string, normalizedPaymentStatus: string) {
+    if (normalizedStatus === 'confirmed') return buildConfirmBookingPayload({}, shouldQueueBookingSync)
+    if (normalizedStatus === 'cancelled') return buildCancelBookingPayload(shouldQueueBookingSync)
+    if (normalizedStatus === 'completed') return buildCompleteBookingPayload(shouldQueueBookingSync)
+    return {
+      bookingStatus: normalizedStatus,
+      status: normalizedStatus === 'pending_approval' ? 'pending' : normalizedStatus,
+      paymentStatus: normalizedPaymentStatus,
+      syncStatus: shouldQueueBookingSync ? 'pending' : 'not_ready',
+      syncReason: shouldQueueBookingSync ? 'booking_updated' : null,
+      syncRequestedAt: shouldQueueBookingSync ? Timestamp.now() : null,
+      syncConfigDetected: shouldQueueBookingSync,
+      updatedAt: serverTimestamp(),
+    }
+  }
+
+  async function savePayload(targetId: string, payload: Record<string, unknown>) {
+    await withTimeout(
+      Promise.all([
+        setDoc(doc(db, 'stores', storeId!, 'integrationBookings', targetId), payload, { merge: true }),
+        setDoc(doc(db, 'integrationBookings', targetId), payload, { merge: true }),
+      ]),
+      15000,
+      'Saving booking timed out. Please try again.',
+    )
   }
 
   async function handleSave() {
@@ -250,72 +300,68 @@ export default function BookingEditor() {
     try {
       const normalizedStatus = (form.status.trim() || 'pending_approval').toLowerCase()
       const normalizedPaymentStatus = form.paymentStatus.trim() || 'payment_pending'
+      const statusPayload = buildStatusPayload(normalizedStatus, normalizedPaymentStatus)
       const payload = {
+        ...statusPayload,
+        name: form.fullName.trim(),
+        fullName: form.fullName.trim(),
+        customerName: form.fullName.trim(),
+        phone: form.phone.trim(),
+        customerPhone: form.phone.trim(),
+        email: form.email.trim(),
+        customerEmail: form.email.trim(),
+        serviceName: form.serviceName.trim(),
+        serviceId: form.serviceId.trim(),
+        date: normalizeDateInput(form.bookingDate),
+        bookingDate: normalizeDateInput(form.bookingDate),
+        time: normalizeTimeInput(form.bookingTime),
+        bookingTime: normalizeTimeInput(form.bookingTime),
+        preferredBranch: form.preferredBranch.trim(),
+        branchLocationName: form.preferredBranch.trim(),
+        preferredContactMethod: form.preferredContactMethod.trim(),
+        quantity: quantityValue,
+        notes: form.notes.trim(),
+        paymentAmount: form.paymentAmount.trim(),
+        depositAmount: form.depositAmount.trim(),
+        paymentMethod: form.paymentMethod.trim(),
+        paymentReference: form.paymentReference.trim(),
+        reference: form.paymentReference.trim(),
+        paymentStatus: normalizedPaymentStatus,
+        payment: {
+          amount: form.paymentAmount.trim(),
+          depositAmount: form.depositAmount.trim(),
+          method: form.paymentMethod.trim(),
+          reference: form.paymentReference.trim(),
+          status: normalizedPaymentStatus,
+          confirmed: ['paid', 'confirmed'].includes(normalizedPaymentStatus.toLowerCase()),
+        },
+        booking: {
+          serviceId: form.serviceId.trim(),
+          serviceName: form.serviceName.trim(),
+          preferredDate: normalizeDateInput(form.bookingDate),
+          preferredTime: normalizeTimeInput(form.bookingTime),
+        },
+        customer: {
           name: form.fullName.trim(),
-          fullName: form.fullName.trim(),
           phone: form.phone.trim(),
           email: form.email.trim(),
-          serviceName: form.serviceName.trim(),
-          serviceId: form.serviceId.trim(),
-          date: normalizeDateInput(form.bookingDate),
-          bookingDate: normalizeDateInput(form.bookingDate),
-          time: normalizeTimeInput(form.bookingTime),
-          bookingTime: normalizeTimeInput(form.bookingTime),
-          preferredBranch: form.preferredBranch.trim(),
-          preferredContactMethod: form.preferredContactMethod.trim(),
-          bookingStatus: normalizedStatus,
-          status: normalizedStatus === 'pending_approval' ? 'pending' : normalizedStatus,
-          quantity: quantityValue,
-          notes: form.notes.trim(),
-          paymentAmount: form.paymentAmount.trim(),
-          depositAmount: form.depositAmount.trim(),
-          paymentMethod: form.paymentMethod.trim(),
-          paymentReference: form.paymentReference.trim(),
-          reference: form.paymentReference.trim(),
-          paymentStatus: normalizedPaymentStatus,
-          payment: {
-            amount: form.paymentAmount.trim(),
-            depositAmount: form.depositAmount.trim(),
-            method: form.paymentMethod.trim(),
-            reference: form.paymentReference.trim(),
-            status: normalizedPaymentStatus,
-            confirmed: ['paid', 'confirmed'].includes(normalizedPaymentStatus.toLowerCase()),
-          },
-          booking: {
-            serviceId: form.serviceId.trim(),
-            serviceName: form.serviceName.trim(),
-            preferredDate: normalizeDateInput(form.bookingDate),
-            preferredTime: normalizeTimeInput(form.bookingTime),
-          },
-          customer: {
-            name: form.fullName.trim(),
-            phone: form.phone.trim(),
-            email: form.email.trim(),
-          },
-          bookingId: targetId,
-          booking_id: targetId,
-          updatedAt: serverTimestamp(),
-          ...(isCreateMode ? {
-            createdAt: serverTimestamp(),
-            source: 'manual_admin',
-            sourceChannel: 'manual_admin',
-            source_channel: 'manual_admin',
-          } : {}),
-        }
-      await withTimeout(
-        Promise.all([
-          setDoc(doc(db, 'stores', storeId, 'integrationBookings', targetId), payload, { merge: true }),
-          setDoc(doc(db, 'integrationBookings', targetId), payload, { merge: true }),
-        ]),
-        15000,
-        'Saving booking timed out. Please try again.',
-      )
+        },
+        bookingId: targetId,
+        booking_id: targetId,
+        updatedAt: serverTimestamp(),
+        ...(isCreateMode ? {
+          createdAt: serverTimestamp(),
+          source: 'manual_admin',
+          sourceChannel: 'manual_admin',
+          source_channel: 'manual_admin',
+          sourceLabel: 'Manual/admin',
+        } : {}),
+      }
+      await savePayload(targetId, payload)
 
-      const saveMessage = isCreateMode
-        ? 'Booking created and queued for the connected booking records.'
-        : 'Booking changes saved successfully. Connected sheets/webhooks can now pick up the updated status.'
-      setSuccessMessage(saveMessage)
-      publish({ tone: 'success', message: saveMessage })
+      const message = saveMessage(isCreateMode, shouldQueueBookingSync)
+      setSuccessMessage(message)
+      publish({ tone: 'success', message })
       void playSound('success')
       if (isCreateMode) navigate('/bookings')
     } catch (error) {
@@ -329,16 +375,48 @@ export default function BookingEditor() {
     }
   }
 
+  async function trySheetSync() {
+    if (!storeId || isCreateMode) return
+    setSaving(true)
+    setErrorMessage(null)
+    setSuccessMessage(null)
+    try {
+      const payload = {
+        syncStatus: shouldQueueBookingSync ? 'pending' : 'not_ready',
+        syncReason: 'manual_sync_test',
+        syncRequestedAt: Timestamp.now(),
+        syncConfigDetected: shouldQueueBookingSync,
+        updatedAt: serverTimestamp(),
+      }
+      await savePayload(bookingId, payload)
+      const message = shouldQueueBookingSync
+        ? 'Sheet sync test queued. Check the booking sheet/App Script logs to confirm delivery.'
+        : 'Saved to reports, but sheet sync is not configured yet. Add the Apps Script URL in Integrations first.'
+      setSuccessMessage(message)
+      publish({ tone: shouldQueueBookingSync ? 'success' : 'warning', message })
+      void playSound(shouldQueueBookingSync ? 'success' : 'error')
+    } catch (error) {
+      console.error('[booking-editor] Failed to queue sheet sync test', error)
+      const message = 'Unable to try sheet sync right now.'
+      setErrorMessage(message)
+      publish({ tone: 'error', message })
+      void playSound('error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
   return (
     <main className="page booking-editor-page">
       <section className="card booking-editor-page__card stack gap-3">
         <header className="stack gap-1">
-          <p className="form__hint">
-            <Link to="/bookings">← Back to bookings</Link>
-          </p>
+          <p className="form__hint"><Link to="/bookings">← Back to bookings</Link></p>
           <h1>{isCreateMode ? 'Add booking' : 'Edit booking'}</h1>
           <p className="form__hint">
-            Update the booking status in this form, then click <strong>Save changes</strong>. This keeps Sedifex, the connected website, and any sheet/webhook sync using the same saved booking record.
+            Update the booking, then click <strong>Save changes</strong>. Saved bookings appear in reports. If booking sheet sync is configured, the update is queued for the sheet.
+          </p>
+          <p className="form__hint">
+            Sheet sync status: <strong>{shouldQueueBookingSync ? 'Configured - updates will be queued' : 'Not configured'}</strong>
           </p>
         </header>
 
@@ -347,13 +425,7 @@ export default function BookingEditor() {
         {successMessage && <p className="form__success">{successMessage}</p>}
 
         {!loading && (
-          <form
-            className="booking-editor-page__form"
-            onSubmit={event => {
-              event.preventDefault()
-              void handleSave()
-            }}
-          >
+          <form className="booking-editor-page__form" onSubmit={event => { event.preventDefault(); void handleSave() }}>
             <label><span>Customer name</span><input value={form.fullName} onChange={event => setForm(prev => ({ ...prev, fullName: event.target.value }))} required /></label>
             <label><span>Phone</span><input value={form.phone} onChange={event => setForm(prev => ({ ...prev, phone: event.target.value }))} /></label>
             <label><span>Email</span><input type="email" value={form.email} onChange={event => setForm(prev => ({ ...prev, email: event.target.value }))} /></label>
@@ -363,60 +435,33 @@ export default function BookingEditor() {
             <label><span>Booking time</span><input type="time" value={form.bookingTime} onChange={event => setForm(prev => ({ ...prev, bookingTime: event.target.value }))} /></label>
             <label><span>Preferred branch</span><input value={form.preferredBranch} onChange={event => setForm(prev => ({ ...prev, preferredBranch: event.target.value }))} /></label>
             <label><span>Preferred contact method</span><input value={form.preferredContactMethod} onChange={event => setForm(prev => ({ ...prev, preferredContactMethod: event.target.value }))} /></label>
-            <label>
-              <span>Status</span>
-              <select value={form.status} onChange={event => setForm(prev => ({ ...prev, status: event.target.value }))}>
-                <option value="pending_approval">Pending approval</option>
-                <option value="pending">Pending</option>
-                <option value="confirmed">Confirmed</option>
-                <option value="rescheduled">Rescheduled</option>
-                <option value="completed">Completed</option>
-                <option value="cancelled">Cancelled</option>
-              </select>
-            </label>
+            <label><span>Status</span><select value={form.status} onChange={event => setForm(prev => ({ ...prev, status: event.target.value }))}><option value="pending_approval">Pending approval</option><option value="pending">Pending</option><option value="confirmed">Confirmed</option><option value="rescheduled">Rescheduled</option><option value="completed">Completed</option><option value="cancelled">Cancelled</option></select></label>
             <label><span>Quantity</span><input type="number" min={1} value={form.quantity} onChange={event => setForm(prev => ({ ...prev, quantity: event.target.value }))} /></label>
             <label><span>Payment amount</span><input value={form.paymentAmount} onChange={event => setForm(prev => ({ ...prev, paymentAmount: event.target.value }))} /></label>
             <label><span>Deposit amount</span><input value={form.depositAmount} onChange={event => setForm(prev => ({ ...prev, depositAmount: event.target.value }))} /></label>
             <label><span>Payment method</span><input value={form.paymentMethod} onChange={event => setForm(prev => ({ ...prev, paymentMethod: event.target.value }))} /></label>
             <label><span>Payment reference</span><input value={form.paymentReference} onChange={event => setForm(prev => ({ ...prev, paymentReference: event.target.value }))} /></label>
-            <label>
-              <span>Payment status</span>
-              <select value={form.paymentStatus} onChange={event => setForm(prev => ({ ...prev, paymentStatus: event.target.value }))}>
-                <option value="payment_pending">Payment pending</option>
-                <option value="paid">Paid</option>
-                <option value="manual_review">Manual review</option>
-                <option value="refunded">Refunded</option>
-              </select>
-            </label>
+            <label><span>Payment status</span><select value={form.paymentStatus} onChange={event => setForm(prev => ({ ...prev, paymentStatus: event.target.value }))}><option value="payment_pending">Payment pending</option><option value="paid">Paid</option><option value="manual_review">Manual review</option><option value="refunded">Refunded</option></select></label>
             <label className="booking-editor-page__notes"><span>Notes</span><textarea value={form.notes} onChange={event => setForm(prev => ({ ...prev, notes: event.target.value }))} rows={4} /></label>
 
             {!isCreateMode && (
               <div className="booking-editor-page__quick-status" aria-label="Quick status shortcuts">
                 <div>
-                  <strong>Quick status</strong>
-                  <p className="form__hint">These buttons only set the fields above. Click Save changes to communicate the update to connected records.</p>
+                  <strong>Booking actions</strong>
+                  <p className="form__hint">Use these buttons, then click Save changes. This saves to reports and queues sheet sync when configured.</p>
                 </div>
                 <div className="booking-editor-page__quick-status-actions">
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('confirmed')}>
-                    Set confirmed
-                  </button>
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('completed')}>
-                    Set completed
-                  </button>
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('cancelled')}>
-                    Set cancelled
-                  </button>
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('confirmed', 'paid')}>
-                    Set confirmed + paid
-                  </button>
+                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('confirmed')}>Confirm</button>
+                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('cancelled')}>Cancel</button>
+                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('completed')}>Complete</button>
+                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('confirmed', 'paid')}>Confirm + mark paid</button>
+                  <button type="button" className="button button--outline" disabled={saving} onClick={() => void trySheetSync()}>Try sheet sync</button>
                 </div>
               </div>
             )}
 
             <div className="booking-editor-page__actions">
-              <button type="submit" className="button button--primary" disabled={saving}>
-                {saving ? 'Saving…' : isCreateMode ? 'Create booking' : 'Save changes'}
-              </button>
+              <button type="submit" className="button button--primary" disabled={saving}>{saving ? 'Saving…' : isCreateMode ? 'Create booking' : 'Save changes'}</button>
             </div>
           </form>
         )}

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -1,11 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { collection, doc, getDoc, getDocs, query, serverTimestamp, setDoc, Timestamp, where } from 'firebase/firestore'
+import { collection, getDocs, query, Timestamp, where } from 'firebase/firestore'
 import { Link } from 'react-router-dom'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
-import { buildCancelBookingPayload, buildCompleteBookingPayload, buildConfirmBookingPayload, hasAppScriptBookingSyncConfigured } from '../utils/bookingActions'
-import { useToast } from '../components/ToastProvider'
-import { playSound } from '../utils/sound'
 import './Bookings.css'
 
 type BookingRecord = {
@@ -97,9 +94,6 @@ export default function Bookings() {
   const [loading, setLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'needs_action' | 'today' | 'upcoming' | 'all' | 'cancelled'>('needs_action')
-  const [updatingBookingId, setUpdatingBookingId] = useState<string | null>(null)
-  const [shouldQueueBookingSync, setShouldQueueBookingSync] = useState(false)
-  const { publish } = useToast()
 
   const hydrateBooking = useCallback((id: string, data: Record<string, unknown>, serviceMap: Map<string, string>, sourcePath: 'store' | 'root') => {
     const nestedData = data.data && typeof data.data === 'object' ? (data.data as Record<string, unknown>) : {}
@@ -157,9 +151,6 @@ export default function Bookings() {
     setLoading(true)
     setErrorMessage(null)
     try {
-      const storeDocSnap = await getDoc(doc(db, 'stores', storeId))
-      setShouldQueueBookingSync(hasAppScriptBookingSyncConfigured(storeDocSnap.data() as Record<string, unknown> | undefined))
-
       const serviceMap = new Map<string, string>()
       for (const collectionName of ['services', 'integrationServices']) {
         const servicesSnapshot = await getDocs(collection(db, 'stores', storeId, collectionName))
@@ -206,31 +197,6 @@ export default function Bookings() {
 
   useEffect(() => { void loadBookings() }, [loadBookings])
 
-  const updateBooking = useCallback(async (
-    booking: BookingRecord,
-    updates: Record<string, unknown>,
-    options: { successMessage: string; errorMessage: string },
-  ) => {
-    if (!storeId) return
-    setUpdatingBookingId(booking.id)
-    try {
-      const payload = { ...updates, updatedAt: updates.updatedAt ?? serverTimestamp() }
-      await Promise.all([
-        setDoc(doc(db, 'stores', storeId, 'integrationBookings', booking.id), payload, { merge: true }),
-        setDoc(doc(db, 'integrationBookings', booking.id), payload, { merge: true }),
-      ])
-      setBookings(prev => prev.map(b => (b.id === booking.id ? { ...b, ...updates } as BookingRecord : b)))
-      publish({ tone: 'success', message: options.successMessage })
-      void playSound('success')
-    } catch (error) {
-      console.error('[bookings] Failed to update booking', error)
-      publish({ tone: 'error', message: options.errorMessage })
-      void playSound('error')
-    } finally {
-      setUpdatingBookingId(null)
-    }
-  }, [publish, storeId])
-
   const todayStr = new Date().toDateString()
   const summary = {
     newToday: bookings.filter(b => b.createdAt?.toDateString() === todayStr).length,
@@ -252,18 +218,10 @@ export default function Bookings() {
     return ['pending','pending_approval','manual_review'].includes(b.status) || b.bookingStatus === 'pending_approval' || ['pending', 'payment_pending', 'manual_review'].includes(b.paymentStatus)
   }), [activeTab, bookings, todayStr])
 
-  const actionsFor = (b: BookingRecord) => {
-    if (['completed', 'cancelled', 'deleted'].includes(b.status)) return ['open']
-    const actions = ['open']
-    if (['pending', 'pending_approval', 'manual_review'].includes(b.status) || b.bookingStatus === 'pending_approval') actions.push('confirm', 'cancel')
-    if (b.status === 'confirmed') actions.push('complete', 'cancel')
-    return actions
-  }
-
   return <main className="page bookings-page"><section className="card stack gap-4 bookings-board">
     <header className="stack gap-2">
       <h1>Bookings</h1>
-      <p className="bookings-page__intro">Manage today’s bookings, payments, confirmations, and follow-ups.</p>
+      <p className="bookings-page__intro">Manage today’s bookings, payments, confirmations, and follow-ups. Open a booking to confirm, cancel, complete, or try sheet sync.</p>
       <div className="bookings-page__row-actions">
         <Link to="/bookings/new" className="btn btn-secondary">Add booking</Link>
         <Link to="/bookings/availability" className="btn btn-secondary">Manage availability</Link>
@@ -281,9 +239,6 @@ export default function Bookings() {
       ['needs_action', 'Needs action'], ['today', 'Today'], ['upcoming', 'Upcoming'], ['all', 'All'], ['cancelled', 'Cancelled'],
     ].map(([id,label]) => <button key={id} type="button" className={`bookings-page__tab ${activeTab===id?'is-active':''}`} onClick={() => setActiveTab(id as typeof activeTab)}>{label}</button>)}</div>
 
-    {loading ? <p>Loading bookings…</p> : errorMessage ? <p className="form__error">{errorMessage}</p> : <div className="bookings-table-wrap"><table className="table bookings-table"><thead><tr><th>Booking</th><th>Customer</th><th>Schedule</th><th>Source</th><th>Payment</th><th>Status</th><th>Actions</th></tr></thead><tbody>{visible.map(b => {
-      const acts = actionsFor(b)
-      return <tr key={b.id}><td><strong>{b.serviceName}</strong><small>{b.reference || b.bookingId || 'No reference'}</small>{b.serviceName === 'Service not named' ? <small className="muted">Service ID: {b.serviceId}</small> : null}{b.duplicateMerged ? <span className="bookings-badge">Duplicate records merged</span> : null}</td><td><strong>{b.customerName || 'Customer'}</strong><small>{b.customerPhone || b.customerEmail || 'No contact'}</small></td><td><strong>{b.bookingDate || 'Date not set'}</strong><small>{b.bookingTime || 'Time not set'}</small><small>{b.preferredBranch || 'Main branch'}</small></td><td><span className="bookings-badge">{b.sourceLabel}</span><small>{b.sourcePath === 'root' ? 'Root booking' : 'Store booking'}</small></td><td><strong>{b.paymentAmount || '—'}</strong><small>{paymentLabel(b.paymentStatus)}</small><small>{b.paymentMethod || 'Method not set'}</small></td><td><span className={`bookings-page__status bookings-page__status--${b.bookingStatus}`}>{statusLabel(b.bookingStatus)}</span><small>{b.paymentStatus === 'paid' && b.bookingStatus !== 'confirmed' ? 'Paid - waiting for store confirmation' : ''}</small><small>{b.syncStatus === 'pending' ? 'Sync pending' : b.syncStatus === 'synced' ? 'Synced' : ''}</small></td><td><div className="bookings-page__row-actions">{acts.includes('confirm') && <button className="btn btn-secondary" onClick={() => void updateBooking(b, buildConfirmBookingPayload(b.payment, shouldQueueBookingSync), { successMessage: 'Booking confirmed successfully.', errorMessage: 'Unable to confirm booking right now.' })} disabled={updatingBookingId===b.id}>Confirm booking</button>}{acts.includes('cancel') && <button className="btn btn-secondary" onClick={() => void updateBooking(b, buildCancelBookingPayload(shouldQueueBookingSync), { successMessage: 'Booking cancelled successfully.', errorMessage: 'Unable to cancel booking right now.' })} disabled={updatingBookingId===b.id}>Cancel booking</button>}{acts.includes('complete') && <button className="btn btn-secondary" onClick={() => void updateBooking(b, buildCompleteBookingPayload(shouldQueueBookingSync), { successMessage: 'Booking marked as completed.', errorMessage: 'Unable to complete booking right now.' })} disabled={updatingBookingId===b.id}>Complete</button>}<Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link></div></td></tr>
-    })}</tbody></table><div className="bookings-cards">{visible.map(b => <article key={`${b.id}-card`} className="bookings-card"><h3>{b.serviceName}</h3><p>{b.customerName || 'Customer'} • {b.bookingDate || 'Date not set'} {b.bookingTime || ''}</p><p>{statusLabel(b.status)} • {paymentLabel(b.paymentStatus)}</p><Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link></article>)}</div></div>}
+    {loading ? <p>Loading bookings…</p> : errorMessage ? <p className="form__error">{errorMessage}</p> : <div className="bookings-table-wrap"><table className="table bookings-table"><thead><tr><th>Booking</th><th>Customer</th><th>Schedule</th><th>Source</th><th>Payment</th><th>Status</th><th>Actions</th></tr></thead><tbody>{visible.map(b => <tr key={b.id}><td><strong>{b.serviceName}</strong><small>{b.reference || b.bookingId || 'No reference'}</small>{b.serviceName === 'Service not named' ? <small className="muted">Service ID: {b.serviceId}</small> : null}{b.duplicateMerged ? <span className="bookings-badge">Duplicate records merged</span> : null}</td><td><strong>{b.customerName || 'Customer'}</strong><small>{b.customerPhone || b.customerEmail || 'No contact'}</small></td><td><strong>{b.bookingDate || 'Date not set'}</strong><small>{b.bookingTime || 'Time not set'}</small><small>{b.preferredBranch || 'Main branch'}</small></td><td><span className="bookings-badge">{b.sourceLabel}</span><small>{b.sourcePath === 'root' ? 'Root booking' : 'Store booking'}</small></td><td><strong>{b.paymentAmount || '—'}</strong><small>{paymentLabel(b.paymentStatus)}</small><small>{b.paymentMethod || 'Method not set'}</small></td><td><span className={`bookings-page__status bookings-page__status--${b.bookingStatus}`}>{statusLabel(b.bookingStatus)}</span><small>{b.paymentStatus === 'paid' && b.bookingStatus !== 'confirmed' ? 'Paid - waiting for store confirmation' : ''}</small><small>{b.syncStatus === 'pending' ? 'Sheet sync pending' : b.syncStatus === 'synced' ? 'Sheet synced' : ''}</small></td><td><div className="bookings-page__row-actions"><Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link></div></td></tr>)}</tbody></table><div className="bookings-cards">{visible.map(b => <article key={`${b.id}-card`} className="bookings-card"><h3>{b.serviceName}</h3><p>{b.customerName || 'Customer'} • {b.bookingDate || 'Date not set'} {b.bookingTime || ''}</p><p>{statusLabel(b.status)} • {paymentLabel(b.paymentStatus)}</p><Link className="btn btn-secondary" to={`/bookings/${b.id}`}>Open</Link></article>)}</div></div>}
   </section></main>
 }


### PR DESCRIPTION
## Summary
- Remove Confirm, Cancel, and Complete buttons from the main bookings list.
- Keep only Open on each booking row/card.
- Keep booking actions inside the booking editor.
- Add clearer save messages for reports and sheet sync queueing.
- Add a Try sheet sync button in the booking editor.
- Show whether booking sheet sync is configured.

## Why
The list should be for reviewing bookings. Staff should open a booking before confirming, cancelling, completing, or testing sheet sync.

## Testing
Not run locally.