### PR TITLE
Fix product search filtering

### DIFF
--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -40,6 +40,7 @@ import { requestAiAdvisor } from '../api/aiAdvisor'
 import { useToast } from '../components/ToastProvider'
 import { playSound } from '../utils/sound'
 import { buildPromoSlug } from '../utils/promoSlug'
+import { productMatchesSearch } from '../utils/productSearch'
 
 type CachedProduct = Omit<Product, 'id'>
 type AbcBucket = 'A' | 'B' | 'C'
@@ -905,14 +906,7 @@ export default function Products() {
     }
 
     if (searchText.trim()) {
-      const term = searchText.trim().toLowerCase()
-      result = result.filter(p => {
-        const inName = p.name.toLowerCase().includes(term)
-        const inCategory = (p.category ?? '').toLowerCase().includes(term)
-        const inSku = (p.sku ?? '').toLowerCase().includes(term)
-        const inBarcode = (p.barcode ?? '').toLowerCase().includes(term)
-        return inName || inCategory || inSku || inBarcode
-      })
+      result = result.filter(product => productMatchesSearch(product, searchText))
     }
 
     return result

--- a/web/src/pages/ProductsServiceFirst.tsx
+++ b/web/src/pages/ProductsServiceFirst.tsx
@@ -6,7 +6,6 @@ import {
   doc,
   limit,
   onSnapshot,
-  orderBy,
   query,
   serverTimestamp,
   setDoc,
@@ -20,6 +19,7 @@ import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import { useMemberships } from '../hooks/useMemberships'
 import type { ItemType, Product } from '../types/product'
+import { productMatchesSearch } from '../utils/productSearch'
 
 type ItemFormType = 'product' | 'service' | 'course'
 type ServiceKind = 'consultation' | 'quote_request'
@@ -450,6 +450,10 @@ function normalizeProduct(id: string, data: Record<string, unknown>): Product {
   }
 }
 
+function getProductSortTime(product: Product): number {
+  return toDate(product.updatedAt)?.getTime() ?? toDate(product.createdAt)?.getTime() ?? 0
+}
+
 function buildSavePayload(draft: Draft, storeId: string) {
   const isService = draft.itemType === 'service'
   const isCourse = draft.itemType === 'course'
@@ -587,9 +591,11 @@ export default function ProductsServiceFirst() {
       setItems([])
       return
     }
-    const q = query(collection(db, 'products'), where('storeId', '==', storeId), orderBy('updatedAt', 'desc'), limit(500))
+    const q = query(collection(db, 'products'), where('storeId', '==', storeId), limit(500))
     return onSnapshot(q, snapshot => {
-      const rows = snapshot.docs.map(documentSnapshot => normalizeProduct(documentSnapshot.id, documentSnapshot.data() as Record<string, unknown>))
+      const rows = snapshot.docs
+        .map(documentSnapshot => normalizeProduct(documentSnapshot.id, documentSnapshot.data() as Record<string, unknown>))
+        .sort((a, b) => getProductSortTime(b) - getProductSortTime(a) || a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
       setItems(rows)
     })
   }, [storeId])
