### PR TITLE
Add Stripe Connect routing and Sedifex 3% platform fee to checkout & settlement

### DIFF
--- a/functions/src/integrationQuickPayCheckoutCreate.ts
+++ b/functions/src/integrationQuickPayCheckoutCreate.ts
@@ -122,6 +122,59 @@ function getTransactionChargeMinor(body: CheckoutBody) {
   return value !== null && value > 0 ? Math.round(value) : null
 }
 
+
+function normalizePaymentProvider(value: unknown) {
+  const normalized = clean(value, 80).toLowerCase()
+  return normalized === 'paystack' || normalized === 'stripe' || normalized === 'manual' ? normalized : ''
+}
+
+function hasExplicitPaymentProvider(body: CheckoutBody) {
+  const routing = getRecord(body.paymentRouting)
+  return Boolean(normalizePaymentProvider(body.paymentProvider ?? body.payment_provider ?? body.provider ?? routing.paymentProvider))
+}
+
+function getStorePaymentSettings(storeData: Record<string, unknown>) {
+  const paymentSettings = getRecord(storeData.paymentSettings)
+  const paymentRouting = getRecord(storeData.paymentRouting)
+  return { paymentSettings, paymentRouting }
+}
+
+function getStoreSubaccount(storeData: Record<string, unknown>) {
+  const { paymentSettings, paymentRouting } = getStorePaymentSettings(storeData)
+  return clean(
+    paymentSettings.paystackSubaccountCode
+      ?? paymentRouting.paystackSubaccountCode
+      ?? paymentRouting.subaccountCode
+      ?? storeData.paystackSubaccountCode,
+    140,
+  )
+}
+
+function getStoreStripeConnectedAccount(storeData: Record<string, unknown>) {
+  const { paymentSettings, paymentRouting } = getStorePaymentSettings(storeData)
+  return clean(
+    paymentSettings.stripeConnectedAccountId
+      ?? paymentRouting.stripeConnectedAccountId
+      ?? paymentRouting.connectedAccountId,
+    120,
+  )
+}
+
+function getResolvedPaymentProvider(body: CheckoutBody, storeData: Record<string, unknown>, currency: string) {
+  if (hasExplicitPaymentProvider(body)) return getPaymentProvider(body, currency)
+  const { paymentSettings, paymentRouting } = getStorePaymentSettings(storeData)
+  const storeProvider = normalizePaymentProvider(paymentSettings.provider ?? paymentRouting.provider ?? paymentRouting.paymentProvider)
+  if (storeProvider) return storeProvider
+  return getPaymentProvider({}, currency)
+}
+
+function getResolvedPlatformFeePercent(body: CheckoutBody, storeData: Record<string, unknown>) {
+  const { paymentSettings } = getStorePaymentSettings(storeData)
+  const storePercent = numberValue(paymentSettings.platformFeePercent)
+  if (storePercent !== null) return Math.min(25, Math.max(0, Math.round(storePercent * 100) / 100))
+  return getPlatformFeePercent(body)
+}
+
 function getReturnUrl(body: CheckoutBody) {
   return clean(body.returnUrl ?? body.return_url ?? body.callbackUrl ?? body.callback_url, 700)
 }
@@ -308,7 +361,7 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     const cancelUrl = getCancelUrl(body) || callbackUrl
     const sourceChannel = clean(body.sourceChannel ?? body.source_channel, 80) || 'integration_checkout'
     const sourceLabel = clean(body.sourceLabel ?? body.source_label, 120) || 'Sedifex checkout'
-    const subaccount = getSubaccount(body)
+    const requestSubaccount = getSubaccount(body)
     const transactionChargeMinor = getTransactionChargeMinor(body)
     const details = deriveCheckoutDetails(body)
 
@@ -324,6 +377,13 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       res.status(400).json({ error: 'amount-required' })
       return
     }
+
+    const storeSnap = await defaultDb.collection('stores').doc(storeId).get()
+    const storeData = (storeSnap.data() ?? {}) as Record<string, unknown>
+    const subaccount = requestSubaccount || getStoreSubaccount(storeData)
+    const paymentProvider = getResolvedPaymentProvider(body, storeData, currency)
+    const stripeConnectedAccountId = getStripeConnectedAccount(body) || getStoreStripeConnectedAccount(storeData)
+    const platformFeePercent = getResolvedPlatformFeePercent(body, storeData)
 
     const storedMetadata = {
       ...details.metadata,
@@ -348,14 +408,16 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     }
 
     const amountMinor = Math.round(amountMajor * 100)
