### PR TITLE
Simplify onboarding to navigation selection; enforce industry primary nav and add Account → Navigation settings tab

### DIFF
--- a/web/src/config/navigation.test.ts
+++ b/web/src/config/navigation.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it } from 'vitest'
 import { INDUSTRY_ENABLED_MODULE_PRESETS, resolveNavigation } from './navigation'
 
 describe('resolveNavigation', () => {
+  it('uses the selected industry preset when no enabled modules are stored', () => {
+    const items = resolveNavigation({
+      role: 'owner',
+      workspaceProfile: {
+        industry: 'ngo',
+        labelPolicy: 'industry_aliases',
+        enabledModules: [],
+      },
+    })
+
+    expect(items.map(item => item.id)).toContain('volunteers')
+    expect(items.map(item => item.id)).not.toContain('sell')
+  })
+
   it('applies industry preset aliases, module toggles, custom items, role and permissions', () => {
     const items = resolveNavigation({
       role: 'staff',

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -95,7 +95,11 @@ function hasPermissions(requiredPermissions: string[] | undefined, grantedPermis
 export function resolveNavigation(input: NavigationResolverInput): NavItem[] {
   const { role, workspaceProfile } = input
   const aliasLabels = workspaceProfile.labelPolicy === 'industry_aliases' ? INDUSTRY_LABELS[workspaceProfile.industry] : {}
-  const enabledModules = workspaceProfile.enabledModules && workspaceProfile.enabledModules.length > 0 ? new Set(workspaceProfile.enabledModules) : null
+  const enabledModules = new Set(
+    workspaceProfile.enabledModules && workspaceProfile.enabledModules.length > 0
+      ? workspaceProfile.enabledModules
+      : INDUSTRY_ENABLED_MODULE_PRESETS[workspaceProfile.industry],
+  )
   if (enabledModules && WEBSITE_BUILDER_SECTION_IDS.some(id => enabledModules.has(id))) {
     enabledModules.add('website-builder')
   }
@@ -104,7 +108,7 @@ export function resolveNavigation(input: NavigationResolverInput): NavItem[] {
     if (!item.rolesAllowed.includes(role)) return false
     if (item.industries && !item.industries.includes(workspaceProfile.industry)) return false
     if (item.hideFromPrimaryNav) return false
-    if (item.id !== 'account' && enabledModules && !enabledModules.has(item.id)) return false
+    if (item.id !== 'account' && !enabledModules.has(item.id)) return false
     return hasPermissions(item.requiredPermissions, grantedPermissions)
   }).map(item => {
     const customLabel = workspaceProfile.customLabels?.[item.target]?.trim()

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -389,6 +389,7 @@ type AccountOverviewProps = {
 
 type AccountTab =
   | 'workspace'
+  | 'navigation'
   | 'integrations'
   | 'promotions'
   | 'billing'
@@ -1926,6 +1927,14 @@ export default function AccountOverview({
         <nav className="account-overview__tabs" aria-label="Account sections">
           <button
             type="button"
+            className={`account-overview__tab ${activeTab === 'navigation' ? 'is-active' : ''}`}
+            aria-pressed={activeTab === 'navigation'}
+            onClick={() => setActiveTab('navigation')}
+          >
+            Navigation settings
+          </button>
+          <button
+            type="button"
             className={`account-overview__tab ${activeTab === 'workspace' ? 'is-active' : ''}`}
             aria-pressed={activeTab === 'workspace'}
             onClick={() => setActiveTab('workspace')}
@@ -2029,15 +2038,6 @@ export default function AccountOverview({
               <dd>{formatTimestamp(profile.updatedAt)}</dd>
             </div>
           </dl>
-
-          <NavigationSettingsSection
-            preferences={preferences.navigation}
-            canEdit={isOwner}
-            onSave={async navigation => {
-              await updatePreferences({ navigation })
-              publish({ message: 'Navigation settings updated.', tone: 'success' })
-            }}
-          />
 
           {isOwner && isEditingProfile && (
             <form
@@ -2233,6 +2233,17 @@ export default function AccountOverview({
             </form>
           )}
         </section>
+      )}
+
+      {!isPromotionsView && activeTab === 'navigation' && (
+        <NavigationSettingsSection
+          preferences={preferences.navigation}
+          canEdit={isOwner}
+          onSave={async navigation => {
+            await updatePreferences({ navigation })
+            publish({ message: 'Navigation settings updated.', tone: 'success' })
+          }}
+        />
       )}
 
 

--- a/web/src/pages/Onboarding.test.tsx
+++ b/web/src/pages/Onboarding.test.tsx
@@ -1,215 +1,51 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { MemoryRouter } from 'react-router-dom'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Onboarding from './Onboarding'
 
 const mockNavigate = vi.fn()
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>(
-    'react-router-dom',
-  )
+const mockUpdatePreferences = vi.fn(() => Promise.resolve())
+const mockSetOnboardingStatus = vi.fn((..._args: unknown[]) => Promise.resolve())
 
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  }
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual<typeof import('react-router-dom')>('react-router-dom')),
+  useNavigate: () => mockNavigate,
+}))
+vi.mock('../hooks/useAuthUser', () => ({ useAuthUser: () => ({ uid: 'user-123' }) }))
+vi.mock('../hooks/useActiveStore', () => ({ useActiveStore: () => ({ storeId: 'store-123', isLoading: false, error: null }) }))
+vi.mock('../hooks/useStorePreferences', () => ({
+  useStorePreferences: () => ({
+    preferences: { navigation: { industry: 'shop', labelPolicy: 'industry_aliases', enabledModules: ['dashboard'], dashboardModules: [], primaryMetrics: [], customLabels: {}, customNavItems: [] } },
+    updatePreferences: mockUpdatePreferences,
+  }),
+}))
+vi.mock('../utils/onboarding', () => ({
+  getOnboardingStatus: () => 'pending',
+  fetchOnboardingStatus: () => Promise.resolve('pending'),
+  setOnboardingStatus: (...args: unknown[]) => mockSetOnboardingStatus(...args),
+}))
+vi.mock('../components/MarketplaceCatalogSyncCard', () => ({ default: () => null }))
+
+beforeEach(() => {
+  mockNavigate.mockReset()
+  mockUpdatePreferences.mockClear()
+  mockSetOnboardingStatus.mockClear()
 })
 
-const mockUseAuthUser = vi.fn()
-vi.mock('../hooks/useAuthUser', () => ({
-  useAuthUser: () => mockUseAuthUser(),
-}))
-
-const mockGetOnboardingStatus = vi.fn()
-const mockFetchOnboardingStatus = vi.fn(() => Promise.resolve('pending'))
-const mockSetOnboardingStatus = vi.fn(() => Promise.resolve())
-vi.mock('../utils/onboarding', () => ({
-  getOnboardingStatus: (
-    ...args: Parameters<typeof mockGetOnboardingStatus>
-  ) => mockGetOnboardingStatus(...args),
-  fetchOnboardingStatus: (
-    ...args: Parameters<typeof mockFetchOnboardingStatus>
-  ) => mockFetchOnboardingStatus(...args),
-  setOnboardingStatus: (
-    ...args: Parameters<typeof mockSetOnboardingStatus>
-  ) => mockSetOnboardingStatus(...args),
-}))
-
-// Firestore mocks
-const mockCollection = vi.fn()
-const mockDoc = vi.fn()
-const mockGetDoc = vi.fn()
-const mockGetDocs = vi.fn()
-const mockQuery = vi.fn()
-const mockWhere = vi.fn()
-const mockLimit = vi.fn()
-
-// Only default DB is used now
-vi.mock('../firebase', () => ({
-  db: { __name: 'defaultDb' },
-}))
-
-vi.mock('firebase/firestore', () => ({
-  collection: (...args: Parameters<typeof mockCollection>) =>
-    mockCollection(...args),
-  doc: (...args: Parameters<typeof mockDoc>) => mockDoc(...args),
-  getDoc: (...args: Parameters<typeof mockGetDoc>) => mockGetDoc(...args),
-  getDocs: (...args: Parameters<typeof mockGetDocs>) => mockGetDocs(...args),
-  query: (...args: Parameters<typeof mockQuery>) => mockQuery(...args),
-  where: (...args: Parameters<typeof mockWhere>) => mockWhere(...args),
-  limit: (...args: Parameters<typeof mockLimit>) => mockLimit(...args),
-  Timestamp: class {
-    toDate() {
-      return new Date('2024-01-01T00:00:00.000Z')
-    }
-  },
-}))
-
 describe('Onboarding page', () => {
-  beforeEach(() => {
-    mockUseAuthUser.mockReset()
-    mockGetOnboardingStatus.mockReset()
-    mockFetchOnboardingStatus.mockReset()
-    mockSetOnboardingStatus.mockReset()
-    mockNavigate.mockReset()
-
-    mockCollection.mockReset()
-    mockDoc.mockReset()
-    mockGetDoc.mockReset()
-    mockGetDocs.mockReset()
-    mockQuery.mockReset()
-    mockWhere.mockReset()
-    mockLimit.mockReset()
-
-    // Logged-in owner
-    mockUseAuthUser.mockReturnValue({
-      uid: 'user-123',
-      email: 'owner@example.com',
-    })
-
-    // Onboarding status
-    mockGetOnboardingStatus.mockReturnValue('pending')
-    mockFetchOnboardingStatus.mockResolvedValue('pending')
-
-    // Firestore collection/query helpers (shape doesn’t really matter)
-    mockCollection.mockImplementation((_db, collectionName) => ({
-      __type: 'collection',
-      collectionName,
-    }))
-    mockWhere.mockImplementation((...args) => ({ __type: 'where', args }))
-    mockLimit.mockImplementation((...args) => ({ __type: 'limit', args }))
-    mockQuery.mockImplementation((...args) => ({ __type: 'query', args }))
-
-    // Membership query: /teamMembers where uid == 'user-123'
-    const fakeMembershipDoc = {
-      id: 'store-123',
-      data: () => ({
-        uid: 'user-123',
-        email: 'owner@example.com',
-        storeId: 'store-123',
-        role: 'owner',
-      }),
-    }
-    mockGetDocs.mockResolvedValue({ docs: [fakeMembershipDoc] })
-
-    // Store lookup: /stores/store-123
-    mockDoc.mockImplementation((_db, collectionName, id) => ({
-      __type: 'doc',
-      collectionName,
-      id,
-    }))
-    mockGetDoc.mockResolvedValue({
-      exists: () => true,
-      id: 'store-123',
-      data: () => ({
-        status: 'active',
-        contractStatus: 'active',
-      }),
-    })
+  it('only asks the owner to choose navigation', () => {
+    render(<MemoryRouter><Onboarding /></MemoryRouter>)
+    expect(screen.getByRole('heading', { name: /choose your navigation/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /navigation settings/i })).toBeInTheDocument()
+    expect(screen.queryByText(/contract/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/launch checklist/i)).not.toBeInTheDocument()
   })
 
-  it('renders onboarding content when workspace access is ready', () => {
-    render(
-      <MemoryRouter>
-        <Onboarding />
-      </MemoryRouter>,
-    )
-
-    expect(
-      screen.getByRole('heading', { name: /welcome to sedifex/i }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('heading', { name: /confirm your owner account/i }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText(/let's confirm your workspace details/i),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText(/review your workspace details/i),
-    ).toBeInTheDocument()
-  })
-
-  it('defaults to pending status when no onboarding record exists yet', () => {
-    mockGetOnboardingStatus.mockReturnValueOnce(null)
-
-    render(
-      <MemoryRouter>
-        <Onboarding />
-      </MemoryRouter>,
-    )
-
-    expect(mockSetOnboardingStatus).toHaveBeenCalledWith('user-123', 'pending')
-    expect(
-      screen.getByRole('heading', { name: /welcome to sedifex/i }),
-    ).toBeInTheDocument()
-  })
-
-  it('links the contract step to the billing section', async () => {
-    const user = userEvent.setup()
-
-    render(
-      <MemoryRouter>
-        <Onboarding />
-      </MemoryRouter>,
-    )
-
-    await user.click(
-      screen.getByRole('button', { name: /view contract & billing/i }),
-    )
-
-    expect(mockNavigate).toHaveBeenCalledWith({
-      pathname: '/account',
-      hash: '#account-overview-contract',
-    })
-  })
-
-  it('exposes quick actions that navigate to setup workflows', async () => {
-    const user = userEvent.setup()
-
-    render(
-      <MemoryRouter>
-        <Onboarding />
-      </MemoryRouter>,
-    )
-
-    await user.click(
-      screen.getByRole('button', { name: /add your first product/i }),
-    )
-    expect(mockNavigate).toHaveBeenCalledWith('/products')
-
-    await user.click(
-      screen.getByRole('button', { name: /add your first customer/i }),
-    )
-    expect(mockNavigate).toHaveBeenCalledWith('/customers')
-
-    await user.click(screen.getByRole('button', { name: /run a test sale/i }))
-    expect(mockNavigate).toHaveBeenCalledWith('/sell')
-
-    await user.click(
-      screen.getByRole('button', { name: /set up public page/i }),
-    )
-    expect(mockNavigate).toHaveBeenCalledWith('/public-page')
+  it('completes onboarding and opens the dashboard', async () => {
+    render(<MemoryRouter><Onboarding /></MemoryRouter>)
+    await userEvent.click(screen.getByRole('button', { name: /save and open dashboard/i }))
+    expect(mockSetOnboardingStatus).toHaveBeenCalledWith('user-123', 'completed')
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
   })
 })

--- a/web/src/pages/Onboarding.tsx
+++ b/web/src/pages/Onboarding.tsx
@@ -1,19 +1,9 @@
-import React, { useEffect, useState } from 'react'
-import {
-  collection,
-  doc,
-  getDoc,
-  getDocs,
-  limit,
-  query,
-  Timestamp,
-  where,
-} from 'firebase/firestore'
-import type { DocumentData, QueryDocumentSnapshot } from 'firebase/firestore'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import NavigationSettingsSection from '../components/NavigationSettingsSection'
+import { useActiveStore } from '../hooks/useActiveStore'
 import { useAuthUser } from '../hooks/useAuthUser'
-import { db } from '../firebase' // ✅ use only default Firestore
-import { getStoreIdFromRecord } from '../utils/storeId'
+import { useStorePreferences } from '../hooks/useStorePreferences'
 import {
   fetchOnboardingStatus,
   getOnboardingStatus,
@@ -22,502 +12,78 @@ import {
 } from '../utils/onboarding'
 import './Onboarding.css'
 
-type TeamMemberDocument = {
-  uid?: string | null
-  storeId?: string | null
-  role?: string | null
-  email?: string | null
-  phone?: string | null
-  createdAt?: Timestamp | null
-  updatedAt?: Timestamp | null
-}
-
-type TeamMemberDetails = TeamMemberDocument & { id: string }
-
-type StoreDocument = {
-  ownerId?: string | null
-  status?: string | null
-  contractStatus?: string | null
-  createdAt?: Timestamp | null
-  updatedAt?: Timestamp | null
-}
-
-type StoreDetails = StoreDocument & { id: string }
-
-function formatTimestamp(value: unknown): string | null {
-  if (!value) return null
-
-  if (value instanceof Timestamp) {
-    return value.toDate().toLocaleString()
-  }
-
-  if (value instanceof Date) {
-    return value.toLocaleString()
-  }
-
-  if (typeof value === 'object' && value !== null && 'toDate' in value) {
-    try {
-      const date = (value as { toDate: () => Date }).toDate()
-      return date.toLocaleString()
-    } catch (error) {
-      console.warn('[onboarding] Unable to format timestamp value', error)
-    }
-  }
-
-  if (typeof value === 'string') {
-    return value
-  }
-
-  return null
-}
-
-function formatLabel(value: string | null | undefined): string {
-  if (!value) return '—'
-  const normalized = value.trim()
-  if (!normalized) return '—'
-  return normalized.replace(/\b\w/g, letter => letter.toUpperCase())
-}
-
-function formatRole(value: string | null | undefined): string {
-  const label = formatLabel(value ?? 'Owner')
-  return label
-}
-
 export default function Onboarding() {
   const user = useAuthUser()
   const navigate = useNavigate()
-  const [status, setStatus] = useState<OnboardingStatus>(() =>
-    getOnboardingStatus(user?.uid ?? null) ?? 'pending',
+  const { storeId, isLoading, error } = useActiveStore()
+  const { preferences, updatePreferences } = useStorePreferences(storeId)
+  const [status, setStatus] = useState<OnboardingStatus>(
+    () => getOnboardingStatus(user?.uid ?? null) ?? 'pending',
   )
-  const [teamMemberDetails, setTeamMemberDetails] =
-    useState<TeamMemberDetails | null>(null)
-  const [storeDetails, setStoreDetails] = useState<StoreDetails | null>(null)
-  const [detailsError, setDetailsError] = useState<string | null>(null)
-  const [isLoadingDetails, setIsLoadingDetails] = useState(false)
-
-  const ownerUid = teamMemberDetails?.uid ?? user?.uid ?? '—'
-  const ownerEmail = teamMemberDetails?.email ?? user?.email ?? '—'
-  const ownerRole = formatRole(teamMemberDetails?.role)
-  const createdAtLabel = formatTimestamp(teamMemberDetails?.createdAt ?? null)
-  const storeIdLabel =
-    teamMemberDetails?.storeId ?? storeDetails?.id ?? user?.uid ?? '—'
-  const storeStatusLabel = formatLabel(storeDetails?.status)
-  const contractStatusLabel = formatLabel(storeDetails?.contractStatus)
-  const updatedAtLabel = formatTimestamp(storeDetails?.updatedAt ?? null)
 
   useEffect(() => {
     let isActive = true
-
-    const syncStatus = async () => {
-      const uid = user?.uid ?? null
-      const storedStatus = await fetchOnboardingStatus(uid)
-      const resolvedStatus = storedStatus ?? getOnboardingStatus(uid) ?? 'pending'
-
-      if (!isActive) return
-
-      setStatus(resolvedStatus)
-      await setOnboardingStatus(uid, resolvedStatus)
-    }
-
-    void syncStatus()
-
-    return () => {
-      isActive = false
-    }
-  }, [user?.uid])
-
-  useEffect(() => {
-    if (!user?.uid) {
-      setTeamMemberDetails(null)
-      setStoreDetails(null)
-      setDetailsError(null)
-      setIsLoadingDetails(false)
-      return
-    }
-
-    let isActive = true
-    setIsLoadingDetails(true)
-    setDetailsError(null)
-
-    const fetchDetails = async () => {
-      try {
-        // ✅ read teamMembers from the *default* Firestore DB
-        const teamMembersRef = collection(db, 'teamMembers')
-        const membershipQuery = query(
-          teamMembersRef,
-          where('uid', '==', user.uid),
-          limit(1),
-        )
-        const membershipSnapshot = await getDocs(membershipQuery)
-        const membershipDoc = membershipSnapshot.docs[0] ?? null
-
-        if (!isActive) return
-
-        if (membershipDoc) {
-          setTeamMemberDetails({
-            id: membershipDoc.id,
-            ...(membershipDoc.data() as TeamMemberDocument),
-          })
-        } else {
-          setTeamMemberDetails(null)
-        }
-
-        const storeDetails = await loadStoreDetails(user.uid, membershipDoc)
-        if (!isActive) return
-
-        setStoreDetails(storeDetails)
-      } catch (error) {
-        if (!isActive) return
-        console.warn('[onboarding] Failed to load workspace details', error)
-        setTeamMemberDetails(null)
-        setStoreDetails(null)
-        setDetailsError(
-          'We couldn’t load your workspace details. Refresh to try again.',
-        )
-      } finally {
-        if (isActive) {
-          setIsLoadingDetails(false)
-        }
-      }
-    }
-
-    void fetchDetails()
-
-    return () => {
-      isActive = false
-    }
-  }, [user?.uid])
-
-  const hasCompleted = status === 'completed'
-
-  function handleComplete() {
-    if (!user) return
 
     void (async () => {
-      await setOnboardingStatus(user.uid, 'completed')
-      setStatus('completed')
-      navigate('/', { replace: true })
+      const uid = user?.uid ?? null
+      const resolvedStatus =
+        (await fetchOnboardingStatus(uid)) ?? getOnboardingStatus(uid) ?? 'pending'
+      if (!isActive) return
+      setStatus(resolvedStatus)
+      await setOnboardingStatus(uid, resolvedStatus)
     })()
-  }
 
-  function goToContractAndBilling() {
-    navigate({ pathname: '/account', hash: '#account-overview-contract' })
-  }
+    return () => {
+      isActive = false
+    }
+  }, [user?.uid])
 
-  function goToProducts() {
-    navigate('/products')
-  }
-
-  function goToCustomers() {
-    navigate('/customers')
-  }
-
-  function goToSell() {
-    navigate('/sell')
-  }
-
-  function goToPublicPage() {
-    navigate('/public-page')
+  async function handleComplete() {
+    if (!user) return
+    await setOnboardingStatus(user.uid, 'completed')
+    setStatus('completed')
+    navigate('/', { replace: true })
   }
 
   return (
-    <div
-      className="page onboarding-page"
-      role="region"
-      aria-labelledby="onboarding-title"
-    >
+    <div className="page onboarding-page" role="region" aria-labelledby="onboarding-title">
       <header className="page__header onboarding-page__header">
         <div>
-          <h1 className="page__title" id="onboarding-title">
-            Welcome to Sedifex
-          </h1>
+          <h1 className="page__title" id="onboarding-title">Choose your navigation</h1>
           <p className="page__subtitle">
-            Let&apos;s confirm your workspace details and walk through your
-            contract next steps.
-          </p>
-          <p className="page__subtitle">
-            New here? Start with <a href="/docs/how-to-use-sedifex">/docs/how-to-use-sedifex</a> and continue setup from the linked guides.
+            Select your business type and the pages your team needs. Sedifex starts with
+            the recommended primary navigation for your industry.
           </p>
         </div>
-        {hasCompleted && (
-          <span
-            className="onboarding-page__status"
-            role="status"
-            aria-live="polite"
-          >
-            Onboarding complete
-          </span>
+        {status === 'completed' && (
+          <span className="onboarding-page__status" role="status">Onboarding complete</span>
         )}
       </header>
 
-      <section
-        className="card onboarding-card"
-        aria-labelledby="onboarding-step-1"
-      >
-        <header className="onboarding-card__header">
-          <span className="onboarding-card__step">Step 1</span>
-          <h2 className="onboarding-card__title" id="onboarding-step-1">
-            Confirm your owner account
-          </h2>
-        </header>
-        <p>
-          You&apos;re signed in as the workspace owner. We recommend keeping
-          this login private and using it only for high-impact controls like
-          payouts, data exports, and team access. Add a recovery email in case
-          you ever need to reset your password.
-        </p>
-        <ul className="onboarding-card__list">
-          <li>Keep your owner credentials secure.</li>
-          <li>Turn on multi-factor authentication for extra protection.</li>
-          <li>Plan which teammates need day-to-day access to Sedifex.</li>
-        </ul>
-        <div className="onboarding-card__details" aria-live="polite">
-          <div className="onboarding-card__details-header">
-            <h3
-              className="onboarding-card__details-title"
-              id="onboarding-owner-details"
-            >
-              Review your workspace details
-            </h3>
-            <p className="onboarding-card__details-subtitle">
-              Confirm that your owner profile and store information look correct
-              before inviting your team.
-            </p>
-          </div>
-          {isLoadingDetails ? (
-            <p className="onboarding-card__details-status">
-              Loading your workspace data…
-            </p>
-          ) : detailsError ? (
-            <p className="onboarding-card__details-status onboarding-card__details-status--error">
-              {detailsError}
-            </p>
-          ) : (
-            <div
-              className="onboarding-card__details-columns"
-              aria-describedby="onboarding-owner-details"
-            >
-              <div className="onboarding-card__details-section">
-                <p className="onboarding-card__details-section-title">
-                  Account
-                </p>
-                <dl className="onboarding-card__details-grid">
-                  <div className="onboarding-card__details-row">
-                    <dt className="onboarding-card__details-term">Owner UID</dt>
-                    <dd className="onboarding-card__details-value">
-                      {ownerUid}
-                    </dd>
-                  </div>
-                  <div className="onboarding-card__details-row">
-                    <dt className="onboarding-card__details-term">Email</dt>
-                    <dd className="onboarding-card__details-value">
-                      {ownerEmail}
-                    </dd>
-                  </div>
-                  <div className="onboarding-card__details-row">
-                    <dt className="onboarding-card__details-term">Role</dt>
-                    <dd className="onboarding-card__details-value">
-                      {ownerRole}
-                    </dd>
-                  </div>
-                  {createdAtLabel ? (
-                    <div className="onboarding-card__details-row">
-                      <dt className="onboarding-card__details-term">
-                        Created
-                      </dt>
-                      <dd className="onboarding-card__details-value">
-                        {createdAtLabel}
-                      </dd>
-                    </div>
-                  ) : null}
-                </dl>
-              </div>
-              <div className="onboarding-card__details-section">
-                <p className="onboarding-card__details-section-title">Store</p>
-                <dl className="onboarding-card__details-grid">
-                  <div className="onboarding-card__details-row">
-                    <dt className="onboarding-card__details-term">Store ID</dt>
-                    <dd className="onboarding-card__details-value">
-                      {storeIdLabel}
-                    </dd>
-                  </div>
-                  <div className="onboarding-card__details-row">
-                    <dt className="onboarding-card__details-term">Status</dt>
-                    <dd className="onboarding-card__details-value">
-                      {storeStatusLabel}
-                    </dd>
-                  </div>
-                  <div className="onboarding-card__details-row">
-                    <dt className="onboarding-card__details-term">
-                      Contract
-                    </dt>
-                    <dd className="onboarding-card__details-value">
-                      {contractStatusLabel}
-                    </dd>
-                  </div>
-                  {updatedAtLabel ? (
-                    <div className="onboarding-card__details-row">
-                      <dt className="onboarding-card__details-term">
-                        Last updated
-                      </dt>
-                      <dd className="onboarding-card__details-value">
-                        {updatedAtLabel}
-                      </dd>
-                    </div>
-                  ) : null}
-                </dl>
-              </div>
-            </div>
-          )}
-        </div>
+      <section className="card onboarding-card" aria-label="Navigation setup">
+        {isLoading ? (
+          <p role="status">Loading your workspace…</p>
+        ) : error ? (
+          <p role="alert">{error}</p>
+        ) : storeId ? (
+          <NavigationSettingsSection
+            preferences={preferences.navigation}
+            canEdit
+            onSave={async navigation => updatePreferences({ navigation })}
+          />
+        ) : (
+          <p role="status">Select a workspace to configure its navigation.</p>
+        )}
       </section>
 
-      <section
-        className="card onboarding-card"
-        aria-labelledby="onboarding-step-2"
+      <button
+        type="button"
+        className="button button--primary onboarding-card__cta"
+        disabled={!storeId}
+        onClick={() => void handleComplete()}
       >
-        <header className="onboarding-card__header">
-          <span className="onboarding-card__step">Step 2</span>
-          <h2 className="onboarding-card__title" id="onboarding-step-2">
-            Review your contract
-          </h2>
-        </header>
-        <p>
-          Your Sedifex contract outlines workspace ownership, billing,
-          and support expectations. Review the terms to understand renewal
-          timelines and who to contact for updates.
-        </p>
-        <ul className="onboarding-card__list">
-          <li>Confirm the active contract status for this store.</li>
-          <li>Note your billing plan and renewal cadence.</li>
-          <li>Keep your account manager details handy for changes.</li>
-        </ul>
-        <p className="onboarding-card__cta">
-          Need to adjust the contract? Your Sedifex account manager can help
-          with renewals, plan changes, or updated contacts.
-        </p>
-        <button
-          type="button"
-          className="button button--primary onboarding-card__cta"
-          onClick={goToContractAndBilling}
-        >
-          View contract &amp; billing
-        </button>
-      </section>
-
-      <section
-        className="card onboarding-card"
-        aria-labelledby="onboarding-step-3"
-      >
-        <header className="onboarding-card__header">
-          <span className="onboarding-card__step">Step 3</span>
-          <h2 className="onboarding-card__title" id="onboarding-step-3">
-            Finish setup
-          </h2>
-        </header>
-        <p>
-          When you&apos;re ready, head to the dashboard to start using Sedifex.
-          You can return to your contract details anytime from the Account
-          page.
-        </p>
-        <button
-          type="button"
-          className="secondary-button onboarding-card__cta"
-          onClick={handleComplete}
-        >
-          {hasCompleted ? 'Return to dashboard' : 'I’m ready to continue'}
-        </button>
-      </section>
-
-      <section
-        className="card onboarding-card"
-        aria-labelledby="onboarding-step-4"
-      >
-        <header className="onboarding-card__header">
-          <span className="onboarding-card__step">Step 4</span>
-          <h2 className="onboarding-card__title" id="onboarding-step-4">
-            Launch checklist for new stores
-          </h2>
-        </header>
-        <p>
-          New stores move faster when the team practices one full sales cycle:
-          add a product, add a customer, run a sale, and confirm staff access.
-          Use these quick actions to teach your team by doing.
-        </p>
-        <div className="onboarding-card__quick-actions">
-          <button
-            type="button"
-            className="button button--primary"
-            onClick={goToProducts}
-          >
-            Add your first product
-          </button>
-          <button
-            type="button"
-            className="button button--ghost"
-            onClick={goToCustomers}
-          >
-            Add your first customer
-          </button>
-          <button
-            type="button"
-            className="button button--ghost"
-            onClick={goToSell}
-          >
-            Run a test sale
-          </button>
-          <button
-            type="button"
-            className="button button--ghost"
-            onClick={goToPublicPage}
-          >
-            Set up public page
-          </button>
-        </div>
-        <ol className="onboarding-card__playbook">
-          <li>Products: Create at least 3 real items with prices.</li>
-          <li>Customers: Add one repeat customer profile.</li>
-          <li>Sell: Complete one cash sale and one digital payment test.</li>
-          <li>Public page: Publish store details customers can find online.</li>
-        </ol>
-      </section>
+        Save and open dashboard
+      </button>
     </div>
   )
-}
-
-function normalizeStoreIdCandidate(value: unknown): string | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  return trimmed ? trimmed : null
-}
-
-async function loadStoreDetails(
-  userUid: string,
-  membershipDoc: QueryDocumentSnapshot<DocumentData> | null,
-): Promise<StoreDetails | null> {
-  const membershipData = membershipDoc?.data() as
-    | TeamMemberDocument
-    | undefined
-  const storeIdFromRecord = membershipData
-    ? getStoreIdFromRecord(membershipData)
-    : null
-  const candidates = Array.from(
-    new Set(
-      [storeIdFromRecord, membershipDoc?.id, userUid]
-        .map(normalizeStoreIdCandidate)
-        .filter((value): value is string => Boolean(value)),
-    ),
-  )
-
-  for (const candidateId of candidates) {
-    const snapshot = await getDoc(doc(db, 'stores', candidateId))
-    if (snapshot.exists()) {
-      return {
-        id: snapshot.id,
-        ...(snapshot.data() as StoreDocument),
-      }
-    }
-  }
-
-  return null
 }


### PR DESCRIPTION
### Motivation
- Replace the long multi-step post-signup flow with a focused step that makes navigation selection the only required onboarding action.  
- Ensure the workspace uses an industry-specific primary navigation by default so new signups don’t see a confusingly large sidebar.  
- Surface navigation configuration more clearly by exposing it as a dedicated sub-tab under Account.

### Description
- Replaced the previous multi-card onboarding UI with a streamlined onboarding page that only exposes the navigation selection UI (`web/src/pages/Onboarding.tsx`).  
- Added a new "Navigation settings" Account sub-tab and moved the `NavigationSettingsSection` out from the Workspace tab into its own tab in `AccountOverview` (`web/src/pages/AccountOverview.tsx`).  
- Changed the navigation resolver to treat an empty `enabledModules` as meaning “use the industry preset”, and always use the selected industry preset as the starting primary nav (`web/src/config/navigation.ts`).  
- Updated and added unit test coverage to reflect the new behavior for onboarding and navigation resolution (`web/src/pages/Onboarding.test.tsx`, `web/src/config/navigation.test.ts`).

### Testing
- Added/updated unit tests for onboarding and navigation resolution, but attempting to run `vitest` for the modified tests failed because the test runner was not available in the environment.  
- Running `npm ci` to install test dependencies also failed with a `403 Forbidden` from the npm registry for `@azure/msal-browser`, so the full test suite could not be executed in this environment.  
- Basic repository checks such as `git diff --check` completed without introducing style errors, and the modified unit tests are present and ready to run once dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f31bb231883218227e28c244d1fc9)