### PR TITLE
Accept draft-prefixed service IDs in Integration Bookings API

### DIFF
--- a/functions/src/integrationBookings.ts
+++ b/functions/src/integrationBookings.ts
@@ -31,6 +31,13 @@ function clean(value: unknown, max = 500) {
   return typeof value === 'string' ? value.trim().slice(0, max) : ''
 }
 
+
+function normalizeServiceId(rawValue: unknown) {
+  const value = clean(rawValue, 220)
+  if (!value) return ''
+  return value.toLowerCase().startsWith('draft-') ? value.slice(6).trim() : value
+}
+
 function setCors(res: functions.Response) {
   res.set('Access-Control-Allow-Origin', '*')
   res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-api-key, X-Sedifex-Contract-Version')
@@ -151,7 +158,7 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res):
   try {
     if (req.method === 'GET') {
       const status = clean(req.query.status, 80).toLowerCase()
-      const serviceId = clean(req.query.serviceId, 220)
+      const serviceId = normalizeServiceId(req.query.serviceId)
 
       let query: FirebaseFirestore.Query = defaultDb
         .collection('stores')
@@ -169,7 +176,7 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res):
     }
 
     const body = asObject(req.body) as BookingRequestBody
-    const serviceId = clean(body.serviceId, 220)
+    const serviceId = normalizeServiceId(body.serviceId)
     const slotId = clean(body.slotId, 220)
     const quantity = Math.max(1, Math.floor(toNumber(body.quantity, 1)))
     const notes = clean(body.notes, 2000)


### PR DESCRIPTION
### Motivation
- Allow booking clients to submit `serviceId` values that begin with `draft-` so bookings and queries do not fail during draft/published transitions.

### Description
- Add `normalizeServiceId(rawValue)` which trims the input and strips a leading `draft-` prefix when present, and apply it to both the `GET` query path (`req.query.serviceId`) and the `POST` request body (`body.serviceId`) in `v1IntegrationBookings`.

### Testing
- Built the functions package with `npm --prefix functions run build` which completed successfully, and committed the change (`Accept draft-prefixed service IDs in integration bookings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d418fec083218531d19edf4d3cb0)