### PR TITLE
Add Website Builder navigation hub

### DIFF
--- a/web/src/components/NavigationSettingsSection.tsx
+++ b/web/src/components/NavigationSettingsSection.tsx
@@ -28,9 +28,11 @@ const PAGE_GROUPS: PageGroup[] = [
   { title: 'Daily work', ids: ['dashboard', 'reports', 'products', 'sell', 'marketplace-orders', 'customers', 'bookings'] },
   { title: 'Documents, payments & expenses', ids: ['quick-pay', 'invoices', 'receipts', 'expenses', 'settlement', 'donor-management', 'funds-ledger'] },
   { title: 'Bookings, registration & cases', ids: ['upcoming-events', 'student-registration', 'volunteers', 'support-requests'] },
-  { title: 'Website & marketing', ids: ['integrations', 'blog', 'promo', 'gallery', 'social-links', 'bulk-messaging', 'bulk-email'] },
+  { title: 'Website & marketing', ids: ['integrations', 'website-builder', 'blog', 'bulk-messaging', 'bulk-email'] },
   { title: 'Account', ids: ['account'] },
 ]
+
+const CONFIGURABLE_NAV_ITEMS = NAV_ITEMS.filter(item => !item.hideFromPrimaryNav)
 
 function uniqueList(values: string[]) {
   return Array.from(new Set(values.filter(Boolean)))
@@ -41,13 +43,13 @@ function moduleIsEnabled(enabledModules: string[], id: string) {
 }
 
 function moduleSummary(enabledModules: string[]) {
-  if (enabledModules.length === 0) return `${NAV_ITEMS.length} pages active`
-  const count = NAV_ITEMS.filter(item => enabledModules.includes(item.id)).length
+  if (enabledModules.length === 0) return `${CONFIGURABLE_NAV_ITEMS.length} pages active`
+  const count = CONFIGURABLE_NAV_ITEMS.filter(item => enabledModules.includes(item.id)).length
   return `${count} ${count === 1 ? 'page' : 'pages'} active`
 }
 
 function findNavItem(id: string) {
-  return NAV_ITEMS.find(item => item.id === id)
+  return CONFIGURABLE_NAV_ITEMS.find(item => item.id === id)
 }
 
 export default function NavigationSettingsSection({ preferences, onSave, canEdit }: Props) {
@@ -70,7 +72,7 @@ export default function NavigationSettingsSection({ preferences, onSave, canEdit
   const selectedIndustry = INDUSTRY_OPTIONS.find(option => option.value === draft.industry) ?? INDUSTRY_OPTIONS[0]
 
   const enabledModuleIds = useMemo(() => {
-    if (draft.enabledModules.length === 0) return NAV_ITEMS.map(item => item.id)
+    if (draft.enabledModules.length === 0) return CONFIGURABLE_NAV_ITEMS.map(item => item.id)
     return uniqueList(draft.enabledModules)
   }, [draft.enabledModules])
 
@@ -78,7 +80,7 @@ export default function NavigationSettingsSection({ preferences, onSave, canEdit
 
   const ungroupedItems = useMemo(() => {
     const groupedIds = new Set(PAGE_GROUPS.flatMap(group => group.ids))
-    return NAV_ITEMS.filter(item => !groupedIds.has(item.id))
+    return CONFIGURABLE_NAV_ITEMS.filter(item => !groupedIds.has(item.id))
   }, [])
 
   const save = async () => {
@@ -107,7 +109,7 @@ export default function NavigationSettingsSection({ preferences, onSave, canEdit
 
   const toggleModule = (id: string) => {
     setDraft(current => {
-      const currentEnabled = current.enabledModules.length === 0 ? NAV_ITEMS.map(item => item.id) : current.enabledModules
+      const currentEnabled = current.enabledModules.length === 0 ? CONFIGURABLE_NAV_ITEMS.map(item => item.id) : current.enabledModules
       const enabled = currentEnabled.includes(id) ? currentEnabled.filter(item => item !== id) : [...currentEnabled, id]
       return { ...current, enabledModules: uniqueList(enabled), customNavItems: [] }
     })
@@ -119,7 +121,7 @@ export default function NavigationSettingsSection({ preferences, onSave, canEdit
   }
 
   const showAllPages = () => {
-    setDraft(current => ({ ...current, enabledModules: NAV_ITEMS.map(item => item.id), customNavItems: [] }))
+    setDraft(current => ({ ...current, enabledModules: CONFIGURABLE_NAV_ITEMS.map(item => item.id), customNavItems: [] }))
     setError(null)
   }
 

--- a/web/src/config/navigation.test.ts
+++ b/web/src/config/navigation.test.ts
@@ -53,9 +53,24 @@ describe('resolveNavigation', () => {
     expect(items.find(item => item.target === '/bookings')?.label).toBe('Classes')
   })
 
+  it('groups website content behind the website builder nav item', () => {
+    const items = resolveNavigation({
+      role: 'staff',
+      workspaceProfile: {
+        industry: 'shop',
+        labelPolicy: 'shared',
+        enabledModules: ['promo', 'gallery', 'website-hero-slides', 'social-links'],
+      },
+    })
+
+    expect(items.map(item => item.id)).toEqual(['website-builder'])
+    expect(items[0].target).toBe('/website-builder')
+  })
+
   it('includes document modules in enabled module presets by industry', () => {
     expect(INDUSTRY_ENABLED_MODULE_PRESETS.shop).toContain('invoices')
     expect(INDUSTRY_ENABLED_MODULE_PRESETS.shop).toContain('receipts')
+    expect(INDUSTRY_ENABLED_MODULE_PRESETS.shop).toContain('website-builder')
     expect(INDUSTRY_ENABLED_MODULE_PRESETS.travel).toContain('invoices')
     expect(INDUSTRY_ENABLED_MODULE_PRESETS.travel).toContain('receipts')
     expect(INDUSTRY_ENABLED_MODULE_PRESETS.ngo).toContain('invoices')

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -11,6 +11,7 @@ export type NavItem = {
   sortOrder: number
   end?: boolean
   parentTarget?: string
+  hideFromPrimaryNav?: boolean
   rolesAllowed: NavRole[]
   industries?: Industry[]
   requiredPermissions?: string[]
@@ -36,10 +37,11 @@ export const NAV_ITEMS: NavItem[] = [
   { id: 'settlement', label: 'Payments / Settlement', type: 'module', target: '/settlement', rolesAllowed: ['owner'], sortOrder: 58 },
   { id: 'integrations', label: 'Integrations', type: 'module', target: '/settings/integrations/website', rolesAllowed: ['owner'], sortOrder: 59 },
   { id: 'blog', label: 'Blog', type: 'module', target: '/blog', rolesAllowed: ['owner', 'staff'], sortOrder: 60 },
-  { id: 'promo', label: 'Promo', type: 'module', target: '/promo', rolesAllowed: ['owner', 'staff'], sortOrder: 61 },
-  { id: 'gallery', label: 'Gallery', type: 'module', target: '/gallery', rolesAllowed: ['owner', 'staff'], sortOrder: 62 },
-  { id: 'website-hero-slides', label: 'Website Hero Slides', type: 'module', target: '/website-hero-slides', rolesAllowed: ['owner', 'staff'], sortOrder: 62.5 },
-  { id: 'social-links', label: 'Social links', type: 'module', target: '/social-links', rolesAllowed: ['owner', 'staff'], sortOrder: 63 },
+  { id: 'website-builder', label: 'Website Builder', type: 'module', target: '/website-builder', rolesAllowed: ['owner', 'staff'], sortOrder: 61 },
+  { id: 'promo', label: 'Promo', type: 'module', target: '/promo', parentTarget: '/website-builder', hideFromPrimaryNav: true, rolesAllowed: ['owner', 'staff'], sortOrder: 61.1 },
+  { id: 'gallery', label: 'Gallery', type: 'module', target: '/gallery', parentTarget: '/website-builder', hideFromPrimaryNav: true, rolesAllowed: ['owner', 'staff'], sortOrder: 61.2 },
+  { id: 'website-hero-slides', label: 'Website Hero Slides', type: 'module', target: '/website-hero-slides', parentTarget: '/website-builder', hideFromPrimaryNav: true, rolesAllowed: ['owner', 'staff'], sortOrder: 61.3 },
+  { id: 'social-links', label: 'Social links', type: 'module', target: '/social-links', parentTarget: '/website-builder', hideFromPrimaryNav: true, rolesAllowed: ['owner', 'staff'], sortOrder: 61.4 },
   { id: 'bulk-messaging', label: 'SMS', type: 'module', target: '/bulk-messaging', rolesAllowed: ['owner'], sortOrder: 70 },
   { id: 'bulk-email', label: 'Bulk email', type: 'module', target: '/bulk-email', rolesAllowed: ['owner'], sortOrder: 80 },
   { id: 'donor-management', label: 'Donor management', type: 'module', target: '/donor-management', rolesAllowed: ['owner', 'staff'], sortOrder: 90 },
@@ -49,9 +51,9 @@ export const NAV_ITEMS: NavItem[] = [
 
 const INDUSTRY_LABELS: Record<Industry, Partial<Record<string, string>>> = {
   shop: {},
-  travel: { '/customers': 'Travelers', '/bookings': 'Trips', '/upcoming-events': 'Upcoming trips', '/marketplace-orders': 'Online Orders', '/promo': 'Trip promos', '/gallery': 'Trip gallery', '/social-links': 'Contact links' },
-  ngo: { '/customers': 'Donors', '/bookings': 'Campaigns', '/upcoming-events': 'Upcoming campaigns', '/marketplace-orders': 'Online Orders', '/promo': 'Campaign promo', '/gallery': 'Impact gallery', '/social-links': 'Contact links', '/expenses': 'Petty expenses' },
-  school: { '/customers': 'Contacts', '/students': 'Students', '/bookings': 'Classes', '/upcoming-events': 'Upcoming classes', '/marketplace-orders': 'Registrations & Orders', '/promo': 'Admissions promo', '/gallery': 'School gallery', '/social-links': 'Contact links' },
+  travel: { '/customers': 'Travelers', '/bookings': 'Trips', '/upcoming-events': 'Upcoming trips', '/marketplace-orders': 'Online Orders', '/website-builder': 'Website Builder', '/promo': 'Trip promos', '/gallery': 'Trip gallery', '/social-links': 'Contact links' },
+  ngo: { '/customers': 'Donors', '/bookings': 'Campaigns', '/upcoming-events': 'Upcoming campaigns', '/marketplace-orders': 'Online Orders', '/website-builder': 'Website Builder', '/promo': 'Campaign promo', '/gallery': 'Impact gallery', '/social-links': 'Contact links', '/expenses': 'Petty expenses' },
+  school: { '/customers': 'Contacts', '/students': 'Students', '/bookings': 'Classes', '/upcoming-events': 'Upcoming classes', '/marketplace-orders': 'Registrations & Orders', '/website-builder': 'Website Builder', '/promo': 'Admissions promo', '/gallery': 'School gallery', '/social-links': 'Contact links' },
 }
 
 export type CustomNavItem = {
@@ -72,11 +74,13 @@ export type NavigationSettings = {
   customNavItems?: CustomNavItem[]
 }
 
+export const WEBSITE_BUILDER_SECTION_IDS = ['promo', 'gallery', 'website-hero-slides', 'social-links'] as const
+
 export const INDUSTRY_ENABLED_MODULE_PRESETS: Record<Industry, string[]> = {
-  shop: ['dashboard', 'reports', 'products', 'sell', 'marketplace-orders', 'quick-pay', 'invoices', 'receipts', 'expenses', 'customers', 'bookings', 'upcoming-events', 'settlement', 'integrations', 'blog', 'promo', 'gallery', 'website-hero-slides', 'social-links', 'donor-management'],
-  travel: ['dashboard', 'reports', 'products', 'marketplace-orders', 'quick-pay', 'invoices', 'receipts', 'expenses', 'bookings', 'upcoming-events', 'settlement', 'integrations', 'blog', 'promo', 'gallery', 'website-hero-slides', 'social-links', 'customers', 'bulk-messaging', 'bulk-email', 'donor-management'],
-  ngo: ['dashboard', 'reports', 'products', 'marketplace-orders', 'quick-pay', 'invoices', 'receipts', 'expenses', 'customers', 'volunteers', 'support-requests', 'upcoming-events', 'settlement', 'integrations', 'blog', 'promo', 'gallery', 'website-hero-slides', 'social-links', 'bulk-messaging', 'bulk-email', 'donor-management', 'funds-ledger'],
-  school: ['dashboard', 'reports', 'products', 'marketplace-orders', 'quick-pay', 'invoices', 'receipts', 'expenses', 'bookings', 'upcoming-events', 'student-registration', 'students', 'settlement', 'integrations', 'blog', 'promo', 'gallery', 'website-hero-slides', 'social-links', 'customers', 'bulk-messaging', 'bulk-email'],
+  shop: ['dashboard', 'reports', 'products', 'sell', 'marketplace-orders', 'quick-pay', 'invoices', 'receipts', 'expenses', 'customers', 'bookings', 'upcoming-events', 'settlement', 'integrations', 'blog', 'website-builder', 'donor-management'],
+  travel: ['dashboard', 'reports', 'products', 'marketplace-orders', 'quick-pay', 'invoices', 'receipts', 'expenses', 'bookings', 'upcoming-events', 'settlement', 'integrations', 'blog', 'website-builder', 'customers', 'bulk-messaging', 'bulk-email', 'donor-management'],
+  ngo: ['dashboard', 'reports', 'products', 'marketplace-orders', 'quick-pay', 'invoices', 'receipts', 'expenses', 'customers', 'volunteers', 'support-requests', 'upcoming-events', 'settlement', 'integrations', 'blog', 'website-builder', 'bulk-messaging', 'bulk-email', 'donor-management', 'funds-ledger'],
+  school: ['dashboard', 'reports', 'products', 'marketplace-orders', 'quick-pay', 'invoices', 'receipts', 'expenses', 'bookings', 'upcoming-events', 'student-registration', 'students', 'settlement', 'integrations', 'blog', 'website-builder', 'customers', 'bulk-messaging', 'bulk-email'],
 }
 
 export type NavigationResolverInput = { role: NavRole; workspaceProfile: NavigationSettings; permissions?: string[] }
@@ -92,10 +96,14 @@ export function resolveNavigation(input: NavigationResolverInput): NavItem[] {
   const { role, workspaceProfile } = input
   const aliasLabels = workspaceProfile.labelPolicy === 'industry_aliases' ? INDUSTRY_LABELS[workspaceProfile.industry] : {}
   const enabledModules = workspaceProfile.enabledModules && workspaceProfile.enabledModules.length > 0 ? new Set(workspaceProfile.enabledModules) : null
+  if (enabledModules && WEBSITE_BUILDER_SECTION_IDS.some(id => enabledModules.has(id))) {
+    enabledModules.add('website-builder')
+  }
   const grantedPermissions = input.permissions && input.permissions.length > 0 ? new Set(input.permissions) : null
   const baseItems = NAV_ITEMS.filter(item => {
     if (!item.rolesAllowed.includes(role)) return false
     if (item.industries && !item.industries.includes(workspaceProfile.industry)) return false
+    if (item.hideFromPrimaryNav) return false
     if (item.id !== 'account' && enabledModules && !enabledModules.has(item.id)) return false
     return hasPermissions(item.requiredPermissions, grantedPermissions)
   }).map(item => {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -57,6 +57,7 @@ import PromoSettings from './pages/PromoSettings'
 import GallerySettings from './pages/GallerySettings'
 import WebsiteHeroSlides from './pages/WebsiteHeroSlides'
 import SocialLinksSettings from './pages/SocialLinksSettings'
+import WebsiteBuilder from './pages/WebsiteBuilder'
 import BookingMappingSettings from './pages/BookingMappingSettings'
 import IntegrationWebsiteSettings from './pages/IntegrationWebsiteSettings'
 import IntegrationBookingsSettings from './pages/IntegrationBookingsSettings'
@@ -159,6 +160,7 @@ const router = createBrowserRouter([
       { path: 'account', element: <CleanAccountOverview /> },
       { path: 'account/overview', element: <CleanAccountOverview /> },
       { path: 'public-page', element: <Navigate to="/account" replace /> },
+      { path: 'website-builder', element: <WebsiteBuilder /> },
       { path: 'promo', element: <PromoSettings /> },
       { path: 'gallery', element: <GallerySettings /> },
       { path: 'website-hero-slides', element: <WebsiteHeroSlides /> },

--- a/web/src/pages/WebsiteBuilder.css
+++ b/web/src/pages/WebsiteBuilder.css
@@ -1,0 +1,37 @@
+.website-builder-page {
+  gap: 18px;
+}
+
+.website-builder-page__header {
+  align-items: flex-start;
+}
+
+.website-builder-page__switcher {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.website-builder-page__switcher label {
+  display: grid;
+  gap: 8px;
+  max-width: 520px;
+}
+
+.website-builder-page__switcher label > span {
+  color: #334155;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.website-builder-page__switcher select {
+  width: min(100%, 420px);
+}
+
+.website-builder-page__section > .account-overview {
+  padding: 0;
+}
+
+.website-builder-page__section > .account-overview > .account-overview__section-header:first-child {
+  margin-top: 0;
+}

--- a/web/src/pages/WebsiteBuilder.tsx
+++ b/web/src/pages/WebsiteBuilder.tsx
@@ -1,0 +1,98 @@
+import React, { useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import GallerySettings from './GallerySettings'
+import PromoSettings from './PromoSettings'
+import SocialLinksSettings from './SocialLinksSettings'
+import WebsiteHeroSlides from './WebsiteHeroSlides'
+import './AccountOverview.css'
+import './WebsiteBuilder.css'
+
+type BuilderSectionId = 'promo' | 'gallery' | 'hero' | 'social'
+
+type BuilderSection = {
+  id: BuilderSectionId
+  label: string
+  description: string
+  Component: React.ComponentType
+}
+
+const BUILDER_SECTIONS: BuilderSection[] = [
+  {
+    id: 'promo',
+    label: 'Promo',
+    description: 'Update the public promo title, dates, summary, image, and Sedifex public link content.',
+    Component: PromoSettings,
+  },
+  {
+    id: 'gallery',
+    label: 'Gallery',
+    description: 'Manage albums and images your public website can show in gallery sections.',
+    Component: GallerySettings,
+  },
+  {
+    id: 'hero',
+    label: 'Hero page',
+    description: 'Create homepage hero slides and banners for connected website templates.',
+    Component: WebsiteHeroSlides,
+  },
+  {
+    id: 'social',
+    label: 'Social settings',
+    description: 'Maintain public profile, contact, social links, logos, and share images.',
+    Component: SocialLinksSettings,
+  },
+]
+
+function isBuilderSectionId(value: string | null): value is BuilderSectionId {
+  return BUILDER_SECTIONS.some(section => section.id === value)
+}
+
+export default function WebsiteBuilder() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const requestedSectionId = searchParams.get('section')
+  const selectedSectionId: BuilderSectionId = isBuilderSectionId(requestedSectionId) ? requestedSectionId : 'promo'
+
+  const selectedSection = useMemo(
+    () => BUILDER_SECTIONS.find(section => section.id === selectedSectionId) ?? BUILDER_SECTIONS[0],
+    [selectedSectionId],
+  )
+  const SelectedComponent = selectedSection.Component
+
+  function selectSection(nextSectionId: BuilderSectionId) {
+    setSearchParams({ section: nextSectionId })
+  }
+
+  return (
+    <div className="account-overview website-builder-page">
+      <header className="account-overview__section-header website-builder-page__header">
+        <div>
+          <p className="account-overview__eyebrow">Website building</p>
+          <h1>Website Builder</h1>
+          <p className="account-overview__subtitle">
+            Select Promo, Gallery, Hero page, or Social settings from one place. Each section keeps its existing design so stores can update website content without hunting through the main navigation.
+          </p>
+        </div>
+      </header>
+
+      <section className="account-overview__card website-builder-page__switcher" aria-labelledby="website-builder-section-label">
+        <label htmlFor="website-builder-section">
+          <span id="website-builder-section-label">Choose website section to update</span>
+          <select
+            id="website-builder-section"
+            value={selectedSection.id}
+            onChange={event => selectSection(event.target.value as BuilderSectionId)}
+          >
+            {BUILDER_SECTIONS.map(section => (
+              <option key={section.id} value={section.id}>{section.label}</option>
+            ))}
+          </select>
+        </label>
+        <p className="account-overview__hint">{selectedSection.description}</p>
+      </section>
+
+      <div className="website-builder-page__section" aria-live="polite">
+        <SelectedComponent />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a single “Website Builder” workspace page so stores can manage promo, gallery, hero slides and social settings from one place while preserving each section's existing UI.
- Group website-related modules under a single primary nav item to simplify the sidebar and make it easier for clients to find website-building tools.

### Description
- Add a new `WebsiteBuilder` page with a dropdown that loads the existing `PromoSettings`, `GallerySettings`, `WebsiteHeroSlides`, and `SocialLinksSettings` components so each section keeps its current design (`web/src/pages/WebsiteBuilder.tsx`, `web/src/pages/WebsiteBuilder.css`).
- Register the `/website-builder` route and import the new page in `main.tsx` so the page is available from the primary nav.
- Update navigation configuration in `web/src/config/navigation.ts` to add a `website-builder` nav item, mark `promo`, `gallery`, `website-hero-slides`, and `social-links` as `hideFromPrimaryNav` children, add `WEBSITE_BUILDER_SECTION_IDS`, and expand industry presets to include `website-builder`.
- Ensure backwards compatibility by mapping workspaces that still have child builder module IDs enabled to show `website-builder` in `resolveNavigation` when any child ID is enabled.
- Update the Account → Navigation settings UI (`web/src/components/NavigationSettingsSection.tsx`) to treat hidden builder child items as non-configurable (introduce `CONFIGURABLE_NAV_ITEMS`) and show `website-builder` under the “Website & marketing” group.
- Add a unit test that asserts website content is grouped behind the new `website-builder` nav item (`web/src/config/navigation.test.ts`).

### Testing
- `git diff --check` ran successfully to validate no whitespace errors.
- `npm test -- --run web/src/config/navigation.test.ts` could not be executed in this environment because `vitest` is not installed (test runner not available); test file was added to cover the new grouping behavior.
- `npm run build` could not be completed here due to missing dev dependencies/type definitions in the environment.
- `npm install` was attempted but blocked by the environment (registry returned `403 Forbidden` for `@azure/msal-browser`), preventing full local test/build runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1980dd29d48321a9ed8bebe0f38386)