### PR TITLE
Defer persisting integration orders until payment settles (checkoutIntents)

### DIFF
--- a/functions/lib/paystack.js
+++ b/functions/lib/paystack.js
@@ -94,6 +94,18 @@ async function findStoreIntegrationOrderRefs(storeId, identifiers) {
     }
     return Array.from(refs.values());
 }
+async function loadCheckoutIntent(reference, storeId) {
+    if (!reference)
+        return null;
+    const snap = await firestore_1.defaultDb.collection('checkoutIntents').doc(reference).get();
+    if (!snap.exists)
+        return null;
+    const data = (snap.data() ?? {});
+    const intentStoreId = toTrimmedString(data.storeId) || toTrimmedString(data.merchantId);
+    if (intentStoreId && intentStoreId !== storeId)
+        return null;
+    return data;
+}
 function getFulfillmentTypeFromMetadata(metadata) {
     const value = toTrimmedString(metadata.fulfillmentType || metadata.fulfillment_type || metadata.deliveryMethod || metadata.delivery_method).toLowerCase();
     return ['pickup', 'self_pickup', 'collection'].includes(value) ? 'pickup' : 'delivery';
@@ -311,6 +323,7 @@ async function updateIntegrationOrderFromPaystackEvent(evtType, data) {
         toTrimmedString(metadata.bookingId),
         toTrimmedString(metadata.booking_id),
     ];
+    const checkoutIntent = await loadCheckoutIntent(reference, storeId);
     const storeOrderRefs = await findStoreIntegrationOrderRefs(storeId, initialIdentifiers);
     if (storeOrderRefs.length) {
         for (let index = 0; index < storeOrderRefs.length; index += 450) {
@@ -319,8 +332,11 @@ async function updateIntegrationOrderFromPaystackEvent(evtType, data) {
             await batch.commit();
         }
     }
+    else if (isSuccess) {
+        await orderRef.set({ ...(checkoutIntent ?? {}), ...orderUpdate, checkoutIntent: false, persistedAsOrder: true }, { merge: true });
+    }
     else {
-        await orderRef.set(orderUpdate, { merge: true });
+        await firestore_1.defaultDb.collection('checkoutIntents').doc(reference).set({ ...orderUpdate, persistedAsOrder: false }, { merge: true });
     }
     const orderSnap = await orderRef.get();
     const orderData = (orderSnap.data() ?? {});
@@ -384,7 +400,7 @@ async function updateIntegrationOrderFromPaystackEvent(evtType, data) {
             });
         }
     }
