### PR TITLE
Adjust travel navigation labels and AccountOverview tab labels

### DIFF
--- a/web/src/config/navigation.test.ts
+++ b/web/src/config/navigation.test.ts
@@ -48,7 +48,7 @@ describe('resolveNavigation', () => {
     })
 
     expect(items.map(item => item.id)).toEqual(['reports', 'sell', 'customers', 'blog'])
-    expect(items.find(item => item.id === 'customers')?.label).toBe('Travelers')
+    expect(items.find(item => item.id === 'customers')?.label).toBe('Customers')
   })
 
   it('prefers custom labels over industry aliases', () => {

--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -51,7 +51,7 @@ export const NAV_ITEMS: NavItem[] = [
 
 const INDUSTRY_LABELS: Record<Industry, Partial<Record<string, string>>> = {
   shop: {},
-  travel: { '/customers': 'Travelers', '/bookings': 'Trips', '/upcoming-events': 'Upcoming trips', '/marketplace-orders': 'Online Orders', '/website-builder': 'Website Builder', '/promo': 'Trip promos', '/gallery': 'Trip gallery', '/social-links': 'Contact links' },
+  travel: { '/customers': 'Customers', '/bookings': 'Booking', '/upcoming-events': 'Upcoming trips', '/marketplace-orders': 'Online Orders', '/website-builder': 'Website Builder', '/promo': 'Trip promos', '/gallery': 'Trip gallery', '/social-links': 'Contact links' },
   ngo: { '/customers': 'Donors', '/bookings': 'Campaigns', '/upcoming-events': 'Upcoming campaigns', '/marketplace-orders': 'Online Orders', '/website-builder': 'Website Builder', '/promo': 'Campaign promo', '/gallery': 'Impact gallery', '/social-links': 'Contact links', '/expenses': 'Petty expenses' },
   school: { '/customers': 'Contacts', '/students': 'Students', '/bookings': 'Classes', '/upcoming-events': 'Upcoming classes', '/marketplace-orders': 'Registrations & Orders', '/website-builder': 'Website Builder', '/promo': 'Admissions promo', '/gallery': 'School gallery', '/social-links': 'Contact links' },
 }

--- a/web/src/layout/Shell.test.tsx
+++ b/web/src/layout/Shell.test.tsx
@@ -302,6 +302,6 @@ describe('Shell', () => {
 
     renderShell(['/dashboard'])
     expect(screen.getByRole('link', { name: 'Guests' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Trips' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Booking' })).toBeInTheDocument()
   })
 })

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -1927,6 +1927,14 @@ export default function AccountOverview({
         <nav className="account-overview__tabs" aria-label="Account sections">
           <button
             type="button"
+            className={`account-overview__tab ${activeTab === 'workspace' ? 'is-active' : ''}`}
+            aria-pressed={activeTab === 'workspace'}
+            onClick={() => setActiveTab('workspace')}
+          >
+            Account
+          </button>
+          <button
+            type="button"
             className={`account-overview__tab ${activeTab === 'navigation' ? 'is-active' : ''}`}
             aria-pressed={activeTab === 'navigation'}
             onClick={() => setActiveTab('navigation')}
@@ -1935,19 +1943,11 @@ export default function AccountOverview({
           </button>
           <button
             type="button"
-            className={`account-overview__tab ${activeTab === 'workspace' ? 'is-active' : ''}`}
-            aria-pressed={activeTab === 'workspace'}
-            onClick={() => setActiveTab('workspace')}
-          >
-            Workspace
-          </button>
-          <button
-            type="button"
             className={`account-overview__tab ${activeTab === 'integrations' ? 'is-active' : ''}`}
             aria-pressed={activeTab === 'integrations'}
             onClick={() => setActiveTab('integrations')}
           >
-            Integrations
+            Integration
           </button>
           <button
             type="button"

--- a/web/src/pages/docs/HowToUseSedifexPage.tsx
+++ b/web/src/pages/docs/HowToUseSedifexPage.tsx
@@ -25,7 +25,7 @@ export default function HowToUseSedifexPage() {
         <h2>Pick your workspace type</h2>
         <ul>
           <li><strong>Retail / Shop:</strong> Items, Sell, Marketplace Orders, Quick Pay, Customers, Bookings, Website Builder, and Reports.</li>
-          <li><strong>Travel:</strong> Trips, Travelers, Upcoming trips, Online Orders, Trip promos, Trip gallery, and Contact links.</li>
+          <li><strong>Travel:</strong> Booking, Customers, Upcoming trips, Online Orders, Trip promos, Trip gallery, and Contact links.</li>
           <li><strong>NGO:</strong> Donors, Campaigns, Upcoming campaigns, Volunteers, Support requests, Campaign promo, Impact gallery, and Petty expenses.</li>
           <li><strong>School:</strong> Students, Classes, Upcoming classes, Student registration, Registrations & Orders, Admissions promo, and School gallery.</li>
         </ul>


### PR DESCRIPTION
### Motivation
- Standardize wording for the travel industry navigation items and update UI text to match the new labels. 
- Keep documentation and tests in sync with the updated labels and small UI text corrections.

### Description
- Changed travel industry aliases in `INDUSTRY_LABELS` to use `'/customers': 'Customers'` and `'/bookings': 'Booking'` and adjusted related label strings. 
- Updated the user-facing docs in `HowToUseSedifexPage.tsx` to reflect the new travel labels. 
- Swapped and corrected tab labels in `AccountOverview.tsx` so the primary two tabs read `Account` and `Navigation settings`, and changed `Integrations` to `Integration`. 
- Updated unit tests in `navigation.test.ts` and `Shell.test.tsx` to expect the new labels.

### Testing
- Ran the unit test suite (`navigation.test.ts` and `Shell.test.tsx`) after updates and the modified tests passed. 
- Executed the project test runner (`yarn test`/`npm test`) and no failures were reported for the changed tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fc45742188321aaae525c4d3afedb)