### PR TITLE
Persist edited hero slide image uploads

### DIFF
--- a/web/src/pages/WebsiteHeroSlides.tsx
+++ b/web/src/pages/WebsiteHeroSlides.tsx
@@ -261,13 +261,26 @@ export default function WebsiteHeroSlides() {
     setUploading(true)
     setMessage('')
     try {
+      const isEditingExistingSlide = Boolean(editingId && draft.id)
       const slideId = draft.id || `slide-${Date.now()}`
       const filename = `${safePathSegment(draft.title || slideId)}-${Date.now()}${fileExtension(imageFile)}`
       const imagePath = `stores/${storeId}/hero-slides/${slideId}/${filename}`
       const url = await uploadProductImage(imageFile, { storagePath: imagePath })
+      const imageUpdate = { imageUrl: url, imagePath, updatedAt: new Date().toISOString() }
+
+      if (isEditingExistingSlide) {
+        await setDoc(doc(db, 'stores', storeId, COLLECTION_NAME, slideId), imageUpdate, { merge: true })
+        setSlides(current => sortSlides(current.map(slide => slide.id === slideId ? { ...slide, ...imageUpdate } : slide)))
+      }
+
       setDraft(current => ({ ...current, imageUrl: url, imagePath }))
       setImageFile(null)
-      publish({ message: 'Hero slide image uploaded. Fill the text fields, then save the slide.', tone: 'success' })
+      publish({
+        message: isEditingExistingSlide
+          ? 'Hero slide image uploaded and saved. It will remain after refresh.'
+          : 'Hero slide image uploaded. Fill the text fields, then save the slide.',
+        tone: 'success',
+      })
     } catch (uploadError) {
       console.error('[website-hero-slides] upload failed', uploadError)
       setMessage('Unable to upload hero slide image. Try a smaller image.')
@@ -420,7 +433,7 @@ export default function WebsiteHeroSlides() {
           ) : (
             <section className="account-overview__card">
               <h2>{editingId ? 'Edit slide' : 'Add slide'}</h2>
-              <p className="account-overview__hint">Step 1: upload the image. Step 2: fill the text fields. Step 3: save the slide.</p>
+              <p className="account-overview__hint">{editingId ? 'Uploading a replacement image saves it to this slide immediately. Change any text fields, then save the slide.' : 'Step 1: upload the image. Step 2: fill the text fields. Step 3: save the slide.'}</p>
               <form className="account-overview__profile-form" onSubmit={saveSlide}>
                 <div style={{ border: '1px dashed #cbd5e1', borderRadius: 18, background: '#f8fafc', padding: 16 }}>
                   <Field label="Upload hero image first">
@@ -452,7 +465,7 @@ export default function WebsiteHeroSlides() {
                 </div>
                 <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
                   {editingId ? <button type="button" className="button button--ghost" onClick={() => { setDraft(emptyDraft(slides.length + 1)); setEditingId(null) }}>Cancel edit</button> : null}
-                  <button className="button button--primary" type="submit" disabled={busy}>{busy ? 'Saving…' : 'Save slide'}</button>
+                  <button className="button button--primary" type="submit" disabled={busy || uploading}>{busy ? 'Saving…' : 'Save slide'}</button>
                 </div>
               </form>
             </section>


### PR DESCRIPTION
### Motivation
- Users editing an existing website hero slide were uploading a replacement image but the new image URL/path was not being persisted, so the edit appeared to revert after a refresh.
- The intent is to save replacement images immediately when editing a slide so the UI and backend stay consistent.

### Description
- Updated `uploadImage` in `web/src/pages/WebsiteHeroSlides.tsx` to detect edit mode and persist the uploaded `imageUrl`/`imagePath` to Firestore with `setDoc` when editing an existing slide.
- Kept the in-memory slides list synchronized by updating the `slides` state so the new image shows immediately without needing a refresh.
- Clarified the edit-mode helper text so users know replacement uploads are saved immediately, while new slides still need the normal `Save slide` step.
- Prevented submitting the slide form while an image upload is in progress by disabling the Save button when `uploading` is true.

### Testing
- Ran `npm run lint` (automated) and it was blocked by missing/install issues: ESLint failed due to unresolved `@eslint/js` dependency.
- Ran `npm run build` (automated) and it was blocked by missing dev dependencies and type definitions (`vite/client`, `vitest/globals`).
- Ran `npm ci` (automated) and it failed due to registry access returning `403 Forbidden` for `@azure/msal-browser`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a98ea4db88321a5f858c9e3f64516)