### PR TITLE
Website preview: on-demand loading, caching, refresh and share tools

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,7 +9,6 @@ import DashboardHub from './pages/DashboardHub'
 import Products from './pages/ProductsServiceFirst'
 import Sell from './pages/Sell'
 import QuickPay from './pages/QuickPay'
-import WebsiteBuilderPreview from './pages/WebsiteBuilderPreview'
 import QuickPayPrint from './pages/QuickPayPrint'
 import PublicQuickPayCheckout from './pages/PublicQuickPayCheckout'
 import PublicQuickPayReceipt from './pages/PublicQuickPayReceipt'
@@ -83,6 +82,7 @@ import './studentRegistrationTabs.css'
 const SalesCashReport = React.lazy(() => import('./pages/reports/SalesCashReport'))
 const BusinessExpenses = React.lazy(() => import('./pages/BusinessExpenses'))
 const WebsiteBuilder = React.lazy(() => import('./pages/WebsiteBuilder'))
+const WebsiteBuilderPreview = React.lazy(() => import('./pages/WebsiteBuilderPreview'))
 
 function LazyPage({ children }: { children: React.ReactNode }) {
   return (
@@ -127,7 +127,7 @@ const router = createBrowserRouter([
       { path: 'sell', element: <Sell /> },
       { path: 'quick-pay', element: <QuickPay /> },
       { path: 'website-builder', element: <LazyPage><WebsiteBuilder /></LazyPage> },
-      { path: 'website-builder/preview', element: <WebsiteBuilderPreview /> },
+      { path: 'website-builder/preview', element: <LazyPage><WebsiteBuilderPreview /></LazyPage> },
       { path: 'quick-pay/print', element: <QuickPayPrint /> },
       { path: 'customers', element: <Customers /> },
       { path: 'students', element: <Students /> },

--- a/web/src/pages/WebsiteBuilderPreview.tsx
+++ b/web/src/pages/WebsiteBuilderPreview.tsx
@@ -204,12 +204,20 @@ function previewText(value: string, fallback: string) {
   return clean.length > 220 ? `${clean.slice(0, 217)}…` : clean
 }
 
+const PREVIEW_CACHE_TTL_MS = 5 * 60 * 1000
+const previewSettingsCache = new Map<string, { savedAt: number; data: WebsitePreviewSettings }>()
+
 export default function WebsiteBuilderPreview() {
   const { storeId, isLoading } = useActiveStore()
   const [settings, setSettings] = useState<WebsitePreviewSettings>(() => defaultSettings())
   const [previewMode, setPreviewMode] = useState<PreviewMode>('desktop')
-  const [loading, setLoading] = useState(true)
+  const [shouldLoadPreview, setShouldLoadPreview] = useState(false)
+  const [forceReloadToken, setForceReloadToken] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [copyFeedback, setCopyFeedback] = useState<string | null>(null)
+  const [showShareTools, setShowShareTools] = useState(false)
+  const [lastLoadedAt, setLastLoadedAt] = useState<number | null>(null)
   const url = publicUrl(settings)
   const profile = PREVIEW_PROFILES[settings.websiteType]
   const theme = THEME_OPTIONS[settings.theme]
@@ -225,6 +233,16 @@ export default function WebsiteBuilderPreview() {
   const shareImage = settings.seoSettings.socialShareImage || settings.coverImageUrl || settings.businessLogoUrl
 
   useEffect(() => {
+    if (!storeId) return
+    const cached = previewSettingsCache.get(storeId)
+    if (!cached || Date.now() - cached.savedAt >= PREVIEW_CACHE_TTL_MS) return
+    setSettings(cached.data)
+    setLastLoadedAt(cached.savedAt)
+    setShouldLoadPreview(true)
+  }, [storeId])
+
+  useEffect(() => {
+    if (!shouldLoadPreview) return
     let mounted = true
 
     async function loadPreview() {
@@ -234,7 +252,16 @@ export default function WebsiteBuilderPreview() {
       }
 
       setLoading(true)
+      setLoadError(null)
       try {
+        const forceRefresh = forceReloadToken > 0
+        const cached = previewSettingsCache.get(storeId)
+        if (!forceRefresh && cached && Date.now() - cached.savedAt < PREVIEW_CACHE_TTL_MS) {
+          setSettings(cached.data)
+          setLastLoadedAt(cached.savedAt)
+          return
+        }
+
         const [settingsSnap, storeSnap] = await Promise.all([
           getDoc(doc(db, 'storeSettings', storeId)),
           getDoc(doc(db, 'stores', storeId)),
@@ -251,7 +278,7 @@ export default function WebsiteBuilderPreview() {
         const domainSettings = { ...DEFAULT_DOMAIN_SETTINGS, ...record(settingsData.domainSettings) } as DomainSettings
         const businessName = stringValue(settingsData.businessName, stringValue(storeData.businessName, stringValue(storeData.storeName, stringValue(storeData.name, defaults.businessName))))
 
-        setSettings({
+        const nextSettings: WebsitePreviewSettings = {
           ...defaults,
           slug: stringValue(settingsData.slug, businessName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')),
           websiteType: isWebsiteType(settingsData.websiteType) ? settingsData.websiteType : defaults.websiteType,
@@ -273,7 +300,14 @@ export default function WebsiteBuilderPreview() {
           contentDrafts,
           seoSettings,
           domainSettings,
-        })
+        }
+        setSettings(nextSettings)
+        const savedAt = Date.now()
+        previewSettingsCache.set(storeId, { savedAt, data: nextSettings })
+        setLastLoadedAt(savedAt)
+      } catch (error) {
+        console.error('[website-preview] Unable to load preview', error)
+        setLoadError('Unable to load website preview right now. Please try again.')
       } finally {
         if (mounted) setLoading(false)
       }
@@ -283,7 +317,7 @@ export default function WebsiteBuilderPreview() {
     return () => {
       mounted = false
     }
-  }, [storeId])
+  }, [storeId, shouldLoadPreview, forceReloadToken])
 
   async function copyText(text: string, message: string) {
     try {
@@ -296,7 +330,29 @@ export default function WebsiteBuilderPreview() {
     window.setTimeout(() => setCopyFeedback(null), 2500)
   }
 
-  if (isLoading || loading) {
+  if (isLoading) {
+    return (
+      <PageSection title="Website Preview" subtitle="Loading your website preview…">
+        <div className="rounded-3xl border border-slate-200 bg-white p-8 text-slate-600">Preparing preview…</div>
+      </PageSection>
+    )
+  }
+
+  if (!shouldLoadPreview) {
+    return (
+      <PageSection title="Website Preview" subtitle="Load the latest saved Website Builder data when you are ready.">
+        <section className="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-bold text-slate-950">Load preview on demand</h2>
+          <p className="mt-2 text-sm text-slate-600">To keep this page fast, preview data is loaded only when requested.</p>
+          <button type="button" className="button button--primary mt-4" onClick={() => setShouldLoadPreview(true)}>
+            Load website preview
+          </button>
+        </section>
+      </PageSection>
+    )
+  }
+
+  if (loading) {
     return (
       <PageSection title="Website Preview" subtitle="Loading your website preview…">
         <div className="rounded-3xl border border-slate-200 bg-white p-8 text-slate-600">Preparing preview…</div>
@@ -393,20 +449,34 @@ export default function WebsiteBuilderPreview() {
         <aside className="space-y-5">
           <section className="rounded-[2rem] border border-slate-200 bg-white p-5 shadow-sm">
             <p className="text-sm font-bold uppercase tracking-wide text-indigo-600">Website actions</p>
+            {loadError ? <p className="mt-3 rounded-2xl bg-rose-50 p-3 text-sm font-semibold text-rose-700">{loadError}</p> : null}
+            {lastLoadedAt ? <p className="mt-2 text-xs font-semibold text-slate-500">Last updated: {new Date(lastLoadedAt).toLocaleString()}</p> : null}
             <div className="mt-4 grid gap-3">
+              <button type="button" className="rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm font-bold text-slate-700" onClick={() => setForceReloadToken(current => current + 1)}>
+                Refresh preview data
+              </button>
               <button type="button" className="rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm font-bold text-slate-700" onClick={() => void copyText(url, 'Website link copied.')}>Copy link</button>
-              <a className="rounded-2xl bg-emerald-600 px-4 py-3 text-center text-sm font-bold text-white" href={whatsappShareUrl} target="_blank" rel="noreferrer">Share to WhatsApp</a>
-              <a className="rounded-2xl bg-blue-600 px-4 py-3 text-center text-sm font-bold text-white" href={facebookShareUrl} target="_blank" rel="noreferrer">Share to Facebook</a>
-              <button type="button" className="rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm font-bold text-slate-700" onClick={() => void copyText(instagramCaption, 'Instagram caption copied.')}>Copy Instagram caption</button>
+              <button type="button" className="rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm font-bold text-slate-700" onClick={() => setShowShareTools(current => !current)}>
+                {showShareTools ? 'Hide share tools' : 'Show share tools'}
+              </button>
+              {showShareTools ? (
+                <>
+                  <a className="rounded-2xl bg-emerald-600 px-4 py-3 text-center text-sm font-bold text-white" href={whatsappShareUrl} target="_blank" rel="noreferrer">Share to WhatsApp</a>
+                  <a className="rounded-2xl bg-blue-600 px-4 py-3 text-center text-sm font-bold text-white" href={facebookShareUrl} target="_blank" rel="noreferrer">Share to Facebook</a>
+                  <button type="button" className="rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm font-bold text-slate-700" onClick={() => void copyText(instagramCaption, 'Instagram caption copied.')}>Copy Instagram caption</button>
+                </>
+              ) : null}
             </div>
             {copyFeedback ? <p className="mt-3 rounded-2xl bg-indigo-50 p-3 text-sm font-semibold text-indigo-700">{copyFeedback}</p> : null}
           </section>
 
-          <section className="rounded-[2rem] border border-slate-200 bg-white p-5 text-center shadow-sm">
-            <p className="text-sm font-bold uppercase tracking-wide text-indigo-600">QR code</p>
-            <img src={qrCodeUrl(url)} alt="Website QR code" className="mx-auto mt-4 h-56 w-56 rounded-2xl" />
-            <p className="mt-3 break-all text-xs font-semibold text-slate-500">{url}</p>
-          </section>
+          {showShareTools ? (
+            <section className="rounded-[2rem] border border-slate-200 bg-white p-5 text-center shadow-sm">
+              <p className="text-sm font-bold uppercase tracking-wide text-indigo-600">QR code</p>
+              <img src={qrCodeUrl(url)} alt="Website QR code" className="mx-auto mt-4 h-56 w-56 rounded-2xl" />
+              <p className="mt-3 break-all text-xs font-semibold text-slate-500">{url}</p>
+            </section>
+          ) : null}
 
           <section className="rounded-[2rem] border border-slate-200 bg-white p-5 shadow-sm">
             <p className="text-sm font-bold uppercase tracking-wide text-slate-500">Google preview</p>


### PR DESCRIPTION
### Motivation

- Reduce initial page load and unnecessary data fetching for the Website Builder preview by loading preview data on demand and reusing recently fetched data.
- Provide a better UX for refreshing, sharing, and troubleshooting preview data with explicit controls and error messages.

### Description

- Replaced the eager import of `WebsiteBuilderPreview` in `web/src/main.tsx` with a lazy-loaded component and wrapped its route in `LazyPage` to defer bundle loading.
- Implemented an in-memory preview cache (`previewSettingsCache`) with a TTL (`PREVIEW_CACHE_TTL_MS`) and logic to read from or populate the cache in `web/src/pages/WebsiteBuilderPreview.tsx`.
- Changed the preview to load on demand using `shouldLoadPreview` and added a `forceReloadToken` to trigger a cache bypass and fresh fetch, plus `loadError` and `lastLoadedAt` state for visibility.
- Added UI controls for "Load preview on demand", "Refresh preview data", a toggled share tools panel (including QR code), copy feedback, and improved loading/error states and messages.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1820813cd483219066fa9e5f6d757f)