### PR TITLE
Fix functions build for data consistency repair config

### DIFF
--- a/functions/params.yaml
+++ b/functions/params.yaml
@@ -39,3 +39,6 @@ params:
   - name: REPORTS_SHEET_ID
     type: string
     default: ""
+  - name: SEDIFEX_ADMIN_REPAIR_TOKEN
+    type: string
+    default: ""

--- a/functions/src/dataConsistency.ts
+++ b/functions/src/dataConsistency.ts
@@ -1,6 +1,9 @@
 import * as functions from 'firebase-functions/v1'
+import { defineString } from 'firebase-functions/params'
 import { admin, defaultDb } from './firestore'
 import { upsertStoreCustomerFromCheckout } from './customerUpsert'
+
+const SEDIFEX_ADMIN_REPAIR_TOKEN = defineString('SEDIFEX_ADMIN_REPAIR_TOKEN', { default: '' })
 
 function clean(value: unknown, max = 500) {
   return typeof value === 'string' ? value.trim().slice(0, max) : ''
@@ -84,7 +87,7 @@ function setCors(res: functions.Response) {
 }
 
 function isAllowed(req: functions.https.Request) {
-  const expected = functions.config().sedifex?.admin_repair_token || process.env.SEDIFEX_ADMIN_REPAIR_TOKEN || ''
+  const expected = SEDIFEX_ADMIN_REPAIR_TOKEN.value()?.trim() || process.env.SEDIFEX_ADMIN_REPAIR_TOKEN?.trim() || ''
   if (!expected) return false
   const received = clean(req.get('x-sedifex-admin-repair-token') || req.get('authorization')?.replace(/^Bearer\s+/i, ''), 300)
   return received === expected


### PR DESCRIPTION
### Motivation
- The TypeScript build failed with `TS2349` because `functions.config()` was removed in `firebase-functions` v7 and `config` is declared as `never`, so the repair-token lookup needed to be migrated to the new params API.
- Keep compatibility with existing deployments by preserving the `process.env.SEDIFEX_ADMIN_REPAIR_TOKEN` fallback while registering the parameter.

### Description
- Replace the removed `functions.config()` repair-token lookup with a Firebase params `defineString('SEDIFEX_ADMIN_REPAIR_TOKEN')` and add the required `import { defineString } from 'firebase-functions/params'` in `functions/src/dataConsistency.ts`.
- Add `SEDIFEX_ADMIN_REPAIR_TOKEN` to `functions/params.yaml` with an empty default and keep the `process.env.SEDIFEX_ADMIN_REPAIR_TOKEN` fallback in the runtime check.

### Testing
- Ran `npm run build` in `functions/` which completed successfully.
- Ran `npx tsc --noEmit` in `functions/` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab92cb50c8321b03306bae5e412ff)