### PR TITLE
Respect item type for service checkouts and show service-specific actions + report filtering

### DIFF
--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -164,6 +164,23 @@ function getFirstText(record: Record<string, unknown>, keys: string[], max = 220
   return ''
 }
 
+
+function normalizeStoredItemType(value: unknown): 'product' | 'service' | 'course' | null {
+  const normalized = clean(value, 50).toLowerCase().replace(/[\s_-]+/g, '_')
+  if (normalized === 'service' || normalized === 'service_booking' || normalized === 'booking') return 'service'
+  if (normalized === 'course' || normalized === 'class' || normalized === 'training') return 'course'
+  if (normalized === 'product' || normalized === 'product_order' || normalized === 'physical_product') return 'product'
+  return null
+}
+
+function getCheckoutItemType(base: Record<string, unknown>, snapshotMatch: Record<string, unknown> | undefined, metadata: Record<string, unknown>) {
+  return normalizeStoredItemType(
+    base.itemType ?? base.item_type ?? base.listingType ?? base.listing_type ?? base.type
+    ?? snapshotMatch?.itemType ?? snapshotMatch?.item_type ?? snapshotMatch?.listingType ?? snapshotMatch?.listing_type ?? snapshotMatch?.type
+    ?? metadata.itemType ?? metadata.item_type ?? metadata.listingType ?? metadata.listing_type ?? metadata.type,
+  )
+}
+
 function getSnapshotItems(body: CheckoutBody) {
   const snapshot = getRecord(body.pricing_snapshot)
   return Array.isArray(snapshot.items) ? snapshot.items : []
@@ -183,12 +200,14 @@ function enrichCheckoutItems(body: CheckoutBody) {
     const itemName = getFirstText(base, ['itemName']) || getFirstText(snapshotMatch ?? {}, ['itemName'])
     const productName = getFirstText(base, ['productName']) || getFirstText(snapshotMatch ?? {}, ['productName'])
     const serviceName = getFirstText(base, ['serviceName']) || getFirstText(snapshotMatch ?? {}, ['serviceName'])
+    const itemType = getCheckoutItemType(base, snapshotMatch, metadata)
     return {
       ...base,
       ...(name ? { name } : {}),
       ...(itemName ? { itemName } : {}),
       ...(productName ? { productName } : {}),
       ...(serviceName ? { serviceName } : {}),
+      ...(itemType ? { itemType, item_type: itemType } : {}),
     }
   })
 
