### PR TITLE
Add public website route for /sites/:slug

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -12,6 +12,7 @@ import QuickPay from './pages/QuickPay'
 import WebsiteBuilder from './pages/WebsiteBuilder'
 import QuickPayPrint from './pages/QuickPayPrint'
 import PublicQuickPayCheckout from './pages/PublicQuickPayCheckout'
+import PublicWebsiteEngine from './pages/PublicWebsiteEngine'
 import CloseDay from './pages/CloseDay'
 import Customers from './pages/Customers'
 import Students from './pages/Students'
@@ -81,6 +82,7 @@ const router = createBrowserRouter([
   { path: '/promo/:slug', element: <PromoLandingPage /> },
   { path: '/login', element: <Navigate to="/" replace /> },
   { path: '/s/:storeId', element: <PublicQuickPayCheckout /> },
+  { path: '/sites/:slug', element: <PublicWebsiteEngine /> },
   { path: '/:slug', element: <PromoLandingPage /> },
   { path: '/customer-display', element: <CustomerDisplay /> },
   { path: '/display', element: <CustomerDisplay /> },


### PR DESCRIPTION
### Motivation
- Allow public websites to be served at `/sites/:slug` (e.g. `https://www.sedifex.com/sites/glittering-med-spa`) and ensure those slugs resolve before the existing catch-all `/:slug` route.

### Description
- Imported `PublicWebsiteEngine` in `web/src/main.tsx` and added a top-level router entry `{ path: '/sites/:slug', element: <PublicWebsiteEngine /> }` immediately before the `/:slug` route so site slugs route to the website engine.

### Testing
- No automated tests were run for this routing-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107a5cb50c8321be7c3287cc19c7bb)