### PR TITLE
Add sandbox checkout mode

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -886,6 +886,70 @@ Recommended flow:
 
 Do not trust totals calculated only in the browser. Always confirm totals server-side with Sedifex before payment.
 
+### Sandbox checkout testing
+
+Developers can test website checkout plumbing without creating a Paystack transaction and without saving an `integrationOrders` record in Sedifex. Send any one of these flags on the checkout-create request:
+
+- Header: `X-Sedifex-Sandbox: true`
+- Body: `sandbox: true`
+- Body: `testMode: true`
+- Body: `mode: "sandbox"`
+- Metadata: `metadata.sandbox: true`
+
+Sandbox mode still validates the store ID, customer email, amount, item details, contract version, and payment-routing snapshot. The response returns `sandbox: true`, `persisted: false`, `payment_status: "sandbox_created"`, and a synthetic `checkoutUrl`. Because the order is intentionally not persisted, do not call the order-status endpoint for sandbox references.
+
+Example request:
+
+```http
+POST /integrationCheckoutCreate
+X-Sedifex-Contract-Version: 2026-04-13
+X-Sedifex-Sandbox: true
+Content-Type: application/json
+```
+
+```json
+{
+  "storeId": "store_123",
+  "reference": "sandbox_order_001",
+  "amount": 600,
+  "currency": "GHS",
+  "customer": {
+    "email": "developer@example.com",
+    "name": "Developer Test"
+  },
+  "sourceChannel": "client_website",
+  "returnUrl": "https://clientsite.com/checkout/complete",
+  "items": [
+    {
+      "item_id": "service-schengen-travel-assistance-a65e6f",
+      "name": "Schengen Travel Assistance",
+      "qty": 1,
+      "type": "SERVICE"
+    }
+  ],
+  "metadata": {
+    "sandbox": true
+  }
+}
+```
+
+Example response:
+
+```json
+{
+  "ok": true,
+  "sandbox": true,
+  "persisted": false,
+  "reference": "sandbox_order_001",
+  "payment_status": "sandbox_created",
+  "order_status": "sandbox_created",
+  "paymentProvider": "sandbox",
+  "checkoutUrl": "https://clientsite.com/checkout/complete?sedifex_sandbox=true&reference=sandbox_order_001&status=sandbox_created"
+}
+```
+
+Use this mode for checkout UI tests, end-to-end smoke tests, and developer test accounts that should not appear in Sedifex dashboards or reports. Remove the sandbox flag when testing real Paystack test keys or when you want Sedifex to save the order.
+
 ---
 
 ## 9. Next.js server example

--- a/functions/src/integrationQuickPayCheckoutCreate.ts
+++ b/functions/src/integrationQuickPayCheckoutCreate.ts
@@ -41,6 +41,42 @@ function getFirstArrayRecord(value: unknown): Record<string, unknown> {
 }
 
 
