### PR TITLE
Add Europe Stripe Connect payments documentation and integration API updates

### DIFF
--- a/docs/europe-stripe-connect-payments.md
+++ b/docs/europe-stripe-connect-payments.md
@@ -1,0 +1,92 @@
+# Europe Stripe Connect Payments
+
+This guide documents how Sedifex routes European and global online checkout payments through Stripe Connect while keeping the existing Paystack flow for Africa/GHS transactions.
+
+## Overview
+
+Sedifex supports two primary online payment routes:
+
+- **Africa/GHS payments use Paystack.** Ghana cedi (`GHS`) checkouts should continue through Paystack, including Paystack split/subaccount behavior where configured.
+- **Europe and global currencies can use Stripe Connect.** Checkouts in currencies such as `EUR`, `GBP`, and `USD` can be routed to Stripe Connect when the seller has a Stripe connected account.
+- **Sedifex platform commission defaults to 3%.** Unless another supported platform fee percentage is provided, Sedifex applies a 3% platform commission to Stripe Connect checkouts.
+
+Stripe Connect checkouts require a seller-specific connected account ID so Stripe can route the direct charge to the seller account and apply the Sedifex application/platform fee.
+
+## Fee example: EUR 100 checkout
+
+For a customer checkout of **EUR 100**:
+
+1. The customer pays **EUR 100** at Stripe Checkout.
+2. Sedifex applies a **3% platform fee**, so the Sedifex platform fee is **EUR 3**.
+3. Stripe deducts its own processing fee according to the Stripe account, country, card, and payment-method pricing that applies to the transaction.
+4. The seller receives **EUR 100 minus the Stripe fee minus the Sedifex 3% platform fee**.
+
+In formula form:
+
+```txt
+Seller payout = EUR 100 - Stripe processing fee - EUR 3 Sedifex platform fee
+```
+
+## Required Firebase params
+
+Configure these Firebase params before enabling Stripe Connect checkout in production:
+
+```txt
+STRIPE_SECRET_KEY
+STRIPE_WEBHOOK_SECRET
+```
+
+- `STRIPE_SECRET_KEY` is used by the checkout-create flow to create Stripe Checkout Sessions for connected accounts.
+- `STRIPE_WEBHOOK_SECRET` is used by the webhook handler to verify that inbound Stripe webhook requests were signed by Stripe.
+
+## Checkout payload example
+
+A Europe Stripe Connect checkout request should include `paymentProvider: "stripe"`, a supported Stripe currency, the seller's connected account ID, and the Sedifex platform fee percentage.
+
+```json
+{
+  "paymentProvider": "stripe",
+  "currency": "EUR",
+  "amount": 100,
+  "stripeConnectedAccountId": "acct_xxxxxxxxx",
+  "platformFeePercent": 3,
+  "customer": {
+    "email": "client@example.com",
+    "name": "Test Client",
+    "phone": "+49123456789"
+  }
+}
+```
+
+Notes:
+
+- `amount` is the customer-facing checkout total in major currency units. For example, `100` with `EUR` means EUR 100.
+- `stripeConnectedAccountId` must be the seller's Stripe connected account ID, typically beginning with `acct_`.
+- `platformFeePercent` should normally be `3` unless Sedifex intentionally overrides the default commission for that checkout.
+- Production requests must still include the normal Sedifex integration checkout fields required by the calling surface, such as store/merchant identifiers, reference/client order identifiers, items, and return URLs when applicable.
+
+## Provider fallback routing
+
+Sedifex should use the following fallback behavior when `paymentProvider` is not explicitly provided:
+
+- If the checkout currency is `EUR`, `GBP`, or `USD`, route the payment to **Stripe Connect**.
+- If the checkout currency is `GHS`, route the payment to **Paystack**.
+- For other currencies, keep the existing default routing behavior unless a supported provider is explicitly selected.
+
+This means a request with `currency: "EUR"` and no `paymentProvider` should still create a Stripe Connect checkout as long as the seller's `stripeConnectedAccountId` is available.
+
+## Stripe webhook setup
+
+The Stripe webhook URL should point to the exported `stripeWebhook` Firebase function.
+
+Configure Stripe to send relevant checkout and payment-intent events to that function URL. The handler should verify every webhook request using `STRIPE_WEBHOOK_SECRET` before trusting the event payload.
+
+At minimum, the webhook flow must:
+
+1. Receive Stripe events at the deployed `stripeWebhook` function URL.
+2. Read the `Stripe-Signature` request header.
+3. Verify the signature using `STRIPE_WEBHOOK_SECRET` and the raw request body.
+4. Reject requests with missing or invalid signatures.
+5. Only after verification, update the matching Sedifex order/payment state from the Stripe event metadata and payment status.
+
+The exported `stripeConnectWebhook` alias may point to the same implementation, but Stripe dashboard configuration should use the deployed endpoint that Sedifex exposes for `stripeWebhook` unless a separate alias URL is intentionally chosen.

