### PR TITLE
Quick Pay: load store Paystack routing, gross-up fees, and show processing fee in public checkout

### DIFF
--- a/functions/src/integrationQuickPayCheckoutCreate.ts
+++ b/functions/src/integrationQuickPayCheckoutCreate.ts
@@ -12,6 +12,20 @@ type CheckoutBody = Record<string, unknown>
 
 type NormalizedItemType = 'product' | 'service' | 'course'
 
+const DEFAULT_PAYSTACK_PROCESSING_FEE_PERCENT = 1.95
+const DEFAULT_SEDIFEX_COMMISSION_PERCENT = 3
+
+type ResolvedPaymentRouting = {
+  paystackSubaccountCode: string
+  percentageCharge: number
+  settlementMode: string
+  status: string
+  source: string
+  splitEnabled: boolean
+  splitDisabledReason: string | null
+  raw: Record<string, unknown>
+}
+
 function clean(value: unknown, max = 500) {
   return typeof value === 'string' ? value.trim().slice(0, max) : ''
 }
@@ -142,8 +156,153 @@ function getSubaccount(body: CheckoutBody) {
 
 function getTransactionChargeMinor(body: CheckoutBody) {
   const split = getRecord(body.splitPayment)
-  const value = numberValue(split.transactionChargeMinor ?? split.transaction_charge ?? split.transactionCharge)
+  const value = numberValue(split.transactionChargeMinor ?? split.transaction_charge ?? split.transactionCharge ?? body.transactionChargeMinor ?? body.transaction_charge)
   return value !== null && value > 0 ? Math.round(value) : null
+}
+
+function getPercentageCharge(value: unknown, fallback = DEFAULT_SEDIFEX_COMMISSION_PERCENT) {
+  const parsed = numberValue(value)
+  return parsed !== null && parsed > 0 ? parsed : fallback
+}
+
+function isQuickPayCheckout(body: CheckoutBody, metadata: Record<string, unknown>, sourceChannel: string) {
+  return metadata.quickPay === true
+    || metadata.quick_pay === true
+    || clean(body.quickPay, 20).toLowerCase() === 'true'
+    || clean(body.quick_pay, 20).toLowerCase() === 'true'
+    || sourceChannel.toLowerCase().startsWith('quick_pay')
+}
+
+function calculateCustomerProcessingFeeMinor(
+  baseTotalMinor: number,
+  feePercent = DEFAULT_PAYSTACK_PROCESSING_FEE_PERCENT,
+) {
+  if (!Number.isFinite(baseTotalMinor) || baseTotalMinor <= 0) return 0
+  if (!Number.isFinite(feePercent) || feePercent <= 0) return 0
+
+  const rate = feePercent / 100
+
+  if (rate >= 1) {
+    throw new Error('Processing fee percent must be less than 100.')
+  }
+
+  return Math.max(0, Math.ceil(baseTotalMinor / (1 - rate)) - baseTotalMinor)
+}
+
+function calculateSedifexCommissionMinor(
+  baseTotalMinor: number,
+  commissionPercent = DEFAULT_SEDIFEX_COMMISSION_PERCENT,
+) {
+  if (!Number.isFinite(baseTotalMinor) || baseTotalMinor <= 0) return 0
+  if (!Number.isFinite(commissionPercent) || commissionPercent <= 0) return 0
+
+  return Math.round(baseTotalMinor * (commissionPercent / 100))
+}
+
+function normalizeRoutingSnapshot(input: {
+  subaccount: string
+  percentageCharge?: unknown
+  settlementMode?: unknown
+  status?: unknown
+  source: string
+  raw?: Record<string, unknown>
+}): ResolvedPaymentRouting {
+  const subaccount = clean(input.subaccount, 140)
+  const settlementMode = clean(input.settlementMode, 80) || (subaccount ? 'subaccount' : '')
+  const status = clean(input.status, 80) || (subaccount ? 'active' : '')
+  const inactive = ['inactive', 'disabled', 'blocked', 'suspended'].includes(status.toLowerCase())
+  const wrongMode = Boolean(settlementMode) && settlementMode.toLowerCase() !== 'subaccount'
+  const splitEnabled = Boolean(subaccount) && !inactive && !wrongMode
+  return {
+    paystackSubaccountCode: subaccount,
+    percentageCharge: getPercentageCharge(input.percentageCharge),
+    settlementMode: settlementMode || 'subaccount',
+    status: status || (splitEnabled ? 'active' : 'missing'),
+    source: input.source,
+    splitEnabled,
+    splitDisabledReason: splitEnabled ? null : (!subaccount ? 'missing_paystack_subaccount' : inactive ? `routing_${status.toLowerCase()}` : 'settlement_mode_not_subaccount'),
+    raw: input.raw ?? {},
+  }
+}
+
+function routingFromBody(body: CheckoutBody): ResolvedPaymentRouting | null {
+  const split = getRecord(body.splitPayment)
+  const routing = getRecord(body.paymentRouting)
+  const subaccount = getSubaccount(body)
+  if (!subaccount) return null
+  return normalizeRoutingSnapshot({
+    subaccount,
+    percentageCharge: routing.percentageCharge ?? routing.percentage_charge ?? split.percentageCharge ?? split.percentage_charge,
+    settlementMode: routing.settlementMode ?? routing.settlement_mode ?? split.settlementMode ?? split.settlement_mode,
+    status: routing.status ?? split.status,
+    source: 'request_body',
+    raw: { ...routing, ...split },
+  })
+}
+
+async function loadPaymentRoutingFromFirestore(storeId: string): Promise<ResolvedPaymentRouting> {
+  const empty = normalizeRoutingSnapshot({
+    subaccount: '',
+    source: 'firestore',
+    raw: {},
+  })
+  if (!storeId) return empty
+
+  const storeSnap = await defaultDb.collection('stores').doc(storeId).get()
+  const storeData = storeSnap.exists ? getRecord(storeSnap.data()) : {}
+  const storeRouting = getRecord(storeData.paymentRouting)
+  const storeNestedCode = clean(storeRouting.paystackSubaccountCode ?? storeRouting.subaccountCode, 140)
+  if (storeNestedCode) {
+    return normalizeRoutingSnapshot({
+      subaccount: storeNestedCode,
+      percentageCharge: storeRouting.percentageCharge ?? storeRouting.percentage_charge,
+      settlementMode: storeRouting.settlementMode ?? storeRouting.settlement_mode,
+      status: storeRouting.status,
+      source: 'stores.paymentRouting',
+      raw: storeRouting,
+    })
+  }
+
+  const storeRootCode = clean(storeData.paystackSubaccountCode ?? storeData.paystack_subaccount_code, 140)
+  if (storeRootCode) {
+    return normalizeRoutingSnapshot({
+      subaccount: storeRootCode,
+      percentageCharge: storeRouting.percentageCharge ?? storeRouting.percentage_charge,
+      settlementMode: storeRouting.settlementMode ?? storeRouting.settlement_mode,
+      status: storeRouting.status,
+      source: 'stores.paystackSubaccountCode',
+      raw: storeRouting,
+    })
+  }
+
+  const settingsSnap = await defaultDb.collection('storeSettings').doc(storeId).get()
+  const settingsData = settingsSnap.exists ? getRecord(settingsSnap.data()) : {}
+  const settingsRouting = getRecord(settingsData.paymentRouting)
+  const settingsNestedCode = clean(settingsRouting.paystackSubaccountCode ?? settingsRouting.subaccountCode, 140)
+  if (settingsNestedCode) {
+    return normalizeRoutingSnapshot({
+      subaccount: settingsNestedCode,
+      percentageCharge: settingsRouting.percentageCharge ?? settingsRouting.percentage_charge,
+      settlementMode: settingsRouting.settlementMode ?? settingsRouting.settlement_mode,
+      status: settingsRouting.status,
+      source: 'storeSettings.paymentRouting',
+      raw: settingsRouting,
+    })
+  }
+
+  const settingsRootCode = clean(settingsData.paystackSubaccountCode ?? settingsData.paystack_subaccount_code, 140)
+  if (settingsRootCode) {
+    return normalizeRoutingSnapshot({
+      subaccount: settingsRootCode,
+      percentageCharge: settingsRouting.percentageCharge ?? settingsRouting.percentage_charge,
+      settlementMode: settingsRouting.settlementMode ?? settingsRouting.settlement_mode,
+      status: settingsRouting.status,
+      source: 'storeSettings.paystackSubaccountCode',
+      raw: settingsRouting,
+    })
+  }
+
+  return empty
 }
 
 function normalizeItemType(value: unknown): NormalizedItemType | '' {
@@ -320,9 +479,9 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     const callbackUrl = clean(body.returnUrl, 700) || APP_BASE_URL.value() || undefined
     const sourceChannel = clean(body.sourceChannel ?? body.source_channel, 80) || 'integration_checkout'
     const sourceLabel = clean(body.sourceLabel ?? body.source_label, 120) || 'Sedifex checkout'
-    const subaccount = getSubaccount(body)
     const transactionChargeMinor = getTransactionChargeMinor(body)
     const details = deriveCheckoutDetails(body)
+    const quickPayCheckout = isQuickPayCheckout(body, details.metadata, sourceChannel)
 
     if (!storeId) {
       res.status(400).json({ error: 'missing-store-id' })
@@ -337,9 +496,68 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       return
     }
 
+    const baseTotalMinor = Math.round(amountMajor * 100)
+    const bodyRouting = routingFromBody(body)
+    const firestoreRouting = quickPayCheckout && !bodyRouting
+      ? await loadPaymentRoutingFromFirestore(storeId)
+      : null
+    const paymentRouting = bodyRouting ?? firestoreRouting ?? normalizeRoutingSnapshot({ subaccount: '', source: 'none' })
+    const subaccount = paymentRouting.splitEnabled ? paymentRouting.paystackSubaccountCode : ''
+    const commissionPercent = paymentRouting.percentageCharge || DEFAULT_SEDIFEX_COMMISSION_PERCENT
+    const processingFeeMinor = quickPayCheckout
+      ? calculateCustomerProcessingFeeMinor(baseTotalMinor)
+      : 0
+    const customerTotalMinor = baseTotalMinor + processingFeeMinor
+    const sedifexCommissionMinor = subaccount
+      ? (quickPayCheckout
+        ? calculateSedifexCommissionMinor(baseTotalMinor, commissionPercent)
+        : transactionChargeMinor ?? 0)
+      : 0
+    const pricingSnapshot = {
+      baseTotalMinor,
+      processingFeeMinor,
+      customerTotalMinor,
+      sedifexCommissionMinor,
+      customerPaysProcessingFee: quickPayCheckout,
+      merchantPaysCommission: sedifexCommissionMinor > 0,
+    }
+    const paymentRoutingSnapshot = {
+      paystackSubaccountCode: paymentRouting.paystackSubaccountCode || null,
+      percentageCharge: commissionPercent,
+      settlementMode: paymentRouting.settlementMode,
+      status: paymentRouting.status,
+      source: paymentRouting.source,
+      splitEnabled: Boolean(subaccount),
+      splitDisabledReason: subaccount ? null : paymentRouting.splitDisabledReason,
+    }
+    const paystackSplitSnapshot = subaccount ? {
+      enabled: true,
+      provider: 'paystack',
+      mode: 'subaccount',
+      subaccount,
+      transactionChargeMinor: sedifexCommissionMinor,
+      transaction_charge: sedifexCommissionMinor,
+      bearer: sedifexCommissionMinor > 0 ? 'subaccount' : null,
+      percentageCharge: commissionPercent,
+      customerPaysProcessingFee: quickPayCheckout,
+      merchantPaysCommission: sedifexCommissionMinor > 0,
+    } : {
+      enabled: false,
+      provider: 'paystack',
+      mode: 'subaccount',
+      subaccount: null,
+      transactionChargeMinor: 0,
+      transaction_charge: 0,
+      bearer: null,
+      percentageCharge: commissionPercent,
+      customerPaysProcessingFee: quickPayCheckout,
+      merchantPaysCommission: false,
+      splitDisabledReason: paymentRouting.splitDisabledReason,
+    }
+
     const storedMetadata = {
       ...details.metadata,
-      quickPay: details.metadata.quickPay ?? true,
+      quickPay: details.metadata.quickPay ?? quickPayCheckout,
       storeId,
       merchantId: storeId,
       clientOrderId: clean(body.client_order_id ?? body.clientOrderId, 220) || reference,
@@ -358,22 +576,32 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       orderType: details.recordType,
       recordType: details.recordType,
       paystackSubaccountCode: subaccount || null,
+      baseTotalMinor,
+      processingFeeMinor,
+      customerTotalMinor,
+      sedifexCommissionMinor,
+      customerPaysProcessingFee: quickPayCheckout,
+      merchantPaysCommission: sedifexCommissionMinor > 0,
+      settlementMode: paymentRouting.settlementMode,
       splitEnabled: Boolean(subaccount),
+      splitDisabledReason: subaccount ? null : paymentRouting.splitDisabledReason,
     }
 
     const paystackPayload: Record<string, unknown> = {
       email: customer.email,
-      amount: Math.round(amountMajor * 100),
+      amount: customerTotalMinor,
       reference,
       currency,
       callback_url: callbackUrl,
       metadata: storedMetadata,
     }
 
-    if (subaccount) paystackPayload.subaccount = subaccount
-    if (subaccount && transactionChargeMinor) {
-      paystackPayload.transaction_charge = transactionChargeMinor
-      paystackPayload.bearer = 'subaccount'
+    if (subaccount) {
+      paystackPayload.subaccount = subaccount
+      if (sedifexCommissionMinor > 0) {
+        paystackPayload.transaction_charge = sedifexCommissionMinor
+        paystackPayload.bearer = 'subaccount'
+      }
     }
 
     const paystack = await initializePaystack(paystackPayload)
@@ -405,9 +633,18 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       customer_email: customer.email,
       customerPhone: customer.phone || null,
       customer_phone: customer.phone || null,
-      amount: amountMajor,
-      amountMinor: Math.round(amountMajor * 100),
-      amount_minor: Math.round(amountMajor * 100),
+      amount: customerTotalMinor / 100,
+      amountMinor: customerTotalMinor,
+      amount_minor: customerTotalMinor,
+      baseAmount: baseTotalMinor / 100,
+      baseAmountMinor: baseTotalMinor,
+      base_amount_minor: baseTotalMinor,
+      processingFeeMinor,
+      processing_fee_minor: processingFeeMinor,
+      customerTotalMinor,
+      customer_total_minor: customerTotalMinor,
+      sedifexCommissionMinor,
+      sedifex_commission_minor: sedifexCommissionMinor,
       currency,
       itemName: details.itemName || details.productName || details.serviceName || null,
       productName: details.productName || null,
@@ -428,8 +665,10 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
         recordType: details.recordType,
       },
       items: details.enrichedItems,
-      pricingSnapshot: body.pricing_snapshot ?? body.pricingSnapshot ?? null,
-      pricing_snapshot: body.pricing_snapshot ?? body.pricingSnapshot ?? null,
+      pricingSnapshot,
+      pricing_snapshot: pricingSnapshot,
+      clientPricingSnapshot: body.pricing_snapshot ?? body.pricingSnapshot ?? null,
+      client_pricing_snapshot: body.pricing_snapshot ?? body.pricingSnapshot ?? null,
       marketplaceFees: body.marketplace_fees ?? body.marketplaceFees ?? null,
       marketplace_fees: body.marketplace_fees ?? body.marketplaceFees ?? null,
       metadata: storedMetadata,
@@ -447,7 +686,9 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       status: 'pending_payment',
       paymentCollectionMode: 'online_checkout',
       payment_collection_mode: 'online_checkout',
-      paystackSplit: subaccount ? { enabled: true, subaccount, transactionChargeMinor, bearer: transactionChargeMinor ? 'subaccount' : null, commissionControlledBy: 'sedifex' } : { enabled: false },
+      paymentRouting: paymentRoutingSnapshot,
+      payment_routing: paymentRoutingSnapshot,
+      paystackSplit: paystackSplitSnapshot,
       authorizationUrl,
       checkoutUrl: authorizationUrl,
       orderDate: nowIso,
@@ -481,7 +722,8 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       order_status: 'pending_payment',
       recordType: details.recordType,
       orderType: details.recordType,
-      paystackSplit: subaccount ? { enabled: true, subaccount } : { enabled: false },
+      pricingSnapshot,
+      paystackSplit: paystackSplitSnapshot,
     })
   } catch (error) {
     functions.logger.error('integrationCheckoutCreate failed', { error })

--- a/functions/test/helpers/mockFirestore.js
+++ b/functions/test/helpers/mockFirestore.js
@@ -82,10 +82,64 @@ class MockDocumentReference {
   }
 }
 
