### PR TITLE
Lazy-load Website Builder preview route

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,7 +9,6 @@ import DashboardHub from './pages/DashboardHub'
 import Products from './pages/ProductsServiceFirst'
 import Sell from './pages/Sell'
 import QuickPay from './pages/QuickPay'
-import WebsiteBuilderPreview from './pages/WebsiteBuilderPreview'
 import QuickPayPrint from './pages/QuickPayPrint'
 import PublicQuickPayCheckout from './pages/PublicQuickPayCheckout'
 import PublicQuickPayReceipt from './pages/PublicQuickPayReceipt'
@@ -83,6 +82,7 @@ import './studentRegistrationTabs.css'
 const SalesCashReport = React.lazy(() => import('./pages/reports/SalesCashReport'))
 const BusinessExpenses = React.lazy(() => import('./pages/BusinessExpenses'))
 const WebsiteBuilder = React.lazy(() => import('./pages/WebsiteBuilder'))
+const WebsiteBuilderPreview = React.lazy(() => import('./pages/WebsiteBuilderPreview'))
 
 function LazyPage({ children }: { children: React.ReactNode }) {
   return (
@@ -127,7 +127,7 @@ const router = createBrowserRouter([
       { path: 'sell', element: <Sell /> },
       { path: 'quick-pay', element: <QuickPay /> },
       { path: 'website-builder', element: <LazyPage><WebsiteBuilder /></LazyPage> },
-      { path: 'website-builder/preview', element: <WebsiteBuilderPreview /> },
+      { path: 'website-builder/preview', element: <LazyPage><WebsiteBuilderPreview /></LazyPage> },
       { path: 'quick-pay/print', element: <QuickPayPrint /> },
       { path: 'customers', element: <Customers /> },
       { path: 'students', element: <Students /> },


### PR DESCRIPTION
### Motivation
- Prevent the heavy preview code from being bundled into the initial app so the Website Builder page opens faster and loads preview assets only when the user navigates to them.

### Description
- Replaced the eager import of `WebsiteBuilderPreview` with a lazy-loaded `React.lazy(() => import('./pages/WebsiteBuilderPreview'))` and added it alongside other lazy routes in `web/src/main.tsx`.
- Wrapped the `/website-builder/preview` route element with the existing `LazyPage` suspense boundary (`<LazyPage><WebsiteBuilderPreview /></LazyPage>`), ensuring consistent loading UI while the chunk downloads.

### Testing
- Ran `npm run build` in `web/`, which failed due to missing type definition files for `vite/client` and `vitest/globals`, preventing a full build verification.
- Ran `npm install` in `web/`, which was blocked with `403 Forbidden` for `@azure/msal-browser` from the registry, so dependencies could not be installed and build validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1820813cd483219066fa9e5f6d757f)