+
+function isTruthyFlag(value: unknown) {
+  if (value === true) return true
+  const normalized = clean(value, 40).toLowerCase()
+  return ['1', 'true', 'yes', 'y', 'on', 'sandbox', 'test', 'test_mode'].includes(normalized)
+}
+
+function isSandboxCheckout(req: functions.https.Request, body: CheckoutBody) {
+  const metadata = getRecord(body.metadata)
+  return isTruthyFlag(req.get('x-sedifex-sandbox'))
+    || isTruthyFlag(body.sandbox)
+    || isTruthyFlag(body.sandboxMode)
+    || isTruthyFlag(body.sandbox_mode)
+    || isTruthyFlag(body.testMode)
+    || isTruthyFlag(body.test_mode)
+    || clean(body.mode, 40).toLowerCase() === 'sandbox'
+    || isTruthyFlag(metadata.sandbox)
+    || isTruthyFlag(metadata.sandboxMode)
+    || isTruthyFlag(metadata.sandbox_mode)
+    || isTruthyFlag(metadata.testMode)
+    || isTruthyFlag(metadata.test_mode)
+}
+
+function getSandboxCheckoutUrl(reference: string, callbackUrl?: string) {
+  if (!callbackUrl) return `https://sandbox.sedifex.test/checkout/${encodeURIComponent(reference)}`
+  try {
+    const url = new URL(callbackUrl)
+    url.searchParams.set('sedifex_sandbox', 'true')
+    url.searchParams.set('reference', reference)
+    url.searchParams.set('status', 'sandbox_created')
+    return url.toString()
+  } catch (_error) {
+    return `https://sandbox.sedifex.test/checkout/${encodeURIComponent(reference)}`
+  }
+}
+
 function getBookingId(body: CheckoutBody) {
   const metadata = getRecord(body.metadata)
   return firstText([body.booking_id, body.bookingId, metadata.booking_id, metadata.bookingId], 220)
@@ -86,7 +122,7 @@ function firstText(values: unknown[], max = 220) {
 
 function setCors(res: functions.Response, methods = 'POST, OPTIONS') {
   res.set('Access-Control-Allow-Origin', '*')
-  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-api-key, X-Sedifex-Contract-Version')
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-api-key, X-Sedifex-Contract-Version, X-Sedifex-Sandbox')
   res.set('Access-Control-Allow-Methods', methods)
 }
 
@@ -482,6 +518,7 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     const transactionChargeMinor = getTransactionChargeMinor(body)
     const details = deriveCheckoutDetails(body)
     const quickPayCheckout = isQuickPayCheckout(body, details.metadata, sourceChannel)
+    const sandboxCheckout = isSandboxCheckout(req, body)
 
     if (!storeId) {
       res.status(400).json({ error: 'missing-store-id' })
@@ -585,6 +622,33 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
       settlementMode: paymentRouting.settlementMode,
       splitEnabled: Boolean(subaccount),
       splitDisabledReason: subaccount ? null : paymentRouting.splitDisabledReason,
+    }
+
+    if (sandboxCheckout) {
+      const sandboxCheckoutUrl = getSandboxCheckoutUrl(reference, callbackUrl)
+      res.status(200).json({
+        ok: true,
+        sandbox: true,
+        persisted: false,
+        reference,
+        payment_reference: reference,
+        authorizationUrl: sandboxCheckoutUrl,
+        checkoutUrl: sandboxCheckoutUrl,
+        accessCode: `sandbox_${reference}`,
+        orderId: reference,
+        payment_status: 'sandbox_created',
+        order_status: 'sandbox_created',
+        status: 'sandbox_created',
+        paymentProvider: 'sandbox',
+        payment_provider: 'sandbox',
+        recordType: details.recordType,
+        orderType: details.recordType,
+        pricingSnapshot,
+        paymentRouting: paymentRoutingSnapshot,
+        paystackSplit: paystackSplitSnapshot,
+        message: 'Sandbox checkout validated successfully. No Paystack transaction was initialized and no Sedifex order was saved.',
+      })
+      return
     }
 
     const paystackPayload: Record<string, unknown> = {

--- a/functions/test/integrationQuickPayCheckoutCreate.test.js
+++ b/functions/test/integrationQuickPayCheckoutCreate.test.js
@@ -251,6 +251,39 @@ async function runExternalBodySubaccountCompatibilityTest() {
   assert.strictEqual(payload.metadata.customerPaysProcessingFee, false)
 }
 
+
+async function runSandboxCheckoutDoesNotPersistTest() {
+  currentDefaultDb = new MockFirestore({
+    'stores/store-123': {
+      paymentRouting: {
+        paystackSubaccountCode: 'ACCT_sandbox_store',
+        percentageCharge: 3,
+        settlementMode: 'subaccount',
+        status: 'active',
+      },
+    },
+  })
+  process.env.PAYSTACK_SECRET_KEY = 'test_secret'
+  paystackPayloads = []
+
+  const { integrationCheckoutCreate } = loadQuickPayModule()
+  const state = await post(integrationCheckoutCreate, quickPayBody({
+    reference: 'qp_sandbox_checkout',
+    sandbox: true,
+    returnUrl: 'https://merchant.example/thanks',
+  }))
+
+  assert.strictEqual(state.statusCode, 200)
+  assert.strictEqual(state.body.sandbox, true)
+  assert.strictEqual(state.body.persisted, false)
+  assert.strictEqual(state.body.payment_status, 'sandbox_created')
+  assert.strictEqual(state.body.paymentProvider, 'sandbox')
+  assert.strictEqual(state.body.checkoutUrl, 'https://merchant.example/thanks?sedifex_sandbox=true&reference=qp_sandbox_checkout&status=sandbox_created')
+  assert.strictEqual(paystackPayloads.length, 0)
+  assert.strictEqual(currentDefaultDb.getDoc('integrationOrders/qp_sandbox_checkout'), undefined)
+  assert.strictEqual(currentDefaultDb.getDoc('stores/store-123/integrationOrders/qp_sandbox_checkout'), undefined)
+}
+
 async function runCashQuickPayNoProcessingFeeTest() {
   currentDefaultDb = new MockFirestore({ 'stores/store-123': {} })
   const { integrationCashCheckoutCreate } = loadCashModule()
@@ -277,6 +310,7 @@ async function run() {
   await runQuickPayStoreRoutingTest()
   await runMissingSubaccountTest()
   await runExternalBodySubaccountCompatibilityTest()
+  await runSandboxCheckoutDoesNotPersistTest()
   await runCashQuickPayNoProcessingFeeTest()
 }
 


### PR DESCRIPTION
### Motivation
- Enable developers to validate checkout flows without creating real Paystack transactions or persisting `integrationOrders` in Sedifex dashboards.
- Provide a predictable, non-persistent response for UI tests, smoke tests, and developer test accounts while still exercising validation and pricing/routing logic.
- Document the sandbox usage so integrators know how to trigger and interpret sandbox responses.

### Description
- Added sandbox detection utilities (`isTruthyFlag`, `isSandboxCheckout`, `getSandboxCheckoutUrl`) and included `X-Sedifex-Sandbox` in CORS allow-list in `functions/src/integrationQuickPayCheckoutCreate.ts`.
- Short-circuited the checkout-create flow to return a synthetic sandbox response (`sandbox_created`) that includes pricing and routing snapshots but does not call Paystack or write `integrationOrders` when sandbox is requested.
- Updated `docs/integration-api-guide.md` with a `Sandbox checkout testing` section describing headers/body/metadata flags and example request/response.
- Added a regression test `runSandboxCheckoutDoesNotPersistTest` to `functions/test/integrationQuickPayCheckoutCreate.test.js` that verifies no Paystack call and no persisted order for sandbox requests.

### Testing
- Built the functions with `npm --prefix functions run build` which completed successfully.
- Ran the modified test script with `node functions/test/integrationQuickPayCheckoutCreate.test.js` and the test suite reported success (`integrationQuickPayCheckoutCreate tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df1b37730832187ab8d196990902e)