### PR TITLE
Add product `brand` field to Items UI and integration products feed

### DIFF
--- a/docs/integration-api-guide.md
+++ b/docs/integration-api-guide.md
@@ -103,7 +103,7 @@ Full URL example:
 https://us-central1-sedifex-web.cloudfunctions.net/v1IntegrationProducts?storeId=<storeId>
 ```
 
-Use this endpoint when a client website needs to show Sedifex products or services.
+Use this endpoint when a client website needs to show Sedifex products or services. Product records include `brand` (with `manufacturerName` kept as a backward-compatible alias), so websites can build brand pages that group products by the same label.
 
 ### PowerShell test
 
@@ -136,6 +136,8 @@ Invoke-RestMethod -Uri $url -Headers $headers -Method GET | ConvertTo-Json -Dept
       "storeId": "store_123",
       "name": "Place Holder",
       "category": "General Services",
+      "brand": null,
+      "manufacturerName": null,
       "description": "Service description",
       "price": 600,
       "priceMinor": 60000,

--- a/docs/integration-quickstart.md
+++ b/docs/integration-quickstart.md
@@ -356,6 +356,8 @@ type Product = {
   stockCount?: number
   imageUrl?: string | null
   imageUrls?: string[]
+  brand?: string | null
+  manufacturerName?: string | null
 }
 
 const FALLBACK_PRODUCTS: Product[] = [
@@ -425,6 +427,15 @@ function groupByCategory(products: Product[]) {
     const category = product.category?.trim() || 'Uncategorized'
     if (!acc[category]) acc[category] = []
     acc[category].push(product)
+    return acc
+  }, {})
+}
+
+function groupByBrand(products: Product[]) {
+  return products.reduce<Record<string, Product[]>>((acc, product) => {
+    const brand = product.brand?.trim() || product.manufacturerName?.trim() || 'Other brands'
+    if (!acc[brand]) acc[brand] = []
+    acc[brand].push(product)
     return acc
   }, {})
 }

--- a/functions/src/googleShopping.ts
+++ b/functions/src/googleShopping.ts
@@ -17,6 +17,7 @@ type IntegrationProduct = {
   imageUrl?: string | null
   sku?: string | null
   barcode?: string | null
+  brand?: string | null
   manufacturerName?: string | null
 }
 
@@ -686,7 +687,8 @@ async function fetchIntegrationProducts(params: {
       imageUrl: normalizeString(entry.imageUrl) || null,
       sku: normalizeString(entry.sku) || null,
       barcode: normalizeString(entry.barcode) || null,
-      manufacturerName: normalizeString(entry.manufacturerName) || null,
+      brand: normalizeString(entry.brand ?? entry.manufacturerName) || null,
+      manufacturerName: normalizeString(entry.manufacturerName ?? entry.brand) || null,
     }
   })
 }
@@ -701,6 +703,7 @@ function validateAndTransform(
   const description = normalizeString(product.description)
   const imageLink = normalizeString(product.imageUrl)
   const brand =
+    normalizeString(product.brand) ||
     normalizeString(product.manufacturerName) ||
     normalizeString(options.storeBrandFallback) ||
     resolveCategoryBrandDefault(product.category)

--- a/functions/src/integrationProducts.ts
+++ b/functions/src/integrationProducts.ts
@@ -31,6 +31,8 @@ type IntegrationProductItem = {
   imageUrl?: string | null
   imageUrls: string[]
   imageAlt?: string | null
+  brand?: string | null
+  manufacturerName?: string | null
   sortOrder?: number | null
   order?: number | null
   updatedAt?: string | null
@@ -193,6 +195,7 @@ function normalizeDoc(id: string, storeId: string, record: Record<string, unknow
   const priceMinor = getPriceMinor(record)
   const imageUrls = getImageUrls(record)
   const order = numberValue(record.order)
+  const brand = cleanIntegrationText(record.brand ?? record.manufacturerName ?? record.manufacturer ?? record.vendor, 180)
   const sortOrder = numberValue(record.sortOrder ?? record.featuredRank ?? record.rank)
 
   return {
@@ -209,6 +212,8 @@ function normalizeDoc(id: string, storeId: string, record: Record<string, unknow
     imageUrl: imageUrls[0] || null,
     imageUrls,
     imageAlt: cleanIntegrationText(record.imageAlt ?? record.alt, 220) || name,
+    brand: brand || null,
+    manufacturerName: brand || null,
     sortOrder: sortOrder === null ? null : sortOrder,
     order: order === null ? null : order,
     updatedAt: toDateIso(record.updatedAt ?? record.createdAt),

--- a/functions/src/types/product.ts
+++ b/functions/src/types/product.ts
@@ -12,6 +12,8 @@ export type ProductReadModel = {
   imageUrl: string | null
   imageUrls: string[]
   imageAlt: string | null
+  brand?: string | null
+  manufacturerName?: string | null
   updatedAt: FirebaseFirestore.Timestamp | null
   listingType?: 'product' | 'service' | 'course' | null
   salesMode?: 'buy_now' | 'book_now' | 'register' | 'request_quote' | null

--- a/web/src/pages/ProductsServiceFirst.tsx
+++ b/web/src/pages/ProductsServiceFirst.tsx
@@ -38,6 +38,7 @@ type Draft = {
   expiryDate: string
   imageUrl: string
   imageAlt: string
+  brand: string
   serviceKind: ServiceKind
   durationMinutes: string
   location: string
@@ -117,6 +118,7 @@ const blankDraft: Draft = {
   expiryDate: '',
   imageUrl: '',
   imageAlt: '',
+  brand: '',
   serviceKind: 'consultation',
   durationMinutes: '',
   location: '',
@@ -412,7 +414,8 @@ function normalizeProduct(id: string, data: Record<string, unknown>): Product {
     taxRate: cleanNumber(data.taxRate),
     expiryDate: itemType === 'product' ? toDate(data.expiryDate) : null,
     productionDate: itemType === 'product' ? toDate(data.productionDate) : null,
-    manufacturerName: itemType === 'product' && typeof data.manufacturerName === 'string' ? data.manufacturerName : null,
+    brand: itemType === 'product' ? cleanText(data.brand ?? data.manufacturerName) : null,
+    manufacturerName: itemType === 'product' ? cleanText(data.manufacturerName ?? data.brand) : null,
     batchNumber: itemType === 'product' && typeof data.batchNumber === 'string' ? data.batchNumber : null,
     showOnReceipt: itemType === 'product' && data.showOnReceipt === true,
     imageUrl,
@@ -480,6 +483,7 @@ function buildSavePayload(draft: Draft, storeId: string) {
   const isPublished = draft.isPublished === true
   const status: 'draft' | 'published' = isPublished ? 'published' : 'draft'
   const description = cleanSavedDescription(draft.description)
+  const brand = behavesLikeService ? null : draft.brand.trim() || null
 
   return {
     storeId,
@@ -525,7 +529,8 @@ function buildSavePayload(draft: Draft, storeId: string) {
     courseMode: isCourse ? draft.courseMode : null,
     classTimes: isCourse ? draft.preferredTimes.trim() || draft.classTimes.trim() || null : null,
     productionDate: null,
-    manufacturerName: null,
+    brand,
+    manufacturerName: brand,
     batchNumber: null,
     showOnReceipt: false,
     imageUrl: trimmedImageUrl || null,
@@ -682,6 +687,7 @@ export default function ProductsServiceFirst() {
       expiryDate: itemType === 'product' ? formatDateInput(item.expiryDate) : '',
       imageUrl: item.imageUrl ?? '',
       imageAlt: item.imageAlt ?? item.name,
+      brand: item.itemType === 'product' ? (item.brand ?? item.manufacturerName ?? '') : '',
       serviceKind: ((item as any).serviceKind === 'quote_request' ? 'quote_request' : 'consultation') as ServiceKind,
       durationMinutes: typeof (item as any).durationMinutes === 'number' ? String((item as any).durationMinutes) : '',
       location: typeof (item as any).location === 'string' ? (item as any).location : '',
@@ -878,6 +884,10 @@ export default function ProductsServiceFirst() {
                   <input id="item-sku" value={draft.sku} onChange={event => updateDraft('sku', event.target.value)} />
                 </div>
                 <div className="field">
+                  <label className="field__label" htmlFor="item-brand">Brand</label>
+                  <input id="item-brand" value={draft.brand} onChange={event => updateDraft('brand', event.target.value)} placeholder="e.g. Nike, Samsung, Local label" />
+                </div>
+                <div className="field">
                   <label className="field__label" htmlFor="item-cost">Cost price</label>
                   <input id="item-cost" type="number" min="0" step="0.01" value={draft.costPrice} onChange={event => updateDraft('costPrice', event.target.value)} />
                 </div>
@@ -1064,6 +1074,7 @@ export default function ProductsServiceFirst() {
                     ) : (
                       <>
                         <div className="products-page__list-field"><label className="field__label">Product category</label><p className="products-page__list-value">{normalizeCategory(item.category, item.itemType)}</p></div>
+                        <div className="products-page__list-field"><label className="field__label">Brand</label><p className="products-page__list-value">{item.brand || item.manufacturerName || '—'}</p></div>
                         <div className="products-page__list-field"><label className="field__label">SKU / Barcode</label><p className="products-page__list-value">{item.sku || item.barcode || '—'}</p></div>
                         <div className="products-page__list-field"><label className="field__label">On hand</label><p className="products-page__list-value">{item.stockCount ?? 0}</p></div>
                         <div className="products-page__list-field"><label className="field__label">Reorder point</label><p className="products-page__list-value">{item.reorderPoint ?? '—'}</p></div>

--- a/web/src/types/product.ts
+++ b/web/src/types/product.ts
@@ -17,6 +17,7 @@ export type Product = {
   imageAlt?: string | null
   taxRate?: number | null
   expiryDate?: Date | null
+  brand?: string | null
   manufacturerName?: string | null
   productionDate?: Date | null
   batchNumber?: string | null


### PR DESCRIPTION
### Motivation
- Provide a first-class `brand` field on product records (renaming the visible manufacturer entry to Brand) so websites can build brand pages grouping products by the same label. 
- Preserve backwards compatibility by keeping `manufacturerName` as an alias for existing integrations and feeds. 
- Surface the same field to downstream systems such as Google Shopping and the integration API so external sites can rely on `brand` in addition to legacy fields.

### Description
- Added a `brand` input to the Items form and draft model and persist `brand` in product payloads while also writing the legacy `manufacturerName` alias; relevant changes are in `web/src/pages/ProductsServiceFirst.tsx` (form, `buildSavePayload`, `normalizeProduct`) and `web/src/types/product.ts`. 
- Exposed `brand` and the backward-compatible `manufacturerName` from the integration feed by extracting `brand` from `record.brand ?? record.manufacturerName ?? record.manufacturer ?? record.vendor` in `functions/src/integrationProducts.ts` and including both fields in the response. 
- Updated server-side consumers to prefer `brand` but fall back to `manufacturerName`, including `functions/src/googleShopping.ts` normalization and `functions/src/types/product.ts` type additions. 
- Updated integration docs and the quickstart examples to document `brand` and show a `groupByBrand` helper in `docs/integration-api-guide.md` and `docs/integration-quickstart.md`.

### Testing
- Ran `npm --prefix functions run build` which completed successfully. 
- Ran `npm --prefix functions test` which failed due to an existing unit test asserting `__testing` exports (unrelated test failure). 
- Attempted `npm --prefix web run build` which failed because `web/node_modules` is not installed and TypeScript could not find `vite/client` and `vitest/globals`. 
- Attempted `npm --prefix web ci` which failed due to `package.json` / `package-lock.json` mismatch (lockfile out of sync).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd2ed51508321aeaf60a1eb44e966)