-class MockCollectionReference {
-  constructor(db, path) {
+class MockQuerySnapshot {
+  constructor(docs) {
+    this.docs = docs
+  }
+
+  get empty() {
+    return this.docs.length === 0
+  }
+}
+
+class MockQueryDocumentSnapshot extends MockDocSnapshot {
+  constructor(ref, data) {
+    super(data)
+    this.ref = ref
+    this.id = ref.id
+  }
+}
+
+function getNestedField(data, field) {
+  return String(field)
+    .split('.')
+    .reduce((value, key) => (value && typeof value === 'object' ? value[key] : undefined), data)
+}
+
+class MockQuery {
+  constructor(db, path, filters = [], limitCount = null) {
     this._db = db
     this._path = path
+    this._filters = filters
+    this._limitCount = limitCount
+  }
+
+  where(field, op, value) {
+    return new MockQuery(this._db, this._path, [...this._filters, { field, op, value }], this._limitCount)
+  }
+
+  limit(count) {
+    return new MockQuery(this._db, this._path, this._filters, count)
+  }
+
+  async get() {
+    let docs = this._db
+      .listCollection(this._path)
+      .filter(({ data }) => this._filters.every(({ field, op, value }) => {
+        const actual = getNestedField(data, field)
+        if (op === '==') return actual === value
+        if (op === 'in') return Array.isArray(value) && value.includes(actual)
+        return false
+      }))
+      .map(({ id, data }) => new MockQueryDocumentSnapshot(new MockDocumentReference(this._db, `${this._path}/${id}`), data))
+    if (Number.isFinite(this._limitCount)) docs = docs.slice(0, this._limitCount)
+    return new MockQuerySnapshot(docs)
+  }
+}
+
+class MockCollectionReference extends MockQuery {
+  constructor(db, path) {
+    super(db, path)
   }
 
   doc(id) {

--- a/functions/test/integrationQuickPayCheckoutCreate.test.js
+++ b/functions/test/integrationQuickPayCheckoutCreate.test.js
@@ -1,0 +1,288 @@
+const assert = require('assert')
+const Module = require('module')
+const { MockFirestore } = require('./helpers/mockFirestore')
+
+let currentDefaultDb
+const apps = []
+const originalLoad = Module._load
+let paystackPayloads = []
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'firebase-admin') {
+    const firestore = () => currentDefaultDb
+    firestore.FieldValue = {
+      serverTimestamp: () => ({ __mockServerTimestamp: true }),
+      increment: value => ({ __mockIncrement: value }),
+    }
+    firestore.Timestamp = {
+      now: () => ({ __mockTimestamp: true }),
+      fromDate: value => value,
+    }
+
+    return {
+      initializeApp: () => {
+        const app = { name: 'mock-app' }
+        apps[0] = app
+        return app
+      },
+      app: () => apps[0] || null,
+      apps,
+      firestore,
+      auth: () => ({ getUser: async () => null, setCustomUserClaims: async () => {} }),
+    }
+  }
+
+  if (request === 'firebase-functions/v1') {
+    class HttpsError extends Error {
+      constructor(code, message) {
+        super(message)
+        this.code = code
+      }
+    }
+
+    return {
+      https: {
+        onCall: fn => {
+          const handler = (...args) => fn(...args)
+          handler.run = fn
+          return handler
+        },
+        onRequest: fn => {
+          const handler = (req, res) => fn(req, res)
+          handler.run = fn
+          return handler
+        },
+        HttpsError,
+      },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    }
+  }
+
+  if (request === 'firebase-functions/params') {
+    return {
+      defineString: (name, options = {}) => ({
+        value: () => process.env[name] || options.default || '',
+      }),
+    }
+  }
+
+  return originalLoad(request, parent, isMain)
+}
+
+global.fetch = async (_url, options = {}) => {
+  const payload = JSON.parse(options.body || '{}')
+  paystackPayloads.push(payload)
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      status: true,
+      data: {
+        authorization_url: `https://checkout.paystack.test/${payload.reference}`,
+        access_code: `access_${payload.reference}`,
+        reference: payload.reference,
+      },
+    }),
+  }
+}
+
+function resetModules() {
+  for (const key of Object.keys(require.cache)) {
+    if (key.includes('/functions/lib/')) delete require.cache[key]
+  }
+}
+
+function loadQuickPayModule() {
+  resetModules()
+  return require('../lib/integrationQuickPayCheckoutCreate.js')
+}
+
+function loadCashModule() {
+  resetModules()
+  return require('../lib/integrationCashCheckout.js')
+}
+
+function makeResponse() {
+  const state = { statusCode: 0, body: null, headers: {} }
+  const res = {
+    set(name, value) {
+      state.headers[name] = value
+      return res
+    },
+    status(code) {
+      state.statusCode = code
+      return res
+    },
+    json(payload) {
+      state.body = payload
+      return res
+    },
+    send(payload) {
+      state.body = payload
+      return res
+    },
+  }
+  return { res, state }
+}
+
+async function post(handler, body) {
+  const { res, state } = makeResponse()
+  const req = {
+    method: 'POST',
+    body,
+    get: () => '',
+  }
+  await handler(req, res)
+  return state
+}
+
+const quickPayBody = overrides => ({
+  storeId: 'store-123',
+  reference: overrides?.reference || `ref_${Date.now()}`,
+  amount: 1000,
+  currency: 'GHS',
+  customer: { email: 'customer@example.com', name: 'Ama', phone: '+233200000000' },
+  sourceChannel: 'quick_pay_qr',
+  sourceLabel: 'Sedifex Quick Pay',
+  quickPayType: 'SERVICE',
+  accountingType: 'service',
+  metadata: { quickPay: true, itemName: 'Spa package' },
+  items: [{ item_id: 'svc-1', name: 'Spa package', type: 'SERVICE', qty: 1 }],
+  ...(overrides || {}),
+})
+
+async function runQuickPayStoreRoutingTest() {
+  currentDefaultDb = new MockFirestore({
+    'stores/store-123': {
+      paymentRouting: {
+        paystackSubaccountCode: 'ACCT_store_nested',
+        percentageCharge: 3,
+        settlementMode: 'subaccount',
+        status: 'active',
+      },
+    },
+    'storeSettings/store-123': {
+      paymentRouting: {
+        paystackSubaccountCode: 'ACCT_settings_should_not_win',
+        percentageCharge: 10,
+        settlementMode: 'subaccount',
+        status: 'active',
+      },
+    },
+  })
+  process.env.PAYSTACK_SECRET_KEY = 'test_secret'
+  paystackPayloads = []
+
+  const { integrationCheckoutCreate } = loadQuickPayModule()
+  const state = await post(integrationCheckoutCreate, quickPayBody({ reference: 'qp_store_routing' }))
+
+  assert.strictEqual(state.statusCode, 200)
+  assert.strictEqual(paystackPayloads.length, 1)
+  const payload = paystackPayloads[0]
+  assert.strictEqual(payload.subaccount, 'ACCT_store_nested')
+  assert.strictEqual(payload.amount, 101989)
+  assert.strictEqual(payload.transaction_charge, 3000)
+  assert.strictEqual(payload.bearer, 'subaccount')
+  assert.strictEqual(payload.metadata.baseTotalMinor, 100000)
+  assert.strictEqual(payload.metadata.processingFeeMinor, 1989)
+  assert.strictEqual(payload.metadata.customerTotalMinor, 101989)
+  assert.strictEqual(payload.metadata.sedifexCommissionMinor, 3000)
+  assert.strictEqual(payload.metadata.splitEnabled, true)
+
+  const order = currentDefaultDb.getDoc('integrationOrders/qp_store_routing')
+  assert.ok(order, 'Expected integration order to be stored')
+  assert.deepStrictEqual(order.pricingSnapshot, {
+    baseTotalMinor: 100000,
+    processingFeeMinor: 1989,
+    customerTotalMinor: 101989,
+    sedifexCommissionMinor: 3000,
+    customerPaysProcessingFee: true,
+    merchantPaysCommission: true,
+  })
+  assert.strictEqual(order.paymentRouting.source, 'stores.paymentRouting')
+  assert.strictEqual(order.paystackSplit.subaccount, 'ACCT_store_nested')
+  assert.strictEqual(order.paystackSplit.transactionChargeMinor, 3000)
+  assert.strictEqual(state.body.paystackSplit.enabled, true)
+}
+
+async function runMissingSubaccountTest() {
+  currentDefaultDb = new MockFirestore({ 'stores/store-123': { name: 'No routing store' } })
+  process.env.PAYSTACK_SECRET_KEY = 'test_secret'
+  paystackPayloads = []
+
+  const { integrationCheckoutCreate } = loadQuickPayModule()
+  const state = await post(integrationCheckoutCreate, quickPayBody({ reference: 'qp_no_subaccount' }))
+
+  assert.strictEqual(state.statusCode, 200)
+  const payload = paystackPayloads[0]
+  assert.strictEqual(payload.subaccount, undefined)
+  assert.strictEqual(payload.transaction_charge, undefined)
+  assert.strictEqual(payload.metadata.splitEnabled, false)
+  assert.strictEqual(payload.metadata.splitDisabledReason, 'missing_paystack_subaccount')
+  const order = currentDefaultDb.getDoc('integrationOrders/qp_no_subaccount')
+  assert.strictEqual(order.paystackSplit.enabled, false)
+  assert.strictEqual(order.paystackSplit.splitDisabledReason, 'missing_paystack_subaccount')
+}
+
+async function runExternalBodySubaccountCompatibilityTest() {
+  currentDefaultDb = new MockFirestore({})
+  process.env.PAYSTACK_SECRET_KEY = 'test_secret'
+  paystackPayloads = []
+
+  const { integrationCheckoutCreate } = loadQuickPayModule()
+  const state = await post(integrationCheckoutCreate, {
+    storeId: 'external-store',
+    reference: 'external_body_subaccount',
+    amount: 1000,
+    currency: 'GHS',
+    customer: { email: 'buyer@example.com' },
+    sourceChannel: 'integration_checkout',
+    subaccount: 'ACCT_from_body',
+    splitPayment: { transactionChargeMinor: 2500 },
+    metadata: { quickPay: false },
+  })
+
+  assert.strictEqual(state.statusCode, 200)
+  const payload = paystackPayloads[0]
+  assert.strictEqual(payload.amount, 100000)
+  assert.strictEqual(payload.subaccount, 'ACCT_from_body')
+  assert.strictEqual(payload.transaction_charge, 2500)
+  assert.strictEqual(payload.metadata.processingFeeMinor, 0)
+  assert.strictEqual(payload.metadata.customerPaysProcessingFee, false)
+}
+
+async function runCashQuickPayNoProcessingFeeTest() {
+  currentDefaultDb = new MockFirestore({ 'stores/store-123': {} })
+  const { integrationCashCheckoutCreate } = loadCashModule()
+  const state = await post(integrationCashCheckoutCreate, {
+    storeId: 'store-123',
+    reference: 'cash_quickpay',
+    amount: 1000,
+    currency: 'GHS',
+    customer: { email: 'cash@example.com', name: 'Cash Buyer' },
+    sourceChannel: 'quick_pay_cash',
+    metadata: { quickPay: true },
+    items: [{ item_id: 'svc-1', name: 'Service', qty: 1 }],
+  })
+
+  assert.strictEqual(state.statusCode, 200)
+  const cashOrder = currentDefaultDb.getDoc('stores/store-123/cashOrders/cash_quickpay')
+  assert.ok(cashOrder, 'Expected cash order to be stored')
+  assert.strictEqual(cashOrder.amountMinor, 100000)
+  assert.strictEqual(cashOrder.processingFeeMinor, undefined)
+  assert.deepStrictEqual(cashOrder.paystackSplit, { enabled: false, reason: 'store_only_cash_checkout' })
+}
+
+async function run() {
+  await runQuickPayStoreRoutingTest()
+  await runMissingSubaccountTest()
+  await runExternalBodySubaccountCompatibilityTest()
+  await runCashQuickPayNoProcessingFeeTest()
+}
+
+run()
+  .then(() => console.log('integrationQuickPayCheckoutCreate tests passed'))
+  .catch(error => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/web/src/pages/PublicQuickPayCheckout.css
+++ b/web/src/pages/PublicQuickPayCheckout.css
@@ -413,7 +413,10 @@
 }
 
 .qp-total-label { color: #64748b; font-size: 14px; font-weight: 700; }
-.qp-total-value { color: #0f172a; font-size: 26px; font-weight: 900; }
+.qp-total-value { color: #0f172a; font-size: 20px; font-weight: 900; }
+.qp-total-row-final { border-top-color: #cbd5e1; }
+.qp-total-row-final .qp-total-label { color: #0f172a; font-weight: 900; }
+.qp-total-row-final .qp-total-value { color: #0f172a; font-size: 26px; }
 
 .qp-form-fields {
   display: grid;

--- a/web/src/pages/PublicQuickPayCheckout.tsx
+++ b/web/src/pages/PublicQuickPayCheckout.tsx
@@ -38,6 +38,8 @@ const FUNCTION_BASE_URL =
 
 const CONTRACT_VERSION =
   import.meta.env.VITE_SEDIFEX_INTEGRATION_CONTRACT_VERSION || "2026-04-13";
+const DEFAULT_PAYSTACK_PROCESSING_FEE_PERCENT = 1.95;
+
 const MANUAL_PAYMENT_TYPES: ManualPaymentType[] = [
   "SERVICE",
   "PRODUCT",
@@ -63,6 +65,20 @@ function money(value: number) {
     style: "currency",
     currency: "GHS",
   }).format(value);
+}
+
+function calculateCustomerProcessingFee(
+  baseAmount: number,
+  feePercent = DEFAULT_PAYSTACK_PROCESSING_FEE_PERCENT,
+) {
+  if (!Number.isFinite(baseAmount) || baseAmount <= 0) return 0;
+  if (!Number.isFinite(feePercent) || feePercent <= 0) return 0;
+
+  const rate = feePercent / 100;
+  if (rate >= 1) return 0;
+
+  const baseMinor = Math.round(baseAmount * 100);
+  return (Math.max(0, Math.ceil(baseMinor / (1 - rate)) - baseMinor)) / 100;
 }
 
 function normalizeCheckoutItemType(type: QuickPayItemType) {
@@ -214,6 +230,11 @@ export default function PublicQuickPayCheckout() {
     selectedItem?.type === "MANUAL"
       ? Number(customAmount || 0)
       : unitAmount * quantity;
+  const processingFee =
+    paymentMethod === "ONLINE"
+      ? calculateCustomerProcessingFee(finalAmount)
+      : 0;
+  const onlineTotalAmount = finalAmount + processingFee;
 
   useEffect(() => {
     let isMounted = true;
@@ -363,6 +384,9 @@ export default function PublicQuickPayCheckout() {
         },
         metadata: {
           quickPay: true,
+          baseAmount: finalAmount,
+          displayedProcessingFee: processingFee,
+          displayedTotalToPay: onlineTotalAmount,
           storeId,
           itemId: selectedItem.id,
           slotId: selectedItem.slotId || requestedSlotId || null,
@@ -688,9 +712,27 @@ export default function PublicQuickPayCheckout() {
                   </label>
                 )}
                 <div className="qp-total-row">
-                  <span className="qp-total-label">Total</span>
+                  <span className="qp-total-label">Items / services</span>
                   <strong className="qp-total-value">
                     {money(finalAmount || 0)}
+                  </strong>
+                </div>
+                {paymentMethod === "ONLINE" ? (
+                  <div className="qp-total-row">
+                    <span className="qp-total-label">Processing fee</span>
+                    <strong className="qp-total-value">
+                      {money(processingFee || 0)}
+                    </strong>
+                  </div>
+                ) : null}
+                <div className="qp-total-row qp-total-row-final">
+                  <span className="qp-total-label">Total to pay</span>
+                  <strong className="qp-total-value">
+                    {money(
+                      paymentMethod === "ONLINE"
+                        ? onlineTotalAmount || 0
+                        : finalAmount || 0,
+                    )}
                   </strong>
                 </div>
               </div>
@@ -773,7 +815,7 @@ export default function PublicQuickPayCheckout() {
                 : selectedItem
                   ? paymentMethod === "CASH"
                     ? `Save cash order ${money(finalAmount || 0)}`
-                    : `Pay ${money(finalAmount || 0)}`
+                    : `Pay ${money(onlineTotalAmount || 0)}`
                   : "Enter payment details"}
             </button>
             <p className="qp-powered">


### PR DESCRIPTION
### Motivation
- Ensure Quick Pay online checkouts use the store's Paystack subaccount and apply the agreed fee/split rules instead of defaulting to Sedifex when the frontend does not supply routing.
- Compute the customer-facing processing fee server-side (gross-up) and apply Sedifex commission on the base amount only, while preserving compatibility for external integrations that already provide split info.
- Show the processing fee and the corrected total to the customer on the public Quick Pay page while keeping cash Quick Pay unchanged.

### Description
- Added routing helpers and Firestore lookup in `functions/src/integrationQuickPayCheckoutCreate.ts` that prefer `stores/{storeId}.paymentRouting` then `stores/{storeId}.paystackSubaccountCode` and fall back to `storeSettings/{storeId}` entries, normalizing a resolved routing snapshot. 
- Implemented authoritative fee calculations (gross-up processing fee and Sedifex commission) and used them to set Paystack initialization fields (`amount`, `subaccount`, `transaction_charge`, `bearer`) and to build `pricingSnapshot`, `paymentRouting`, and `paystackSplit` snapshots saved on integration order records.
- Preserved compatibility with request-body-provided routing/splits by honoring request `subaccount`/`paymentRouting`/`splitPayment` when present and recording `splitEnabled: false` and `splitDisabledReason` when no valid subaccount is found.
- Updated public checkout UI `web/src/pages/PublicQuickPayCheckout.tsx` and CSS to display "Items / services", "Processing fee", and "Total to pay" for online payments and updated the Pay button to reflect the online total while leaving cash behavior unchanged.
- Added unit/integration-style tests `functions/test/integrationQuickPayCheckoutCreate.test.js` and enhanced `functions/test/helpers/mockFirestore.js` to support the new tests covering: Firestore-loaded subaccounts, processing-fee gross-up, Paystack `amount`/`transaction_charge`/`subaccount` payloads, missing subaccount recording, cash Quick Pay no-fee behavior, and request-body subaccount compatibility.

### Testing
- Ran `npm --prefix functions run build` which compiled the functions and completed successfully.
- Executed the new focused test `node functions/test/integrationQuickPayCheckoutCreate.test.js`, which passed locally against the function build and mocked Firestore/fetch.
- Ran the existing `functions` test suite via `npm --prefix functions test` which failed due to an unrelated expectation in `bookingNormalization.test.js` that expects a `__testing` export from `functions/lib/index.js` (pre-existing issue outside this change).
- Attempted `npm --prefix web run build` but the web build was blocked by missing dev dependency types (`vite/client`, `vitest/globals`) and `npm install` for the workspace failed due to a registry `403` for `@azure/msal-browser`, so web build artifacts were not produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d549975ac8321bb3e2a1c370cc39e)