### PR TITLE
Add public Quick Pay catalog endpoint

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -22,6 +22,7 @@ export {
 export { v1IntegrationAvailability } from './integrationAvailability'
 export { v1IntegrationBookings } from './integrationBookings'
 export { v1IntegrationStudentRegistrations } from './integrationStudentRegistrations'
+export { publicQuickPayCatalog } from './quickPay'
 export { volunteerIntake, supportRequestIntake } from './ngoIntake'
 export {
   notifyNgoVolunteerApplicationReceived,

--- a/functions/src/quickPay.ts
+++ b/functions/src/quickPay.ts
@@ -1,0 +1,148 @@
+import * as functions from 'firebase-functions/v1'
+import { defaultDb } from './firestore'
+
+type CatalogType = 'PRODUCT' | 'SERVICE' | 'COURSE'
+
+type CatalogItem = {
+  id: string
+  name: string
+  type: CatalogType
+  price: number
+  priceMinor: number
+  description?: string | null
+  imageUrl?: string | null
+  category?: string | null
+}
+
+const MAX_READ_PER_COLLECTION = 120
+const MAX_RETURN_ITEMS = 60
+
+function setCors(res: functions.Response, methods = 'GET, OPTIONS') {
+  res.set('Access-Control-Allow-Origin', '*')
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  res.set('Access-Control-Allow-Methods', methods)
+}
+
+function cleanText(value: unknown, max = 500) {
+  return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+
+function numberValue(value: unknown) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function normalizeType(value: unknown, fallback: CatalogType): CatalogType {
+  const text = cleanText(value, 30).toUpperCase()
+  if (text === 'PRODUCT' || text === 'SERVICE' || text === 'COURSE') return text
+  return fallback
+}
+
+function getName(record: Record<string, unknown>) {
+  return cleanText(
+    record.name
+      ?? record.productName
+      ?? record.serviceName
+      ?? record.courseName
+      ?? record.title,
+    220,
+  )
+}
+
+function getPriceMinor(record: Record<string, unknown>) {
+  const minorDirect = numberValue(record.priceMinor ?? record.amountMinor)
+  if (minorDirect !== null) return Math.round(minorDirect)
+
+  const majorValue = numberValue(
+    record.price
+      ?? record.sellingPrice
+      ?? record.salePrice
+      ?? record.amount
+      ?? record.fee,
+  )
+  if (majorValue !== null) return Math.round(majorValue * 100)
+  return 0
+}
+
+function includesQuery(item: CatalogItem, query: string) {
+  if (!query) return true
+  const haystack = [item.name, item.description ?? '', item.category ?? '', item.type].join(' ').toLowerCase()
+  return haystack.includes(query)
+}
+
+function normalizeDoc(id: string, record: Record<string, unknown>, fallbackType: CatalogType): CatalogItem | null {
+  const name = getName(record)
+  if (!name) return null
+
+  const priceMinor = getPriceMinor(record)
+  const type = normalizeType(record.type ?? record.item_type ?? record.itemType, fallbackType)
+
+  return {
+    id,
+    name,
+    type,
+    priceMinor,
+    price: priceMinor / 100,
+    description: cleanText(record.description, 500) || null,
+    imageUrl: cleanText(record.imageUrl ?? record.image ?? record.photoUrl ?? record.coverImageUrl, 2000) || null,
+    category: cleanText(record.category, 180) || null,
+  }
+}
+
+async function fetchCollectionItems(path: string, fallbackType: CatalogType) {
+  const snapshot = await defaultDb.collection(path).limit(MAX_READ_PER_COLLECTION).get()
+  return snapshot.docs
+    .map((doc) => normalizeDoc(doc.id, doc.data() as Record<string, unknown>, fallbackType))
+    .filter((item): item is CatalogItem => item !== null)
+}
+
+async function fetchQueryItems(collection: string, storeId: string, fallbackType: CatalogType) {
+  const snapshot = await defaultDb.collection(collection)
+    .where('storeId', '==', storeId)
+    .limit(MAX_READ_PER_COLLECTION)
+    .get()
+  return snapshot.docs
+    .map((doc) => normalizeDoc(doc.id, doc.data() as Record<string, unknown>, fallbackType))
+    .filter((item): item is CatalogItem => item !== null)
+}
+
+export const publicQuickPayCatalog = functions.https.onRequest(async (req, res) => {
+  setCors(res)
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('')
+    return
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'method-not-allowed' })
+    return
+  }
+
+  const storeId = cleanText(req.query.storeId, 180)
+  if (!storeId) {
+    res.status(400).json({ error: 'missing-store-id' })
+    return
+  }
+
+  const query = cleanText(req.query.q, 200).toLowerCase()
+
+  const [products, services, courses, publicListings, v1IntegrationProducts] = await Promise.all([
+    fetchCollectionItems(`stores/${storeId}/products`, 'PRODUCT'),
+    fetchCollectionItems(`stores/${storeId}/services`, 'SERVICE'),
+    fetchCollectionItems(`stores/${storeId}/courses`, 'COURSE'),
+    fetchQueryItems('publicListings', storeId, 'PRODUCT'),
+    fetchQueryItems('v1IntegrationProducts', storeId, 'PRODUCT'),
+  ])
+
+  const items = [...products, ...services, ...courses, ...publicListings, ...v1IntegrationProducts]
+    .filter(item => includesQuery(item, query))
+    .slice(0, MAX_RETURN_ITEMS)
+
+  res.status(200).json({
+    ok: true,
+    storeId,
+    count: items.length,
+    items,
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide a public read-only catalog endpoint for the new frontend route `/s/:storeId` so customers can scan a QR, search products/services/courses, select an item, and proceed to checkout. 
- Surface a normalized, safe set of fields for public consumption while avoiding exposure of private internals like supplier, owner, stock, or API keys.

### Description
- Add `functions/src/quickPay.ts` which implements an HTTPS function `publicQuickPayCatalog` with CORS enabled and `GET`/`OPTIONS` handling and returns `400 { error: "missing-store-id" }` when `storeId` is absent and `405` for unsupported methods. 
- Read up to `120` documents per source from `stores/{storeId}/products`, `stores/{storeId}/services`, `stores/{storeId}/courses`, and from `publicListings` and `v1IntegrationProducts` filtered by `storeId`, then normalize results and cap returned items to `60`. 
- Normalize each result to the safe public shape `{ id, name, type, price, priceMinor, description?, imageUrl?, category? }` and support the requested fallback fields for names (`name`, `productName`, `serviceName`, `courseName`, `title`), prices (`priceMinor`, `amountMinor`, `price`, `sellingPrice`, `salePrice`, `amount`, `fee`), and types (`type`, `item_type`, `itemType`). 
- Apply optional search filtering (`q`) over `name`, `description`, `category`, and `type`, and export `publicQuickPayCatalog` from `functions/src/index.ts`.

### Testing
- Run `npm --prefix functions run build` to compile TypeScript and the build completed successfully.
- The TypeScript build indicates the new function integrates cleanly with the existing functions setup and produced no compilation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7e52286c8321890f587f1f4a9d86)