### PR TITLE
Show fulfillment actions in Marketplace Orders by adjusting primary status precedence

### DIFF
--- a/web/src/pages/MarketplaceOrders.tsx
+++ b/web/src/pages/MarketplaceOrders.tsx
@@ -294,7 +294,10 @@ function filterRecords(records: OnlineOrderRecord[], tab: OnlineOrderTab) {
 }
 
 function getPrimaryStatus(record: OnlineOrderRecord) {
-  return record.deliveryStatus || record.fulfillmentStatus || (isServiceBooking(record) ? record.bookingStatus || record.orderStatus : record.orderStatus)
+  const deliveryStatus = record.deliveryStatus.toLowerCase()
+  const shouldUseDeliveryFirst = ['out_for_delivery', 'delivered', 'completed'].some(token => deliveryStatus.includes(token))
+  if (shouldUseDeliveryFirst) return record.deliveryStatus
+  return record.fulfillmentStatus || (isServiceBooking(record) ? record.bookingStatus || record.orderStatus : record.orderStatus) || record.deliveryStatus
 }
 
 function buildCustomerContactHref(record: OnlineOrderRecord) {


### PR DESCRIPTION
### Motivation
- Fix the UI issue where clicking `Accept`/`Preparing` did not update the status badge because `deliveryStatus: not_started` masked fulfillment progress.

### Description
- Change `getPrimaryStatus` in `web/src/pages/MarketplaceOrders.tsx` to prefer `deliveryStatus` only when it is a meaningful delivery stage (`out_for_delivery`, `delivered`, or `completed`), otherwise fall back to `fulfillmentStatus` / `bookingStatus` / `orderStatus` so acceptance/preparing updates are visible.

### Testing
- Attempted to build with `cd web && npm run -s build`, which failed in this environment due to missing TypeScript definition files for `vite/client` and `vitest/globals` (no successful automated build available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1455b855448321be30bff6ec043426)