### PR TITLE
Persist and apply selected website templates to preview and public pages

### DIFF
--- a/web/src/pages/PublicWebsiteEngine.tsx
+++ b/web/src/pages/PublicWebsiteEngine.tsx
@@ -28,6 +28,8 @@ type WebsiteSettings = {
   selectedTemplateId: string;
   selectedTemplateName: string;
   layoutKey: string;
+  layoutTemplate: string;
+  templateCategory: string;
   selectedSections: string[];
   pages: string[];
   status: "draft" | "published";
@@ -224,6 +226,86 @@ function uniquePages(labels: string[]): PublicPage[] {
   return pages;
 }
 
+const TEMPLATE_LAYOUTS = new Set([
+  "shop-classic",
+  "travel-visa-consultancy",
+  "beauty-booking",
+  "ngo-impact",
+  "school-academy",
+  "services-booking",
+  "restaurant-menu",
+]);
+
+function resolveTemplateLayout(settings: WebsiteSettings) {
+  return settings.layoutTemplate || settings.selectedTemplateId || settings.layoutKey;
+}
+
+function buildItemCheckoutUrl(storeId: string, item: PublicItem) {
+  const params = new URLSearchParams({
+    mode: "item",
+    itemId: item.id,
+    itemType: item.type,
+    name: item.name,
+    qty: "1",
+  });
+  return `https://pay.sedifex.com/s/${encodeURIComponent(storeId)}?${params.toString()}`;
+}
+
+function templatePublicCopy(layout: string, settings: WebsiteSettings) {
+  const copy: Record<string, { eyebrow: string; primary: string; secondary: string; sections: string[]; itemTitle: string }> = {
+    "shop-classic": { eyebrow: "Classic storefront", primary: "Shop products", secondary: "Pay securely", sections: ["Featured products", "Categories", "Checkout"], itemTitle: "Featured products" },
+    "travel-visa-consultancy": { eyebrow: "Visa & travel consultancy", primary: "Request consultation", secondary: "Check services", sections: ["Visa support", "Travel packages", "Document checks"], itemTitle: "Travel and visa services" },
+    "beauty-booking": { eyebrow: "Beauty booking studio", primary: "Book appointment", secondary: "View services", sections: ["Treatments", "Bookings", "Gallery"], itemTitle: "Beauty services" },
+    "ngo-impact": { eyebrow: "Mission • Impact • Community", primary: "Donate now", secondary: "Volunteer", sections: ["Mission", "Impact", "Programs", "Donate", "Volunteer"], itemTitle: "Programs and support" },
+    "school-academy": { eyebrow: "School academy", primary: "Register now", secondary: "View courses", sections: ["Courses", "Admissions", "Student payments"], itemTitle: "Courses and classes" },
+    "services-booking": { eyebrow: "Service booking", primary: "Book service", secondary: "Request quote", sections: ["Services", "Booking", "Quick Pay"], itemTitle: "Services and bookings" },
+    "restaurant-menu": { eyebrow: "Restaurant menu", primary: "View menu", secondary: "Order and pay", sections: ["Menu", "Specials", "Ordering"], itemTitle: "Menu highlights" },
+  };
+  return copy[layout] || { eyebrow: settings.businessType || "Sedifex website", primary: "Contact us", secondary: "Quick Pay", sections: ["About", "Products", "Services"], itemTitle: "Featured items" };
+}
+
+function TemplateHome({ settings, profile, items, gallery, quickPayUrl, slug }: { settings: WebsiteSettings; profile: StoreProfile; items: PublicItem[]; gallery: GalleryItem[]; quickPayUrl: string; slug: string }) {
+  const layout = resolveTemplateLayout(settings);
+  const copy = templatePublicCopy(layout, settings);
+  const isNgo = layout === "ngo-impact";
+  const isRestaurant = layout === "restaurant-menu";
+  const displayItems = isNgo ? items.filter((item) => item.type !== "PRODUCT") : items;
+  const heroStyle = settings.coverImageUrl
+    ? { backgroundImage: `linear-gradient(135deg, rgba(6, 78, 59, .9), rgba(15, 23, 42, .48)), url(${settings.coverImageUrl})`, backgroundSize: "cover", backgroundPosition: "center" }
+    : undefined;
+  const whatsapp = profile.whatsapp || profile.phone;
+  return (
+    <>
+      <section className={`${isNgo ? "bg-gradient-to-br from-emerald-950 via-teal-900 to-lime-800" : isRestaurant ? "bg-gradient-to-br from-stone-950 via-orange-950 to-amber-800" : "bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900"} px-4 py-24 text-white sm:px-6 lg:px-8`} style={heroStyle}>
+        <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[1.05fr_.95fr] lg:items-center">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-100">{copy.eyebrow}</p>
+            <h1 className="mt-5 text-5xl font-black tracking-tight sm:text-7xl">{settings.tagline || (isNgo ? `${profile.name} impact foundation` : profile.name)}</h1>
+            <p className="mt-5 max-w-2xl text-lg leading-8 text-white/85">{settings.description || settings.contentDrafts.homepage || (isNgo ? "Explore our mission, active programs, donation needs, volunteer opportunities, and community impact." : "Explore our website, services, products, gallery, contact details, and secure payment actions.")}</p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <a className="rounded-2xl bg-white px-6 py-3 font-semibold text-slate-950 no-underline" href={isNgo ? quickPayUrl : pagePath(slug, displayItems.some(i => i.type === "PRODUCT") ? "products" : "services")}>{copy.primary}</a>
+              {whatsapp ? <a className="rounded-2xl border border-white/25 px-6 py-3 font-semibold text-white no-underline" href={`https://wa.me/${whatsapp.replace(/[^0-9]/g, "")}`}>WhatsApp</a> : <Link className="rounded-2xl border border-white/25 px-6 py-3 font-semibold text-white no-underline" to={pagePath(slug, "contact")}>{copy.secondary}</Link>}
+            </div>
+          </div>
+          <div className="rounded-[2rem] border border-white/10 bg-white/10 p-6 shadow-2xl backdrop-blur">
+            <h2 className="text-2xl font-black">{isNgo ? "Impact pathways" : "Explore"}</h2>
+            <div className="mt-5 grid gap-3 text-sm text-white/90">{copy.sections.map(section => <div key={section} className="rounded-2xl bg-white/10 p-4 font-semibold">{section}</div>)}</div>
+          </div>
+        </div>
+      </section>
+      {isNgo ? <section className="bg-white px-4 py-16 sm:px-6 lg:px-8"><div className="mx-auto grid max-w-7xl gap-5 md:grid-cols-3"><ImpactCard title="Mission" body={settings.contentDrafts.about || "Share the communities served, the mission, and the change this organization is building."} /><ImpactCard title="Donate" body="Support programs through Sedifex Quick Pay or contact the team for partnership options." /><ImpactCard title="Volunteer" body="Invite supporters to volunteer, partner, donate resources, or join community programs." /></div></section> : null}
+      {displayItems.length ? <ServicesSection title={copy.itemTitle} items={displayItems.slice(0, isNgo ? 6 : 4)} quickPayUrl={quickPayUrl} ctaHref={pagePath(slug, displayItems.some(i => i.type === "PRODUCT") ? "products" : "services")} storeId={settings.storeId} /> : <section className="px-4 py-12 sm:px-6 lg:px-8"><div className="mx-auto max-w-7xl"><EmptyState title={isNgo ? "No programs added yet" : "No items added yet"} /></div></section>}
+      {gallery.length ? <GallerySection gallery={gallery.slice(0, 6)} ctaHref={pagePath(slug, "gallery")} /> : null}
+      <QuickPayBlock quickPayUrl={quickPayUrl} />
+      <ContactSection profile={profile} brandColor={settings.brandColor} quickPayUrl={quickPayUrl} />
+    </>
+  );
+}
+
+function ImpactCard({ title, body }: { title: string; body: string }) {
+  return <article className="rounded-[2rem] border border-emerald-100 bg-emerald-50 p-6"><p className="text-sm font-semibold uppercase tracking-[0.25em] text-emerald-700">{title}</p><p className="mt-3 text-slate-700">{body}</p></article>;
+}
+
 export default function PublicWebsiteEngine() {
   const { slug = "", pageSlug } = useParams();
   const activePage = normalizePage(pageSlug);
@@ -355,7 +437,9 @@ export default function PublicWebsiteEngine() {
           theme: clean(website.theme, 40) || "modern",
           selectedTemplateId: clean(website.selectedTemplateId, 120),
           selectedTemplateName: clean(website.selectedTemplateName, 160),
-          layoutKey: clean(website.layoutKey ?? website.templateKey, 160),
+          layoutKey: clean(website.layoutKey ?? website.layoutTemplate ?? website.templateKey, 160),
+          layoutTemplate: clean(website.layoutTemplate ?? website.selectedTemplateId ?? website.layoutKey, 160),
+          templateCategory: clean(website.templateCategory ?? website.businessType, 160),
           selectedSections: Array.isArray(website.selectedSections)
             ? website.selectedSections.filter(
                 (section): section is string => typeof section === "string",
@@ -525,17 +609,9 @@ export default function PublicWebsiteEngine() {
   const serviceItems = items.filter((item) => item.type !== "PRODUCT");
   const quickPayUrl = `https://pay.sedifex.com/s/${encodeURIComponent(settings.storeId)}?mode=store`;
 
-  function buildItemCheckoutUrl(storeId: string, item: PublicItem) {
-    const params = new URLSearchParams({
-      mode: "item",
-      itemId: item.id,
-      itemType: item.type,
-      name: item.name,
-      qty: "1",
-    });
+  const resolvedLayout = resolveTemplateLayout(settings);
+  const usesTemplateLayout = TEMPLATE_LAYOUTS.has(resolvedLayout);
 
-    return `https://pay.sedifex.com/s/${encodeURIComponent(storeId)}?${params.toString()}`;
-  }
   const heroStyle = settings.coverImageUrl
     ? {
         backgroundImage: `linear-gradient(135deg, rgba(2, 6, 23, .88), rgba(15, 23, 42, .48)), url(${settings.coverImageUrl})`,
@@ -578,7 +654,10 @@ export default function PublicWebsiteEngine() {
           </nav>
         </div>
       </header>
-      {activePage === "home" ? (
+      {activePage === "home" && usesTemplateLayout ? (
+        <TemplateHome settings={settings} profile={profile} items={items} gallery={gallery} quickPayUrl={quickPayUrl} slug={slug} />
+      ) : null}
+      {activePage === "home" && !usesTemplateLayout ? (
         <>
           <section
             className={`bg-gradient-to-br ${themeClasses(settings.theme)} px-4 py-24 text-white sm:px-6 lg:px-8`}
@@ -634,6 +713,7 @@ export default function PublicWebsiteEngine() {
               items={productItems.slice(0, 4)}
               quickPayUrl={quickPayUrl}
               ctaHref={pagePath(slug, "products")}
+              storeId={settings.storeId}
             />
           ) : null}
           {serviceItems.length ? (
@@ -642,6 +722,7 @@ export default function PublicWebsiteEngine() {
               items={serviceItems.slice(0, 3)}
               quickPayUrl={quickPayUrl}
               ctaHref={pagePath(slug, "services")}
+              storeId={settings.storeId}
             />
           ) : null}
           {gallery.length ? (
@@ -658,6 +739,7 @@ export default function PublicWebsiteEngine() {
           title="Products"
           items={productItems}
           quickPayUrl={quickPayUrl}
+          storeId={settings.storeId}
         />
       ) : null}
       {activePage === "services" ? (
@@ -665,6 +747,7 @@ export default function PublicWebsiteEngine() {
           title="Services, courses & bookings"
           items={serviceItems}
           quickPayUrl={quickPayUrl}
+          storeId={settings.storeId}
         />
       ) : null}
       {activePage === "gallery" ? <GallerySection gallery={gallery} /> : null}
@@ -690,11 +773,13 @@ function ProductsSection({
   items,
   quickPayUrl,
   ctaHref,
+  storeId,
 }: {
   title: string;
   items: PublicItem[];
   quickPayUrl: string;
   ctaHref?: string;
+  storeId: string;
 }) {
   return (
     <section className="px-4 py-16 sm:px-6 lg:px-8">
@@ -722,7 +807,7 @@ function ProductsSection({
                 key={item.id}
                 item={item}
                 quickPayUrl={quickPayUrl}
-                itemCheckoutUrl={buildItemCheckoutUrl(settings.storeId, item)}
+                itemCheckoutUrl={buildItemCheckoutUrl(storeId, item)}
               />
             ))}
           </div>
@@ -738,11 +823,13 @@ function ServicesSection({
   items,
   quickPayUrl,
   ctaHref,
+  storeId,
 }: {
   title: string;
   items: PublicItem[];
   quickPayUrl: string;
   ctaHref?: string;
+  storeId: string;
 }) {
   return (
     <section className="bg-white px-4 py-16 sm:px-6 lg:px-8">
@@ -770,7 +857,7 @@ function ServicesSection({
                 key={item.id}
                 item={item}
                 quickPayUrl={quickPayUrl}
-                itemCheckoutUrl={buildItemCheckoutUrl(settings.storeId, item)}
+                itemCheckoutUrl={buildItemCheckoutUrl(storeId, item)}
               />
             ))}
           </div>

--- a/web/src/pages/WebsiteBuilder.tsx
+++ b/web/src/pages/WebsiteBuilder.tsx
@@ -87,6 +87,7 @@ type TemplateSelection = {
   businessType: string;
   theme: WebsiteTheme;
   layoutKey: string;
+  templateCategory?: string;
   brandColor: string;
   pages: string[];
   selectedSections: string[];
@@ -117,6 +118,8 @@ type WebsiteBuilderSettings = {
   selectedTemplateId: string;
   selectedTemplateName: string;
   layoutKey: string;
+  layoutTemplate: string;
+  templateCategory: string;
   selectedSections: string[];
   pages: string[];
   status: StoredWebsiteStatus;
@@ -737,7 +740,9 @@ function createDefaultSettings(): WebsiteBuilderSettings {
     theme: "modern",
     selectedTemplateId: "",
     selectedTemplateName: "",
-    layoutKey: "modern-storefront-grid",
+    layoutKey: "shop-classic",
+    layoutTemplate: "",
+    templateCategory: "",
     selectedSections: ["hero", "featured-products", "quick-pay", "contact"],
     pages: [...PAGE_OPTIONS_BY_TYPE.shop],
     status: "draft",
@@ -1264,8 +1269,14 @@ export default function WebsiteBuilder() {
             layoutKey: readString(
               website,
               "layoutKey",
-              readString(website, "templateKey", previous.layoutKey),
+              readString(website, "layoutTemplate", readString(website, "templateKey", previous.layoutKey)),
             ),
+            layoutTemplate: readString(
+              website,
+              "layoutTemplate",
+              readString(website, "selectedTemplateId", previous.layoutTemplate),
+            ),
+            templateCategory: readString(website, "templateCategory", previous.templateCategory),
             selectedSections: Array.isArray(website.selectedSections)
               ? website.selectedSections.filter(
                   (section): section is string =>
@@ -1625,6 +1636,11 @@ export default function WebsiteBuilder() {
         openingHours: settings.openingHours.trim(),
         businessLogoUrl: settings.businessLogoUrl.trim(),
         coverImageUrl: settings.coverImageUrl.trim(),
+        selectedTemplateId: settings.selectedTemplateId.trim(),
+        selectedTemplateName: settings.selectedTemplateName.trim(),
+        layoutTemplate: (settings.layoutTemplate || settings.selectedTemplateId || settings.layoutKey).trim(),
+        templateCategory: settings.templateCategory.trim(),
+        layoutKey: (settings.layoutKey || settings.layoutTemplate || settings.selectedTemplateId).trim(),
         brandColor: normalizeBrandColor(settings.brandColor),
         socialLinks: mergeSocialLinks(settings.socialLinks),
         contentDrafts: mergeContentDrafts(settings.contentDrafts),
@@ -1716,6 +1732,8 @@ export default function WebsiteBuilder() {
         businessType: template.businessType,
         theme: template.theme,
         layoutKey: template.layoutKey,
+        layoutTemplate: template.layoutKey || template.id,
+        templateCategory: template.templateCategory || template.businessType,
         selectedSections: template.selectedSections,
         brandColor: normalizeBrandColor(template.brandColor),
         pages: filterPagesForType(template.websiteType, template.pages),
@@ -1744,7 +1762,7 @@ export default function WebsiteBuilder() {
       saveDraftToLocalPreview(nextSettings);
       return nextSettings;
     });
-    setFeedback(`Now using ${template.name} template.`);
+    setFeedback(`${template.name} template applied. Preview now uses this design.`);
   }
 
   function previewWithMyData() {
@@ -1826,6 +1844,12 @@ export default function WebsiteBuilder() {
                 <p className="mt-3 break-all rounded-xl bg-white/10 px-3 py-2 text-cyan-100">
                   {publicWebsiteUrl}
                 </p>
+                <p className="mt-2 rounded-xl bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-100">
+                  Current template: {settings.selectedTemplateName || "Generic Sedifex"}
+                </p>
+                <p className="mt-2 text-xs font-semibold text-cyan-100">
+                  Live website will use this template after publishing.
+                </p>
               </div>
             </div>
           </section>
@@ -1853,6 +1877,9 @@ export default function WebsiteBuilder() {
                 <p className="mt-1 text-sm text-slate-500">
                   Step {safeStepIndex + 1} of {BUILDER_STEPS.length}:{" "}
                   {currentStep.description}
+                </p>
+                <p className="mt-2 inline-flex rounded-full bg-emerald-50 px-3 py-1 text-xs font-bold text-emerald-700">
+                  Current template: {settings.selectedTemplateName || "Generic Sedifex"}
                 </p>
               </div>
               <span className="rounded-full bg-indigo-50 px-3 py-1 text-sm font-bold text-indigo-700">
@@ -2993,7 +3020,7 @@ export default function WebsiteBuilder() {
                   Home page preview
                 </h3>
                 <p className="mt-1 text-sm text-slate-500">
-                  Live preview updates from type, generated content, smart
+                  Live preview updates from type, selected template, generated content, smart
                   pages, identity, SEO, domain, and brand color.
                 </p>
               </div>

--- a/web/src/pages/WebsiteBuilderAssistantPanel.tsx
+++ b/web/src/pages/WebsiteBuilderAssistantPanel.tsx
@@ -49,12 +49,12 @@ type Props = {
 
 const TEMPLATES: TemplatePreset[] = [
   {
-    id: "beauty-premium",
-    name: "Beauty Spa Premium",
+    id: "beauty-booking",
+    name: "Beauty Booking",
     websiteType: "beauty",
     businessType: "Beauty / salon website",
     theme: "luxury",
-    layoutKey: "beauty-premium-hero",
+    layoutKey: "beauty-booking",
     brandColor: "#a855f7",
     pages: [
       "Home",
@@ -94,12 +94,12 @@ const TEMPLATES: TemplatePreset[] = [
     },
   },
   {
-    id: "shop-modern",
-    name: "Modern Storefront",
+    id: "shop-classic",
+    name: "Shop Classic",
     websiteType: "shop",
     businessType: "Shop website",
     theme: "modern",
-    layoutKey: "modern-storefront-grid",
+    layoutKey: "shop-classic",
     brandColor: "#4f46e5",
     pages: [
       "Home",
@@ -137,12 +137,12 @@ const TEMPLATES: TemplatePreset[] = [
     },
   },
   {
-    id: "school-clean",
-    name: "Academy Clean",
+    id: "school-academy",
+    name: "School Academy",
     websiteType: "school",
     businessType: "School website",
     theme: "clean",
-    layoutKey: "academy-clean-sections",
+    layoutKey: "school-academy",
     brandColor: "#2563eb",
     pages: [
       "Home",
@@ -178,6 +178,94 @@ const TEMPLATES: TemplatePreset[] = [
         "Explore courses and classes, register students, contact the school, and manage student payments online.",
       keywords: "courses, registration, classes, school, student payments",
     },
+  },
+  {
+    id: "travel-visa-consultancy",
+    name: "Travel Visa Consultancy",
+    websiteType: "travel",
+    businessType: "Travel / visa consultancy website",
+    theme: "modern",
+    layoutKey: "travel-visa-consultancy",
+    brandColor: "#0891b2",
+    pages: ["Home", "Services", "Bookings", "Gallery", "Blog", "Quick Pay", "Contact"],
+    selectedSections: ["hero", "destinations", "visa-services", "consultation", "gallery", "quick-pay", "contact"],
+    tagline: "Visa, travel, and consultation support made simple",
+    description: "A consultation-led travel layout for visa services, packages, enquiry actions, documents guidance, and Quick Pay.",
+    contentDrafts: {
+      homepage: "Guide travellers from enquiry to consultation with clear visa services, destinations, documents support, and secure Sedifex payment actions.",
+      about: "Share your travel expertise, consultation process, destination knowledge, and customer support standards.",
+      serviceDescriptions: "List visa support, travel packages, ticketing, hotel support, document checks, consultations, and booking requirements.",
+      seoTitle: "Visa Consultancy, Travel Services & Bookings",
+    },
+    seoSettings: {
+      title: "Visa Consultancy, Travel Services & Bookings",
+      metaDescription: "Get visa support, travel consultation, destination guidance, bookings, and secure online payments.",
+      keywords: "visa consultancy, travel agency, bookings, destinations, quick pay",
+    },
+  },
+  {
+    id: "ngo-impact",
+    name: "NGO Impact",
+    websiteType: "ngo",
+    businessType: "NGO / foundation website",
+    theme: "clean",
+    layoutKey: "ngo-impact",
+    brandColor: "#16a34a",
+    pages: ["Home", "Programs", "Donate", "Volunteer", "Blog", "Gallery", "Contact", "Quick Pay"],
+    selectedSections: ["hero", "mission", "impact", "programs", "donation", "volunteer", "gallery", "quick-pay", "contact"],
+    tagline: "Mobilizing people and resources for measurable impact",
+    description: "An impact-first NGO layout for mission, programs, donations, volunteers, stories, gallery, contact, and Quick Pay.",
+    contentDrafts: {
+      homepage: "Show your mission, active programs, community impact, donation options, volunteer calls, and transparent contact actions in one trustworthy website.",
+      about: "Explain the purpose, communities served, program model, accountability, and change your organization is building.",
+      serviceDescriptions: "Present programs, beneficiary support, campaigns, volunteer roles, donation needs, events, and partner opportunities.",
+      seoTitle: "NGO Programs, Donations & Volunteer Support",
+    },
+    seoSettings: {
+      title: "NGO Programs, Donations & Volunteer Support",
+      metaDescription: "Support community programs, donate securely, volunteer, read impact stories, and contact the foundation.",
+      keywords: "NGO, foundation, charity, donations, volunteer, community impact",
+    },
+  },
+  {
+    id: "services-booking",
+    name: "Services Booking",
+    websiteType: "service",
+    businessType: "Services / appointments website",
+    theme: "bold",
+    layoutKey: "services-booking",
+    brandColor: "#7c3aed",
+    pages: ["Home", "Services", "Bookings", "Quick Pay", "Gallery", "Contact"],
+    selectedSections: ["hero", "services", "booking", "process", "quick-pay", "contact"],
+    tagline: "Book trusted services and pay securely",
+    description: "A booking-focused layout for service packages, appointment requests, trust points, Quick Pay, and contact actions.",
+    contentDrafts: {
+      homepage: "Help customers understand your services, choose the right package, request a booking, chat on WhatsApp, and pay securely.",
+      about: "Show your experience, response times, customer care, and service standards.",
+      serviceDescriptions: "Describe service packages, booking requirements, availability, quote requests, deposits, and payment steps.",
+      seoTitle: "Professional Services, Bookings & Quick Pay",
+    },
+    seoSettings: { title: "Professional Services, Bookings & Quick Pay", metaDescription: "Book services, request quotes, contact the business, and pay securely online.", keywords: "services, booking, appointments, quotes, quick pay" },
+  },
+  {
+    id: "restaurant-menu",
+    name: "Restaurant Menu",
+    websiteType: "restaurant",
+    businessType: "Restaurant / menu website",
+    theme: "luxury",
+    layoutKey: "restaurant-menu",
+    brandColor: "#ea580c",
+    pages: ["Home", "Menu", "Ordering", "Gallery", "Quick Pay", "Contact"],
+    selectedSections: ["hero", "menu", "ordering", "specials", "gallery", "quick-pay", "contact"],
+    tagline: "Explore the menu, order, and pay with ease",
+    description: "A food-first layout for menu highlights, ordering actions, specials, photos, opening hours, and Quick Pay.",
+    contentDrafts: {
+      homepage: "Make customers hungry with menu highlights, specials, food gallery, order actions, contact details, and secure payments.",
+      about: "Share your cuisine, kitchen story, dining style, and service promise.",
+      serviceDescriptions: "List menu categories, signature meals, ordering options, delivery or pickup notes, reservations, and payment steps.",
+      seoTitle: "Restaurant Menu, Ordering & Quick Pay",
+    },
+    seoSettings: { title: "Restaurant Menu, Ordering & Quick Pay", metaDescription: "View menu items, order food, see gallery highlights, contact the restaurant, and pay online.", keywords: "restaurant, menu, food ordering, reservations, quick pay" },
   },
 ];
 
@@ -215,11 +303,11 @@ export default function WebsiteBuilderAssistantPanel({
               className={`mt-4 rounded-xl px-3 py-2 text-sm font-bold ${isActive ? "bg-emerald-600 text-white" : "bg-slate-900 text-white"}`}
               onClick={() => {
                 onApplyTemplate(template);
-                setStatusMessage(`Now using ${template.name} template.`);
+                setStatusMessage(`${template.name} template applied. Preview now uses this design.`);
                 window.setTimeout(() => setStatusMessage(null), 2500);
               }}
             >
-              {isActive ? `Now using ${template.name}` : "Select"}
+              {isActive ? `Now using ${template.name}` : "Use template"}
             </button>
           </article>
         );

--- a/web/src/pages/WebsiteBuilderPreview.tsx
+++ b/web/src/pages/WebsiteBuilderPreview.tsx
@@ -61,6 +61,8 @@ type WebsitePreviewSettings = {
   selectedTemplateId: string;
   selectedTemplateName: string;
   layoutKey: string;
+  layoutTemplate: string;
+  templateCategory: string;
   selectedSections: string[];
   pages: string[];
   status: "draft" | "published";
@@ -237,7 +239,9 @@ function defaultSettings(): WebsitePreviewSettings {
     theme: "modern",
     selectedTemplateId: "",
     selectedTemplateName: "",
-    layoutKey: "modern-storefront-grid",
+    layoutKey: "shop-classic",
+    layoutTemplate: "",
+    templateCategory: "",
     selectedSections: ["hero", "featured-products", "quick-pay", "contact"],
     pages: [
       "Home",
@@ -354,8 +358,13 @@ function normalizePreviewSettings(
     selectedTemplateName: stringValue(source.selectedTemplateName),
     layoutKey: stringValue(
       source.layoutKey,
-      stringValue(source.templateKey, defaults.layoutKey),
+      stringValue(source.layoutTemplate, stringValue(source.templateKey, defaults.layoutKey)),
     ),
+    layoutTemplate: stringValue(
+      source.layoutTemplate,
+      stringValue(source.selectedTemplateId, defaults.layoutTemplate),
+    ),
+    templateCategory: stringValue(source.templateCategory, defaults.templateCategory),
     selectedSections: stringArray(
       source.selectedSections,
       defaults.selectedSections,
@@ -414,6 +423,62 @@ function previewText(value: string, fallback: string) {
   return clean.length > 220 ? `${clean.slice(0, 217)}…` : clean;
 }
 
+const TEMPLATE_LAYOUTS = new Set([
+  "shop-classic",
+  "travel-visa-consultancy",
+  "beauty-booking",
+  "ngo-impact",
+  "school-academy",
+  "services-booking",
+  "restaurant-menu",
+]);
+
+function resolveTemplateLayout(settings: WebsitePreviewSettings) {
+  return settings.layoutTemplate || settings.selectedTemplateId || settings.layoutKey;
+}
+
+function templateCopy(layout: string, profile: PreviewProfile) {
+  const config: Record<string, { eyebrow: string; cta: string; cards: string[]; impact: string[] }> = {
+    "shop-classic": { eyebrow: "Featured storefront", cta: "Shop products", cards: ["Best sellers", "Categories", "Secure checkout"], impact: ["Fast checkout", "Product discovery", "Quick Pay"] },
+    "travel-visa-consultancy": { eyebrow: "Visa & travel desk", cta: "Request consultation", cards: ["Visa support", "Destinations", "Document checks"], impact: ["Consult", "Prepare", "Travel"] },
+    "beauty-booking": { eyebrow: "Beauty booking studio", cta: "Book appointment", cards: ["Treatments", "Gallery", "Deposits"], impact: ["Choose service", "Reserve time", "Pay securely"] },
+    "ngo-impact": { eyebrow: "Mission • Impact • Community", cta: "Donate or volunteer", cards: ["Mission", "Programs", "Volunteer"], impact: ["Programs", "Donations", "Community impact"] },
+    "school-academy": { eyebrow: "Learning academy", cta: "Register interest", cards: ["Courses", "Admissions", "Student payments"], impact: ["Learn", "Register", "Pay fees"] },
+    "services-booking": { eyebrow: "Service booking hub", cta: "Book service", cards: ["Packages", "Availability", "Quotes"], impact: ["Request", "Schedule", "Pay"] },
+    "restaurant-menu": { eyebrow: "Menu & ordering", cta: "View menu", cards: ["Popular meals", "Specials", "Order & pay"], impact: ["Browse menu", "Order", "Pickup / delivery"] },
+  };
+  return config[layout] || { eyebrow: profile.eyebrow, cta: profile.cta, cards: profile.cards, impact: profile.cards };
+}
+
+function TemplatePreview({ settings, profile, previewMode }: { settings: WebsitePreviewSettings; profile: PreviewProfile; previewMode: PreviewMode }) {
+  const layout = resolveTemplateLayout(settings);
+  const copy = templateCopy(layout, profile);
+  const isNgo = layout === "ngo-impact";
+  const title = settings.tagline || (isNgo ? `Support ${settings.businessName}'s mission` : profile.headline);
+  const body = previewText(settings.contentDrafts.homepage || settings.description, isNgo ? "Share mission, impact, programs, donations, volunteer opportunities, stories, and contact actions." : profile.body);
+  return (
+    <div className={isNgo ? "bg-emerald-50" : "bg-white"}>
+      <section className={`${isNgo ? "bg-gradient-to-br from-emerald-900 via-teal-800 to-lime-700" : "bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900"} p-5 text-white md:p-7`}>
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            {settings.businessLogoUrl ? <img src={settings.businessLogoUrl} alt="Business logo" className="h-12 w-12 shrink-0 rounded-2xl object-cover ring-1 ring-white/40" /> : <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-white/15 text-xl">{isNgo ? "🤝" : profile.icon}</span>}
+            <div className="min-w-0"><p className="truncate text-base font-black">{settings.businessName}</p><p className="truncate text-xs opacity-75">{settings.selectedTemplateName || copy.eyebrow}</p></div>
+          </div>
+          <span className="rounded-full bg-white px-4 py-2 text-xs font-bold text-slate-950">{isNgo ? "Donate" : "Pay"}</span>
+        </div>
+        <div className={`${previewMode === "mobile" ? "grid gap-5" : "grid gap-7 lg:grid-cols-[1fr_.85fr]"} mt-8 items-center`}>
+          <div><p className="text-xs font-bold uppercase tracking-[0.28em] text-emerald-100">{copy.eyebrow}</p><h1 className={`${previewMode === "mobile" ? "text-3xl" : "text-5xl"} mt-3 font-black leading-tight`}>{title}</h1><p className="mt-4 text-sm leading-7 text-white/90">{body}</p><div className="mt-5 flex flex-wrap gap-2"><span className="rounded-full bg-white px-5 py-3 text-sm font-bold text-slate-950">{copy.cta}</span><span className="rounded-full border border-white/30 px-5 py-3 text-sm font-bold text-white">WhatsApp</span></div></div>
+          <div className="rounded-3xl bg-white/12 p-4 backdrop-blur"><p className="text-sm font-bold">{isNgo ? "Impact snapshot" : "Website sections"}</p><div className="mt-4 grid gap-3">{copy.impact.map(item => <div key={item} className="rounded-2xl bg-white/12 p-3 text-sm font-semibold">{item}</div>)}</div></div>
+        </div>
+      </section>
+      <section className="grid gap-3 p-5 sm:grid-cols-3">
+        {copy.cards.map(card => <article key={card} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"><p className="text-sm font-black text-slate-950">{card}</p><p className="mt-2 text-xs leading-5 text-slate-500">{isNgo && card === "Programs" ? "Programs appear here when added in Sedifex." : "Uses your real Sedifex data when available."}</p></article>)}
+      </section>
+      <section className="border-t border-slate-200 bg-white p-5 text-sm text-slate-600"><div className="flex flex-wrap gap-2"><span className="rounded-full bg-slate-100 px-3 py-1 font-semibold">{settings.phone || settings.whatsapp || "Phone / WhatsApp"}</span>{settings.email ? <span className="rounded-full bg-slate-100 px-3 py-1 font-semibold">{settings.email}</span> : null}{settings.location ? <span className="rounded-full bg-slate-100 px-3 py-1 font-semibold">{settings.location}</span> : null}</div></section>
+    </div>
+  );
+}
+
 const PREVIEW_CACHE_TTL_MS = 5 * 60 * 1000;
 const previewSettingsCache = new Map<
   string,
@@ -464,6 +529,8 @@ export default function WebsiteBuilderPreview() {
     settings.seoSettings.socialShareImage ||
     settings.coverImageUrl ||
     settings.businessLogoUrl;
+  const resolvedLayout = resolveTemplateLayout(settings);
+  const usesTemplateLayout = TEMPLATE_LAYOUTS.has(resolvedLayout);
 
   useEffect(() => {
     if (!storeId) return;
@@ -791,6 +858,10 @@ export default function WebsiteBuilderPreview() {
                   onError={() => setCoverLoadFailed(true)}
                 />
               ) : null}
+              {usesTemplateLayout ? (
+                <TemplatePreview settings={settings} profile={profile} previewMode={previewMode} />
+              ) : (
+                <>
               <div
                 className={`bg-gradient-to-br ${theme.previewClassName} p-5 md:p-7 ${theme.textClassName}`}
                 style={
@@ -949,6 +1020,8 @@ export default function WebsiteBuilderPreview() {
                   ) : null}
                 </div>
               </div>
+                </>
+              )}
             </div>
           </div>
         </section>


### PR DESCRIPTION
### Motivation
- Users selecting a template in the Website Builder must see that design in the preview and on the live public URL rather than the generic Sedifex layout. 
- Template metadata must persist through draft save and publish flows so the `PublicWebsiteEngine` can render the chosen layout for visitors. 
- Templates should change structure (not only colors) and use real business data (contact, products/services, gallery, Quick Pay, etc.).

### Description
- Persisted template metadata: added `selectedTemplateId`, `selectedTemplateName`, `layoutTemplate`, and `templateCategory` to the builder/draft model and ensured these fields are read on load and written on `Save draft` and `Publish` in `web/src/pages/WebsiteBuilder.tsx`.
- Assistant: expanded the assistant catalog with supported layout IDs (including `ngo-impact`, `shop-classic`, `travel-visa-consultancy`, `beauty-booking`, `school-academy`, `services-booking`, `restaurant-menu`) and updated the apply/copy UX to `Use template` and `"<Name> template applied. Preview now uses this design."` in `web/src/pages/WebsiteBuilderAssistantPanel.tsx`.
- Preview: `WebsiteBuilderPreview` now reads `layoutTemplate` / `selectedTemplateId`, resolves supported template layouts, and renders a `TemplatePreview` when a template layout is active so the preview reflects the chosen structure and business data instead of a generic hero (changes in `web/src/pages/WebsiteBuilderPreview.tsx`).
- Public: `PublicWebsiteEngine` now reads the published template fields and resolves `layoutTemplate` to route recognized templates to a `TemplateHome` renderer that composes NGO, shop, travel, beauty, school, services, and restaurant layouts using real `store` data, items, gallery and Quick Pay actions (changes in `web/src/pages/PublicWebsiteEngine.tsx`).
- Other UX: added visible builder status text `Current template: <Name>` and the note `Live website will use this template after publishing.` in the builder UI; avoided direct DOM manipulation and used the existing React state/save/publish flows.

### Testing
- `git diff --check` was run and returned clean results with the modified files staged. 
- Attempted `npm run build` in `web` but build was blocked because `web/node_modules` is not installed (TypeScript reported missing `vite/client` and `vitest/globals`).
- Attempted `npm install` to restore dependencies but it failed due to a registry `403 Forbidden` for `@azure/msal-browser`, so a full build/test run could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1849cd1bfc83218fcafad60f7299fb)