### PR TITLE
Remove Google Business support from social posts and integrations; add quick navigation settings card

### DIFF
--- a/web/src/api/socialPost.ts
+++ b/web/src/api/socialPost.ts
@@ -3,7 +3,7 @@ import { FirebaseError } from 'firebase/app'
 import { functions } from '../firebase'
 import { requestAiAdvisor } from './aiAdvisor'
 
-export type SocialPlatform = 'instagram' | 'tiktok' | 'google_business'
+export type SocialPlatform = 'instagram' | 'tiktok'
 
 export type SocialPostProductPayload = {
   id?: string
@@ -67,7 +67,7 @@ async function requestSocialPostFallback(payload: GenerateSocialPostPayload): Pr
     'Generate a social media post draft as strict JSON only (no markdown, no prose).',
     `Platform: ${payload.platform}`,
     'Return this schema exactly:',
-    '{"platform":"instagram|tiktok|google_business","caption":"string","hashtags":["#tag"],"imagePrompt":"string","cta":"string","designSpec":{"aspectRatio":"string","safeTextZones":["string"],"visualStyle":"string"},"disclaimer":"string|null"}',
+    '{"platform":"instagram|tiktok","caption":"string","hashtags":["#tag"],"imagePrompt":"string","cta":"string","designSpec":{"aspectRatio":"string","safeTextZones":["string"],"visualStyle":"string"},"disclaimer":"string|null"}',
     'Product JSON:',
     JSON.stringify(product).slice(0, 3_000),
   ].join('\n')
@@ -106,9 +106,7 @@ async function requestSocialPostFallback(payload: GenerateSocialPostPayload): Pr
       platform:
         parsed.platform === 'tiktok'
           ? 'tiktok'
-          : parsed.platform === 'google_business'
-            ? 'google_business'
-            : payload.platform,
+          : payload.platform,
       caption: typeof parsed.caption === 'string' ? parsed.caption.trim() : '',
       hashtags,
       imagePrompt: typeof parsed.imagePrompt === 'string' ? parsed.imagePrompt.trim() : '',

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -172,7 +172,6 @@ const router = createBrowserRouter([
       { path: 'settings/integrations/website', element: <IntegrationWebsiteSettings /> },
       { path: 'settings/integrations/bookings', element: <IntegrationBookingsSettings /> },
       { path: 'settings/integrations/email', element: <IntegrationEmailSettings /> },
-      { path: 'settings/integrations/google-business', element: <Navigate to="/account" replace /> },
     ]},
     { path: 'reset-password', element: <ResetPassword /> },
     { path: 'verify-email', element: <VerifyEmail /> },

--- a/web/src/pages/AccountOverview.css
+++ b/web/src/pages/AccountOverview.css
@@ -242,6 +242,32 @@
   opacity: 0.65;
 }
 