--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -588,6 +588,14 @@ Use `profile` for full website content and `socialLinks` for compact icon/link r
 
 Product purchases should use checkout/order endpoints, not booking endpoints.
 
+### Checkout create endpoint
+
+```http
+POST /integrationCheckoutCreate
+```
+
+Use this endpoint for online payment checkout creation from a website backend. Send the same integration authentication headers described above.
+
 Recommended flow:
 
 1. Customer selects product/service on the website.
@@ -599,6 +607,78 @@ Recommended flow:
 7. Website shows the final order status from Sedifex.
 
 Do not trust totals calculated only in the browser. Always confirm totals server-side with Sedifex before payment.
+
+### Europe/global Stripe Connect checkout
+
+Sedifex supports both the existing Paystack checkout route and the newer Stripe Connect route from the same integration checkout create flow. Use this payment-provider routing when a website creates an online checkout:
+
+- **Africa/GHS:** Ghana cedi (`GHS`) checkouts use Paystack.
+- **Europe/global currencies:** `EUR`, `GBP`, and `USD` checkouts can use Stripe Connect when the seller has a Stripe connected account.
+- **Default Sedifex commission:** Stripe Connect checkouts default to a **3%** Sedifex platform commission unless an allowed override is intentionally supplied.
+
+The Stripe Connect checkout requires the seller's Stripe connected account ID. Sedifex uses that account ID when creating the Stripe Checkout Session and applies the Sedifex platform fee as the application fee.
+
+#### Fee example: EUR 100
+
+For a customer checkout of **EUR 100**:
+
+1. The customer pays **EUR 100**.
+2. Sedifex applies its default **3%** platform fee, so the Sedifex platform fee is **EUR 3**.
+3. Stripe deducts its own processing fee.
+4. The seller receives **EUR 100 minus the Stripe fee minus the Sedifex 3% platform fee**.
+
+```txt
+Seller payout = EUR 100 - Stripe processing fee - EUR 3 Sedifex platform fee
+```
+
+#### Required Firebase params for Stripe
+
+These params must be configured in Firebase Functions before Stripe Connect checkout and webhooks are enabled:
+
+```txt
+STRIPE_SECRET_KEY
+STRIPE_WEBHOOK_SECRET
+```
+
+`STRIPE_SECRET_KEY` is used to create Stripe Checkout Sessions. `STRIPE_WEBHOOK_SECRET` is used to verify Stripe webhook signatures before Sedifex trusts any event payload.
+
+#### Stripe checkout payload example
+
+A website backend can request Stripe explicitly by sending `paymentProvider: "stripe"` with a supported Stripe currency and seller connected account ID:
+
+```json
+{
+  "paymentProvider": "stripe",
+  "currency": "EUR",
+  "amount": 100,
+  "stripeConnectedAccountId": "acct_xxxxxxxxx",
+  "platformFeePercent": 3,
+  "customer": {
+    "email": "client@example.com",
+    "name": "Test Client",
+    "phone": "+49123456789"
+  }
+}
+```
+
+Production checkout-create requests should also include the standard Sedifex integration fields needed by the calling surface, such as `storeId`/`merchantId`, a reference or client order ID, item details, source metadata, and return/cancel URLs when applicable.
+
+#### Provider fallback routing
+
+If `paymentProvider` is not provided, Sedifex should route by currency:
+
+- `EUR`, `GBP`, or `USD` routes to **Stripe Connect**.
+- `GHS` routes to **Paystack**.
+
+If Stripe is selected by explicit provider or fallback routing, the request must provide a valid `stripeConnectedAccountId`; otherwise Sedifex should reject the checkout instead of silently falling back to another provider.
+
+#### Stripe webhook
+
+The Stripe webhook URL should point to the exported `stripeWebhook` Firebase function. Configure Stripe to send checkout/payment events to that deployed function URL. Sedifex must verify the `Stripe-Signature` header with `STRIPE_WEBHOOK_SECRET` and the raw request body before updating order or payment state.
+
+The exported `stripeConnectWebhook` alias may use the same implementation, but integrations should use the Sedifex-deployed `stripeWebhook` endpoint unless a separate alias URL is intentionally configured.
+
+For the standalone payment-operations reference, see `docs/europe-stripe-connect-payments.md`.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Document a new Stripe Connect payment route for Europe/global currencies while preserving Paystack for Africa/GHS transactions.
- Clarify required Firebase params, webhook verification, platform fee defaults, and provider fallback routing for integration consumers.

### Description

- Add `docs/europe-stripe-connect-payments.md` describing overview, fee example, checkout payload example, required Firebase params, provider fallback routing, and webhook setup.
- Update `docs/integration-api-guide.md` to include the `POST /integrationCheckoutCreate` endpoint and a new section explaining Europe/global Stripe Connect checkout flows, payload examples, fee behavior, fallback routing, and webhook requirements.
- Specify the required environment params `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` and the default Sedifex platform commission of `3%` for Stripe Connect checkouts.
- Link the integration guide to the standalone `docs/europe-stripe-connect-payments.md` for detailed reference.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a03c5243083218e099d7ffdfa97f9)