### PR TITLE
Load Quick Pay popular stores from live Sedifex data

### DIFF
--- a/functions/src/quickPay.ts
+++ b/functions/src/quickPay.ts
@@ -227,15 +227,32 @@ export const publicQuickPayStores = functions.https.onRequest(async (req, res) =
 
   try {
     const query = cleanText(req.query.q, 200)
-    if (normalizeSearchText(query).length < 2) {
-      res.status(200).json({ ok: true, count: 0, stores: [] })
-      return
+    const normalizedQuery = normalizeSearchText(query)
+
+    let stores: PublicStore[] = []
+    let source: 'index' | 'fallback' = 'index'
+
+    if (normalizedQuery.length < 2) {
+      const snapshot = await defaultDb.collection('quickPayStoreIndex')
+        .orderBy('updatedAt', 'desc')
+        .limit(MAX_STORE_RESULTS)
+        .get()
+
+      stores = snapshot.docs
+        .map(doc => normalizeStore(doc.id, doc.data() as Record<string, unknown>))
+        .filter((store): store is PublicStore => store !== null)
+
+      if (!stores.length) {
+        stores = await fetchFallbackStores('')
+        source = 'fallback'
+      }
+    } else {
+      const indexedStores = await fetchIndexedStores(query)
+      stores = indexedStores.length ? indexedStores : await fetchFallbackStores(query)
+      source = indexedStores.length ? 'index' : 'fallback'
     }
 
-    const indexedStores = await fetchIndexedStores(query)
-    const stores = indexedStores.length ? indexedStores : await fetchFallbackStores(query)
-
-    res.status(200).json({ ok: true, count: stores.length, stores: stores.slice(0, MAX_STORE_RESULTS), source: indexedStores.length ? 'index' : 'fallback' })
+    res.status(200).json({ ok: true, count: stores.length, stores: stores.slice(0, MAX_STORE_RESULTS), source })
   } catch (error) {
     functions.logger.error('publicQuickPayStores failed', { error })
     res.status(500).json({ error: 'quick-pay-store-search-failed' })

--- a/web/src/pages/QuickPayLanding.tsx
+++ b/web/src/pages/QuickPayLanding.tsx
@@ -18,11 +18,6 @@ const FUNCTION_BASE_URL =
 
 const QUICK_CATEGORIES = ['All', 'Products', 'Beauty', 'Food', 'Electronics', 'Fashion', 'Home']
 
-const SAMPLE_STORES: PublicStore[] = [
-  { storeId: 'demo-kwaku-lottery', name: 'Kwaku Lottery', category: 'Beauty & Wellness' },
-  { storeId: 'demo-grace-bakery', name: 'Grace Bakery', category: 'Food & Beverages' },
-]
-
 function getStorePayUrl(storeId: string) {
   return `/s/${encodeURIComponent(storeId)}?mode=store`
 }
@@ -64,7 +59,7 @@ function StoreRow({ store, compact = false }: { store: PublicStore; compact?: bo
 export default function QuickPayLanding() {
   const [query, setQuery] = useState('')
   const [stores, setStores] = useState<PublicStore[]>([])
-  const [recentStores, setRecentStores] = useState<PublicStore[]>(SAMPLE_STORES)
+  const [recentStores, setRecentStores] = useState<PublicStore[]>([])
   const [status, setStatus] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -75,6 +70,29 @@ export default function QuickPayLanding() {
     if (!canSearch) return 'Type at least 2 letters to search.'
     return status ?? 'Choose the correct business from the results.'
   }, [canSearch, query, status])
+
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    async function loadRecentStores() {
+      try {
+        const response = await fetch(`${FUNCTION_BASE_URL}/publicQuickPayStores`, { signal: controller.signal })
+        if (!response.ok) throw new Error(`Popular stores failed (${response.status})`)
+        const payload = await response.json() as { stores?: PublicStore[] }
+        const nextStores = Array.isArray(payload.stores) ? payload.stores : []
+        setRecentStores(nextStores.slice(0, 4))
+      } catch (popularError) {
+        if (controller.signal.aborted) return
+        console.warn('[quick-pay] Popular stores load failed', popularError)
+        setRecentStores([])
+      }
+    }
+
+    void loadRecentStores()
+
+    return () => controller.abort()
+  }, [])
 
   useEffect(() => {
     if (!canSearch) {


### PR DESCRIPTION
### Motivation

- Replace hardcoded demo entries on the Quick Pay landing page with real, up-to-date store data so the “Popular on Sedifex” list reflects live stores.
- Serve a useful default result when users open the landing page (no search) by returning recent indexed stores instead of an empty set.
- Keep existing search behavior while providing a robust fallback to the main `stores` collection if the index is empty.

### Description

- Removed the `SAMPLE_STORES` demo data and initialize `recentStores` as empty in `web/src/pages/QuickPayLanding.tsx`.
- Added a startup `useEffect` in `web/src/pages/QuickPayLanding.tsx` to fetch `publicQuickPayStores` and populate the Popular list (`recentStores`) from the live endpoint.
- Updated `functions/src/quickPay.ts` `publicQuickPayStores` handler to return recent documents from `quickPayStoreIndex` ordered by `updatedAt` when the normalized query is shorter than 2 characters, and to fall back to `stores` collection if the index returns no records; the response now includes a `source` field.
- Preserved the existing search flow where queries with >=2 characters use the index (with fallback) and update the popular list with search results when applicable.

### Testing

- Ran `npm --prefix functions run build` and the functions TypeScript build completed successfully.
- Ran `npm --prefix web run lint` in this environment and linting failed due to a missing dev dependency (`@eslint/js`) in the environment, which is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116f251ac083218fe58b42805fc80e)