### PR TITLE
Fix Quick Pay viewport scaling on mobile

### DIFF
--- a/web/src/pages/PublicQuickPayCheckout.tsx
+++ b/web/src/pages/PublicQuickPayCheckout.tsx
@@ -112,6 +112,24 @@ export default function PublicQuickPayCheckout() {
   const hiddenItemCount = Math.max(filteredItems.length - visibleItems.length, 0)
 
   const unitAmount = selectedItem?.price ?? 0
+
+  useEffect(() => {
+    const existingViewport = document.querySelector('meta[name="viewport"]')
+    if (existingViewport) {
+      existingViewport.setAttribute('content', 'width=device-width, initial-scale=1.0')
+      return
+    }
+
+    const meta = document.createElement('meta')
+    meta.name = 'viewport'
+    meta.content = 'width=device-width, initial-scale=1.0'
+    document.head.appendChild(meta)
+
+    return () => {
+      meta.remove()
+    }
+  }, [])
+
   const finalAmount = selectedItem?.type === 'MANUAL' ? Number(customAmount || 0) : unitAmount * quantity
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Prevent the Quick Pay checkout page from rendering at desktop scale on phones by ensuring a correct mobile viewport is present at runtime.
- Make the page responsive in environments where the hosting HTML may be missing or have a malformed `viewport` meta tag.

### Description
- Added a `useEffect` in `web/src/pages/PublicQuickPayCheckout.tsx` that locates `meta[name="viewport"]` and sets its `content` to `width=device-width, initial-scale=1.0` if found.
- If no viewport meta exists the effect creates one with `content: "width=device-width, initial-scale=1.0"` and removes it on component unmount.
- The change only affects the Quick Pay public checkout page and is defensive to avoid duplicating tags when one already exists.

### Testing
- Attempted `npm run -s build` in `web/` and the build step failed in this environment due to missing TypeScript type definitions for `vite/client` and `vitest/globals`, so a full build verification could not be completed.
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104669452883218abfb5e5fdf0f5a9)