### PR TITLE
Include active storeId in account integration and webhook callables

### DIFF
--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -751,7 +751,7 @@ export default function AccountOverview({
     try {
       setIntegrationKeysLoading(true)
       const callable = httpsCallable(functions, 'listIntegrationApiKeys')
-      const response = await callable({})
+      const response = await callable({ storeId })
       const payload = (response.data ?? {}) as {
         keys?: Array<Record<string, unknown>>
       }
@@ -819,7 +819,7 @@ export default function AccountOverview({
     try {
       setWebhookEndpointsLoading(true)
       const callable = httpsCallable(functions, 'listWebhookEndpoints')
-      const response = await callable({})
+      const response = await callable({ storeId })
       const payload = (response.data ?? {}) as {
         endpoints?: Array<Record<string, unknown>>
       }
@@ -1422,7 +1422,7 @@ export default function AccountOverview({
     try {
       setIsCreatingIntegrationKey(true)
       const callable = httpsCallable(functions, 'createIntegrationApiKey')
-      const response = await callable({ name: integrationKeyName.trim() })
+      const response = await callable({ name: integrationKeyName.trim(), storeId })
       const data = (response.data ?? {}) as { token?: unknown }
       const token = typeof data.token === 'string' ? data.token : ''
 
@@ -1462,7 +1462,7 @@ export default function AccountOverview({
     try {
       setActioningKeyId(keyId)
       const callable = httpsCallable(functions, 'revokeIntegrationApiKey')
-      await callable({ keyId })
+      await callable({ keyId, storeId })
       publish({ message: 'Integration API key revoked.', tone: 'success' })
       await refreshIntegrationApiKeys()
     } catch (error) {
@@ -1477,7 +1477,7 @@ export default function AccountOverview({
     try {
       setActioningKeyId(keyId)
       const callable = httpsCallable(functions, 'rotateIntegrationApiKey')
-      const response = await callable({ keyId })
+      const response = await callable({ keyId, storeId })
       const data = (response.data ?? {}) as { token?: unknown }
       const token = typeof data.token === 'string' ? data.token : ''
       if (token) {
@@ -1559,6 +1559,7 @@ export default function AccountOverview({
         url: webhookEndpointUrl.trim(),
         secret: webhookSecret.trim(),
         events: ['booking.created', 'booking.updated', 'booking.cancelled', 'booking.confirmed', 'booking.approved'],
+        storeId,
       })
       publish({ message: 'Webhook endpoint saved.', tone: 'success' })
       setWebhookSecret('')
@@ -1575,7 +1576,7 @@ export default function AccountOverview({
     try {
       setActioningWebhookEndpointId(endpointId)
       const callable = httpsCallable(functions, 'revokeWebhookEndpoint')
-      await callable({ endpointId })
+      await callable({ endpointId, storeId })
       publish({ message: 'Webhook endpoint revoked.', tone: 'success' })
       await refreshWebhookEndpoints()
     } catch (error) {
@@ -1606,7 +1607,7 @@ export default function AccountOverview({
     try {
       setActioningWebhookEndpointId(endpointId)
       const callable = httpsCallable(functions, 'deleteWebhookEndpoint')
-      await callable({ endpointId })
+      await callable({ endpointId, storeId })
       publish({ message: 'Webhook endpoint deleted.', tone: 'success' })
       await refreshWebhookEndpoints()
     } catch (error) {

--- a/web/src/pages/__tests__/AccountOverview.test.tsx
+++ b/web/src/pages/__tests__/AccountOverview.test.tsx
@@ -782,6 +782,29 @@ describe('AccountOverview', () => {
     expect(await screen.findByText(/bulk email delivery integration/i)).toBeInTheDocument()
   })
 
+
+  it('passes the active store when creating integration API keys', async () => {
+    const createCallable = vi.fn(async () => ({ data: { token: 'sedx_test_token' } }))
+    httpsCallableMock.mockReturnValue(createCallable)
+    mockUseMemberships.mockReturnValue({
+      memberships: [{ storeId: 'store-123', role: 'owner', status: 'active', email: 'owner@example.com' }],
+      loading: false,
+      error: null,
+    })
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn(async () => undefined) },
+    })
+
+    render(<AccountOverview defaultAccountTab="integrations" defaultIntegrationTab="keys" />)
+
+    await userEvent.type(await screen.findByLabelText(/new integration key name/i), 'Website key')
+    await userEvent.click(screen.getByRole('button', { name: /create integration key/i }))
+
+    await waitFor(() =>
+      expect(createCallable).toHaveBeenCalledWith({ name: 'Website key', storeId: 'store-123' }),
+    )
+  })
+
   it('keeps owner-only integration key controls restricted for non-owners', async () => {
     mockUseMemberships.mockReturnValue({
       memberships: [{ storeId: 'store-123', role: 'staff', status: 'active', email: 'staff@example.com' }],


### PR DESCRIPTION
### Motivation
- Cloud Functions for integration API keys and webhook endpoints require a `storeId` and were rejecting client requests with `storeId is required` because the UI omitted it from callable payloads.
- Calls that create/list/rotate/revoke integration keys and manage webhook endpoints must be explicitly scoped to the selected workspace to avoid cross-store ambiguity and permission errors.

### Description
- Updated `web/src/pages/AccountOverview.tsx` to pass the active `storeId` to `httpsCallable` calls for `listIntegrationApiKeys`, `createIntegrationApiKey`, `revokeIntegrationApiKey`, and `rotateIntegrationApiKey` so key operations are scoped to the selected store.
- Updated `web/src/pages/AccountOverview.tsx` to pass the active `storeId` to webhook-related callables (`listWebhookEndpoints`, `upsertWebhookEndpoint`, `revokeWebhookEndpoint`, and `deleteWebhookEndpoint`) and include `storeId` in the `upsertWebhookEndpoint` payload for consistent scoping.
- Added a unit test in `web/src/pages/__tests__/AccountOverview.test.tsx` that asserts the create integration key callable receives `{ name, storeId }` to prevent regressions.

### Testing
- Ran `git diff --check` to verify no whitespace or simple diff issues and it passed.
- Attempted to run the component tests with `npm test -- --runInBand src/pages/__tests__/AccountOverview.test.tsx`, but execution was blocked because local dependencies are not installed and `vitest` was not available (tests could not be executed in this environment).
- Attempted `npm run build`, but the build was blocked by missing local dev dependencies (TypeScript could not find `vite/client` and `vitest/globals` type definitions) so the bundle was not built here.
- The new unit test was added and committed, but could not be run in this environment due to the dependency constraints described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32a6fe274c8321ad442f194969bcd5)