### PR TITLE
Update checkout payment routing to auto-resolve Stripe settings

### DIFF
--- a/functions/src/integrationQuickPayCheckoutCreate.ts
+++ b/functions/src/integrationQuickPayCheckoutCreate.ts
@@ -4,7 +4,6 @@ import { admin, defaultDb } from './firestore'
 import {
   calculatePlatformFeeMinor,
   getPaymentProvider,
-  getPlatformFeePercent,
   getStripeConnectedAccount,
   initializeStripeConnectCheckout,
 } from './stripeConnect'
@@ -150,29 +149,55 @@ function getStoreSubaccount(storeData: Record<string, unknown>) {
   )
 }
 
+function clampPlatformFeePercent(value: number) {
+  return Math.min(25, Math.max(0, Math.round(value * 100) / 100))
+}
+
 function getStoreStripeConnectedAccount(storeData: Record<string, unknown>) {
-  const { paymentSettings, paymentRouting } = getStorePaymentSettings(storeData)
-  return clean(
-    paymentSettings.stripeConnectedAccountId
-      ?? paymentRouting.stripeConnectedAccountId
-      ?? paymentRouting.connectedAccountId,
-    120,
-  )
+  const { paymentSettings } = getStorePaymentSettings(storeData)
+  return clean(paymentSettings.stripeConnectedAccountId, 120)
 }
 
 function getResolvedPaymentProvider(body: CheckoutBody, storeData: Record<string, unknown>, currency: string) {
   if (hasExplicitPaymentProvider(body)) return getPaymentProvider(body, currency)
-  const { paymentSettings, paymentRouting } = getStorePaymentSettings(storeData)
-  const storeProvider = normalizePaymentProvider(paymentSettings.provider ?? paymentRouting.provider ?? paymentRouting.paymentProvider)
+
+  const { paymentSettings } = getStorePaymentSettings(storeData)
+  const storeProvider = normalizePaymentProvider(paymentSettings.provider)
   if (storeProvider) return storeProvider
+
   return getPaymentProvider({}, currency)
 }
 
+function getRequestPlatformFeePercent(body: CheckoutBody) {
+  const paymentRouting = getRecord(body.paymentRouting)
+  const marketplaceFees = getRecord(body.marketplaceFees ?? body.marketplace_fees)
+  const splitPayment = getRecord(body.splitPayment)
+  const requested = numberValue(
+    body.platformFeePercent
+      ?? body.platform_fee_percent
+      ?? paymentRouting.platformFeePercent
+      ?? marketplaceFees.platformFeePercent
+      ?? splitPayment.platformFeePercent,
+  )
+  return requested !== null ? clampPlatformFeePercent(requested) : null
+}
+
 function getResolvedPlatformFeePercent(body: CheckoutBody, storeData: Record<string, unknown>) {
+  const requestPercent = getRequestPlatformFeePercent(body)
+  if (requestPercent !== null) return requestPercent
+
   const { paymentSettings } = getStorePaymentSettings(storeData)
   const storePercent = numberValue(paymentSettings.platformFeePercent)
-  if (storePercent !== null) return Math.min(25, Math.max(0, Math.round(storePercent * 100) / 100))
-  return getPlatformFeePercent(body)
+  if (storePercent !== null) return clampPlatformFeePercent(storePercent)
+
+  return 3
+}
+
+function isStripeActive(storeData: Record<string, unknown>, stripeConnectedAccountId: string) {
+  const { paymentSettings } = getStorePaymentSettings(storeData)
+  return paymentSettings.enabled === true
+    && clean(paymentSettings.approvalStatus, 80).toLowerCase() === 'active'
+    && Boolean(stripeConnectedAccountId)
 }
 
 function getReturnUrl(body: CheckoutBody) {
@@ -420,8 +445,11 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     }
 
     if (paymentProvider === 'stripe') {
-      if (!stripeConnectedAccountId) {
-        res.status(400).json({ error: 'stripe-connected-account-required' })
+      if (!isStripeActive(storeData, stripeConnectedAccountId)) {
+        res.status(400).json({
+          error: 'stripe-not-active',
+          message: 'Stripe payments are not active for this store.',
+        })
         return
       }
 


### PR DESCRIPTION
### Motivation

- Make the public website no longer responsible for providing `stripeConnectedAccountId` for checkout creation by resolving Stripe settings from store data when absent in the request. 
- Prefer explicit request-level routing when present, fall back to `stores/{storeId}.paymentSettings.provider`, and then to currency-based defaults. 
- Ensure Stripe checkouts only proceed when the store's Stripe settings are active and configured, returning a clear `stripe-not-active` error otherwise.

### Description

- Add `clampPlatformFeePercent`, `getRequestPlatformFeePercent`, and `isStripeActive` helpers, and simplify `getStoreStripeConnectedAccount` to read the value from `store.paymentSettings.stripeConnectedAccountId`.
- Update `getResolvedPaymentProvider` to prefer an explicit request provider, then `store.paymentSettings.provider`, then currency defaults using existing logic in `getPaymentProvider`.
- Change `getResolvedPlatformFeePercent` to prefer a request-sent platform fee, then the store setting, then default to `3` percent, and apply clamping to the resolved percent.
- Gate Stripe flows with `isStripeActive(storeData, stripeConnectedAccountId)` and return `{ error: 'stripe-not-active', message: 'Stripe payments are not active for this store.' }` when Stripe cannot be used, while preserving existing Paystack behavior (including subaccount fallback) and keeping Stripe record fields and settlement status in the pending order.

### Testing

- Ran `npm run build` in `functions` and the TypeScript build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a12a17f0883219846fe847c5a70cf)