-    const paymentProvider = getPaymentProvider(body, currency)
-    const stripeConnectedAccountId = getStripeConnectedAccount(body)
-    const platformFeePercent = getPlatformFeePercent(body)
     const platformFeeMinor = calculatePlatformFeeMinor(amountMinor, platformFeePercent)
     const platformFeeMajor = platformFeeMinor / 100
     const now = admin.firestore.FieldValue.serverTimestamp()
     const nowIso = new Date().toISOString()
     const clientOrderId = clean(body.client_order_id ?? body.clientOrderId, 220) || reference
+
+    if (paymentProvider === 'manual') {
+      res.status(400).json({ error: 'manual-provider-not-supported-for-online-checkout' })
+      return
+    }
 
     if (paymentProvider === 'stripe') {
       if (!stripeConnectedAccountId) {
@@ -464,6 +526,8 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
         sedifexPlatformFeeMajor: platformFeeMajor,
         paymentStatus: 'pending',
         payment_status: 'pending',
+        settlementStatus: 'pending_payment',
+        settlement_status: 'pending_payment',
         orderStatus: 'pending_payment',
         order_status: 'pending_payment',
         status: 'pending_payment',
@@ -595,6 +659,8 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       paystackReference: reference,
       paymentStatus: 'pending',
       payment_status: 'pending',
+      settlementStatus: 'pending_payment',
+      settlement_status: 'pending_payment',
       orderStatus: 'pending_payment',
       order_status: 'pending_payment',
       status: 'pending_payment',

--- a/functions/src/paystackSubaccounts.ts
+++ b/functions/src/paystackSubaccounts.ts
@@ -276,6 +276,11 @@ export const createPaystackMerchantSubaccount = functions.https.onCall(
     await defaultDb.collection('paystackSubaccounts').doc(storeId).set(docPayload, { merge: true })
     await defaultDb.collection('stores').doc(storeId).set(
       {
+        paymentSettings: {
+          paystackSubaccountCode: response.data.subaccount_code,
+          managedBy: 'sedifex',
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        },
         paymentRouting: {
           provider: 'paystack',
           settlementMode: 'subaccount',

--- a/functions/src/stripeConnect.ts
+++ b/functions/src/stripeConnect.ts
@@ -296,6 +296,8 @@ async function updateStripeIntegrationOrder(event: StripeEvent) {
     Object.assign(orderUpdate, paidFulfillmentUpdateFields(reference, storeId, fulfillmentType))
     orderUpdate.paymentStatus = 'paid'
     orderUpdate.payment_status = 'paid'
+    orderUpdate.settlementStatus = 'pending_settlement'
+    orderUpdate.settlement_status = 'pending_settlement'
     orderUpdate.orderStatus = 'confirmed'
     orderUpdate.order_status = 'confirmed'
     orderUpdate.status = 'confirmed'
@@ -305,6 +307,8 @@ async function updateStripeIntegrationOrder(event: StripeEvent) {
     Object.assign(orderUpdate, paymentFailedFulfillmentUpdateFields(reference, storeId, fulfillmentType))
     orderUpdate.paymentStatus = 'failed'
     orderUpdate.payment_status = 'failed'
+    orderUpdate.settlementStatus = 'payment_failed'
+    orderUpdate.settlement_status = 'payment_failed'
     orderUpdate.orderStatus = 'payment_failed'
     orderUpdate.order_status = 'payment_failed'
     orderUpdate.status = 'payment_failed'

--- a/web/src/pages/PaymentSettlement.tsx
+++ b/web/src/pages/PaymentSettlement.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { doc, onSnapshot, serverTimestamp, setDoc } from 'firebase/firestore'
+import { getIdTokenResult } from 'firebase/auth'
 import { httpsCallable } from 'firebase/functions'
-import { functions } from '../firebase'
+import { db, functions } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useMemberships } from '../hooks/useMemberships'
 import { useToast } from '../components/ToastProvider'
+import { useAuthUser } from '../hooks/useAuthUser'
 import './AccountOverview.css'
 
 type SetupStatus = {
@@ -15,6 +18,50 @@ type SetupStatus = {
   percentageCharge?: number | null
   active?: boolean | number | null
   isVerified?: boolean | null
+}
+
+
+type PaymentSettings = {
+  enabled?: boolean
+  approvalStatus?: 'pending' | 'active' | 'disabled' | string
+  region?: 'africa' | 'europe' | 'global' | string
+  provider?: 'paystack' | 'stripe' | 'manual' | string
+  platformFeePercent?: number | null
+  feePaidBy?: 'seller' | string
+  paystackSubaccountCode?: string | null
+  stripeConnectedAccountId?: string | null
+  managedBy?: string | null
+  adminNote?: string | null
+}
+
+type StoreDocument = {
+  paymentSettings?: PaymentSettings
+  paymentRouting?: Record<string, unknown>
+  paystackSubaccountCode?: string | null
+}
+
+const defaultPaymentSettings: Required<Pick<PaymentSettings, 'enabled' | 'approvalStatus' | 'region' | 'provider' | 'platformFeePercent' | 'feePaidBy'>> = {
+  enabled: true,
+  approvalStatus: 'pending',
+  region: 'africa',
+  provider: 'paystack',
+  platformFeePercent: 3,
+  feePaidBy: 'seller',
+}
+
+function asText(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function readPaymentSettings(store: StoreDocument | null, status: SetupStatus | null): PaymentSettings {
+  const settings = store?.paymentSettings ?? {}
+  const routing = store?.paymentRouting ?? {}
+  return {
+    ...defaultPaymentSettings,
+    ...settings,
+    paystackSubaccountCode: asText(settings.paystackSubaccountCode ?? routing.paystackSubaccountCode ?? store?.paystackSubaccountCode ?? status?.subaccountCode, '') || null,
+    stripeConnectedAccountId: asText(settings.stripeConnectedAccountId ?? routing.stripeConnectedAccountId, '') || null,
+  }
 }
 
 type SettlementBankOption = {
@@ -50,6 +97,7 @@ const digitsOnly = (value: string, max: number) => value.replace(/\D/g, '').slic
 
 export default function PaymentSettlement() {
   const { storeId, isLoading: storeLoading, error: storeError } = useActiveStore()
+  const user = useAuthUser()
   const { memberships } = useMemberships()
   const { publish } = useToast()
   const [businessName, setBusinessName] = useState('')
@@ -61,6 +109,10 @@ export default function PaymentSettlement() {
   const [contactName, setContactName] = useState('')
   const [contactPhone, setContactPhone] = useState('')
   const [status, setStatus] = useState<SetupStatus | null>(null)
+  const [storeDocument, setStoreDocument] = useState<StoreDocument | null>(null)
+  const [adminForm, setAdminForm] = useState<PaymentSettings>(defaultPaymentSettings)
+  const [isSedifexAdmin, setIsSedifexAdmin] = useState(false)
+  const [isSavingAdminSettings, setIsSavingAdminSettings] = useState(false)
   const [bankOptions, setBankOptions] = useState<SettlementBankOption[]>([])
   const [isLoadingBanks, setIsLoadingBanks] = useState(false)
   const [isLoadingStatus, setIsLoadingStatus] = useState(false)
@@ -72,7 +124,9 @@ export default function PaymentSettlement() {
     return memberships.find(member => member.storeId === storeId) ?? null
   }, [memberships, storeId])
   const isOwner = activeMembership?.role === 'owner'
+  const canManageSettlement = isOwner || isSedifexAdmin
   const template = paymentTemplates[paymentType]
+  const currentPaymentSettings = useMemo(() => readPaymentSettings(storeDocument, status), [status, storeDocument])
 
   const filteredOptions = useMemo(() => {
     const selectedType = paymentType === 'mobile_money' ? 'mobile_money' : 'bank'
@@ -83,6 +137,41 @@ export default function PaymentSettlement() {
   const selectedOption = useMemo(() => {
     return bankOptions.find(option => option.code === selectedBankCode) ?? null
   }, [bankOptions, selectedBankCode])
+
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadClaims() {
+      if (!user) {
+        setIsSedifexAdmin(false)
+        return
+      }
+      try {
+        const token = await getIdTokenResult(user)
+        const email = user.email?.toLowerCase() ?? ''
+        const adminClaim = token.claims.admin === true || token.claims.sedifexAdmin === true
+        if (!cancelled) setIsSedifexAdmin(adminClaim || email.endsWith('@sedifex.com'))
+      } catch {
+        if (!cancelled) setIsSedifexAdmin((user.email?.toLowerCase() ?? '').endsWith('@sedifex.com'))
+      }
+    }
+    void loadClaims()
+    return () => { cancelled = true }
+  }, [user])
+
+  useEffect(() => {
+    if (!storeId) {
+      setStoreDocument(null)
+      return undefined
+    }
+    return onSnapshot(doc(db, 'stores', storeId), snapshot => {
+      setStoreDocument((snapshot.data() ?? {}) as StoreDocument)
+    })
+  }, [storeId])
+
+  useEffect(() => {
+    setAdminForm(currentPaymentSettings)
+  }, [currentPaymentSettings])
 
   async function refreshSubaccount() {
     if (!storeId || !isOwner) {
@@ -176,6 +265,57 @@ export default function PaymentSettlement() {
     }
   }
 
+
+  async function handleSaveAdminSettings(event: React.FormEvent) {
+    event.preventDefault()
+    if (!storeId || !isSedifexAdmin) return
+    const platformFeePercent = Number(adminForm.platformFeePercent ?? 3)
+    if (!Number.isFinite(platformFeePercent) || platformFeePercent < 0 || platformFeePercent > 25) {
+      setErrorMessage('Platform fee percent must be between 0 and 25.')
+      return
+    }
+    try {
+      setIsSavingAdminSettings(true)
+      setErrorMessage('')
+      const paystackSubaccountCode = asText(adminForm.paystackSubaccountCode, '') || null
+      const stripeConnectedAccountId = asText(adminForm.stripeConnectedAccountId, '') || null
+      await setDoc(doc(db, 'stores', storeId), {
+        paymentSettings: {
+          enabled: adminForm.enabled === true,
+          approvalStatus: adminForm.approvalStatus || 'pending',
+          region: adminForm.region || 'africa',
+          provider: adminForm.provider || 'paystack',
+          platformFeePercent,
+          feePaidBy: 'seller',
+          paystackSubaccountCode,
+          stripeConnectedAccountId,
+          managedBy: 'sedifex',
+          updatedBy: 'sedifex_admin',
+          adminNote: asText(adminForm.adminNote, '') || null,
+          updatedAt: serverTimestamp(),
+        },
+        paymentRouting: {
+          provider: adminForm.provider || 'paystack',
+          paymentProvider: adminForm.provider || 'paystack',
+          paystackSubaccountCode,
+          stripeConnectedAccountId,
+          percentageCharge: platformFeePercent,
+          commissionControlledBy: 'sedifex',
+          status: adminForm.approvalStatus || 'pending',
+          updatedAt: serverTimestamp(),
+        },
+        paystackSubaccountCode,
+        updatedAt: serverTimestamp(),
+      }, { merge: true })
+      publish({ message: 'Europe and platform payment routing saved.', tone: 'success' })
+    } catch (error) {
+      console.error('[payment-settlement] admin payment routing save failed', error)
+      setErrorMessage('Unable to save admin payment routing settings.')
+    } finally {
+      setIsSavingAdminSettings(false)
+    }
+  }
+
   if (storeError) return <div role="alert">{storeError}</div>
 
   return (
@@ -184,8 +324,8 @@ export default function PaymentSettlement() {
       <p className="account-overview__subtitle">Add where store payouts should settle after Sedifex online checkout.</p>
       {storeLoading ? <p>Loading workspace…</p> : null}
       {!storeId && !storeLoading ? <p>Select a workspace to configure settlement.</p> : null}
-      {storeId && !isOwner ? <div className="account-overview__error" role="alert">Only the workspace owner can set up settlement.</div> : null}
-      {storeId && isOwner ? (
+      {storeId && !canManageSettlement ? <div className="account-overview__error" role="alert">Only the workspace owner or Sedifex admin can set up settlement.</div> : null}
+      {storeId && canManageSettlement ? (
         <>
           <section aria-labelledby="settlement-status">
             <div className="account-overview__section-header">
@@ -203,6 +343,44 @@ export default function PaymentSettlement() {
               <div><dt>Verified</dt><dd>{status?.isVerified === true ? 'Yes' : status?.isVerified === false ? 'No' : '—'}</dd></div>
             </dl>
           </section>
+
+          <section aria-labelledby="store-payment-routing">
+            <div className="account-overview__section-header">
+              <h2 id="store-payment-routing">Payment routing status</h2>
+              <p className="account-overview__hint">Sedifex controls provider, payout account, approval, and platform fee settings.</p>
+            </div>
+            <dl className="account-overview__grid">
+              <div><dt>Provider</dt><dd>{currentPaymentSettings.provider ?? 'paystack'}</dd></div>
+              <div><dt>Payment status</dt><dd>{currentPaymentSettings.enabled ? currentPaymentSettings.approvalStatus ?? 'pending' : 'disabled'}</dd></div>
+              <div><dt>Sedifex fee percent</dt><dd>{typeof currentPaymentSettings.platformFeePercent === 'number' ? `${currentPaymentSettings.platformFeePercent}%` : '3%'}</dd></div>
+              <div><dt>Connected payout status</dt><dd>{currentPaymentSettings.provider === 'stripe' ? (currentPaymentSettings.stripeConnectedAccountId ? 'Stripe connected' : 'Stripe account missing') : currentPaymentSettings.paystackSubaccountCode ? 'Paystack subaccount connected' : 'Paystack setup pending'}</dd></div>
+            </dl>
+            <p className="account-overview__hint">Estimated deduction: Customer payment - gateway fee - Sedifex platform fee = seller payout.</p>
+          </section>
+
+          {isSedifexAdmin ? (
+            <section aria-labelledby="platform-routing">
+              <div className="account-overview__section-header">
+                <h2 id="platform-routing">Europe &amp; Platform Payment Routing</h2>
+                <p className="account-overview__hint">Sedifex-team controls for Paystack, Stripe Connect, manual routing, splits, approval, and the default 3% platform fee.</p>
+              </div>
+              <form className="account-overview__profile-form" onSubmit={handleSaveAdminSettings}>
+                <div className="account-overview__form-grid">
+                  <label><span>Payment enabled</span><select value={adminForm.enabled ? 'true' : 'false'} onChange={event => setAdminForm(prev => ({ ...prev, enabled: event.target.value === 'true' }))}><option value="true">Enabled</option><option value="false">Disabled</option></select></label>
+                  <label><span>Approval status</span><select value={adminForm.approvalStatus ?? 'pending'} onChange={event => setAdminForm(prev => ({ ...prev, approvalStatus: event.target.value }))}><option value="pending">Pending</option><option value="active">Active</option><option value="disabled">Disabled</option></select></label>
+                  <label><span>Region</span><select value={adminForm.region ?? 'africa'} onChange={event => setAdminForm(prev => ({ ...prev, region: event.target.value }))}><option value="africa">Africa</option><option value="europe">Europe</option><option value="global">Global</option></select></label>
+                  <label><span>Provider</span><select value={adminForm.provider ?? 'paystack'} onChange={event => setAdminForm(prev => ({ ...prev, provider: event.target.value }))}><option value="paystack">Paystack</option><option value="stripe">Stripe</option><option value="manual">Manual</option></select></label>
+                  <label><span>Platform fee percent</span><input type="number" min="0" max="25" step="0.01" value={adminForm.platformFeePercent ?? 3} onChange={event => setAdminForm(prev => ({ ...prev, platformFeePercent: Number(event.target.value) }))} /></label>
+                  <label><span>Fee paid by</span><input value="Seller" readOnly /></label>
+                  <label><span>Paystack subaccount code</span><input value={adminForm.paystackSubaccountCode ?? ''} onChange={event => setAdminForm(prev => ({ ...prev, paystackSubaccountCode: event.target.value }))} placeholder="ACCT_xxxxx" /></label>
+                  <label><span>Stripe connected account ID</span><input value={adminForm.stripeConnectedAccountId ?? ''} onChange={event => setAdminForm(prev => ({ ...prev, stripeConnectedAccountId: event.target.value }))} placeholder="acct_xxxxx" /></label>
+                  <label style={{ gridColumn: '1 / -1' }}><span>Notes/internal admin note</span><textarea value={adminForm.adminNote ?? ''} onChange={event => setAdminForm(prev => ({ ...prev, adminNote: event.target.value }))} rows={3} /></label>
+                </div>
+                <div className="account-overview__actions"><p className="account-overview__hint">Store owners can view these settings, but cannot edit provider, split, approval, or Sedifex fee controls.</p><button type="submit" className="button button--primary" disabled={isSavingAdminSettings}>{isSavingAdminSettings ? 'Saving…' : 'Save routing settings'}</button></div>
+              </form>
+            </section>
+          ) : null}
+
           <section aria-labelledby="settlement-form">
             <div className="account-overview__section-header"><h2 id="settlement-form">Create or update setup</h2><p className="account-overview__hint">Choose bank or mobile money to auto-fill the Paystack routing code. Manual code entry remains available if a provider is missing.</p></div>
             <form className="account-overview__profile-form" onSubmit={handleSubmit}>

--- a/web/src/pages/reports/SettlementReport.tsx
+++ b/web/src/pages/reports/SettlementReport.tsx
@@ -14,13 +14,17 @@ type SettlementRow = {
   grossAmount: number
   baseAmount: number
   customerProcessingFee: number
+  gatewayProvider: string
+  gatewayFee: number
   sedifexCommission: number
   merchantNet: number
   currency: string
   paymentStatus: string
+  settlementStatus: string
   orderStatus: string
   paymentCollectionMode: string
   subaccountCode: string
+  stripeConnectedAccountId: string
   splitEnabled: boolean
   transactionCharge: number
   createdAt: Date | null
@@ -121,12 +125,48 @@ function readPaystackSplit(data: Record<string, unknown>) {
   }
 }
 
+
+function readPaymentProvider(data: Record<string, unknown>) {
+  const payment = getNestedObject(data, 'payment')
+  const fees = readMarketplaceFees(data)
+  const stripeConnect = getNestedObject(data, 'stripeConnect')
+  const paystackSplit = getNestedObject(data, 'paystackSplit')
+  const provider = asText(data.paymentProvider ?? data.payment_provider ?? data.provider ?? payment.provider ?? fees.provider, '').toLowerCase()
+  if (provider) return provider
+  if (asText(data.stripeConnectedAccountId ?? stripeConnect.connectedAccountId, '')) return 'stripe'
+  if (paystackSplit.enabled === true || asText(data.paystackReference, '')) return 'paystack'
+  return 'unknown'
+}
+
+function readStripeConnectedAccountId(data: Record<string, unknown>) {
+  const stripeConnect = getNestedObject(data, 'stripeConnect')
+  return asText(data.stripeConnectedAccountId ?? stripeConnect.connectedAccountId, '')
+}
+
+function readGatewayFee(data: Record<string, unknown>) {
+  const payment = getNestedObject(data, 'payment')
+  const fees = readMarketplaceFees(data)
+  const gatewayFees = getNestedObject(data, 'gatewayFees')
+  return firstNonZero(
+    readMinorAsMajor(data.gatewayFeeMinor),
+    readMinorAsMajor(data.stripeFeeMinor),
+    readMinorAsMajor(data.paystackFeeMinor),
+    readMinorAsMajor(fees.gatewayFeeMinor),
+    readMinorAsMajor(fees.paymentGatewayFeeMinor),
+    readMinorAsMajor(gatewayFees.gatewayFeeMinor),
+    asNumber(data.gatewayFee ?? payment.gatewayFee, 0),
+  )
+}
+
 function readSedifexCommission(data: Record<string, unknown>) {
   const payment = getNestedObject(data, 'payment')
   const feePolicy = getNestedObject(data, 'feePolicy')
   const fees = readMarketplaceFees(data)
   const split = readPaystackSplit(data)
   return firstNonZero(
+    readMinorAsMajor(data.sedifexPlatformFeeMinor),
+    readMinorAsMajor(fees.platformFeeMinor),
+    readMinorAsMajor(fees.sedifexPlatformFeeMinor),
     split.transactionCharge,
     readMinorAsMajor(fees.sedifexCommissionMinor),
     asNumber(payment.sedifexCommission ?? payment.sedifexCommissionMajor, 0),
@@ -145,7 +185,7 @@ function readMerchantNet(data: Record<string, unknown>) {
     readMinorAsMajor(fees.estimatedMerchantNetMinor),
   )
   if (explicit > 0) return explicit
-  return Math.max(0, readBaseAmount(data) - readSedifexCommission(data))
+  return Math.max(0, readAmount(data) - readGatewayFee(data) - readSedifexCommission(data))
 }
 
 function isOnlineCheckout(data: Record<string, unknown>) {
@@ -165,6 +205,8 @@ function mapSettlementRow(id: string, collectionName: 'integrationOrders' | 'int
   const sourceChannel = normalizeSourceChannel(data.sourceChannel ?? data.source_channel ?? data.source)
   const paymentStatus = asText(data.paymentStatus ?? data.payment_status ?? payment.status, 'pending')
   const split = readPaystackSplit(data)
+  const provider = readPaymentProvider(data)
+  const stripeConnectedAccountId = readStripeConnectedAccountId(data)
   return {
     id,
     collectionName,
@@ -175,14 +217,18 @@ function mapSettlementRow(id: string, collectionName: 'integrationOrders' | 'int
     grossAmount: readAmount(data),
     baseAmount: readBaseAmount(data),
     customerProcessingFee: readCustomerProcessingFee(data),
+    gatewayProvider: provider,
+    gatewayFee: readGatewayFee(data),
     sedifexCommission: readSedifexCommission(data),
     merchantNet: readMerchantNet(data),
     currency: readCurrency(data),
     paymentStatus,
+    settlementStatus: asText(data.settlementStatus ?? data.settlement_status, 'pending'),
     orderStatus: asText(data.orderStatus ?? data.order_status ?? data.bookingStatus, 'pending'),
     paymentCollectionMode: asText(data.paymentCollectionMode ?? payment.mode, 'online_checkout'),
     subaccountCode: split.subaccount,
-    splitEnabled: split.enabled,
+    stripeConnectedAccountId,
+    splitEnabled: provider === 'stripe' ? Boolean(stripeConnectedAccountId) : split.enabled,
     transactionCharge: split.transactionCharge,
     createdAt: toDate(data.createdAtServer ?? data.createdAt),
   }
@@ -260,14 +306,18 @@ export default function SettlementReport() {
       grossAmount: row.grossAmount,
       baseAmount: row.baseAmount,
       customerProcessingFee: row.customerProcessingFee,
+      gatewayProvider: row.gatewayProvider,
+      gatewayFee: row.gatewayFee,
       sedifexCommission: row.sedifexCommission,
       merchantNet: row.merchantNet,
       currency: row.currency,
       paymentStatus: row.paymentStatus,
+      settlementStatus: row.settlementStatus,
       orderStatus: row.orderStatus,
       paymentCollectionMode: row.paymentCollectionMode,
-      splitEnabled: row.splitEnabled ? 'yes' : 'no',
+      routingEnabled: row.splitEnabled ? 'yes' : 'no',
       subaccountCode: row.subaccountCode,
+      stripeConnectedAccountId: row.stripeConnectedAccountId,
       date: formatDate(row.createdAt),
     })))
   }
@@ -300,14 +350,14 @@ export default function SettlementReport() {
       <section className="workspace-card">
         <p className="workspace-eyebrow">Reports / Settlement</p>
         <h1>Settlement report</h1>
-        <p className="workspace-muted">Track gross online payments, customer processing fees, Sedifex commission, Paystack split status, and expected merchant settlement.</p>
+        <p className="workspace-muted">Track gross online payments, provider fees, Sedifex platform fees, Stripe/Paystack routing status, and expected merchant settlement.</p>
       </section>
 
       <section className="workspace-grid workspace-grid--four">
         <article className="workspace-card"><strong>{formatMoney(totals.gross, totals.currency)}</strong><span>Gross paid/selected</span></article>
         <article className="workspace-card"><strong>{formatMoney(totals.commission, totals.currency)}</strong><span>Sedifex commission</span></article>
         <article className="workspace-card"><strong>{formatMoney(totals.merchantNet, totals.currency)}</strong><span>Expected merchant net</span></article>
-        <article className="workspace-card"><strong>{totals.missingSplit}</strong><span>Online records missing split</span></article>
+        <article className="workspace-card"><strong>{totals.missingSplit}</strong><span>Online records missing routing</span></article>
       </section>
 
       <section className="workspace-card">
@@ -353,7 +403,7 @@ export default function SettlementReport() {
           <article className="workspace-card"><strong>{totals.records}</strong><span>Selected records</span></article>
           <article className="workspace-card"><strong>{totals.paidRecords}</strong><span>Paid/confirmed records</span></article>
           <article className="workspace-card"><strong>{totals.splitEnabled}</strong><span>Split enabled</span></article>
-          <article className="workspace-card"><strong>{formatMoney(totals.customerFees, totals.currency)}</strong><span>Customer processing fees</span></article>
+          <article className="workspace-card"><strong>{formatMoney(totals.customerFees, totals.currency)}</strong><span>Gateway/customer fees</span></article>
         </div>
 
         <div className="workspace-table-wrap">
@@ -361,12 +411,12 @@ export default function SettlementReport() {
             <thead>
               <tr>
                 <th>Reference</th>
-                <th>Source</th>
-                <th>Gross</th>
-                <th>Fees / commission</th>
-                <th>Merchant net</th>
-                <th>Split</th>
-                <th>Status</th>
+                <th>Store / source</th>
+                <th>Gross amount</th>
+                <th>Gateway / fees</th>
+                <th>Net seller payout estimate</th>
+                <th>Routing</th>
+                <th>Payment / settlement</th>
                 <th>Date</th>
               </tr>
             </thead>
@@ -376,10 +426,10 @@ export default function SettlementReport() {
                   <td><strong>{row.reference}</strong><br /><small>{row.collectionName === 'integrationBookings' ? 'Service booking' : 'Product order'}</small></td>
                   <td>{row.sourceLabel}<br /><small>{row.customerName}</small></td>
                   <td>{formatMoney(row.grossAmount, row.currency)}<br /><small>Base: {formatMoney(row.baseAmount, row.currency)}</small></td>
-                  <td>{formatMoney(row.sedifexCommission, row.currency)}<br /><small>Customer fee: {formatMoney(row.customerProcessingFee, row.currency)}</small></td>
+                  <td><strong>{row.gatewayProvider}</strong><br /><small>Gateway fee: {formatMoney(row.gatewayFee || row.customerProcessingFee, row.currency)}</small><br /><small>Sedifex fee: {formatMoney(row.sedifexCommission, row.currency)}</small></td>
                   <td>{formatMoney(row.merchantNet, row.currency)}</td>
-                  <td>{row.splitEnabled ? 'Enabled' : 'Missing'}<br /><small>{row.subaccountCode || 'No subaccount'}</small></td>
-                  <td>{row.paymentStatus}<br /><small>{row.orderStatus}</small></td>
+                  <td>{row.splitEnabled ? 'Connected' : 'Missing'}<br /><small>{row.gatewayProvider === 'stripe' ? row.stripeConnectedAccountId || 'No Stripe account' : row.subaccountCode || 'No subaccount'}</small></td>
+                  <td>{row.paymentStatus}<br /><small>{row.settlementStatus}</small><br /><small>{row.orderStatus}</small></td>
                   <td>{formatDate(row.createdAt)}</td>
                 </tr>
               ))}


### PR DESCRIPTION
### Motivation
- Enable Europe/global payments via Stripe Connect while keeping Paystack for Africa and preserving existing Paystack subaccount/split behavior. 
- Surface Sedifex-controlled platform fee and routing settings in the existing Payments / Settlement UI so admins can manage Europe & platform routing and stores can view read-only routing details.

### Description
- Resolve payment provider in `integrationCheckoutCreate` by: using an explicit `paymentProvider` if provided, else `stores/{storeId}.paymentSettings.provider`, else currency defaults (EUR/GBP/USD → Stripe, otherwise Paystack), and fall back to existing logic; read store-level `paystackSubaccountCode` and `stripeConnectedAccountId` when available. (functions/src/integrationQuickPayCheckoutCreate.ts)
- Add Stripe Connect checkout flow: create Stripe Connect Checkout session using `Stripe-Account` header and `application_fee_amount`, persist session ids and Sedifex platform fee fields on `integrationOrders` and store subcollection, and mark new orders with `paymentStatus: pending` and `settlementStatus: pending_payment`. (functions/src/stripeConnect.ts, functions/src/integrationQuickPayCheckoutCreate.ts)
- Update Stripe webhook handling so successful payments set orders to `paymentStatus: paid`, `orderStatus: confirmed`, `settlementStatus: pending_settlement`, and failures set `paymentStatus: failed`, `orderStatus: payment_failed`, `settlementStatus: payment_failed`. (functions/src/stripeConnect.ts)
- Preserve Paystack behavior and add `paymentSettings` writes when creating Paystack subaccounts so store doc contains `paymentSettings.paystackSubaccountCode`. (functions/src/paystackSubaccounts.ts)
- Extend Payments / Settlement admin page to show a Sedifex-team/admin-only section titled “Europe & Platform Payment Routing” with fields: Payment enabled, Approval status, Region, Provider, Platform fee percent (default 3), Fee paid by (Seller), Paystack subaccount code, Stripe connected account ID, and Notes; store owners see read-only provider, payment status, Sedifex fee percent, connected payout status, and an estimated-deduction explanation. (web/src/pages/PaymentSettlement.tsx)
- Update Settlement report UI and mapping so Stripe and Paystack orders appear together showing gross amount, gateway/provider, gateway fee (when known), Sedifex platform fee, net seller payout estimate, settlement status, payment status, reference, store/source, and date. (web/src/pages/reports/SettlementReport.tsx)
- Add helpers and small data-model fields (e.g., `sedifexPlatformFeeMinor`, `settlementStatus`) used by checkout and webhook flows; keep Paystack webhook/flow intact.

### Testing
- Built Cloud Functions: ran `npm run build` in `functions` and it completed successfully. ✅
- Performed repository checks: `git diff --check` reported no issues. ✅
- Attempted web build: `npm run build` in `web` failed because `node_modules` are not present and `npm install` is blocked in this environment (registry 403 for a dependency), so the frontend TypeScript build could not be completed here. ⚠️
- No automated runtime webhook/integration tests were executed in this environment; server-side TypeScript compiled without errors. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a06896bc08321bb3be307dd777bc0)