### PR TITLE
Add “Used by growing businesses” landing section with branded cards and logo fallbacks

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -766,3 +766,203 @@ label {
     justify-self: end;
   }
 }
+
+.used-businesses {
+  width: min(1280px, 100%);
+  z-index: 1;
+  display: grid;
+  gap: clamp(22px, 4vw, 34px);
+  padding: clamp(22px, 5vw, 42px);
+  border-radius: 34px;
+  color: #0f172a;
+  background:
+    radial-gradient(circle at 12% 12%, rgba(56, 189, 248, 0.18), transparent 28%),
+    radial-gradient(circle at 92% 6%, rgba(168, 85, 247, 0.16), transparent 26%),
+    linear-gradient(180deg, rgba(248, 250, 252, 0.98), rgba(239, 246, 255, 0.94));
+  border: 1px solid rgba(226, 232, 240, 0.94);
+  box-shadow: 0 34px 84px -46px rgba(15, 23, 42, 0.8);
+}
+
+.used-businesses .app__pill {
+  color: #075985;
+  background: rgba(14, 165, 233, 0.12);
+  border-color: rgba(14, 165, 233, 0.22);
+}
+
+.used-businesses__header {
+  display: grid;
+  gap: 12px;
+  max-width: 920px;
+}
+
+.used-businesses__header h2 {
+  margin: 0;
+  color: #0f172a;
+  font-size: clamp(24px, 4vw, 38px);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+}
+
+.used-businesses__header p {
+  margin: 0;
+  color: #475569;
+  font-size: clamp(15px, 2vw, 17px);
+  line-height: 1.7;
+}
+
+.used-businesses__purpose {
+  max-width: 820px;
+  padding-left: 14px;
+  border-left: 3px solid rgba(14, 165, 233, 0.55);
+}
+
+.used-businesses__grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 1fr;
+}
+
+.used-businesses__card {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  gap: 18px;
+  min-height: 220px;
+  padding: 20px;
+  border-radius: 26px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(203, 213, 225, 0.82);
+  box-shadow: 0 22px 54px -38px rgba(15, 23, 42, 0.78);
+}
+
+.used-businesses__card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 5px;
+  background: linear-gradient(90deg, var(--color-accent-start), var(--color-accent-end));
+}
+
+.used-businesses__card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.used-businesses__logo {
+  width: 68px;
+  height: 68px;
+  flex: 0 0 68px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(248, 250, 252, 0.95), rgba(226, 232, 240, 0.86));
+  border: 1px solid rgba(148, 163, 184, 0.34);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.82), 0 16px 28px -22px rgba(15, 23, 42, 0.7);
+}
+
+.used-businesses__logo img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+  padding: 10px;
+}
+
+.used-businesses__logo--placeholder {
+  color: #f8fafc;
+  font-size: 21px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  background:
+    radial-gradient(circle at 25% 18%, rgba(255, 255, 255, 0.24), transparent 30%),
+    linear-gradient(135deg, var(--color-accent-start), var(--color-accent-solid) 58%, var(--color-accent-end));
+  border-color: rgba(255, 255, 255, 0.54);
+}
+
+.used-businesses__badge {
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  border-radius: 999px;
+  padding: 7px 10px;
+  color: #0369a1;
+  background: #e0f2fe;
+  border: 1px solid rgba(14, 165, 233, 0.18);
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.used-businesses__card-copy {
+  display: grid;
+  gap: 10px;
+  align-content: end;
+}
+
+.used-businesses__card-copy h3 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 20px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.used-businesses__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 0;
+  color: #64748b;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.used-businesses__modules {
+  width: fit-content;
+  margin: 4px 0 0;
+  padding: 9px 11px;
+  border-radius: 14px;
+  color: #334155;
+  background: #f8fafc;
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.used-businesses__cta {
+  display: flex;
+  justify-content: center;
+}
+
+.used-businesses__cta-button {
+  width: auto;
+  min-width: min(100%, 310px);
+}
+
+@media (min-width: 640px) {
+  .used-businesses__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1100px) {
+  .used-businesses__grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .used-businesses {
+    border-radius: 26px;
+    padding: 22px;
+  }
+
+  .used-businesses__card {
+    min-height: 0;
+  }
+}

--- a/web/src/components/UsedByBusinesses.tsx
+++ b/web/src/components/UsedByBusinesses.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react'
+
+type BusinessCardData = {
+  id: string
+  name: string
+  category?: string
+  location?: string
+  modules: string[]
+  logoUrl?: string
+}
+
+type UsedByBusinessesProps = {
+  onCtaClick: () => void
+}
+
+function svgLogoDataUrl(label: string, accent: string, background: string) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"><rect width="160" height="160" rx="38" fill="${background}"/><circle cx="118" cy="42" r="24" fill="${accent}" opacity="0.18"/><path d="M36 102c18-38 42-58 72-60 11-.8 19 7 17 18-4 28-26 50-63 64-18 7-34-5-26-22Z" fill="${accent}" opacity="0.92"/><text x="80" y="92" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="900" fill="white">${label}</text></svg>`
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+}
+
+const sampleBusinesses: BusinessCardData[] = [
+  {
+    id: 'ama-fresh-mart',
+    name: 'Ama Fresh Mart',
+    category: 'Grocery & provisions',
+    location: 'Kumasi, Ghana',
+    modules: ['Inventory', 'Sales', 'Payments'],
+    logoUrl: svgLogoDataUrl('AF', '#06b6d4', '#0f172a'),
+  },
+  {
+    id: 'northstar-beauty-studio',
+    name: 'Northstar Beauty Studio',
+    category: 'Salon & appointments',
+    location: 'Accra, Ghana',
+    modules: ['Bookings', 'Customers', 'Payments'],
+  },
+  {
+    id: 'kente-lane-boutique',
+    name: 'Kente Lane Boutique',
+    category: 'Fashion retail',
+    location: 'East Legon',
+    modules: ['Inventory', 'Website', 'Sales'],
+    logoUrl: svgLogoDataUrl('KL', '#8b5cf6', '#1e1b4b'),
+  },
+  {
+    id: 'cedar-scholars-academy',
+    name: 'Cedar Scholars Academy',
+    category: 'Training school',
+    location: 'Tema, Ghana',
+    modules: ['Students', 'Registrations', 'Payments'],
+  },
+  {
+    id: 'urbanbite-kitchen',
+    name: 'UrbanBite Kitchen',
+    category: 'Food service',
+    location: 'Osu, Accra',
+    modules: ['Sales', 'Quick Pay', 'Customers'],
+    logoUrl: '/missing-urbanbite-logo.png',
+  },
+  {
+    id: 'noble-care-pharmacy',
+    name: 'Noble Care Pharmacy',
+    category: 'Health retail',
+    location: 'Takoradi',
+    modules: ['Inventory', 'Receipts', 'Reports'],
+  },
+  {
+    id: 'bluepath-travel',
+    name: 'BluePath Travel',
+    category: 'Travel services',
+    location: 'Spintex, Accra',
+    modules: ['Bookings', 'Invoices', 'Customers'],
+    logoUrl: svgLogoDataUrl('BP', '#0ea5e9', '#172554'),
+  },
+  {
+    id: 'hopebridge-foundation',
+    name: 'HopeBridge Foundation',
+    category: 'Nonprofit operations',
+    location: 'Cape Coast',
+    modules: ['Donors', 'Funds', 'Reports'],
+  },
+]
+
+function getInitials(name: string) {
+  const words = name.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return 'S'
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
+  return `${words[0][0]}${words[1][0]}`.toUpperCase()
+}
+
+function BusinessLogo({ business }: { business: BusinessCardData }) {
+  const [shouldUsePlaceholder, setShouldUsePlaceholder] = useState(!business.logoUrl)
+  const initials = getInitials(business.name)
+
+  if (shouldUsePlaceholder || !business.logoUrl) {
+    return (
+      <div className="used-businesses__logo used-businesses__logo--placeholder" aria-hidden="true">
+        {initials}
+      </div>
+    )
+  }
+
+  return (
+    <div className="used-businesses__logo" aria-hidden="true">
+      <img
+        src={business.logoUrl}
+        alt=""
+        loading="lazy"
+        onError={() => setShouldUsePlaceholder(true)}
+        onLoad={event => {
+          const image = event.currentTarget
+          if (image.naturalWidth < 56 || image.naturalHeight < 56) {
+            setShouldUsePlaceholder(true)
+          }
+        }}
+      />
+    </div>
+  )
+}
+
+function BusinessCard({ business }: { business: BusinessCardData }) {
+  return (
+    <article className="used-businesses__card">
+      <div className="used-businesses__card-header">
+        <BusinessLogo business={business} />
+        <span className="used-businesses__badge">Sedifex Store</span>
+      </div>
+      <div className="used-businesses__card-copy">
+        <h3>{business.name}</h3>
+        {(business.category || business.location) && (
+          <p className="used-businesses__meta">
+            {business.category && <span>{business.category}</span>}
+            {business.category && business.location && <span aria-hidden="true">•</span>}
+            {business.location && <span>{business.location}</span>}
+          </p>
+        )}
+        <p className="used-businesses__modules">{business.modules.join(' • ')}</p>
+      </div>
+    </article>
+  )
+}
+
+export default function UsedByBusinesses({ onCtaClick }: UsedByBusinessesProps) {
+  return (
+    <section className="used-businesses" aria-labelledby="used-businesses-title">
+      <header className="used-businesses__header">
+        <span className="app__pill">Trusted by stores</span>
+        <h2 id="used-businesses-title">Used by growing businesses</h2>
+        <p>
+          Stores, service providers, and brands are already using Sedifex to manage sales,
+          inventory, bookings, payments, and customer operations.
+        </p>
+        <p className="used-businesses__purpose">
+          This section is designed to make every signed-up business look organized and professional,
+          even when their uploaded logo is missing, inconsistent, or not homepage-ready.
+        </p>
+      </header>
+
+      <div className="used-businesses__grid">
+        {sampleBusinesses.map(business => (
+          <BusinessCard key={business.id} business={business} />
+        ))}
+      </div>
+
+      <div className="used-businesses__cta">
+        <button type="button" className="primary-button used-businesses__cta-button" onClick={onCtaClick}>
+          Join businesses using Sedifex
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -26,6 +26,7 @@ import { setOnboardingStatus } from '../utils/onboarding'
 import { normalizeGhanaPhoneE164 } from '../utils/phone'
 import { INDUSTRY_ENABLED_MODULE_PRESETS, type Industry } from '../config/navigation'
 import { SEDIFEX_PRICING_PLANS, SEDIFEX_PRICING_RULES } from '../config/pricingPlans'
+import UsedByBusinesses from '../components/UsedByBusinesses'
 
 const AUTH_VISUAL_IMAGE_URL = 'https://images.unsplash.com/photo-1556761175-b413da4baf72?auto=format&fit=crop&w=1200&q=80'
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -237,6 +238,7 @@ export default function AuthPage() {
         <aside className="app__visual" aria-label="Sedifex business operating system"><div className="app__visual-media" role="presentation"><img src={AUTH_VISUAL_IMAGE_URL} alt="Business team using a laptop" loading="lazy" /></div><div className="app__visual-overlay" /><div className="app__visual-dashboard" aria-hidden="true"><div><span>Today sales</span><strong>GHS 2,450</strong></div><div><span>Bookings</span><strong>18</strong></div><div><span>Website</span><strong>Published</strong></div></div><div className="app__visual-caption"><span className="app__visual-pill">Africa-first. Global-ready.</span><h2>Run your business. Sell online. Grow from one workspace.</h2><p>Manage operations, publish connected websites, sync to Sedifex Market, accept payments, and grow with automation tools.</p></div></aside>
       </div>
       <section className="app__promo-strategy" aria-label="Why businesses choose Sedifex"><header className="app__promo-strategy-header"><span className="app__pill">What Sedifex does</span><h2>One connected workspace for growing businesses in Africa and beyond.</h2><p>Sedifex helps shops, schools, NGOs, service businesses, travel businesses, and booking businesses manage operations, websites, payments, marketplace sales, customers, and growth tools without switching between many systems.</p></header><div className="app__promo-pillars"><h3>What you can run</h3><ul><li><strong>Operate:</strong> sales, inventory, receipts, invoices, bookings, customers, students, donors, and funds.</li><li><strong>Publish:</strong> connected websites with products, services, bookings, gallery, social links, SEO, and custom domains.</li><li><strong>Sell:</strong> accept payments, use Quick Pay, sync products/services to Sedifex Market, and track marketplace sales.</li><li><strong>Grow:</strong> branded text messaging, email, automation tools, reports, and integrations from one business workspace.</li></ul></div></section>
+      <UsedByBusinesses onCtaClick={startSignup} />
       <section className="app__pricing" aria-label="Sedifex pricing plans">
         <header className="app__pricing-header"><span className="app__pill">Simple pricing</span><h2>Start free. Upgrade when you need marketplace sync, websites, bookings, payments, and growth tools.</h2><p>Paid plans include unlimited products/services under fair use. Branded text messaging is available when message credits are purchased.</p></header>
         <div className="grid gap-5 lg:grid-cols-3">


### PR DESCRIPTION
### Motivation

- Surface real stores on the landing page in a clean, consistent way so businesses look professional even when uploaded logos are missing, low-quality, or inconsistent.

### Description

- Add a reusable `UsedByBusinesses` component at `web/src/components/UsedByBusinesses.tsx` that renders responsive business cards with mock data (8 sample businesses) and can be wired to backend store records later. 
- Implement robust logo handling that displays uploaded logos inside a fixed rounded frame and falls back to a generated branded placeholder (initials) when a logo is missing, broken, or too small. 
- Insert the new section after the main features/hero area and before pricing by importing and rendering the component in `web/src/pages/AuthPage.tsx` with the CTA wired to the existing `startSignup` flow. 
- Add light SaaS-style styles and responsive grid rules to `web/src/App.css`, including consistent frame size, soft borders, rounded corners, subtle shadow, Sedifex accent colors, and mobile/tablet/desktop layouts (1 / 2 / 4 columns).

### Testing

- Ran `git diff --check` to validate diffs: succeeded.
- Attempted `npm run build --prefix web` (TypeScript + Vite build): failed due to missing installed deps causing type resolution errors for `vite/client` and `vitest/globals` (no `web/node_modules` in environment).
- Attempted `npm ci --prefix web` to install deps: failed with `npm` registry access error (`403 Forbidden` for `@azure/msal-browser`) so local build/lint could not be completed.
- Attempted `npm run lint --prefix web`: failed because local dev dependencies were unavailable (ESLint could not resolve `@eslint/js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22d79ae7d083218c3dc45c68232a30)