@@ -203,8 +222,10 @@ function enrichCheckoutItems(body: CheckoutBody) {
   const serviceName = getFirstText(firstItem, ['serviceName'])
     || getFirstText(firstSnapshotItem, ['serviceName'])
     || getFirstText(metadata, ['serviceName'])
+  const itemType = getCheckoutItemType(firstItem, firstSnapshotItem, metadata)
+    ?? (serviceName ? 'service' : productName ? 'product' : null)
 
-  return { enrichedItems, itemName, productName, serviceName }
+  return { enrichedItems, itemName, productName, serviceName, itemType }
 }
 function getTransactionChargeMinor(body: CheckoutBody) {
   const split = body.splitPayment && typeof body.splitPayment === 'object' ? body.splitPayment as Record<string, unknown> : {}
@@ -813,7 +834,7 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
 
     const paystack = await initializePaystack(paystackPayload)
     const authorizationUrl = paystack.data?.authorization_url ?? null
-    const { enrichedItems, itemName, productName, serviceName } = enrichCheckoutItems(body)
+    const { enrichedItems, itemName, productName, serviceName, itemType } = enrichCheckoutItems(body)
     const now = admin.firestore.FieldValue.serverTimestamp()
     const record = {
       storeId,
@@ -831,7 +852,10 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       itemName: itemName || null,
       productName: productName || null,
       serviceName: serviceName || null,
-      data: { itemName: itemName || null, productName: productName || null, serviceName: serviceName || null },
+      itemType: itemType || 'product',
+      item_type: itemType || 'product',
+      recordType: itemType === 'service' || itemType === 'course' ? 'service_booking' : 'product_order',
+      data: { itemName: itemName || null, productName: productName || null, serviceName: serviceName || null, itemType: itemType || 'product' },
       items: enrichedItems,
       pricingSnapshot: body.pricing_snapshot ?? null,
       marketplaceFees: body.marketplace_fees ?? null,

--- a/web/src/pages/MarketplaceOrders.tsx
+++ b/web/src/pages/MarketplaceOrders.tsx
@@ -44,6 +44,7 @@ type OnlineOrderRecord = {
   sourceLabel: string
   createdAt: Date | null
   notes: string
+  itemType: 'product' | 'service' | 'course' | 'manual'
 }
 
 const PRODUCT_ACTIONS: ActionConfig[] = [
@@ -96,6 +97,49 @@ function toDate(value: unknown): Date | null {
   }
   if (typeof (value as any)?.toDate === 'function') return (value as any).toDate()
   return null
+}
+
+
+function normalizeItemType(value: unknown): 'product' | 'service' | 'course' | '' {
+  const normalized = asText(value).toLowerCase().replace(/[\s_-]+/g, '_')
+  if (normalized === 'service' || normalized === 'service_booking' || normalized === 'booking') return 'service'
+  if (normalized === 'course' || normalized === 'class' || normalized === 'training') return 'course'
+  if (normalized === 'product' || normalized === 'product_order' || normalized === 'physical_product') return 'product'
+  return ''
+}
+
+function readItemType(source: Record<string, unknown>, collectionName: OrderCollection, recordType: string): 'product' | 'service' | 'course' | 'manual' {
+  if (collectionName === 'cashOrders' || recordType === 'manual_cash_sale') return 'manual'
+
+  const item = firstItem(source)
+  const metadata = getNestedObject(source, 'metadata')
+  const data = getNestedObject(source, 'data')
+  const pricingSnapshot = getNestedObject(source, 'pricingSnapshot')
+  const pricingSnapshotSnake = getNestedObject(source, 'pricing_snapshot')
+  const snapshotItems = Array.isArray(pricingSnapshot.items) ? pricingSnapshot.items : Array.isArray(pricingSnapshotSnake.items) ? pricingSnapshotSnake.items : []
+  const snapshotFirst = snapshotItems[0] && typeof snapshotItems[0] === 'object' ? snapshotItems[0] as Record<string, unknown> : {}
+
+  const explicitType = normalizeItemType(
+    source.itemType ?? source.item_type ?? source.listingType ?? source.listing_type ?? source.type
+    ?? item.itemType ?? item.item_type ?? item.listingType ?? item.listing_type ?? item.type
+    ?? snapshotFirst.itemType ?? snapshotFirst.item_type ?? snapshotFirst.listingType ?? snapshotFirst.listing_type ?? snapshotFirst.type
+    ?? metadata.itemType ?? metadata.item_type ?? metadata.listingType ?? metadata.listing_type ?? metadata.type
+    ?? data.itemType ?? data.item_type ?? data.listingType ?? data.listing_type ?? data.type
+    ?? recordType,
+  )
+  if (explicitType) return explicitType
+  if (collectionName === 'integrationBookings') return 'service'
+
+  const hasServiceSignal = Boolean(
+    source.serviceName || source.serviceId || source.service_id
+    || item.serviceName || item.serviceId || item.service_id
+    || snapshotFirst.serviceName || snapshotFirst.serviceId || snapshotFirst.service_id
+    || metadata.serviceName || metadata.serviceId || metadata.service_id
+    || data.serviceName || data.serviceId || data.service_id,
+  )
+  if (hasServiceSignal) return 'service'
+
+  return 'product'
 }
 
 function normalizeStatus(value: string) {
@@ -155,7 +199,8 @@ function mapOrderRecord(id: string, collectionName: OrderCollection, data: Recor
   const item = firstItem(data)
   const metadata = getNestedObject(data, 'metadata')
   const channel = collectionName === 'cashOrders' ? 'quick_pay_cash' : readSourceChannel(data)
-  const recordType = asText(data.recordType ?? data.orderType, collectionName === 'integrationBookings' ? 'service_booking' : collectionName === 'cashOrders' ? 'manual_cash_sale' : 'product_order')
+  const recordType = asText(data.recordType ?? data.orderType ?? data.itemType ?? data.item_type, collectionName === 'integrationBookings' ? 'service_booking' : collectionName === 'cashOrders' ? 'manual_cash_sale' : 'product_order')
+  const itemType = readItemType(data, collectionName, recordType)
 
   return {
     id,
@@ -166,7 +211,7 @@ function mapOrderRecord(id: string, collectionName: OrderCollection, data: Recor
     customerName: asText(customer.name ?? data.customerName, 'Customer'),
     customerEmail: asText(customer.email ?? data.customerEmail, ''),
     customerPhone: asText(customer.phone ?? data.customerPhone, ''),
-    itemName: asText(data.itemName ?? data.productName ?? data.serviceName ?? item.name ?? item.itemName ?? item.productName, recordType === 'service_booking' ? 'Service booking' : 'Manual sale'),
+    itemName: asText(data.itemName ?? data.productName ?? data.serviceName ?? item.name ?? item.itemName ?? item.productName ?? item.serviceName, itemType === 'service' || itemType === 'course' ? 'Service booking' : itemType === 'manual' ? 'Manual sale' : 'Product order'),
     quantity: asNumber(item.quantity ?? item.qty, 1),
     amount: readAmount(data),
     currency: readCurrency(data),
@@ -182,15 +227,16 @@ function mapOrderRecord(id: string, collectionName: OrderCollection, data: Recor
     sourceLabel: asText(data.sourceLabel ?? data.source_label, sourceLabel(channel)),
     createdAt: toDate(data.createdAtServer ?? data.createdAt),
     notes: asText(data.notes, ''),
+    itemType,
   }
 }
 
 function isServiceBooking(record: OnlineOrderRecord) {
-  return record.recordType === 'service_booking' || record.collectionName === 'integrationBookings' || record.recordType === 'service'
+  return record.itemType === 'service' || record.itemType === 'course' || record.recordType === 'service_booking' || record.collectionName === 'integrationBookings' || record.recordType === 'service'
 }
 
 function isManualStoreOrder(record: OnlineOrderRecord) {
-  return record.collectionName === 'cashOrders' || record.recordType === 'manual_cash_sale' || Boolean(record.storeOnly)
+  return record.itemType === 'manual' || record.collectionName === 'cashOrders' || record.recordType === 'manual_cash_sale' || Boolean(record.storeOnly)
 }
 
 function isProductOrder(record: OnlineOrderRecord) {
@@ -592,7 +638,7 @@ export default function MarketplaceOrders({ compactHeader = false }: { compactHe
                   return (
                     <tr key={`${record.collectionName}-${record.id}`} style={{ borderBottom: '1px solid #E2E8F0', verticalAlign: 'top' }}>
                       <td style={{ padding: '12px 8px' }}><strong style={{ color: '#0F172A' }}>{record.customerName}</strong><br /><span style={{ color: '#64748B', fontSize: 13 }}>{record.customerPhone || record.customerEmail || 'No contact'}</span></td>
-                      <td style={{ padding: '12px 8px' }}><strong style={{ color: '#0F172A' }}>{record.itemName}</strong><br /><span style={{ color: '#64748B', fontSize: 13 }}>{actionGroup === 'product' ? `Qty: ${record.quantity || 1}` : actionGroup === 'service' ? 'Service booking' : 'Manual entry'}</span></td>
+                      <td style={{ padding: '12px 8px' }}><strong style={{ color: '#0F172A' }}>{record.itemName}</strong><br /><span style={{ color: '#64748B', fontSize: 13 }}>{actionGroup === 'product' ? `Product · Qty: ${record.quantity || 1}` : actionGroup === 'service' ? `${normalizeStatus(record.itemType)} booking` : 'Manual entry'}</span></td>
                       <td style={{ padding: '12px 8px' }}><strong style={{ color: '#0F172A' }}>{record.sourceLabel}</strong><br /><span style={{ color: record.storeOnly ? '#92400E' : '#64748B', fontSize: 12, fontWeight: 800 }}>{record.storeOnly ? 'Store-only data' : record.collectionName}</span></td>
                       <td style={{ padding: '12px 8px', color: '#0F172A', fontWeight: 800 }}>{formatMoney(record.amount, record.currency)}</td>
                       <td style={{ padding: '12px 8px' }}><strong>{normalizeStatus(record.paymentCollectionMode)}</strong><br /><span style={{ color: '#64748B', fontSize: 13 }}>{normalizeStatus(record.paymentStatus)}</span>{cashOrder ? <><br /><span style={{ color: record.cashConfirmed ? '#16A34A' : '#92400E', fontSize: 12, fontWeight: 900 }}>{record.cashConfirmed ? 'Cash confirmed' : 'Awaiting cash'}</span></> : null}</td>

--- a/web/src/pages/reports/WebsiteSalesReport.tsx
+++ b/web/src/pages/reports/WebsiteSalesReport.tsx
@@ -17,7 +17,58 @@ type OrderRow = {
   paymentStatus: string
   orderStatus: string
   paymentCollectionMode: string
+  itemName: string
+  itemType: 'product' | 'service' | 'course' | 'manual'
   createdAt: Date | null
+}
+
+
+function firstItem(source: Record<string, unknown>): Record<string, unknown> {
+  const items = Array.isArray(source.items) ? source.items : Array.isArray(source.cart) ? source.cart : []
+  const first = items[0]
+  return first && typeof first === 'object' ? first as Record<string, unknown> : {}
+}
+
+function normalizeItemType(value: unknown): 'product' | 'service' | 'course' | '' {
+  const normalized = asText(value).toLowerCase().replace(/[\s_-]+/g, '_')
+  if (normalized === 'service' || normalized === 'service_booking' || normalized === 'booking') return 'service'
+  if (normalized === 'course' || normalized === 'class' || normalized === 'training') return 'course'
+  if (normalized === 'product' || normalized === 'product_order' || normalized === 'physical_product') return 'product'
+  return ''
+}
+
+function readItemType(data: Record<string, unknown>): 'product' | 'service' | 'course' | 'manual' {
+  const item = firstItem(data)
+  const metadata = getNestedObject(data, 'metadata')
+  const nestedData = getNestedObject(data, 'data')
+  const pricingSnapshot = getNestedObject(data, 'pricingSnapshot')
+  const pricingSnapshotSnake = getNestedObject(data, 'pricing_snapshot')
+  const snapshotItems = Array.isArray(pricingSnapshot.items) ? pricingSnapshot.items : Array.isArray(pricingSnapshotSnake.items) ? pricingSnapshotSnake.items : []
+  const snapshotFirst = snapshotItems[0] && typeof snapshotItems[0] === 'object' ? snapshotItems[0] as Record<string, unknown> : {}
+  const explicitType = normalizeItemType(
+    data.itemType ?? data.item_type ?? data.listingType ?? data.listing_type ?? data.type ?? data.recordType ?? data.orderType
+    ?? item.itemType ?? item.item_type ?? item.listingType ?? item.listing_type ?? item.type
+    ?? snapshotFirst.itemType ?? snapshotFirst.item_type ?? snapshotFirst.listingType ?? snapshotFirst.listing_type ?? snapshotFirst.type
+    ?? metadata.itemType ?? metadata.item_type ?? metadata.listingType ?? metadata.listing_type ?? metadata.type
+    ?? nestedData.itemType ?? nestedData.item_type ?? nestedData.listingType ?? nestedData.listing_type ?? nestedData.type,
+  )
+  if (explicitType) return explicitType
+  if (data.paymentCollectionMode === 'cash' || data.payment_collection_mode === 'cash') return 'manual'
+  if (
+    data.serviceName || data.serviceId || data.service_id
+    || item.serviceName || item.serviceId || item.service_id
+    || snapshotFirst.serviceName || snapshotFirst.serviceId || snapshotFirst.service_id
+    || metadata.serviceName || metadata.serviceId || metadata.service_id
+    || nestedData.serviceName || nestedData.serviceId || nestedData.service_id
+  ) return 'service'
+  return 'product'
+}
+
+function itemTypeLabel(type: OrderRow['itemType']) {
+  if (type === 'service') return 'Service'
+  if (type === 'course') return 'Course'
+  if (type === 'manual') return 'Manual'
+  return 'Product'
 }
 
 function readAmount(data: Record<string, unknown>) {
@@ -40,6 +91,8 @@ function mapOrder(id: string, data: Record<string, unknown>): OrderRow {
   const customer = getNestedObject(data, 'customer')
   const payment = getNestedObject(data, 'payment')
   const sourceChannel = normalizeSourceChannel(data.sourceChannel ?? data.source_channel ?? data.source)
+  const item = firstItem(data)
+  const itemType = readItemType(data)
   return {
     id,
     reference: asText(data.reference ?? data.paymentReference ?? data.payment_reference ?? payment.reference, id),
@@ -52,6 +105,8 @@ function mapOrder(id: string, data: Record<string, unknown>): OrderRow {
     paymentStatus: asText(data.paymentStatus ?? data.payment_status ?? payment.status, 'pending'),
     orderStatus: asText(data.orderStatus ?? data.order_status ?? data.status, 'pending'),
     paymentCollectionMode: asText(data.paymentCollectionMode ?? data.payment_collection_mode ?? payment.mode, 'online_checkout'),
+    itemName: asText(data.itemName ?? data.productName ?? data.serviceName ?? item.name ?? item.itemName ?? item.productName ?? item.serviceName, itemType === 'service' || itemType === 'course' ? 'Service booking' : 'Product order'),
+    itemType,
     createdAt: toDate(data.createdAtServer ?? data.createdAt ?? data.updatedAt),
   }
 }
@@ -106,6 +161,7 @@ export default function WebsiteSalesReport() {
   const [paymentMode, setPaymentMode] = useState('all')
   const [range, setRange] = useState('30d')
   const [paymentStatus, setPaymentStatus] = useState('all')
+  const [itemType, setItemType] = useState('all')
 
   useEffect(() => {
     if (!storeId) {
@@ -123,8 +179,9 @@ export default function WebsiteSalesReport() {
     const modeOk = paymentMode === 'all' || order.paymentCollectionMode === paymentMode
     const dateOk = inDateRange(order.createdAt, range)
     const statusOk = paymentStatus === 'all' || (paymentStatus === 'paid' ? isPaidLike(order.paymentStatus) : order.paymentStatus.toLowerCase().includes(paymentStatus))
-    return channelOk && modeOk && dateOk && statusOk
-  }), [channel, orders, paymentMode, paymentStatus, range])
+    const typeOk = itemType === 'all' || order.itemType === itemType
+    return channelOk && modeOk && dateOk && statusOk && typeOk
+  }), [channel, itemType, orders, paymentMode, paymentStatus, range])
 
   const totals = useMemo(() => ({
     count: filtered.length,
@@ -136,6 +193,8 @@ export default function WebsiteSalesReport() {
     pending: filtered.filter(order => order.paymentStatus.toLowerCase().includes('pending')).length,
     cancelled: filtered.filter(order => order.orderStatus.toLowerCase().includes('cancel')).length,
     payOnDelivery: filtered.filter(order => order.paymentCollectionMode === 'pay_on_delivery').length,
+    products: filtered.filter(order => order.itemType === 'product').length,
+    services: filtered.filter(order => order.itemType === 'service' || order.itemType === 'course').length,
     websiteValue: filtered.filter(order => order.sourceChannel === 'client_website').reduce((sum, order) => sum + order.amount, 0),
     marketValue: filtered.filter(order => order.sourceChannel === 'sedifex_market').reduce((sum, order) => sum + order.amount, 0),
     publicValue: filtered.filter(order => order.sourceChannel === 'sedifex_custom_page').reduce((sum, order) => sum + order.amount, 0),
@@ -146,6 +205,7 @@ export default function WebsiteSalesReport() {
     { key: 'reference', label: 'Reference', sortable: true, value: row => row.reference },
     { key: 'source', label: 'Source', sortable: true, value: row => row.sourceLabel },
     { key: 'customer', label: 'Customer', sortable: true, value: row => row.customerName, render: row => <><strong>{row.customerName}</strong><br /><small>{row.customerPhone || 'No contact'}</small></> },
+    { key: 'item', label: 'Item', sortable: true, value: row => row.itemName, render: row => <><strong>{row.itemName}</strong><br /><small>{itemTypeLabel(row.itemType)}</small></> },
     { key: 'amount', label: 'Amount', sortable: true, align: 'right', value: row => row.amount, render: row => formatMoney(row.amount, row.currency) },
     { key: 'payment', label: 'Payment', sortable: true, value: row => row.paymentStatus, render: row => <>{row.paymentStatus}<br /><small>{row.paymentCollectionMode}</small></> },
     { key: 'order', label: 'Order', sortable: true, value: row => row.orderStatus },
@@ -160,6 +220,8 @@ export default function WebsiteSalesReport() {
       contact: order.customerPhone,
       amount: order.amount,
       currency: order.currency,
+      itemName: order.itemName,
+      itemType: itemTypeLabel(order.itemType),
       paymentStatus: order.paymentStatus,
       orderStatus: order.orderStatus,
       paymentCollectionMode: order.paymentCollectionMode,
@@ -175,6 +237,7 @@ export default function WebsiteSalesReport() {
         { label: 'Orders', value: totals.count },
         { label: 'Order value', value: formatMoney(totals.revenue, totals.currency) },
         { label: 'Paid orders', value: totals.paid },
+        { label: 'Services/courses', value: totals.services },
         { label: 'Pay on delivery', value: totals.payOnDelivery },
       ],
       rows: filtered.map(order => ({
@@ -184,6 +247,8 @@ export default function WebsiteSalesReport() {
         contact: order.customerPhone,
         amount: order.amount,
         currency: order.currency,
+        itemName: order.itemName,
+        itemType: itemTypeLabel(order.itemType),
         paymentStatus: order.paymentStatus,
         orderStatus: order.orderStatus,
         paymentCollectionMode: order.paymentCollectionMode,
@@ -204,6 +269,7 @@ export default function WebsiteSalesReport() {
         <article className="workspace-card"><strong>{formatMoney(totals.revenue, totals.currency)}</strong><span>Order value</span></article>
         <article className="workspace-card"><strong>{totals.paid}</strong><span>Paid orders</span></article>
         <article className="workspace-card"><strong>{totals.pending}</strong><span>Pending payment</span></article>
+        <article className="workspace-card"><strong>{totals.services}</strong><span>Services / courses</span></article>
       </section>
       <section className="workspace-grid workspace-grid--three">
         <article className="workspace-card"><strong>{formatMoney(totals.marketValue, totals.currency)}</strong><span>Sedifex Market · {totals.market} orders</span></article>
@@ -233,6 +299,12 @@ export default function WebsiteSalesReport() {
             <option value="client_website">Client website</option>
             <option value="sedifex_market">Sedifex Market</option>
             <option value="sedifex_custom_page">Sedifex public page</option>
+          </select>
+          <select value={itemType} onChange={event => setItemType(event.target.value)}>
+            <option value="all">All item types</option>
+            <option value="product">Products only</option>
+            <option value="service">Services only</option>
+            <option value="course">Courses only</option>
           </select>
           <select value={paymentMode} onChange={event => setPaymentMode(event.target.value)}>
             <option value="all">All payment modes</option>


### PR DESCRIPTION
### Motivation
- Service payments were being treated as product orders, exposing product delivery actions (`Accept`, `Preparing`, `Delivered`) for bookings instead of service booking actions.
- Marketplace order UI and website reports lacked reliable item-type detection and reporting, causing incorrect actions and poor filtering in reports.

### Description
- Preserve and infer checkout `itemType` when creating integration orders in `functions/src/integrationCheckout.ts` so online service/course payments are saved with `itemType`, `item_type`, and an appropriate `recordType` (service booking vs product order).
- Add robust item-type inference logic in `web/src/pages/MarketplaceOrders.tsx` that examines top-level fields, line items, pricing snapshots, metadata, and service signals to classify orders as `product`, `service`, `course`, or `manual`, and route UI actions accordingly (product → delivery actions; service → booking actions).
- Update Marketplace Orders UI to include `itemType` on records and adjust row labels so service rows show service booking actions and product rows show delivery actions.
- Extend `web/src/pages/reports/WebsiteSalesReport.tsx` to detect `itemType`, add an Item column, include service/course totals, export item info to CSV/PDF, and provide an item-type filter.

### Testing
- Ran `git diff --check` to ensure no whitespace/conflict markers (passed).
- Compiled `functions/src/integrationCheckout.ts` with `tsc` to validate the new checkout/item-type logic (`./node_modules/.bin/tsc ... src/integrationCheckout.ts`) (passed).
- Attempted `npm run build` in `web/` but dependency installation is blocked in this environment (`npm ci` failed due to registry `403` for `@azure/msal-browser`), so full web build could not be run (blocked).
- Attempted `npm run build` in `functions/` but the repo has an existing unrelated TypeScript error in `src/dataConsistency.ts` that prevents a full functions build in this environment (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b447ec288321b39d95e0127fe241)