### PR TITLE
Retry transient Firebase function-listing failures in CI deployment

### DIFF
--- a/.github/scripts/deploy-functions-with-retry.sh
+++ b/.github/scripts/deploy-functions-with-retry.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly MAX_ATTEMPTS=3
+readonly RETRYABLE_ERROR='Error: Failed to list functions for'
+output_file=$(mktemp)
+trap 'rm -f "$output_file"' EXIT
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  echo "Firebase Functions deployment attempt ${attempt}/${MAX_ATTEMPTS}"
+
+  : > "$output_file"
+  set +e
+  firebase deploy --only "${FUNCTIONS_ONLY:?FUNCTIONS_ONLY must be set}" --project "${FIREBASE_PROJECT_ID:?FIREBASE_PROJECT_ID must be set}" --force 2>&1 | tee "$output_file"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ $status -eq 0 ]]; then
+    exit 0
+  fi
+
+  if [[ $attempt -eq $MAX_ATTEMPTS ]] || ! grep -Fq "$RETRYABLE_ERROR" "$output_file"; then
+    exit "$status"
+  fi
+
+  delay=$((attempt * 15))
+  echo "Firebase could not list functions; retrying in ${delay} seconds..."
+  sleep "$delay"
+done

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -9,6 +9,7 @@ on:
       - 'firebase.json'
       - '.firebaserc'
       - '.github/workflows/deploy-functions.yml'
+      - '.github/scripts/deploy-functions-with-retry.sh'
 
 concurrency:
   group: firebase-functions-deploy
@@ -51,6 +52,7 @@ jobs:
           echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcp-key.json" >> "$GITHUB_ENV"
           echo "GOOGLE_CLOUD_PROJECT=sedifex-web" >> "$GITHUB_ENV"
           echo "GCLOUD_PROJECT=sedifex-web" >> "$GITHUB_ENV"
+          echo "FIREBASE_PROJECT_ID=sedifex-web" >> "$GITHUB_ENV"
 
       - name: Activate Google service account
         run: |
@@ -81,4 +83,4 @@ jobs:
           echo "FUNCTIONS_ONLY=$(printf '%s' "$FUNCTIONS_LIST" | sed 's/[^,]*/functions:&/g')" >> "$GITHUB_ENV"
 
       - name: Deploy Firebase Functions
-        run: firebase deploy --only "$FUNCTIONS_ONLY" --project sedifex-web --force
+        run: .github/scripts/deploy-functions-with-retry.sh


### PR DESCRIPTION
### Motivation

- CI Firebase Functions deployments intermittently fail with the transient error `Failed to list functions for ...`, causing whole workflow failures despite later attempts succeeding. 
- Make the deployment workflow resilient to this known transient while failing immediately for other, non-retryable errors.

### Description

- Add a helper script ` .github/scripts/deploy-functions-with-retry.sh` that runs `firebase deploy` and retries up to 3 times only when the CLI output contains the retryable string `Error: Failed to list functions for`, preserving live CLI output and exit codes. 
- Update ` .github/workflows/deploy-functions.yml` to include the helper in workflow triggers, export `FIREBASE_PROJECT_ID` to the environment, and invoke the helper instead of calling `firebase deploy` directly. 
- The helper uses incremental backoff (`15s`, `30s`, ...) and exits immediately for non-retryable failures so other errors are not masked.

### Testing

- Ran shell syntax check `bash -n .github/scripts/deploy-functions-with-retry.sh` which succeeded. 
- Executed mocked integration tests that validated the helper recovers from transient `Failed to list functions for` failures and that it fails immediately for a fatal/non-retryable error, and both mocked tests passed. 
- Built the functions with `npm --prefix functions run build` which succeeded. 
- Ran repository checks `git diff --check` which succeeded, and ran `npm --prefix functions test` which failed due to an existing, unrelated test (`functions/test/bookingNormalization.test.js`) that expects a missing `__testing` export.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297afbf3088321acc11d140f58a9cb)