### PR TITLE
Add Stripe Connect checkout routing and webhook for EUR/GBP/USD (preserve Paystack)

### DIFF
--- a/functions/src/dataConsistency.ts
+++ b/functions/src/dataConsistency.ts
@@ -84,7 +84,8 @@ function setCors(res: functions.Response) {
 }
 
 function isAllowed(req: functions.https.Request) {
-  const expected = functions.config().sedifex?.admin_repair_token || process.env.SEDIFEX_ADMIN_REPAIR_TOKEN || ''
+  const legacyConfig = typeof (functions as any).config === 'function' ? (functions as any).config() : {}
+  const expected = legacyConfig.sedifex?.admin_repair_token || process.env.SEDIFEX_ADMIN_REPAIR_TOKEN || ''
   if (!expected) return false
   const received = clean(req.get('x-sedifex-admin-repair-token') || req.get('authorization')?.replace(/^Bearer\s+/i, ''), 300)
   return received === expected

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,7 @@
 // functions/src/index.ts
 export { checkSignupUnlock, createCheckout, paystackWebhook } from './paystack'
 export { handlePaystackWebhook } from './marketplacePaystackWebhook'
+export { stripeConnectWebhook } from './stripeConnect'
 export {
   createPaystackMerchantSubaccount,
   fetchPaystackMerchantSubaccount,

--- a/functions/src/integrationQuickPayCheckoutCreate.ts
+++ b/functions/src/integrationQuickPayCheckoutCreate.ts
@@ -1,6 +1,13 @@
 import * as functions from 'firebase-functions/v1'
 import { defineString } from 'firebase-functions/params'
 import { admin, defaultDb } from './firestore'
+import {
+  calculateApplicationFeeAmount,
+  createStripeCheckoutSession,
+  resolveStripeCommissionPercent,
+  resolveStripeConnectedAccount,
+  shouldUseStripeForCheckout,
+} from './stripeConnect'
 
 const PAYSTACK_SECRET_KEY = defineString('PAYSTACK_SECRET_KEY')
 const APP_BASE_URL = defineString('APP_BASE_URL', { default: '' })
@@ -113,6 +120,18 @@ function getTransactionChargeMinor(body: CheckoutBody) {
   const split = getRecord(body.splitPayment)
   const value = numberValue(split.transactionChargeMinor ?? split.transaction_charge ?? split.transactionCharge)
   return value !== null && value > 0 ? Math.round(value) : null
+}
+
+function getReturnUrl(body: CheckoutBody) {
+  return clean(body.returnUrl ?? body.return_url ?? body.callbackUrl ?? body.callback_url, 700)
+}
+
+function getCancelUrl(body: CheckoutBody) {
+  return clean(body.cancelUrl ?? body.cancel_url, 700)
+}
+
+function getCheckoutDescription(details: ReturnType<typeof deriveCheckoutDetails>, sourceLabel: string) {
+  return details.itemName || details.productName || details.serviceName || sourceLabel || 'Sedifex checkout'
 }
 
 function normalizeItemType(value: unknown): NormalizedItemType | '' {
@@ -285,7 +304,8 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     const amountMajor = getAmountMajor(body)
     const reference = clean(body.payment_reference ?? body.reference, 220) || clean(body.client_order_id ?? body.clientOrderId, 220) || `${storeId}_${Date.now()}`
     const currency = clean(body.currency, 20) || 'GHS'
-    const callbackUrl = clean(body.returnUrl, 700) || APP_BASE_URL.value() || undefined
+    const callbackUrl = getReturnUrl(body) || APP_BASE_URL.value() || undefined
+    const cancelUrl = getCancelUrl(body) || callbackUrl
     const sourceChannel = clean(body.sourceChannel ?? body.source_channel, 80) || 'integration_checkout'
     const sourceLabel = clean(body.sourceLabel ?? body.source_label, 120) || 'Sedifex checkout'
     const subaccount = getSubaccount(body)
@@ -327,9 +347,155 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       splitEnabled: Boolean(subaccount),
     }
 
+    const amountMinor = Math.round(amountMajor * 100)
+    const now = admin.firestore.FieldValue.serverTimestamp()
+    const nowIso = new Date().toISOString()
+    const clientOrderId = clean(body.client_order_id ?? body.clientOrderId, 220) || reference
+
+    if (shouldUseStripeForCheckout(body, currency)) {
+      const connectedAccountId = await resolveStripeConnectedAccount({ storeId, body })
+      if (!connectedAccountId) {
+        res.status(400).json({ error: 'stripe-connected-account-required' })
+        return
+      }
+
+      const commissionPercent = resolveStripeCommissionPercent(body)
+      const applicationFeeAmount = calculateApplicationFeeAmount(amountMinor, commissionPercent)
+      const stripeMetadata = {
+        ...storedMetadata,
+        currency: currency.toUpperCase(),
+        stripeConnectedAccountId: connectedAccountId,
+        applicationFeeAmount,
+        applicationFeePercent: commissionPercent,
+        paystackSubaccountCode: null,
+        splitEnabled: true,
+      }
+      const stripe = await createStripeCheckoutSession({
+        connectedAccountId,
+        email: customer.email,
+        amountMinor,
+        currency: currency.toUpperCase(),
+        reference,
+        callbackUrl,
+        cancelUrl,
+        description: getCheckoutDescription(details, sourceLabel),
+        applicationFeeAmount,
+        metadata: stripeMetadata,
+      })
+      const authorizationUrl = stripe.url ?? null
+      const record = {
+        storeId,
+        merchantId: storeId,
+        reference,
+        clientOrderId,
+        client_order_id: clientOrderId,
+        sourceChannel,
+        source_channel: sourceChannel,
+        sourceLabel,
+        source_label: sourceLabel,
+        customer: {
+          name: customer.name || null,
+          email: customer.email,
+          phone: customer.phone || null,
+        },
+        customerName: customer.name || null,
+        customer_name: customer.name || null,
+        customerEmail: customer.email,
+        customer_email: customer.email,
+        customerPhone: customer.phone || null,
+        customer_phone: customer.phone || null,
+        amount: amountMajor,
+        amountMinor,
+        amount_minor: amountMinor,
+        currency: currency.toUpperCase(),
+        itemName: details.itemName || details.productName || details.serviceName || null,
+        productName: details.productName || null,
+        serviceName: details.serviceName || null,
+        itemType: details.itemType,
+        item_type: details.itemType,
+        accountingType: details.accountingType,
+        accounting_type: details.accountingType,
+        recordType: details.recordType,
+        orderType: details.recordType,
+        order_type: details.recordType,
+        data: {
+          itemName: details.itemName || null,
+          productName: details.productName || null,
+          serviceName: details.serviceName || null,
+          itemType: details.itemType,
+          accountingType: details.accountingType,
+          recordType: details.recordType,
+        },
+        items: details.enrichedItems,
+        pricingSnapshot: body.pricing_snapshot ?? body.pricingSnapshot ?? null,
+        pricing_snapshot: body.pricing_snapshot ?? body.pricingSnapshot ?? null,
+        marketplaceFees: body.marketplace_fees ?? body.marketplaceFees ?? null,
+        marketplace_fees: body.marketplace_fees ?? body.marketplaceFees ?? null,
+        metadata: stripeMetadata,
+        paymentProvider: 'stripe',
+        payment_provider: 'stripe',
+        paymentMethod: 'ONLINE',
+        payment_method: 'ONLINE',
+        paymentReference: reference,
+        payment_reference: reference,
+        stripeCheckoutSessionId: stripe.id ?? null,
+        stripePaymentIntentId: stripe.payment_intent ?? null,
+        stripeConnectedAccountId: connectedAccountId,
+        paymentStatus: 'pending',
+        payment_status: 'pending',
+        orderStatus: 'pending_payment',
+        order_status: 'pending_payment',
+        status: 'pending_payment',
+        paymentCollectionMode: 'online_checkout',
+        payment_collection_mode: 'online_checkout',
+        stripeConnect: {
+          enabled: true,
+          connectedAccountId,
+          applicationFeeAmount,
+          commissionPercent,
+          chargeType: 'direct',
+          commissionControlledBy: 'sedifex',
+        },
+        paystackSplit: { enabled: false },
+        authorizationUrl,
+        checkoutUrl: authorizationUrl,
+        orderDate: nowIso,
+        order_date: nowIso,
+        createdAt: now,
+        createdAtIso: nowIso,
+        created_at: now,
+        updatedAt: now,
+        updatedAtIso: nowIso,
+      }
+
+      await Promise.all([
+        defaultDb.collection('integrationOrders').doc(reference).set(record, { merge: true }),
+        defaultDb.collection('stores').doc(storeId).collection('integrationOrders').doc(reference).set(record, { merge: true }),
+      ])
+
+      res.status(200).json({
+        ok: true,
+        reference,
+        payment_reference: reference,
+        authorizationUrl,
+        checkoutUrl: authorizationUrl,
+        stripeCheckoutSessionId: stripe.id ?? null,
+        stripePaymentIntentId: stripe.payment_intent ?? null,
+        stripeConnect: { enabled: true, connectedAccountId, applicationFeeAmount, commissionPercent, chargeType: 'direct' },
+        orderId: reference,
+        payment_status: 'pending',
+        order_status: 'pending_payment',
+        recordType: details.recordType,
+        orderType: details.recordType,
+        paymentProvider: 'stripe',
+        payment_provider: 'stripe',
+      })
+      return
+    }
+
     const paystackPayload: Record<string, unknown> = {
       email: customer.email,
-      amount: Math.round(amountMajor * 100),
+      amount: amountMinor,
       reference,
       currency,
       callback_url: callbackUrl,
@@ -344,9 +510,6 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
 
     const paystack = await initializePaystack(paystackPayload)
     const authorizationUrl = paystack.data?.authorization_url ?? null
-    const now = admin.firestore.FieldValue.serverTimestamp()
-    const nowIso = new Date().toISOString()
-    const clientOrderId = clean(body.client_order_id ?? body.clientOrderId, 220) || reference
 
     const record = {
       storeId,
@@ -370,8 +533,8 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       customerPhone: customer.phone || null,
       customer_phone: customer.phone || null,
       amount: amountMajor,
-      amountMinor: Math.round(amountMajor * 100),
-      amount_minor: Math.round(amountMajor * 100),
+      amountMinor,
+      amount_minor: amountMinor,
       currency,
       itemName: details.itemName || details.productName || details.serviceName || null,
       productName: details.productName || null,

--- a/functions/src/stripeConnect.ts
+++ b/functions/src/stripeConnect.ts
@@ -1,0 +1,378 @@
+import * as functions from 'firebase-functions/v1'
+import * as crypto from 'crypto'
+import { defineString } from 'firebase-functions/params'
+import { admin, defaultDb } from './firestore'
+import { paidFulfillmentUpdateFields, paymentFailedFulfillmentUpdateFields } from './orderFulfillment'
+
+const STRIPE_SECRET_KEY = defineString('STRIPE_SECRET_KEY', { default: '' })
+const STRIPE_WEBHOOK_SECRET = defineString('STRIPE_WEBHOOK_SECRET', { default: '' })
+const DEFAULT_STRIPE_COMMISSION_PERCENT = defineString('SEDIFEX_DEFAULT_STRIPE_COMMISSION_PERCENT', {
+  default: '3',
+})
+
+export const STRIPE_SUPPORTED_CHECKOUT_CURRENCIES = new Set(['EUR', 'GBP', 'USD'])
+
+export type StripeCheckoutSessionResponse = {
+  id?: string
+  object?: string
+  url?: string | null
+  payment_intent?: string | null
+  payment_status?: string | null
+  status?: string | null
+  client_reference_id?: string | null
+  amount_total?: number | null
+  currency?: string | null
+  metadata?: Record<string, string>
+  error?: { message?: string }
+}
+
+type StripeEvent = {
+  id?: string
+  type?: string
+  account?: string
+  data?: { object?: Record<string, unknown> }
+}
+
+type StripeRoutingInput = {
+  storeId: string
+  body: Record<string, unknown>
+}
+
+type StripeSessionInput = {
+  connectedAccountId: string
+  email: string
+  amountMinor: number
+  currency: string
+  reference: string
+  callbackUrl?: string
+  cancelUrl?: string
+  description: string
+  applicationFeeAmount: number
+  metadata: Record<string, unknown>
+}
+
+function clean(value: unknown, max = 500) {
+  return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+
+function getRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function numberValue(value: unknown) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function getStripeSecret() {
+  const key = STRIPE_SECRET_KEY.value()?.trim() || process.env.STRIPE_SECRET_KEY?.trim() || ''
+  if (!key) throw new Error('Stripe secret is not configured')
+  return key
+}
+
+function getWebhookSecret() {
+  return STRIPE_WEBHOOK_SECRET.value()?.trim() || process.env.STRIPE_WEBHOOK_SECRET?.trim() || ''
+}
+
+export function shouldUseStripeForCheckout(body: Record<string, unknown>, currency: string) {
+  const routing = getRecord(body.paymentRouting)
+  const provider = clean(
+    body.paymentProvider
+      ?? body.payment_provider
+      ?? body.provider
+      ?? routing.paymentProvider
+      ?? routing.payment_provider
+      ?? routing.provider,
+    80,
+  ).toLowerCase()
+  const normalizedCurrency = currency.toUpperCase()
+  const isStripeCurrency = STRIPE_SUPPORTED_CHECKOUT_CURRENCIES.has(normalizedCurrency)
+
+  if (provider === 'paystack') return false
+  if (provider === 'stripe' || provider === 'stripe_connect') return isStripeCurrency
+  return isStripeCurrency
+}
+
+export function resolveStripeCommissionPercent(body: Record<string, unknown>) {
+  const routing = getRecord(body.paymentRouting)
+  const split = getRecord(body.splitPayment)
+  const configured = numberValue(
+    body.stripeCommissionPercent
+      ?? body.commissionPercent
+      ?? routing.stripeCommissionPercent
+      ?? routing.commissionPercent
+      ?? split.commissionPercent,
+  )
+  const raw = configured ?? numberValue(DEFAULT_STRIPE_COMMISSION_PERCENT.value() || process.env.SEDIFEX_DEFAULT_STRIPE_COMMISSION_PERCENT) ?? 3
+  if (!Number.isFinite(raw) || raw < 0 || raw > 100) throw new Error('Stripe commission percent must be between 0 and 100')
+  return Math.round(raw * 100) / 100
+}
+
+export function calculateApplicationFeeAmount(amountMinor: number, commissionPercent: number) {
+  return Math.max(0, Math.round(amountMinor * (commissionPercent / 100)))
+}
+
+export async function resolveStripeConnectedAccount(input: StripeRoutingInput) {
+  const routing = getRecord(input.body.paymentRouting)
+  const split = getRecord(input.body.splitPayment)
+  const direct = clean(
+    input.body.stripeAccountId
+      ?? input.body.stripe_account_id
+      ?? input.body.connectedAccountId
+      ?? input.body.connected_account_id
+      ?? input.body.stripeConnectedAccountId
+      ?? input.body.stripe_connected_account_id
+      ?? routing.stripeAccountId
+      ?? routing.stripe_account_id
+      ?? routing.connectedAccountId
+      ?? routing.connected_account_id
+      ?? routing.stripeConnectedAccountId
+      ?? routing.stripe_connected_account_id
+      ?? split.stripeAccountId
+      ?? split.connectedAccountId,
+    120,
+  )
+  if (direct) return direct
+
+  const storeSnap = await defaultDb.collection('stores').doc(input.storeId).get()
+  const store = (storeSnap.data() ?? {}) as Record<string, unknown>
+  const storeRouting = getRecord(store.paymentRouting)
+  const stripeRouting = getRecord(store.stripeConnect ?? store.stripe ?? store.stripe_connect)
+
+  return clean(
+    storeRouting.stripeAccountId
+      ?? storeRouting.stripe_account_id
+      ?? storeRouting.connectedAccountId
+      ?? storeRouting.connected_account_id
+      ?? storeRouting.stripeConnectedAccountId
+      ?? storeRouting.stripe_connected_account_id
+      ?? stripeRouting.accountId
+      ?? stripeRouting.account_id
+      ?? stripeRouting.connectedAccountId
+      ?? stripeRouting.connected_account_id
+      ?? store.stripeAccountId
+      ?? store.stripe_account_id
+      ?? store.stripeConnectedAccountId
+      ?? store.stripe_connected_account_id,
+    120,
+  )
+}
+
+function appendReturnQuery(url: string, reference: string) {
+  if (!url) return ''
+  try {
+    const parsed = new URL(url)
+    if (!parsed.searchParams.has('reference')) parsed.searchParams.set('reference', reference)
+    if (!parsed.searchParams.has('provider')) parsed.searchParams.set('provider', 'stripe')
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+function stripeMetadataValue(value: unknown) {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value.slice(0, 500)
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return JSON.stringify(value).slice(0, 500)
+}
+
+function stripeMetadataKey(key: string) {
+  return key.replace(/[^a-zA-Z0-9_]/g, '_').slice(0, 40)
+}
+
+function addMetadata(params: URLSearchParams, prefix: string, metadata: Record<string, unknown>) {
+  Object.entries(metadata).slice(0, 45).forEach(([key, value]) => {
+    const safeKey = stripeMetadataKey(key)
+    if (!safeKey || value === undefined) return
+    params.append(`${prefix}[${safeKey}]`, stripeMetadataValue(value))
+  })
+}
+
+export async function createStripeCheckoutSession(input: StripeSessionInput) {
+  const successUrl = appendReturnQuery(input.callbackUrl || '', input.reference)
+  const cancelUrl = appendReturnQuery(input.cancelUrl || input.callbackUrl || '', input.reference)
+  const metadata = {
+    ...input.metadata,
+    paymentProvider: 'stripe',
+    payment_provider: 'stripe',
+    stripeConnectedAccountId: input.connectedAccountId,
+    applicationFeeAmount: input.applicationFeeAmount,
+  }
+
+  const params = new URLSearchParams()
+  params.append('mode', 'payment')
+  params.append('success_url', successUrl || 'https://sedifex.com/payment/success?provider=stripe')
+  params.append('cancel_url', cancelUrl || 'https://sedifex.com/payment/cancel?provider=stripe')
+  params.append('customer_email', input.email)
+  params.append('client_reference_id', input.reference)
+  params.append('line_items[0][quantity]', '1')
+  params.append('line_items[0][price_data][currency]', input.currency.toLowerCase())
+  params.append('line_items[0][price_data][unit_amount]', String(input.amountMinor))
+  params.append('line_items[0][price_data][product_data][name]', input.description || 'Sedifex checkout')
+  params.append('payment_intent_data[application_fee_amount]', String(input.applicationFeeAmount))
+  params.append('payment_intent_data[metadata][reference]', input.reference)
+  params.append('payment_intent_data[metadata][paymentProvider]', 'stripe')
+  params.append('payment_intent_data[metadata][payment_provider]', 'stripe')
+  addMetadata(params, 'metadata', metadata)
+  addMetadata(params, 'payment_intent_data[metadata]', metadata)
+
+  const response = await fetch('https://api.stripe.com/v1/checkout/sessions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${getStripeSecret()}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Stripe-Account': input.connectedAccountId,
+    },
+    body: params.toString(),
+  })
+  const json = await response.json().catch(() => null) as StripeCheckoutSessionResponse | null
+  if (!response.ok) throw new Error(json?.error?.message || `Stripe checkout session failed (${response.status})`)
+  return json ?? {}
+}
+
+function verifyStripeSignature(req: functions.https.Request) {
+  const secret = getWebhookSecret()
+  if (!secret) throw new Error('Stripe webhook secret is not configured')
+  const header = req.get('stripe-signature') || ''
+  const timestamp = header.split(',').map(part => part.trim()).find(part => part.startsWith('t='))?.slice(2) || ''
+  const signatures = header.split(',').map(part => part.trim()).filter(part => part.startsWith('v1=')).map(part => part.slice(3))
+  if (!timestamp || signatures.length === 0) return false
+  const signedPayload = `${timestamp}.${req.rawBody.toString('utf8')}`
+  const expected = crypto.createHmac('sha256', secret).update(signedPayload).digest('hex')
+  return signatures.some((signature) => signature.length === expected.length && crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected)))
+}
+
+function getFulfillmentType(metadata: Record<string, unknown>) {
+  const value = clean(metadata.fulfillmentType ?? metadata.fulfillment_type ?? metadata.deliveryMethod ?? metadata.delivery_method, 80).toLowerCase()
+  return ['pickup', 'self_pickup', 'collection'].includes(value) ? 'pickup' : 'delivery'
+}
+
+function extractEventDetails(event: StripeEvent) {
+  const object = getRecord(event.data?.object)
+  const metadata = getRecord(object.metadata)
+  const reference = clean(
+    object.client_reference_id
+      ?? metadata.reference
+      ?? metadata.paymentReference
+      ?? metadata.payment_reference
+      ?? metadata.clientOrderId
+      ?? metadata.sedifexOrderId,
+    220,
+  )
+  const storeId = clean(metadata.storeId ?? metadata.merchantId, 180)
+  const amountMinor = numberValue(object.amount_total ?? object.amount_received ?? object.amount)
+  const currency = clean(object.currency, 20).toUpperCase() || clean(metadata.currency, 20).toUpperCase()
+  const paymentIntent = clean(object.payment_intent ?? object.id, 220)
+  return { object, metadata, reference, storeId, amountMinor, currency, paymentIntent }
+}
+
+async function updateStripeIntegrationOrder(event: StripeEvent) {
+  const evtType = event.type || 'unknown'
+  if (!['checkout.session.completed', 'payment_intent.succeeded', 'payment_intent.payment_failed'].includes(evtType)) return false
+
+  const { object, metadata, reference, storeId, amountMinor, currency, paymentIntent } = extractEventDetails(event)
+  if (!reference || !storeId) {
+    functions.logger.warn('Stripe event missing integration order identifiers', { evtType, reference, storeId, metadata })
+    return false
+  }
+
+  const isSuccess = evtType === 'checkout.session.completed' || evtType === 'payment_intent.succeeded'
+  const isFailure = evtType === 'payment_intent.payment_failed'
+  const now = admin.firestore.FieldValue.serverTimestamp()
+  const fulfillmentType = getFulfillmentType(metadata)
+  const amountPaid = amountMinor !== null ? amountMinor / 100 : null
+  const connectedAccountId = event.account || clean(metadata.stripeConnectedAccountId ?? metadata.connectedAccountId, 120) || null
+  const orderUpdate: Record<string, unknown> = {
+    provider: 'stripe',
+    paymentProvider: 'stripe',
+    payment_provider: 'stripe',
+    paymentReference: reference,
+    payment_reference: reference,
+    stripeCheckoutSessionId: evtType === 'checkout.session.completed' ? clean(object.id, 220) || null : null,
+    stripePaymentIntentId: paymentIntent || null,
+    stripeConnectedAccountId: connectedAccountId,
+    stripeStatus: clean(object.status, 80) || null,
+    lastPaymentEvent: evtType,
+    lastPaymentMetadata: metadata,
+    paymentUpdatedAt: now,
+    updatedAt: now,
+  }
+
+  if (amountPaid !== null) orderUpdate.amountPaid = amountPaid
+  if (currency) orderUpdate.currency = currency
+
+  if (isSuccess) {
+    Object.assign(orderUpdate, paidFulfillmentUpdateFields(reference, storeId, fulfillmentType))
+    orderUpdate.paymentStatus = 'paid'
+    orderUpdate.payment_status = 'paid'
+    orderUpdate.paidAt = clean(object.created, 80) || null
+    orderUpdate.paymentConfirmedAt = now
+    orderUpdate.syncStatus = 'pending'
+    orderUpdate.syncRequestedAt = now
+  } else if (isFailure) {
+    Object.assign(orderUpdate, paymentFailedFulfillmentUpdateFields(reference, storeId, fulfillmentType))
+    orderUpdate.paymentStatus = 'failed'
+    orderUpdate.payment_status = 'failed'
+    orderUpdate.paymentFailedAt = now
+  }
+
+  const refs = new Map<string, FirebaseFirestore.DocumentReference>()
+  refs.set(`stores/${storeId}/integrationOrders/${reference}`, defaultDb.collection('stores').doc(storeId).collection('integrationOrders').doc(reference))
+  refs.set(`integrationOrders/${reference}`, defaultDb.collection('integrationOrders').doc(reference))
+
+  const fields = ['reference', 'paymentReference', 'payment_reference', 'clientOrderId', 'client_order_id', 'sedifexOrderId', 'sedifex_order_id', 'stripeCheckoutSessionId', 'stripePaymentIntentId']
+  const identifiers = Array.from(new Set([reference, paymentIntent, clean(object.id, 220)].filter(Boolean)))
+  for (const field of fields) {
+    for (let index = 0; index < identifiers.length; index += 10) {
+      const chunk = identifiers.slice(index, index + 10)
+      if (!chunk.length) continue
+      const snap = await defaultDb.collection('integrationOrders').where(field, 'in', chunk).get()
+      snap.docs.forEach(doc => refs.set(doc.ref.path, doc.ref))
+    }
+  }
+
+  const batch = defaultDb.batch()
+  refs.forEach(ref => batch.set(ref, orderUpdate, { merge: true }))
+  batch.set(defaultDb.collection('stores').doc(storeId).collection('integrationPaymentEvents').doc(`${reference}_${Date.now()}`), {
+    event: evtType,
+    reference,
+    provider: 'stripe',
+    connectedAccountId,
+    data: object,
+    receivedAt: now,
+  })
+  await batch.commit()
+
+  functions.logger.info('Stripe integration payment status updated', {
+    event: evtType,
+    storeId,
+    reference,
+    paymentStatus: isSuccess ? 'paid' : isFailure ? 'failed' : 'pending',
+    matchedCount: refs.size,
+    connectedAccountId,
+  })
+
+  return true
+}
+
+export const stripeConnectWebhook = functions.https.onRequest(async (req, res): Promise<void> => {
+  try {
+    if (req.method !== 'POST') {
+      res.status(405).send('Method Not Allowed')
+      return
+    }
+
+    if (!verifyStripeSignature(req)) {
+      res.status(401).send('Invalid signature')
+      return
+    }
+
+    const event = req.body as StripeEvent
+    await updateStripeIntegrationOrder(event)
+    res.status(200).send('ok')
+  } catch (err) {
+    functions.logger.error('stripeConnectWebhook error', { err })
+    res.status(500).send('error')
+  }
+})


### PR DESCRIPTION
### Motivation
- Enable Europe/global currency payments via Stripe Connect while preserving the existing Paystack flow for Ghana/Africa/GHS and existing Firestore record shapes. 
- Implement platform commission as a configurable default (3%) and use Stripe direct charges so the platform receives `application_fee_amount` while the connected account receives the charge net of Stripe fees.

### Description
- Added `functions/src/stripeConnect.ts` which implements Stripe Checkout Session creation and webhook handling using the Stripe HTTP API via `fetch`, resolves connected accounts from request/store routing, computes the application fee (`calculateApplicationFeeAmount`) from a resolved commission percent (default `3%`), and verifies webhook signatures.  The module avoids adding the Stripe SDK.  
- Updated `functions/src/integrationQuickPayCheckoutCreate.ts` to route integration checkouts to Stripe when `shouldUseStripeForCheckout` selects Stripe (currencies `EUR`, `GBP`, `USD` or explicit routing); it creates a Stripe Checkout Session for direct charges (sets `Stripe-Account` header and `payment_intent_data[application_fee_amount]`) and writes Stripe-specific fields (`stripeCheckoutSessionId`, `stripePaymentIntentId`, `stripeConnectedAccountId`, `stripeConnect` object) while preserving all existing Paystack fields and naming conventions for `integrationOrders`. 
- Kept the Paystack initialize path and split/subaccount logic unchanged for Paystack/GHS requests so existing behavior remains intact. 
- Exported the new `stripeConnectWebhook` from `functions/src/index.ts`. 
- Minor compatibility tweak in `functions/src/dataConsistency.ts` to gracefully read legacy `functions.config()` when present (keeps the repair flow compatible with current typings). 

### Testing
- Built the functions: `npm --prefix functions run build` — succeeded. 
- Type-checked the functions: `cd functions && ./node_modules/.bin/tsc --noEmit --pretty false` — succeeded. 
- Ran the repo test target: `npm --prefix functions test` — failed due to an existing test expectation in `functions/test/bookingNormalization.test.js` (`AssertionError: Expected __testing exports`), which is unrelated to the Stripe changes and reflects an existing test requirement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19fb0e73608321a6cb3ea9a7f09405)