### PR TITLE
Normalize service/item IDs and accept snake_case service_id in bookings

### DIFF
--- a/functions/src/integrationAvailability.ts
+++ b/functions/src/integrationAvailability.ts
@@ -147,6 +147,12 @@ async function isAuthorized(req: functions.https.Request, storeId: string) {
   return false
 }
 
+function normalizeServiceId(rawValue: unknown) {
+  const value = clean(rawValue, 220)
+  if (!value) return ''
+  return value.toLowerCase().startsWith('draft-') ? value.slice(6).trim() : value
+}
+
 function slotMatchesFilters(slot: SlotResponse, fromDate: Date | null, toDateFilter: Date | null, serviceId: string) {
   const start = parseDate(slot.startAt)
   if (!start) return false
@@ -170,7 +176,7 @@ export const v1IntegrationAvailability = functions.https.onRequest(async (req, r
 
   try {
     const storeId = clean(req.query.storeId, 180)
-    const serviceId = clean(req.query.serviceId, 220)
+    const serviceId = normalizeServiceId(req.query.serviceId)
     const fromDate = parseDate(clean(req.query.from, 100))
     const toDateFilter = parseDate(clean(req.query.to, 100))
 
@@ -199,7 +205,7 @@ export const v1IntegrationAvailability = functions.https.onRequest(async (req, r
 
       const capacity = Math.max(0, Math.floor(toNumber(data.capacity, 0)))
       const seatsBooked = Math.max(0, Math.floor(toNumber(data.seatsBooked, 0)))
-      const resolvedServiceId = clean(data.serviceId, 220)
+      const resolvedServiceId = normalizeServiceId(data.serviceId)
       const resolvedServiceName = clean(data.serviceName, 240)
       if (!authorized) {
         const isClosed = data.status === 'closed'

--- a/functions/src/integrationBookings.ts
+++ b/functions/src/integrationBookings.ts
@@ -9,6 +9,7 @@ const SEDIFEX_INTEGRATION_API_KEY = defineString('SEDIFEX_INTEGRATION_API_KEY', 
 
 type BookingRequestBody = {
   serviceId?: unknown
+  service_id?: unknown
   slotId?: unknown
   customer?: unknown
   quantity?: unknown
@@ -29,6 +30,13 @@ type BookingRequestBody = {
 
 function clean(value: unknown, max = 500) {
   return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+
+
+function normalizeServiceId(rawValue: unknown) {
+  const value = clean(rawValue, 220)
+  if (!value) return ''
+  return value.toLowerCase().startsWith('draft-') ? value.slice(6).trim() : value
 }
 
 function setCors(res: functions.Response) {
@@ -151,7 +159,7 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res):
   try {
     if (req.method === 'GET') {
       const status = clean(req.query.status, 80).toLowerCase()
-      const serviceId = clean(req.query.serviceId, 220)
+      const serviceId = normalizeServiceId(req.query.serviceId)
 
       let query: FirebaseFirestore.Query = defaultDb
         .collection('stores')
@@ -169,7 +177,7 @@ export const v1IntegrationBookings = functions.https.onRequest(async (req, res):
     }
 
     const body = asObject(req.body) as BookingRequestBody
-    const serviceId = clean(body.serviceId, 220)
+    const serviceId = normalizeServiceId(body.serviceId ?? body.service_id)
     const slotId = clean(body.slotId, 220)
     const quantity = Math.max(1, Math.floor(toNumber(body.quantity, 1)))
     const notes = clean(body.notes, 2000)

--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -60,6 +60,12 @@ function clean(value: unknown, max = 500) {
   return typeof value === 'string' ? value.trim().slice(0, max) : ''
 }
 
+function normalizeServiceLikeItemId(rawValue: unknown) {
+  const value = clean(rawValue, 220)
+  if (!value) return ''
+  return value.toLowerCase().startsWith('draft-') ? value.slice(6).trim() : value
+}
+
 function numberValue(value: unknown) {
   const parsed = Number(value)
   return Number.isFinite(parsed) ? parsed : null
@@ -667,7 +673,7 @@ export const integrationCheckoutPreview = functions.https.onRequest(async (req, 
 
     for (const rawItem of items) {
       const item = rawItem && typeof rawItem === 'object' ? rawItem as CheckoutPreviewItem : {}
-      const itemId = clean(item.item_id ?? item.itemId ?? item.productId ?? item.serviceId, 220)
+      const itemId = normalizeServiceLikeItemId(item.item_id ?? item.itemId ?? item.productId ?? item.serviceId)
       const qtyRaw = numberValue(item.qty ?? item.quantity)
       const qty = qtyRaw && qtyRaw > 0 ? Math.round(qtyRaw) : 1
       const type = normalizeCheckoutItemType(item.type ?? item.item_type ?? (item.serviceId ? 'SERVICE' : 'PRODUCT'))


### PR DESCRIPTION
### Motivation
- Ensure service and service-like item identifiers are normalized consistently across integrations by stripping leading `draft-` publisher prefixes and trimming, and to accept common snake_case fields from external integrators.
- Improve matching of incoming integration requests to stored records so public/private filtering and lookups behave as expected.

### Description
- Add `normalizeServiceId` helper and use it in `integrationAvailability.ts` to normalize request `serviceId` and stored `serviceId` values before filtering slots. 
- Add `service_id` to `BookingRequestBody` and `normalizeServiceId` to `integrationBookings.ts`, using it to read `serviceId` from both camelCase and snake_case inputs and to normalize query parameters. 
- Add `normalizeServiceLikeItemId` to `integrationCheckout.ts` and use it when resolving checkout `itemId` values to normalize incoming service-like item identifiers.

### Testing
- Built the TypeScript project with `npm run build` successfully. 
- Ran unit tests with `npm test` and they passed. 
- Ran linter with `npm run lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d418fec083218531d19edf4d3cb0)