-    if (topLevelMatched.size > 0) {
+    if (topLevelMatched.size > 0 || isSuccess) {
         const topLevelUpdate = {
             provider: 'paystack',
             paymentProvider: 'paystack',
@@ -415,11 +431,14 @@ async function updateIntegrationOrderFromPaystackEvent(evtType, data) {
             topLevelUpdate.payment_status = 'failed';
             topLevelUpdate.paymentFailedAt = now;
         }
+        if (topLevelMatched.size === 0 && isSuccess) {
+            topLevelMatched.set(firestore_1.defaultDb.collection('integrationOrders').doc(reference).path, firestore_1.defaultDb.collection('integrationOrders').doc(reference));
+        }
         const matchedRefs = Array.from(topLevelMatched.values());
         for (let i = 0; i < matchedRefs.length; i += 450) {
             const batch = firestore_1.defaultDb.batch();
             matchedRefs.slice(i, i + 450).forEach((docRef) => {
-                batch.set(docRef, topLevelUpdate, { merge: true });
+                batch.set(docRef, { ...(checkoutIntent ?? {}), ...topLevelUpdate, checkoutIntent: false, persistedAsOrder: true }, { merge: true });
             });
             await batch.commit();
         }

--- a/functions/src/integrationCheckout.ts
+++ b/functions/src/integrationCheckout.ts
@@ -916,10 +916,11 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     if (matchingOrderRefs.length) {
       await Promise.all(matchingOrderRefs.map(orderRef => orderRef.set({ ...record, updatedAt: now, duplicateSuppressedAt: now }, { merge: true })))
     } else {
-      await Promise.all([
-        defaultDb.collection('integrationOrders').doc(reference).set(record, { merge: true }),
-        defaultDb.collection('stores').doc(storeId).collection('integrationOrders').doc(reference).set(record, { merge: true }),
-      ])
+      await defaultDb.collection('checkoutIntents').doc(reference).set({
+        ...record,
+        checkoutIntent: true,
+        persistedAsOrder: false,
+      }, { merge: true })
     }
 
     res.status(200).json({
@@ -982,6 +983,7 @@ export const integrationOrderStatus = functions.https.onRequest(async (req, res)
     const refs = [
       defaultDb.collection('stores').doc(storeId).collection('integrationOrders').doc(reference),
       defaultDb.collection('integrationOrders').doc(reference),
+      defaultDb.collection('checkoutIntents').doc(reference),
     ]
 
     for (const ref of refs) {

--- a/functions/src/integrationQuickPayCheckoutCreate.ts
+++ b/functions/src/integrationQuickPayCheckoutCreate.ts
@@ -782,10 +782,11 @@ export const integrationCheckoutCreate = functions.https.onRequest(async (req, r
     if (matchingOrderRefs.length) {
       await Promise.all(matchingOrderRefs.map(orderRef => orderRef.set({ ...record, updatedAt: now, updatedAtIso: nowIso, duplicateSuppressedAt: now }, { merge: true })))
     } else {
-      await Promise.all([
-        defaultDb.collection('integrationOrders').doc(reference).set(record, { merge: true }),
-        defaultDb.collection('stores').doc(storeId).collection('integrationOrders').doc(reference).set(record, { merge: true }),
-      ])
+      await defaultDb.collection('checkoutIntents').doc(reference).set({
+        ...record,
+        checkoutIntent: true,
+        persistedAsOrder: false,
+      }, { merge: true })
     }
 
     res.status(200).json({

--- a/functions/src/paystack.ts
+++ b/functions/src/paystack.ts
@@ -112,6 +112,17 @@ async function findStoreIntegrationOrderRefs(storeId: string, identifiers: strin
   return Array.from(refs.values())
 }
 
+
+async function loadCheckoutIntent(reference: string, storeId: string) {
+  if (!reference) return null
+  const snap = await defaultDb.collection('checkoutIntents').doc(reference).get()
+  if (!snap.exists) return null
+  const data = (snap.data() ?? {}) as Record<string, unknown>
+  const intentStoreId = toTrimmedString(data.storeId) || toTrimmedString(data.merchantId)
+  if (intentStoreId && intentStoreId !== storeId) return null
+  return data
+}
+
 function getFulfillmentTypeFromMetadata(metadata: Record<string, any>) {
   const value = toTrimmedString(metadata.fulfillmentType || metadata.fulfillment_type || metadata.deliveryMethod || metadata.delivery_method).toLowerCase()
   return ['pickup', 'self_pickup', 'collection'].includes(value) ? 'pickup' : 'delivery'
@@ -349,6 +360,7 @@ async function updateIntegrationOrderFromPaystackEvent(evtType: string, data: Pa
     toTrimmedString(metadata.bookingId),
     toTrimmedString(metadata.booking_id),
   ]
+  const checkoutIntent = await loadCheckoutIntent(reference, storeId)
   const storeOrderRefs = await findStoreIntegrationOrderRefs(storeId, initialIdentifiers)
   if (storeOrderRefs.length) {
     for (let index = 0; index < storeOrderRefs.length; index += 450) {
@@ -356,8 +368,10 @@ async function updateIntegrationOrderFromPaystackEvent(evtType: string, data: Pa
       storeOrderRefs.slice(index, index + 450).forEach(ref => batch.set(ref, orderUpdate, { merge: true }))
       await batch.commit()
     }
+  } else if (isSuccess) {
+    await orderRef.set({ ...(checkoutIntent ?? {}), ...orderUpdate, checkoutIntent: false, persistedAsOrder: true }, { merge: true })
   } else {
-    await orderRef.set(orderUpdate, { merge: true })
+    await defaultDb.collection('checkoutIntents').doc(reference).set({ ...orderUpdate, persistedAsOrder: false }, { merge: true })
   }
 
   const orderSnap = await orderRef.get()
@@ -426,7 +440,7 @@ async function updateIntegrationOrderFromPaystackEvent(evtType: string, data: Pa
     }
   }
 
-  if (topLevelMatched.size > 0) {
+  if (topLevelMatched.size > 0 || isSuccess) {
     const topLevelUpdate: Record<string, unknown> = {
       provider: 'paystack',
       paymentProvider: 'paystack',
@@ -458,11 +472,15 @@ async function updateIntegrationOrderFromPaystackEvent(evtType: string, data: Pa
       topLevelUpdate.paymentFailedAt = now
     }
 
+    if (topLevelMatched.size === 0 && isSuccess) {
+      topLevelMatched.set(defaultDb.collection('integrationOrders').doc(reference).path, defaultDb.collection('integrationOrders').doc(reference))
+    }
+
     const matchedRefs = Array.from(topLevelMatched.values())
     for (let i = 0; i < matchedRefs.length; i += 450) {
       const batch = defaultDb.batch()
       matchedRefs.slice(i, i + 450).forEach((docRef) => {
-        batch.set(docRef, topLevelUpdate, { merge: true })
+        batch.set(docRef, { ...(checkoutIntent ?? {}), ...topLevelUpdate, checkoutIntent: false, persistedAsOrder: true }, { merge: true })
       })
       await batch.commit()
     }


### PR DESCRIPTION
### Motivation
- Prevent stores from receiving cluttered pending orders for checkouts that never complete by not writing interim pending orders into `integrationOrders` until payment is confirmed. 
- Preserve the ability to poll order status while avoiding creating abandoned order records in store collections.

### Description
- Save newly initialized integration checkouts as `checkoutIntents` with flags `checkoutIntent: true` and `persistedAsOrder: false` instead of immediately writing a pending document into `integrationOrders` (changes in `functions/src/integrationCheckout.ts` and `functions/src/integrationQuickPayCheckoutCreate.ts`).
- Allow `integrationOrderStatus` to return data from `checkoutIntents` so status polling continues to work while the payment is pending (changed refs lookup to include `checkoutIntents`).
- Add `loadCheckoutIntent` helper and update Paystack webhook handling so that on successful payment the webhook hydrates the real store/top-level `integrationOrders` from the `checkoutIntent`, and on failure it records the failed state on the `checkoutIntent` without creating store order clutter (changes in `functions/src/paystack.ts` and compiled `functions/lib/paystack.js`).
- When an existing integration order document already exists we still update it in-place; only new/pending checkout flows are deferred into `checkoutIntents`.

### Testing
- `npm run build` (functions) succeeded. 
- `npm test` (functions) failed due to an unrelated assertion in `test/bookingNormalization.test.js` expecting missing `__testing` exports, not due to these checkout changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a314ee28364832195b620bfcf0e163c)