+.account-overview__quick-settings {
+  margin-bottom: 16px;
+}
+
+.account-overview__quick-settings-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.account-overview__quick-settings-card h2 {
+  margin: 0 0 6px;
+}
+
+.account-overview__quick-settings-card .account-overview__subtitle {
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .account-overview__quick-settings-card {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
 @media (prefers-contrast: more) {
   .account-overview__plan-toggle {
     border-color: #64748b;

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -397,11 +397,7 @@ type AccountTab =
   | 'data-controls'
 type PublicPageTab = 'overview' | 'promo' | 'gallery'
 type PromoGalleryTab = 'upload' | 'view'
-type IntegrationTab = 'keys' | 'booking' | 'webhooks' | 'email' | 'google' | 'tests'
-type GoogleBusinessStatus = {
-  connected: boolean
-  hasRequiredScope: boolean
-}
+type IntegrationTab = 'keys' | 'booking' | 'webhooks' | 'email' | 'tests'
 
 async function postJson<T>(url: string, token: string, body: Record<string, unknown>): Promise<T> {
   const response = await fetch(url, {
@@ -520,9 +516,6 @@ export default function AccountOverview({
   const [bulkEmailSharedToken, setBulkEmailSharedToken] = useState('')
   const [bulkEmailFromName, setBulkEmailFromName] = useState('')
   const [isSavingBulkEmailIntegration, setIsSavingBulkEmailIntegration] = useState(false)
-  const [googleBusinessStatus, setGoogleBusinessStatus] = useState<GoogleBusinessStatus | null>(null)
-  const [checkingGoogleBusiness, setCheckingGoogleBusiness] = useState(false)
-  const [connectingGoogleBusiness, setConnectingGoogleBusiness] = useState(false)
   const isPromotionsView = viewMode === 'promotions'
 
   const activeMembership = useMemo(() => {
@@ -531,12 +524,6 @@ export default function AccountOverview({
   }, [memberships, storeId])
 
   const isOwner = activeMembership?.role === 'owner'
-  const googleBusinessConnectionLabel = useMemo(() => {
-    if (!googleBusinessStatus) return 'Unknown'
-    if (googleBusinessStatus.connected && googleBusinessStatus.hasRequiredScope) return 'Connected'
-    if (googleBusinessStatus.connected && !googleBusinessStatus.hasRequiredScope) return 'Connected (scope missing)'
-    return 'Not connected'
-  }, [googleBusinessStatus])
   const pendingMembers = useMemo(
     () => roster.filter(member => member.status === 'pending'),
     [roster],
@@ -1679,43 +1666,6 @@ export default function AccountOverview({
     }
   }
 
-  async function handleCheckGoogleBusinessStatus() {
-    if (!user || !storeId) return
-    try {
-      setCheckingGoogleBusiness(true)
-      const token = await user.getIdToken()
-      const response = await postJson<{ integrations?: { business?: GoogleBusinessStatus } }>('/api/google/status', token, {
-        storeId,
-        integrations: ['business'],
-      })
-      const business = response.integrations?.business
-      setGoogleBusinessStatus(business ?? { connected: false, hasRequiredScope: false })
-    } catch (error) {
-      console.error('[google-business] status check failed', error)
-      publish({ tone: 'error', message: 'Unable to check Google Business connection.' })
-    } finally {
-      setCheckingGoogleBusiness(false)
-    }
-  }
-
-  async function handleConnectGoogleBusiness() {
-    if (!user || !storeId) return
-    try {
-      setConnectingGoogleBusiness(true)
-      const token = await user.getIdToken()
-      const response = await postJson<{ url: string }>('/api/google/oauth-start', token, {
-        storeId,
-        integrations: ['business'],
-      })
-      if (!response.url) throw new Error('missing-oauth-url')
-      window.location.assign(response.url)
-    } catch (error) {
-      console.error('[google-business] oauth start failed', error)
-      publish({ tone: 'error', message: 'Unable to start Google Business connection.' })
-      setConnectingGoogleBusiness(false)
-    }
-  }
-
   async function handleTestSedifexProducts() {
     try {
       const listStoreProducts = httpsCallable(functions, 'listStoreProducts')
@@ -1974,6 +1924,26 @@ export default function AccountOverview({
             Data
           </button>
         </nav>
+      )}
+
+      {!isPromotionsView && activeTab === 'workspace' && (
+        <section aria-labelledby="account-overview-quick-settings" className="account-overview__quick-settings">
+          <div className="account-overview__card account-overview__quick-settings-card">
+            <div>
+              <h2 id="account-overview-quick-settings">Navigation settings</h2>
+              <p className="account-overview__subtitle">
+                Choose which pages appear in the sidebar, update your business type, or show all available pages.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="button button--primary"
+              onClick={() => setActiveTab('navigation')}
+            >
+              Open navigation settings
+            </button>
+          </div>
+        </section>
       )}
 
       {profile && !isPromotionsView && activeTab === 'workspace' && (
@@ -2252,14 +2222,7 @@ export default function AccountOverview({
           <div className="account-overview__section-header">
             <h2 id="account-overview-integrations">{isFocusedIntegrationView ? "Integration settings" : "Website integrations"}</h2>
             <p className="account-overview__subtitle">
-              Manage integration settings for website, bookings, email, webhooks, and Google Business.
-            </p>
-            <p className="account-overview__hint">
-              Need Google Business OAuth? Open
-              {' '}
-              <Link to="/settings/integrations/google-business">Google settings</Link>
-              {' '}
-              and click <strong>Connect Google Business</strong>.
+              Manage integration settings for website, bookings, email, and webhooks.
             </p>
           </div>
           <div className="account-overview__website-sync" role="status" aria-live="polite">
@@ -2292,13 +2255,6 @@ export default function AccountOverview({
                 onClick={() => setIntegrationTab('email')}
               >
                 Email delivery
-              </button>
-              <button
-                type="button"
-                className={`account-overview__tab ${visibleIntegrationTab === 'google' ? 'is-active' : ''}`}
-                onClick={() => setIntegrationTab('google')}
-              >
-                Google Business
               </button>
               <button
                 type="button"
@@ -2605,32 +2561,6 @@ export default function AccountOverview({
                     disabled={isSavingBulkEmailIntegration}
                   >
                     {isSavingBulkEmailIntegration ? 'Saving…' : 'Save email integration'}
-                  </button>
-                </div>
-              </div>
-            )}
-            {visibleIntegrationTab === 'google' && (
-              <div className="account-overview__website-sync-keys">
-                <p className="account-overview__hint">Google Business Profile integration</p>
-                <p className="account-overview__hint">
-                  <strong>Connection status:</strong> {googleBusinessConnectionLabel}
-                </p>
-                <div className="account-overview__website-sync-actions">
-                  <button
-                    type="button"
-                    className="button button--secondary"
-                    onClick={() => void handleCheckGoogleBusinessStatus()}
-                    disabled={!user || !storeId || storeLoading || checkingGoogleBusiness || connectingGoogleBusiness}
-                  >
-                    {checkingGoogleBusiness ? 'Checking…' : 'Check connection'}
-                  </button>
-                  <button
-                    type="button"
-                    className="button"
-                    onClick={() => void handleConnectGoogleBusiness()}
-                    disabled={!user || !storeId || storeLoading || connectingGoogleBusiness}
-                  >
-                    {connectingGoogleBusiness ? 'Redirecting…' : 'Connect Google Business'}
                   </button>
                 </div>
               </div>

--- a/web/src/pages/IntegrationGoogleBusinessSettings.tsx
+++ b/web/src/pages/IntegrationGoogleBusinessSettings.tsx
@@ -1,5 +1,0 @@
-import AccountOverview from './AccountOverview'
-
-export default function IntegrationGoogleBusinessSettings() {
-  return <AccountOverview headingLevel="h2" defaultAccountTab="integrations" defaultIntegrationTab="google" />
-}

--- a/web/src/pages/SocialMediaPage.tsx
+++ b/web/src/pages/SocialMediaPage.tsx
@@ -27,7 +27,7 @@ type ProductOption = {
 type RegenerateTarget = 'all' | 'caption' | 'hashtags'
 type ContentTone = 'standard' | 'playful' | 'professional'
 type ContentLength = 'short' | 'medium' | 'long'
-type LaunchPlatformTarget = 'instagram' | 'tiktok' | 'google_business'
+type LaunchPlatformTarget = 'instagram' | 'tiktok'
 type SocialHistoryEntry = {
   id: string
   createdAtIso: string
@@ -558,7 +558,7 @@ export default function SocialMediaPage() {
     if (copied) {
       publish({
         tone: 'success',
-        message: `Draft copied with image link. Paste it in ${target === 'instagram' ? 'Instagram' : target === 'tiktok' ? 'TikTok' : 'Google Business Profile'}.`,
+        message: `Draft copied with image link. Paste it in ${target === 'instagram' ? 'Instagram' : 'TikTok'}.`,
       })
     } else {
       publish({
@@ -570,9 +570,7 @@ export default function SocialMediaPage() {
     const destination =
       target === 'instagram'
         ? 'https://www.instagram.com/'
-        : target === 'tiktok'
-          ? 'https://www.tiktok.com/upload?lang=en'
-          : 'https://business.google.com/'
+        : 'https://www.tiktok.com/upload?lang=en'
     window.open(destination, '_blank', 'noopener,noreferrer')
   }
 
@@ -586,7 +584,7 @@ export default function SocialMediaPage() {
       'Manual upload steps:',
       '1. Open the original image link.',
       '2. Hold (mobile) or right-click (desktop) the picture to save it.',
-      `3. Upload image in the ${result.post.platform === 'instagram' ? 'Instagram' : result.post.platform === 'tiktok' ? 'TikTok' : 'Google Business Profile'} app.`,
+      `3. Upload image in the ${result.post.platform === 'instagram' ? 'Instagram' : 'TikTok'} app.`,
       '4. Paste caption + hashtags + image link.',
       '',
       'Draft content:',
@@ -611,7 +609,7 @@ export default function SocialMediaPage() {
 
 
   return (
-    <PageSection title="Social media" subtitle="Generate Instagram, TikTok, or Google Business-ready captions, hashtags, and CTA from your existing product catalog.">
+    <PageSection title="Social media" subtitle="Generate Instagram or TikTok-ready captions, hashtags, and CTA from your existing product catalog.">
       <div
         style={{ display: 'grid', gap: 12 }}
         onKeyDown={event => {
@@ -626,24 +624,8 @@ export default function SocialMediaPage() {
           <select aria-labelledby="social-platform-label" value={platform} onChange={event => setPlatform(event.target.value as SocialPlatform)}>
             <option value="instagram">Instagram</option>
             <option value="tiktok">TikTok</option>
-            <option value="google_business">Google Business</option>
           </select>
         </label>
-
-        {platform === 'google_business' ? (
-          <div style={{ display: 'grid', gap: 8 }}>
-            <button
-              type="button"
-              className="button secondary"
-              onClick={() => window.open('https://business.google.com/', '_blank', 'noopener,noreferrer')}
-            >
-              Open Google Business Profile
-            </button>
-            <p style={{ margin: 0, fontSize: 13, opacity: 0.85 }}>
-              Sedifex generates the Google post draft for you, then copies caption + hashtags + image link. Final posting still happens inside Google Business Profile.
-            </p>
-          </div>
-        ) : null}
 
         <label style={{ display: 'grid', gap: 6 }}>
           <span id="social-product-search-label">Search products or services</span>
@@ -757,7 +739,7 @@ export default function SocialMediaPage() {
               </p>
             ) : null}
             <p style={{ margin: 0, fontSize: 13, opacity: 0.8 }}>
-              Step 1: Open original image and hold/right-click the picture to save. Step 2: Use Send to Instagram/TikTok/Google Business (or open app manually). Step 3: Paste caption + hashtags + image link.
+              Step 1: Open original image and hold/right-click the picture to save. Step 2: Use Send to Instagram/TikTok (or open app manually). Step 3: Paste caption + hashtags + image link.
             </p>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
               <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('instagram')}>
@@ -765,9 +747,6 @@ export default function SocialMediaPage() {
               </button>
               <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('tiktok')}>
                 Send to TikTok
-              </button>
-              <button type="button" className="button secondary" onClick={() => void handleSendToPlatform('google_business')}>
-                Send to Google Business
               </button>
               <button type="button" className="button secondary" onClick={() => void handleCopyPost()}>Copy text + image link</button>
               <button type="button" className="button secondary" onClick={handleDownload}>Download .txt</button>

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -757,8 +757,19 @@ describe('AccountOverview', () => {
     expect(await screen.findByRole('link', { name: /open settings page/i })).toHaveAttribute('href', '/settings/integrations/website')
     expect(screen.getByRole('link', { name: /bookings settings/i })).toHaveAttribute('href', '/settings/integrations/bookings')
     expect(screen.getByRole('link', { name: /email settings/i })).toHaveAttribute('href', '/settings/integrations/email')
-    expect(screen.getByRole('link', { name: /google settings/i })).toHaveAttribute('href', '/settings/integrations/google-business')
+    expect(screen.queryByRole('button', { name: /google business/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /google settings/i })).not.toBeInTheDocument()
     expect(screen.getByText(/integration health summary/i)).toBeInTheDocument()
+  })
+
+  it('surfaces navigation settings from the account tab', async () => {
+    render(<AccountOverview />)
+
+    expect(await screen.findByRole('heading', { name: /navigation settings/i })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /open navigation settings/i }))
+
+    expect(await screen.findByText(/tick the pages you want in the sidebar/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save navigation settings/i })).toBeInTheDocument()
   })
 
   it('switches integration sections from shortcut buttons', async () => {

--- a/web/src/pages/docs/HowToUseSedifexPage.tsx
+++ b/web/src/pages/docs/HowToUseSedifexPage.tsx
@@ -61,7 +61,7 @@ export default function HowToUseSedifexPage() {
           <li>Load catalog records in <strong>Items</strong> and use <strong>Ask Sedifex</strong> for item search, edit prep, and image upload.</li>
           <li>Use <strong>Sell</strong>, <strong>Quick Pay</strong>, <strong>Invoices</strong>, <strong>Receipts</strong>, and <strong>Marketplace Orders</strong> for sales and payments.</li>
           <li>Use <strong>Bookings</strong>, <strong>Upcoming events</strong>, registrations, volunteers, or support requests for operational intake.</li>
-          <li>Build the public site in <strong>Website Builder</strong> and connect APIs, checkout, gallery, Google Business, and email from <strong>Integrations</strong>.</li>
+          <li>Build the public site in <strong>Website Builder</strong> and connect APIs, checkout, gallery, and email from <strong>Integrations</strong>.</li>
         </ol>
       </section>
 


### PR DESCRIPTION
### Motivation
- Simplify and standardize social post generation to only target Instagram and TikTok, and remove Google Business-specific integration flows from the account UI.
- Surface a quick access card for navigation settings on the Account overview to improve discoverability of common workspace configuration.

### Description
- Remove `google_business` from `SocialPlatform` and update the AI fallback schema and parsing in `web/src/api/socialPost.ts` to only include `instagram` and `tiktok`.
- Remove Google Business options and messaging from the social media page in `web/src/pages/SocialMediaPage.tsx`, updating copy, destination links, and UI controls to only offer Instagram and TikTok.
- Remove Google Business integration UI and logic from `AccountOverview` by deleting the `IntegrationGoogleBusinessSettings` page, removing related state, helper functions, tabs, and route references, and updating the `IntegrationTab` type.
- Add a new quick settings card and responsive styles for navigation settings to `AccountOverview.tsx` and `AccountOverview.css` to provide a shortcut to navigation settings.
- Update documentation copy in `HowToUseSedifexPage.tsx` to reflect the removed Google Business mention.
- Update unit tests in `web/src/pages/__tests__/AccountOverview.test.tsx` to assert Google Business controls are absent and to add a test for the new navigation settings shortcut.

### Testing
- Ran the unit test suite with `yarn test`, and the updated tests for `AccountOverview` passed.
- Performed a local dev build (`yarn build`) and smoke-checked the affected pages to confirm no runtime errors and the UI changes render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30fa8b492c83219cd3dae15ab33c9b)