### PR TITLE
docs: clarify client website checkout URL and recommended env var for Cloud Function

### DIFF
--- a/docs/client-website-cart-design-guide.md
+++ b/docs/client-website-cart-design-guide.md
@@ -410,19 +410,21 @@ const payload = {
 }
 ```
 
-For Firebase Functions URLs, the route may map cleanly to:
+Use the direct deployed Cloud Functions endpoint for online checkout creation:
 
 ```text
-https://us-central1-<project>.cloudfunctions.net/integrationCheckoutCreate
+https://us-central1-sedifex-web.cloudfunctions.net/integrationCheckoutCreate
 ```
 
-For proxy/API deployments, it may map to:
+Recommended website environment variable:
 
-```text
-/integration/checkout/create
+```bash
+SEDIFEX_INTEGRATION_CHECKOUT_CREATE_URL=https://us-central1-sedifex-web.cloudfunctions.net/integrationCheckoutCreate
 ```
 
-The client website should hide this difference inside its own server API route.
+If the website stores only the Functions base URL, build the checkout URL as `${SEDIFEX_INTEGRATION_API_BASE_URL}/integrationCheckoutCreate`. Do **not** call `/integration/checkout/create` unless a deployed router or hosting rewrite explicitly maps that path to `integrationCheckoutCreate`; with the current Sedifex structure, the checkout function is exposed directly as `/integrationCheckoutCreate`.
+
+The client website can still hide this URL inside its own server API route, but that route should forward to the dedicated Cloud Functions URL above.
 
 ## Paystack redirect snapshot and success fallback
 


### PR DESCRIPTION
### Motivation

- Clarify which Cloud Functions endpoint the client website should call for creating online checkouts to avoid incorrect proxy paths. 
- Provide a recommended environment variable and guidance for constructing the correct checkout URL. 

### Description

- Updated the client website cart design guide to recommend using the direct deployed Cloud Functions endpoint `https://us-central1-sedifex-web.cloudfunctions.net/integrationCheckoutCreate` for checkout creation. 
- Added a recommended environment variable `SEDIFEX_INTEGRATION_CHECKOUT_CREATE_URL=https://us-central1-sedifex-web.cloudfunctions.net/integrationCheckoutCreate`. 
- Added guidance to build the URL from a stored base (`${SEDIFEX_INTEGRATION_API_BASE_URL}/integrationCheckoutCreate`) and a warning not to call `/integration/checkout/create` unless a router or hosting rewrite explicitly maps that path. 
- Clarified that the website may still proxy the call through its own server route provided that route forwards requests to the dedicated Cloud Functions URL. 

### Testing

- This is a documentation-only change and did not modify application code or automated tests. 
- No automated tests were run as part of this PR because the change only updates documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ded930b988321b8fc6b50eb70725b)