@@ -817,7 +823,7 @@ export default function ProductsServiceFirst() {
   const visibleItems = useMemo(() => {
     const term = search.trim().toLowerCase()
     if (!term) return items
-    return items.filter(item => [item.name, item.category ?? '', item.sku ?? '', item.itemType].join(' ').toLowerCase().includes(term))
+    return items.filter(item => productMatchesSearch(item, term))
   }, [items, search])
 
   return (

--- a/web/src/pages/__tests__/Products.search.test.ts
+++ b/web/src/pages/__tests__/Products.search.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { productMatchesSearch } from '../../utils/productSearch'
+import type { Product } from '../../types/product'
+
+function makeProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 'product-1',
+    name: 'Vitamin C Serum',
+    itemType: 'product',
+    category: 'Skin Care',
+    description: 'Brightening face serum',
+    sku: 'SER-001',
+    barcode: '123456',
+    price: 25,
+    costPrice: null,
+    stockCount: 10,
+    reorderPoint: 2,
+    taxRate: null,
+    expiryDate: null,
+    productionDate: null,
+    brand: 'Glow Lab',
+    manufacturerName: 'Glow Lab',
+    batchNumber: null,
+    showOnReceipt: false,
+    imageUrl: null,
+    imageUrls: [],
+    imageAlt: null,
+    isPublished: false,
+    status: 'draft',
+    isMarketplaceVisible: false,
+    isWebsiteVisible: false,
+    ...overrides,
+  }
+}
+
+describe('productMatchesSearch', () => {
+  it('matches physical products when the user searches for product', () => {
+    expect(productMatchesSearch(makeProduct({ category: 'Skin Care' }), 'product')).toBe(true)
+  })
+
+  it('matches multiple words across item type and category fields', () => {
+    expect(productMatchesSearch(makeProduct({ category: 'Skin Care' }), 'product skin')).toBe(true)
+  })
+
+  it('does not match services for product-only searches', () => {
+    expect(
+      productMatchesSearch(
+        makeProduct({
+          id: 'service-1',
+          name: 'Makeup Consultation',
+          itemType: 'service',
+          category: 'Beauty Services',
+          sku: null,
+          barcode: null,
+        }),
+        'product',
+      ),
+    ).toBe(false)
+  })
+})

--- a/web/src/utils/productSearch.ts
+++ b/web/src/utils/productSearch.ts
@@ -1,0 +1,37 @@
+import type { Product } from '../types/product'
+
+function buildProductSearchText(product: Product): string {
+  const itemTypeLabel =
+    product.itemType === 'service'
+      ? 'service booking service item'
+      : product.itemType === 'course'
+        ? 'course programme program class training item'
+        : 'product physical product inventory stock item'
+
+  return [
+    product.name,
+    product.category,
+    product.sku,
+    product.barcode,
+    product.description,
+    product.manufacturerName,
+    product.brand,
+    itemTypeLabel,
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ')
+    .toLowerCase()
+}
+
+export function productMatchesSearch(product: Product, rawTerm: string): boolean {
+  const terms = rawTerm
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+
+  if (!terms.length) return true
+
+  const searchableText = buildProductSearchText(product)
+  return terms.every(term => searchableText.includes(term))
+}


### PR DESCRIPTION
### Motivation
- Search should reliably find physical products when users type generic terms like “product” and should consider more product fields (description, brand, manufacturer) beyond name/category/SKU/barcode.
- The live items subscription previously ordered by `updatedAt`, which can exclude older documents lacking that field; the query should not drop those documents and sorting should be handled client-side.

### Description
- Added a shared search matcher in `web/src/utils/productSearch.ts` that builds a searchable text from `name`, `category`, `sku`, `barcode`, `description`, `manufacturerName`, `brand`, and item-type label tokens, and exposes `productMatchesSearch` for multi-word matching.
- Rewired both items pages to use the new matcher: `Products` uses `productMatchesSearch` for its `visibleProducts` filter and `ProductsServiceFirst` uses it for `visibleItems` filtering.
- Updated the `ProductsServiceFirst` Firestore subscription to remove the server-side `orderBy('updatedAt')` clause and instead sort the mapped results client-side by `updatedAt`, `createdAt`, then `name` to avoid excluding documents that lack `updatedAt`.
- Added unit tests `web/src/pages/__tests__/Products.search.test.ts` covering matching behavior (including that searching for “product” matches physical products and not services).

### Testing
- Ran `git diff --check` locally to validate diffs (no whitespace errors detected). (success)
- Attempted to run the new unit tests with `cd web && npm test -- src/pages/__tests__/Products.search.test.ts`, but `vitest` is not available in the runtime, so tests could not be executed here. (blocked)
- Attempted dependency install with `npm install` / `npm ci`, but installation was blocked by environment constraints: `npm ci` failed because `package.json` and `package-lock.json` are out of sync, and `npm install` failed with a `403 Forbidden` from the registry for a dev dependency, so test execution was not possible in this environment. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2167a4dabc8321aa5760f3bd762fc7)