### PR TITLE
Simplify Website Builder section copy

### DIFF
--- a/web/src/pages/WebsiteBuilder.css
+++ b/web/src/pages/WebsiteBuilder.css
@@ -77,25 +77,6 @@
   font-weight: 850;
 }
 
-.website-builder-page__section-break p {
-  max-width: 760px;
-  margin: 8px 0 0;
-  color: #475569;
-  line-height: 1.65;
-}
-
-.website-builder-page__section-break .website-builder-page__section-helper {
-  display: inline-flex;
-  margin-top: 12px;
-  border-radius: 999px;
-  background: #eef2ff;
-  padding: 7px 12px;
-  color: #3730a3;
-  font-size: 0.86rem;
-  font-weight: 750;
-  line-height: 1.4;
-}
-
 .website-builder-page__section-body {
   display: grid;
   gap: 18px;
@@ -126,10 +107,6 @@
   .website-builder-page__section-body {
     border-radius: 20px;
     padding: 16px;
-  }
-
-  .website-builder-page__section-break .website-builder-page__section-helper {
-    border-radius: 14px;
   }
 
   .website-builder-page__switcher select {

--- a/web/src/pages/WebsiteBuilder.tsx
+++ b/web/src/pages/WebsiteBuilder.tsx
@@ -12,7 +12,6 @@ type BuilderSectionId = 'promo' | 'gallery' | 'hero' | 'social'
 type BuilderSection = {
   id: BuilderSectionId
   label: string
-  description: string
   Component: React.ComponentType
 }
 
@@ -20,25 +19,21 @@ const BUILDER_SECTIONS: BuilderSection[] = [
   {
     id: 'promo',
     label: 'Promo',
-    description: 'Update the public promo title, dates, summary, image, and Sedifex public link content. Website can pull this through the promo integration.',
     Component: PromoSettings,
   },
   {
     id: 'gallery',
     label: 'Gallery',
-    description: 'Manage albums and images your public website can show in gallery sections. Website can pull this through gallery integration.',
     Component: GallerySettings,
   },
   {
     id: 'hero',
     label: 'Hero page',
-    description: 'Create homepage hero slides and banners for connected website templates. Website can pull this through /v1IntegrationHeroSlides.',
     Component: WebsiteHeroSlides,
   },
   {
     id: 'social',
     label: 'Social settings',
-    description: 'Maintain public profile, contact, social links, logos, and share images. Website can pull this through /v1IntegrationSocialSettings.',
     Component: SocialLinksSettings,
   },
 ]
@@ -87,15 +82,12 @@ export default function WebsiteBuilder() {
             ))}
           </select>
         </label>
-        <p className="account-overview__hint">{selectedSection.description}</p>
       </section>
 
       <section className="website-builder-page__section-shell" aria-live="polite">
         <div className="website-builder-page__section-break">
           <span className="website-builder-page__section-kicker">Current website section</span>
           <h2>{selectedSection.label}</h2>
-          <p>{selectedSection.description}</p>
-          <p className="website-builder-page__section-helper">Connected websites should fetch this from Sedifex instead of hardcoding it.</p>
         </div>
 
         <div className="website-builder-page__section-body">


### PR DESCRIPTION
### Motivation
- Reduce duplicated/verbose copy in the Website Builder UI so the section selector and header only show the section label and component, making the UI cleaner and less repetitive.

### Description
- Removed the `description` field from the `BuilderSection` type and removed long integration description strings from `web/src/pages/WebsiteBuilder.tsx` so sections now only expose `id`, `label`, and `Component`.
- Removed the helper/description paragraphs from the selector and current-section header in `web/src/pages/WebsiteBuilder.tsx` to avoid repeating integration guidance in the UI.
- Deleted the now-unused CSS rules for `.website-builder-page__section-break p` and `.website-builder-page__section-helper` from `web/src/pages/WebsiteBuilder.css`.
- Kept component mapping intact so functionality remains unchanged and each section still renders its corresponding settings component.

### Testing
- Ran `git diff --check` which succeeded with no whitespace/patch errors.
- Ran `npm --prefix web run lint` which failed due to missing local dependencies and ESLint inability to load `@eslint/js` (environment blocking, lint not completed).
- Ran `npm --prefix web ci` which failed due to registry access issues (403) preventing a full install and blocking further automated checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c747108888321afa425135d39d2ff)