### PR TITLE
Add selection and bulk delete for bookings in list and report views

### DIFF
--- a/web/src/pages/Bookings.css
+++ b/web/src/pages/Bookings.css
@@ -26,3 +26,10 @@
   .bookings-card { border: 1px solid #e5e7eb; border-radius: 10px; padding: 12px; background: #fff; }
   .bookings-card h3, .bookings-card p { margin: 0 0 6px; }
 }
+.bookings-page__bulk-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; padding: 10px 12px; border: 1px solid #e5e7eb; border-radius: 10px; background: #f9fafb; }
+.bookings-page__bulk-actions span { color: #374151; font-size: 0.9rem; font-weight: 700; }
+.bookings-table__select { width: 44px; text-align: center; }
+.bookings-card__select { display: inline-flex; align-items: center; gap: 6px; margin-bottom: 10px; color: #374151; font-size: 0.9rem; font-weight: 700; }
+.bookings-page .btn-danger { border-color: #fecaca; background: #fee2e2; color: #991b1b; }
+.bookings-page .btn-danger:hover:not(:disabled) { background: #fecaca; }
+.bookings-page .btn:disabled { cursor: not-allowed; opacity: 0.55; }

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   collection,
+  deleteDoc,
+  doc,
   getDocs,
   query,
   Timestamp,
@@ -116,6 +118,9 @@ export default function Bookings() {
   const [bookings, setBookings] = useState<BookingRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [deletingIds, setDeletingIds] = useState<string[]>([]);
   const [activeTab, setActiveTab] = useState<
     "needs_action" | "today" | "upcoming" | "all" | "cancelled"
   >("needs_action");
@@ -271,6 +276,7 @@ export default function Bookings() {
     if (!storeId) return;
     setLoading(true);
     setErrorMessage(null);
+    setSuccessMessage(null);
     try {
       const serviceMap = new Map<string, string>();
       for (const collectionName of [
@@ -454,6 +460,91 @@ export default function Bookings() {
     [activeTab, bookings, todayStr],
   );
 
+  const deleteBookingRecords = useCallback(
+    async (booking: BookingRecord) => {
+      if (!storeId) return;
+      const collectionName =
+        booking.sourcePath === "order"
+          ? "integrationOrders"
+          : "integrationBookings";
+      await Promise.all([
+        deleteDoc(doc(db, "stores", storeId, collectionName, booking.id)),
+        deleteDoc(doc(db, collectionName, booking.id)),
+      ]);
+    },
+    [storeId],
+  );
+
+  const handleDeleteBooking = useCallback(
+    async (booking: BookingRecord) => {
+      const label = booking.serviceName || booking.reference || "this booking";
+      if (!window.confirm(`Delete ${label}? This cannot be undone.`)) return;
+
+      setDeletingIds((current) => [...new Set([...current, booking.id])]);
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      try {
+        await deleteBookingRecords(booking);
+        setBookings((current) =>
+          current.filter((item) => item.id !== booking.id),
+        );
+        setSelectedIds((current) => current.filter((id) => id !== booking.id));
+        setSuccessMessage("Booking deleted successfully.");
+      } catch (error) {
+        console.error(error);
+        setErrorMessage("Unable to delete booking right now. Please try again.");
+      } finally {
+        setDeletingIds((current) => current.filter((id) => id !== booking.id));
+      }
+    },
+    [deleteBookingRecords],
+  );
+
+  const handleBulkDelete = useCallback(async () => {
+    const selected = bookings.filter((booking) =>
+      selectedIds.includes(booking.id),
+    );
+    if (!selected.length) return;
+    if (
+      !window.confirm(
+        `Delete ${selected.length} selected booking${
+          selected.length === 1 ? "" : "s"
+        }? This cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+
+    setDeletingIds((current) => [
+      ...new Set([...current, ...selected.map((booking) => booking.id)]),
+    ]);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    try {
+      await Promise.all(
+        selected.map((booking) => deleteBookingRecords(booking)),
+      );
+      setBookings((current) =>
+        current.filter((booking) => !selectedIds.includes(booking.id)),
+      );
+      setSelectedIds([]);
+      setSuccessMessage(
+        `${selected.length} booking${
+          selected.length === 1 ? "" : "s"
+        } deleted successfully.`,
+      );
+    } catch (error) {
+      console.error(error);
+      setErrorMessage(
+        "Unable to delete selected bookings right now. Please try again.",
+      );
+    } finally {
+      setDeletingIds((current) =>
+        current.filter((id) => !selected.some((booking) => booking.id === id)),
+      );
+    }
+  }, [bookings, deleteBookingRecords, selectedIds]);
+
   return (
     <main className="page bookings-page">
       <section className="card stack gap-4 bookings-board">
@@ -516,6 +607,42 @@ export default function Bookings() {
           ))}
         </div>
 
+        {!loading && !errorMessage ? (
+          <div className="bookings-page__bulk-actions">
+            <span>{selectedIds.length} selected</span>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() =>
+                setSelectedIds(visible.map((booking) => booking.id))
+              }
+              disabled={!visible.length}
+            >
+              Select visible
+            </button>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setSelectedIds([])}
+              disabled={!selectedIds.length}
+            >
+              Clear selection
+            </button>
+            <button
+              type="button"
+              className="btn btn-danger"
+              onClick={() => void handleBulkDelete()}
+              disabled={!selectedIds.length || deletingIds.length > 0}
+            >
+              {deletingIds.length > 0 ? "Deleting…" : "Delete selected"}
+            </button>
+          </div>
+        ) : null}
+
+        {successMessage ? (
+          <p className="form__success">{successMessage}</p>
+        ) : null}
+
         {loading ? (
           <p>Loading bookings…</p>
         ) : errorMessage ? (
@@ -525,6 +652,33 @@ export default function Bookings() {
             <table className="table bookings-table">
               <thead>
                 <tr>
+                  <th className="bookings-table__select">
+                    <input
+                      type="checkbox"
+                      aria-label="Select all visible bookings"
+                      checked={
+                        visible.length > 0 &&
+                        visible.every((booking) =>
+                          selectedIds.includes(booking.id),
+                        )
+                      }
+                      onChange={(event) =>
+                        setSelectedIds(
+                          event.target.checked
+                            ? Array.from(
+                                new Set([
+                                  ...selectedIds,
+                                  ...visible.map((booking) => booking.id),
+                                ]),
+                              )
+                            : selectedIds.filter(
+                                (id) =>
+                                  !visible.some((booking) => booking.id === id),
+                              ),
+                        )
+                      }
+                    />
+                  </th>
                   <th>Booking</th>
                   <th>Customer</th>
                   <th>Schedule</th>
@@ -538,6 +692,20 @@ export default function Bookings() {
                 {visible.map((b) => {
                   return (
                     <tr key={b.id}>
+                      <td className="bookings-table__select">
+                        <input
+                          type="checkbox"
+                          aria-label={`Select ${b.serviceName}`}
+                          checked={selectedIds.includes(b.id)}
+                          onChange={(event) =>
+                            setSelectedIds((current) =>
+                              event.target.checked
+                                ? Array.from(new Set([...current, b.id]))
+                                : current.filter((id) => id !== b.id),
+                            )
+                          }
+                        />
+                      </td>
                       <td>
                         <strong>{b.serviceName}</strong>
                         <small>
@@ -608,6 +776,16 @@ export default function Bookings() {
                           >
                             Open
                           </Link>
+                          <button
+                            type="button"
+                            className="btn btn-danger"
+                            onClick={() => void handleDeleteBooking(b)}
+                            disabled={deletingIds.includes(b.id)}
+                          >
+                            {deletingIds.includes(b.id)
+                              ? "Deleting…"
+                              : "Delete"}
+                          </button>
                         </div>
                       </td>
                     </tr>
@@ -626,9 +804,36 @@ export default function Bookings() {
                   <p>
                     {statusLabel(b.status)} • {paymentLabel(b.paymentStatus)}
                   </p>
-                  <Link className="btn btn-secondary" to={`/bookings/${b.id}`}>
-                    Open
-                  </Link>
+                  <label className="bookings-card__select">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.includes(b.id)}
+                      onChange={(event) =>
+                        setSelectedIds((current) =>
+                          event.target.checked
+                            ? Array.from(new Set([...current, b.id]))
+                            : current.filter((id) => id !== b.id),
+                        )
+                      }
+                    />
+                    Select
+                  </label>
+                  <div className="bookings-page__row-actions">
+                    <Link
+                      className="btn btn-secondary"
+                      to={`/bookings/${b.id}`}
+                    >
+                      Open
+                    </Link>
+                    <button
+                      type="button"
+                      className="btn btn-danger"
+                      onClick={() => void handleDeleteBooking(b)}
+                      disabled={deletingIds.includes(b.id)}
+                    >
+                      {deletingIds.includes(b.id) ? "Deleting…" : "Delete"}
+                    </button>
+                  </div>
                 </article>
               ))}
             </div>

--- a/web/src/pages/reports/BookingsReport.tsx
+++ b/web/src/pages/reports/BookingsReport.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { collection, onSnapshot, query, where } from 'firebase/firestore'
+import { collection, deleteDoc, doc, onSnapshot, query, where } from 'firebase/firestore'
 import { db } from '../../firebase'
 import { useActiveStore } from '../../hooks/useActiveStore'
 import { asNumber, asText, downloadCsv, exportReportPdf, formatDate, formatMoney, getNestedObject, normalizeSourceChannel, toDate } from './reportUtils'
@@ -186,9 +186,18 @@ function StatusPill({ label, type = 'booking' }: { label: string; type?: 'bookin
   return <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-bold capitalize ${badgeClass(label, type)}`}>{formatLabel(label)}</span>
 }
 
-function BookingCard({ booking }: { booking: BookingRow }) {
+function BookingCard({ booking, checked, deleting, onSelect, onDelete }: { booking: BookingRow; checked: boolean; deleting: boolean; onSelect: (checked: boolean) => void; onDelete: () => void }) {
   return (
     <article className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-md">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 pb-4">
+        <label className="inline-flex items-center gap-2 text-sm font-bold text-slate-700">
+          <input type="checkbox" className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" checked={checked} onChange={event => onSelect(event.target.checked)} />
+          Select booking
+        </label>
+        <button type="button" className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-bold text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-50" onClick={onDelete} disabled={deleting}>
+          {deleting ? 'Deleting…' : 'Delete'}
+        </button>
+      </div>
       <div className="grid gap-5 xl:grid-cols-[minmax(0,1.25fr)_minmax(260px,0.95fr)_minmax(220px,0.7fr)] xl:items-start">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
@@ -253,11 +262,17 @@ export default function BookingsReport() {
   const [source, setSource] = useState('all')
   const [sync, setSync] = useState('all')
   const [range, setRange] = useState('30d')
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+  const [deletingIds, setDeletingIds] = useState<string[]>([])
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
     if (!storeId) {
       setRootBookings([])
       setStoreBookings([])
+      setSelectedIds([])
+      setDeletingIds([])
       return undefined
     }
     const unsubRoot = onSnapshot(query(collection(db, 'integrationBookings'), where('storeId', '==', storeId)), snapshot => {
@@ -289,6 +304,62 @@ export default function BookingsReport() {
     const dateOk = inDateRange(booking.createdAt, range)
     return statusOk && sourceOk && syncOk && dateOk
   }), [bookings, range, source, status, sync])
+
+
+  useEffect(() => {
+    setSelectedIds(current => current.filter(id => filtered.some(booking => booking.id === id)))
+  }, [filtered])
+
+  async function deleteBookingRecords(booking: BookingRow) {
+    if (!storeId) return
+    await Promise.all([
+      deleteDoc(doc(db, 'stores', storeId, 'integrationBookings', booking.id)),
+      deleteDoc(doc(db, 'integrationBookings', booking.id)),
+    ])
+  }
+
+  async function deleteOneBooking(booking: BookingRow) {
+    const label = booking.serviceName || booking.reference || 'this booking'
+    if (!window.confirm(`Delete ${label}? This cannot be undone.`)) return
+
+    setDeletingIds(current => Array.from(new Set([...current, booking.id])))
+    setSuccessMessage(null)
+    setErrorMessage(null)
+    try {
+      await deleteBookingRecords(booking)
+      setSelectedIds(current => current.filter(id => id !== booking.id))
+      setSuccessMessage('Booking deleted successfully.')
+    } catch (error) {
+      console.error(error)
+      setErrorMessage('Unable to delete booking right now. Please try again.')
+    } finally {
+      setDeletingIds(current => current.filter(id => id !== booking.id))
+    }
+  }
+
+  async function deleteSelectedBookings() {
+    const selected = filtered.filter(booking => selectedIds.includes(booking.id))
+    if (!selected.length) return
+    if (!window.confirm(`Delete ${selected.length} selected booking${selected.length === 1 ? '' : 's'}? This cannot be undone.`)) return
+
+    setDeletingIds(current => Array.from(new Set([...current, ...selected.map(booking => booking.id)])))
+    setSuccessMessage(null)
+    setErrorMessage(null)
+    try {
+      await Promise.all(selected.map(booking => deleteBookingRecords(booking)))
+      setSelectedIds([])
+      setSuccessMessage(`${selected.length} booking${selected.length === 1 ? '' : 's'} deleted successfully.`)
+    } catch (error) {
+      console.error(error)
+      setErrorMessage('Unable to delete selected bookings right now. Please try again.')
+    } finally {
+      setDeletingIds(current => current.filter(id => !selected.some(booking => booking.id === id)))
+    }
+  }
+
+  function setBookingSelected(bookingId: string, checked: boolean) {
+    setSelectedIds(current => checked ? Array.from(new Set([...current, bookingId])) : current.filter(id => id !== bookingId))
+  }
 
   const totals = useMemo(() => ({
     count: filtered.length,
@@ -399,6 +470,15 @@ export default function BookingsReport() {
           <span className="w-fit rounded-full bg-indigo-50 px-4 py-2 text-sm font-bold text-indigo-700">{filtered.length} showing</span>
         </div>
 
+        <div className="mt-5 flex flex-wrap items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4">
+          <span className="text-sm font-bold text-slate-700">{selectedIds.length} selected</span>
+          <button type="button" className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-900 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50" onClick={() => setSelectedIds(filtered.map(booking => booking.id))} disabled={!filtered.length}>Select all filtered</button>
+          <button type="button" className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-900 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50" onClick={() => setSelectedIds([])} disabled={!selectedIds.length}>Clear selection</button>
+          <button type="button" className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-bold text-rose-700 shadow-sm transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-50" onClick={() => void deleteSelectedBookings()} disabled={!selectedIds.length || deletingIds.length > 0}>{deletingIds.length ? 'Deleting…' : 'Delete selected'}</button>
+        </div>
+        {successMessage ? <p className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">{successMessage}</p> : null}
+        {errorMessage ? <p className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">{errorMessage}</p> : null}
+
         <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
           <label className="block text-sm font-semibold text-slate-700">
             Date range
@@ -446,7 +526,16 @@ export default function BookingsReport() {
       </section>
 
       <section className="space-y-4">
-        {filtered.map(booking => <BookingCard key={booking.id} booking={booking} />)}
+        {filtered.map(booking => (
+          <BookingCard
+            key={booking.id}
+            booking={booking}
+            checked={selectedIds.includes(booking.id)}
+            deleting={deletingIds.includes(booking.id)}
+            onSelect={checked => setBookingSelected(booking.id, checked)}
+            onDelete={() => void deleteOneBooking(booking)}
+          />
+        ))}
         {!filtered.length ? (
           <div className="rounded-[2rem] border border-dashed border-slate-300 bg-white p-10 text-center shadow-sm">
             <h3 className="text-xl font-semibold text-slate-950">No booking records found</h3>


### PR DESCRIPTION
### Motivation

- Provide the ability to select bookings (individual, visible, or filtered) and delete them either one-by-one or in bulk from both the Bookings page and the Bookings report. 
- Surface transient success/error feedback and disable actions while deletes are in-progress to avoid duplicate operations. 
- Ensure deletions remove both store-scoped and root/integration booking documents in Firestore. 

### Description

- Added UI and styles for bulk actions (`.bookings-page__bulk-actions`, table/card selection, danger button states) in `Bookings.css`. 
- In `Bookings.tsx` added `selectedIds`, `deletingIds`, and `successMessage` state, wired `deleteDoc`/`doc` imports, and implemented `deleteBookingRecords`, `handleDeleteBooking`, and `handleBulkDelete` to remove both store and root records and update local state. 
- Updated the bookings table and responsive cards to include checkboxes, a header "select all visible" checkbox, per-row delete buttons, and a bulk action bar with Select/Clear/Delete controls and feedback messages. 
- In `reports/BookingsReport.tsx` added selection and deletion support mirrored from the main page by extending `BookingCard` to accept `checked`, `deleting`, `onSelect`, and `onDelete` props, and implemented `deleteOneBooking`, `deleteSelectedBookings`, selection state, messages, and UI controls. 

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a315035eaa48321a7a768ff2afa90e4)