### PR TITLE
Add Website Builder route to main router

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,6 +9,7 @@ import DashboardHub from './pages/DashboardHub'
 import Products from './pages/ProductsServiceFirst'
 import Sell from './pages/Sell'
 import QuickPay from './pages/QuickPay'
+import WebsiteBuilder from './pages/WebsiteBuilder'
 import QuickPayPrint from './pages/QuickPayPrint'
 import PublicQuickPayCheckout from './pages/PublicQuickPayCheckout'
 import CloseDay from './pages/CloseDay'
@@ -105,6 +106,7 @@ const router = createBrowserRouter([
       { path: 'products', element: <Products /> },
       { path: 'sell', element: <Sell /> },
       { path: 'quick-pay', element: <QuickPay /> },
+      { path: 'website-builder', element: <WebsiteBuilder /> },
       { path: 'quick-pay/print', element: <QuickPayPrint /> },
       { path: 'customers', element: <Customers /> },
       { path: 'students', element: <Students /> },


### PR DESCRIPTION
### Motivation
- Make the new Website Builder page reachable from the authenticated app UI by exposing it at `/website-builder` so users can navigate to the feature from the sidebar/navigation.

### Description
- Import `WebsiteBuilder` in `web/src/main.tsx` and add the authenticated route `{ path: 'website-builder', element: <WebsiteBuilder /> }` immediately after the `quick-pay` route in the main router, modifying `web/src/main.tsx` (2 insertions).

### Testing
- Verified the changes by running `rg -n "WebsiteBuilder|website-builder" web/src/main.tsx`, which returned the import line and the route entry, confirming the update succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10604d2a9c83218fad1fc23ca0b704)