### PR TITLE
Fix booking sheet sync: use current form state and normalize status fields

### DIFF
--- a/web/src/pages/BookingEditor.css
+++ b/web/src/pages/BookingEditor.css
@@ -14,32 +14,8 @@
   gap: 0.35rem;
 }
 
-.booking-editor-page__notes,
-.booking-editor-page__quick-status {
+.booking-editor-page__notes {
   grid-column: 1 / -1;
-}
-
-.booking-editor-page__quick-status {
-  display: grid;
-  gap: 0.75rem;
-  border: 1px solid #dbe4f0;
-  border-radius: 1rem;
-  background: #f8fafc;
-  padding: 0.9rem;
-}
-
-.booking-editor-page__quick-status strong {
-  color: #0f172a;
-}
-
-.booking-editor-page__quick-status .form__hint {
-  margin: 0.25rem 0 0;
-}
-
-.booking-editor-page__quick-status-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
 }
 
 .booking-editor-page__actions {

--- a/web/src/pages/BookingEditor.tsx
+++ b/web/src/pages/BookingEditor.tsx
@@ -44,7 +44,7 @@ const DEFAULT_FORM: BookingFormState = {
   depositAmount: '',
   paymentMethod: '',
   paymentReference: '',
-  paymentStatus: 'payment_pending',
+  paymentStatus: 'pending',
 }
 
 function stringValue(value: unknown): string {
@@ -69,12 +69,26 @@ function firstStringValue(...values: unknown[]): string {
   return ''
 }
 
+function normalizePaymentStatusValue(value: unknown, fallback = 'pending'): string {
+  const raw = stringValue(value).trim().toLowerCase().replace(/[\s-]+/g, '_')
+  if (!raw) return fallback
+  if (['paid', 'payment_paid', 'confirmed', 'success', 'succeeded', 'complete', 'completed'].includes(raw)) return 'paid'
+  if (['partially_paid', 'partial', 'payment_partial'].includes(raw)) return 'partial'
+  if (['awaiting_verification', 'manual_review', 'payment_awaiting_verification'].includes(raw)) return 'awaiting_verification'
+  if (['pending', 'payment_pending', 'unpaid', 'pending_payment'].includes(raw)) return 'pending'
+  return raw
+}
+
 function normalizePaymentStatus(data: Record<string, unknown>, payment: Record<string, unknown>): string {
   if (payment.confirmed === true) return 'paid'
-  const raw = firstStringValue(data.paymentStatus, data.payment_status, payment.status).toLowerCase()
-  if (!raw) return 'payment_pending'
-  if (['paid', 'confirmed', 'success', 'succeeded', 'complete', 'completed'].includes(raw)) return 'paid'
-  if (['pending', 'payment_pending', 'unpaid'].includes(raw)) return 'payment_pending'
+  return normalizePaymentStatusValue(firstStringValue(data.paymentStatus, data.payment_status, payment.status), 'pending')
+}
+
+function normalizeBookingStatusValue(value: unknown, fallback = 'pending'): string {
+  const raw = stringValue(value).trim().toLowerCase().replace(/[\s-]+/g, '_')
+  if (!raw) return fallback
+  if (['pending_approval', 'pending'].includes(raw)) return 'pending'
+  if (['confirmed', 'completed', 'cancelled'].includes(raw)) return raw
   return raw
 }
 
@@ -82,7 +96,7 @@ function normalizeBookingForm(data: Record<string, unknown>): BookingFormState {
   const customer = recordValue(data.customer)
   const booking = recordValue(data.booking)
   const payment = recordValue(data.payment)
-  const status = firstStringValue(data.bookingStatus, data.status) || 'confirmed'
+  const status = normalizeBookingStatusValue(firstStringValue(data.bookingStatus, data.booking_status, data.status), 'confirmed')
 
   return {
     fullName: firstStringValue(data.fullName, data.name, data.customerName, customer.name),
@@ -138,9 +152,6 @@ function normalizeTimeInput(value: unknown): string {
   return ''
 }
 
-function statusLabel(value: string) {
-  return value.replace(/_/g, ' ').replace(/\b\w/g, letter => letter.toUpperCase())
-}
 
 const bookingAppsScriptUrl = 'https://script.google.com/macros/s/AKfycbxl0IdT746Z_yL2LJbAOKi0wsn3iNct4H1omFYWaxq8nzzI7rc_cebfxXcMxMydtvO4Eg/exec'
 
@@ -174,9 +185,7 @@ async function syncBookingToSheet(payload: BookingSheetPayload) {
     body: JSON.stringify(payload),
   })
 
-  const text = await res.text()
-  console.log('Booking sheet sync response:', text)
-  return text
+  return res.text()
 }
 
 function syncReasonForStatus(status: string, paymentStatus: string) {
@@ -209,10 +218,12 @@ export default function BookingEditor() {
   const [saving, setSaving] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [existingPaymentConfirmedAt, setExistingPaymentConfirmedAt] = useState<unknown>(null)
   const { publish } = useToast()
 
   useEffect(() => {
     if (!storeId || isCreateMode) {
+      setExistingPaymentConfirmedAt(null)
       setLoading(false)
       return
     }
@@ -246,6 +257,7 @@ export default function BookingEditor() {
 
         if (cancelled) return
         setForm(normalizeBookingForm(data))
+        setExistingPaymentConfirmedAt(data.paymentConfirmedAt ?? data.payment_confirmed_at ?? null)
       } catch (error) {
         console.error('[booking-editor] Failed to load booking', error)
         if (!cancelled) {
@@ -266,17 +278,6 @@ export default function BookingEditor() {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 1
   }, [form.quantity])
 
-  function setStatusDraft(nextStatus: string, nextPaymentStatus?: string) {
-    setForm(prev => ({
-      ...prev,
-      status: nextStatus,
-      paymentStatus: nextPaymentStatus ?? prev.paymentStatus,
-    }))
-    const message = `Status set to ${statusLabel(nextStatus)}. Click Save changes to send the update.`
-    setSuccessMessage(message)
-    publish({ tone: 'info', message })
-  }
-
   async function handleSave() {
     if (!storeId) {
       setErrorMessage('Select a workspace before editing bookings.')
@@ -293,81 +294,94 @@ export default function BookingEditor() {
     const targetId = isCreateMode ? doc(db, 'stores', storeId, 'integrationBookings').id : bookingId
 
     try {
-      const normalizedStatus = (form.status.trim() || 'pending_approval').toLowerCase()
-      const normalizedPaymentStatus = form.paymentStatus.trim() || 'payment_pending'
+      const normalizedStatus = normalizeBookingStatusValue(form.status, 'pending')
+      const normalizedPaymentStatus = normalizePaymentStatusValue(form.paymentStatus, 'pending')
+      const isPaid = normalizedPaymentStatus === 'paid'
+      const isConfirmedPaid = normalizedStatus === 'confirmed' && isPaid
       const now = Timestamp.now()
+      const paymentConfirmedAt = existingPaymentConfirmedAt || now
+      const lastEventType = isConfirmedPaid ? 'confirmed_paid' : syncReasonForStatus(normalizedStatus, normalizedPaymentStatus)
       const statusTimestamps = {
         ...(normalizedStatus === 'confirmed' ? { confirmedAt: now, confirmedBy: 'staff_admin' } : {}),
         ...(normalizedStatus === 'completed' ? { completedAt: now } : {}),
         ...(normalizedStatus === 'cancelled' ? { cancelledAt: now } : {}),
-        ...(['paid', 'confirmed'].includes(normalizedPaymentStatus.toLowerCase()) ? {
-          paymentConfirmedAt: now,
+        ...(isPaid ? {
+          paymentConfirmedAt,
+          payment_confirmed_at: paymentConfirmedAt,
           paymentVerifiedAt: now,
           paymentVerifiedBy: 'staff_admin',
         } : {}),
       }
+      const normalizedFormPayload = {
+        name: form.fullName.trim(),
+        fullName: form.fullName.trim(),
+        phone: form.phone.trim(),
+        email: form.email.trim(),
+        serviceName: form.serviceName.trim(),
+        serviceId: form.serviceId.trim(),
+        date: normalizeDateInput(form.bookingDate),
+        bookingDate: normalizeDateInput(form.bookingDate),
+        time: normalizeTimeInput(form.bookingTime),
+        bookingTime: normalizeTimeInput(form.bookingTime),
+        preferredBranch: form.preferredBranch.trim(),
+        preferredContactMethod: form.preferredContactMethod.trim(),
+        quantity: quantityValue,
+        notes: form.notes.trim(),
+        paymentAmount: form.paymentAmount.trim(),
+        depositAmount: form.depositAmount.trim(),
+        paymentMethod: form.paymentMethod.trim(),
+        paymentReference: form.paymentReference.trim(),
+        reference: form.paymentReference.trim(),
+      }
       const payload = {
+        ...normalizedFormPayload,
+        bookingStatus: normalizedStatus,
+        booking_status: normalizedStatus,
+        status: normalizedStatus,
+        paymentStatus: normalizedPaymentStatus,
+        payment_status: normalizedPaymentStatus,
+        lastEventType,
+        last_event_type: lastEventType,
+        payment: {
+          amount: form.paymentAmount.trim(),
+          depositAmount: form.depositAmount.trim(),
+          method: form.paymentMethod.trim(),
+          reference: form.paymentReference.trim(),
+          status: normalizedPaymentStatus,
+          paymentStatus: normalizedPaymentStatus,
+          payment_status: normalizedPaymentStatus,
+          confirmed: isPaid,
+        },
+        booking: {
+          serviceId: form.serviceId.trim(),
+          serviceName: form.serviceName.trim(),
+          preferredDate: normalizeDateInput(form.bookingDate),
+          preferredTime: normalizeTimeInput(form.bookingTime),
+          status: normalizedStatus,
+          bookingStatus: normalizedStatus,
+          booking_status: normalizedStatus,
+        },
+        customer: {
           name: form.fullName.trim(),
-          fullName: form.fullName.trim(),
           phone: form.phone.trim(),
           email: form.email.trim(),
-          serviceName: form.serviceName.trim(),
-          serviceId: form.serviceId.trim(),
-          date: normalizeDateInput(form.bookingDate),
-          bookingDate: normalizeDateInput(form.bookingDate),
-          time: normalizeTimeInput(form.bookingTime),
-          bookingTime: normalizeTimeInput(form.bookingTime),
-          preferredBranch: form.preferredBranch.trim(),
-          preferredContactMethod: form.preferredContactMethod.trim(),
-          bookingStatus: normalizedStatus,
-          status: normalizedStatus === 'pending_approval' ? 'pending' : normalizedStatus,
-          quantity: quantityValue,
-          notes: form.notes.trim(),
-          paymentAmount: form.paymentAmount.trim(),
-          depositAmount: form.depositAmount.trim(),
-          paymentMethod: form.paymentMethod.trim(),
-          paymentReference: form.paymentReference.trim(),
-          reference: form.paymentReference.trim(),
-          paymentStatus: normalizedPaymentStatus,
-          payment: {
-            amount: form.paymentAmount.trim(),
-            depositAmount: form.depositAmount.trim(),
-            method: form.paymentMethod.trim(),
-            reference: form.paymentReference.trim(),
-            status: normalizedPaymentStatus,
-            confirmed: ['paid', 'confirmed'].includes(normalizedPaymentStatus.toLowerCase()),
-          },
-          booking: {
-            serviceId: form.serviceId.trim(),
-            serviceName: form.serviceName.trim(),
-            preferredDate: normalizeDateInput(form.bookingDate),
-            preferredTime: normalizeTimeInput(form.bookingTime),
-          },
-          customer: {
-            name: form.fullName.trim(),
-            phone: form.phone.trim(),
-            email: form.email.trim(),
-          },
-          bookingId: targetId,
-          booking_id: targetId,
-          syncStatus: 'pending',
-          syncReason: syncReasonForStatus(normalizedStatus, normalizedPaymentStatus),
-          syncRequestedAt: now,
-          syncConfigDetected: true,
-          ...statusTimestamps,
-          updatedAt: serverTimestamp(),
-          ...(isCreateMode ? {
-            createdAt: serverTimestamp(),
-            source: 'manual_admin',
-            sourceChannel: 'manual_admin',
-            source_channel: 'manual_admin',
-          } : {}),
-        }
-      const booking = payload as BookingSheetSource
-      if (normalizedStatus === 'confirmed') {
-        console.log('CONFIRM BOOKING CLICKED', booking)
-        console.log('BOOKING WEBHOOK URL', bookingAppsScriptUrl)
+        },
+        bookingId: targetId,
+        booking_id: targetId,
+        syncStatus: 'pending',
+        syncReason: lastEventType,
+        syncRequestedAt: now,
+        syncConfigDetected: true,
+        ...statusTimestamps,
+        updatedAt: serverTimestamp(),
+        ...(isCreateMode ? {
+          createdAt: serverTimestamp(),
+          source: 'manual_admin',
+          sourceChannel: 'manual_admin',
+          source_channel: 'manual_admin',
+        } : {}),
       }
+      const booking = payload as BookingSheetSource & Record<string, unknown>
 
       await withTimeout(
         Promise.all([
@@ -378,20 +392,26 @@ export default function BookingEditor() {
         'Saving booking timed out. Please try again.',
       )
 
-      if (normalizedStatus === 'confirmed') {
-        await syncBookingToSheet({
-          type: 'booking',
-          bookingId: booking.id || booking.bookingId || `BOOK-${Date.now()}`,
-          customerName: booking.customerName || booking.name || '',
-          customerEmail: booking.customerEmail || booking.email || '',
-          customerPhone: booking.customerPhone || booking.phone || '',
-          serviceName: booking.serviceName || booking.service || '',
-          bookingDate: booking.bookingDate || booking.date || '',
-          bookingTime: booking.bookingTime || booking.time || '',
-          status: 'confirmed',
-          source: 'sedifex-booking-confirm',
-        })
-      }
+      await syncBookingToSheet({
+        type: 'booking',
+        bookingId: String(booking.id || booking.bookingId || targetId || `BOOK-${Date.now()}`),
+        booking_id: String(booking.booking_id || booking.bookingId || targetId),
+        customerName: String(booking.customerName || booking.name || ''),
+        customerEmail: String(booking.customerEmail || booking.email || ''),
+        customerPhone: String(booking.customerPhone || booking.phone || ''),
+        serviceName: String(booking.serviceName || booking.service || ''),
+        bookingDate: String(booking.bookingDate || booking.date || ''),
+        bookingTime: String(booking.bookingTime || booking.time || ''),
+        status: normalizedStatus,
+        booking_status: normalizedStatus,
+        bookingStatus: normalizedStatus,
+        payment_status: normalizedPaymentStatus,
+        paymentStatus: normalizedPaymentStatus,
+        payment_confirmed_at: isPaid ? stringValue(paymentConfirmedAt) : '',
+        last_event_type: lastEventType,
+        lastEventType,
+        source: isConfirmedPaid ? 'sedifex-booking-confirmed-paid' : 'sedifex-booking-update',
+      })
 
       const saveMessage = isCreateMode
         ? 'Booking created successfully. Email will be sent to the customer.'
@@ -448,8 +468,7 @@ export default function BookingEditor() {
             <label>
               <span>Status</span>
               <select value={form.status} onChange={event => setForm(prev => ({ ...prev, status: event.target.value }))}>
-                <option value="pending_approval">Pending approval</option>
-                <option value="pending">Pending</option>
+                <option value="pending">Pending approval</option>
                 <option value="confirmed">Confirmed</option>
                 <option value="rescheduled">Rescheduled</option>
                 <option value="completed">Completed</option>
@@ -464,33 +483,13 @@ export default function BookingEditor() {
             <label>
               <span>Payment status</span>
               <select value={form.paymentStatus} onChange={event => setForm(prev => ({ ...prev, paymentStatus: event.target.value }))}>
-                <option value="payment_pending">Payment pending</option>
+                <option value="pending">Payment pending</option>
                 <option value="paid">Paid</option>
-                <option value="manual_review">Manual review</option>
-                <option value="refunded">Refunded</option>
+                <option value="partial">Partially paid</option>
+                <option value="awaiting_verification">Awaiting verification</option>
               </select>
             </label>
             <label className="booking-editor-page__notes"><span>Notes</span><textarea value={form.notes} onChange={event => setForm(prev => ({ ...prev, notes: event.target.value }))} rows={4} /></label>
-
-            {!isCreateMode && (
-              <div className="booking-editor-page__quick-status" aria-label="Quick status shortcuts">
-                <div>
-                  <strong>Quick status</strong>
-                  <p className="form__hint">These buttons only set the fields above. Click Save changes to send the update.</p>
-                </div>
-                <div className="booking-editor-page__quick-status-actions">
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('completed')}>
-                    Set completed
-                  </button>
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('cancelled')}>
-                    Set cancelled
-                  </button>
-                  <button type="button" className="button button--outline" disabled={saving} onClick={() => setStatusDraft('confirmed', 'paid')}>
-                    Set confirmed + paid
-                  </button>
-                </div>
-              </div>
-            )}
 
             <div className="booking-editor-page__actions">
               <Link to="/bookings" className="button button--outline">Back</Link>


### PR DESCRIPTION
### Motivation
- The booking editor saved payload used/overwrote old booking values and sent unnormalized labels to the Google Apps Script, causing `payment_status` to remain `pending` on sheet sync even when the UI showed `Paid`/`Confirmed`.
- The Quick status shortcuts duplicated behavior and caused confusion, so users should set `Status` and `Payment status` directly and click `Save changes`.

### Description
- Add normalization helpers to map UI labels to canonical values and variants and apply them to both booking and payment states using `normalizePaymentStatusValue` and `normalizeBookingStatusValue` (e.g., `Paid` → `paid`, `Partially paid` → `partial`, `Payment pending` → `pending`).
- Build the saved and sheet-sync payload from the current `form` state and explicit normalized fields, using the spread order `{ ...normalizedFormPayload, booking_status: normalizedStatus, payment_status: normalizedPaymentStatus }` so old `booking` values cannot overwrite new form values; include both snake_case and camelCase fields (`payment_status`, `paymentStatus`, `booking_status`, `bookingStatus`, `status`).
- When payment is `paid`, preserve or set `payment_confirmed_at` and include `last_event_type: "confirmed_paid"` when booking `status` is `confirmed` and payment is `paid`.
- Remove the bottom “Quick status” shortcut JSX and related CSS to avoid accidental/ambiguous changes via those buttons.
- Remove noisy console logging from the sheet sync helper while keeping a safe `syncBookingToSheet` POST implementation.

### Testing
- Ran `git diff --check` and code formatting checks which passed without whitespace errors.
- Searched the codebase with `rg` for the bad fallback pattern and quick-status references and confirmed there are no remaining occurrences of the old stale `payment_status` fallback or `Quick status` UI.
- Attempted to run `npm --prefix web ci` and `tsc -p web/tsconfig.json --noEmit` to type-check and install dependencies, but those steps were blocked by registry access (`403 Forbidden` for some packages) and missing dev type packages so a full local build/typecheck could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c26145c98832188e6082d953bfd70)