### PR TITLE
Fix integration API key store resolution

### DIFF
--- a/functions/src/integrationApiKeys.ts
+++ b/functions/src/integrationApiKeys.ts
@@ -47,11 +47,20 @@ export const createIntegrationApiKey = functions.https.onCall(async (rawData: un
   if (!uid) throw new functions.https.HttpsError('unauthenticated', 'Sign in required.')
 
   const body = (rawData ?? {}) as CreateIntegrationApiKeyRequest
-  const storeId = clean(body.storeId, 180)
+  const explicitStoreId = clean(body.storeId, 180)
   const purpose = clean(body.purpose, 80).toLowerCase() || 'website'
   const name = clean(body.name, 180) || `${purpose}-key`
 
-  if (!storeId) throw new functions.https.HttpsError('invalid-argument', 'storeId is required.')
+  const teamSnap = await defaultDb.collection('teamMembers').doc(uid).get()
+  const teamData = (teamSnap.data() ?? {}) as Record<string, unknown>
+  const storeId = explicitStoreId || clean(teamData.storeId, 180)
+
+  if (!storeId) {
+    throw new functions.https.HttpsError(
+      'failed-precondition',
+      'No store is assigned to this account. Please refresh your workspace or contact support.',
+    )
+  }
   if (!(await canManageStore(uid, storeId))) {
     throw new functions.https.HttpsError('permission-denied', 'You cannot create keys for this store.')
   }

--- a/functions/test/integrationApiKeys.test.js
+++ b/functions/test/integrationApiKeys.test.js
@@ -1,0 +1,145 @@
+const assert = require('assert')
+const Module = require('module')
+const { MockFirestore } = require('./helpers/mockFirestore')
+
+let currentDefaultDb
+const apps = []
+
+const originalLoad = Module._load
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'firebase-admin') {
+    const firestore = () => currentDefaultDb
+    firestore.FieldValue = {
+      serverTimestamp: () => ({ __mockServerTimestamp: true }),
+    }
+
+    return {
+      initializeApp: () => {
+        const app = { name: 'mock-app' }
+        apps[0] = app
+        return app
+      },
+      app: () => apps[0] || null,
+      apps,
+      firestore,
+    }
+  }
+
+  if (request === 'firebase-admin/firestore') {
+    return {
+      getFirestore: () => currentDefaultDb,
+    }
+  }
+
+  return originalLoad(request, parent, isMain)
+}
+
+function loadIntegrationApiKeysModule(initialData = {}) {
+  apps.length = 0
+  currentDefaultDb = new MockFirestore(initialData)
+  delete require.cache[require.resolve('../lib/firestore.js')]
+  delete require.cache[require.resolve('../lib/integrationApiKeys.js')]
+  return require('../lib/integrationApiKeys.js')
+}
+
+function authContext(uid = 'owner-uid') {
+  return { auth: { uid } }
+}
+
+async function assertHttpsError(promise, expectedCode, expectedMessage) {
+  try {
+    await promise
+    assert.fail(`Expected ${expectedCode} error`)
+  } catch (error) {
+    assert.strictEqual(error.code, expectedCode)
+    if (expectedMessage) assert.strictEqual(error.message, expectedMessage)
+  }
+}
+
+async function runExplicitStoreIdTest() {
+  const { createIntegrationApiKey } = loadIntegrationApiKeysModule({
+    'teamMembers/owner-uid': { storeId: 'store-a' },
+  })
+
+  const result = await createIntegrationApiKey.run(
+    { storeId: ' store-a ', name: ' Website prod ', purpose: ' Website ' },
+    authContext(),
+  )
+
+  assert.strictEqual(result.ok, true)
+  assert.strictEqual(result.storeId, 'store-a')
+  assert.strictEqual(result.purpose, 'website')
+  assert.ok(result.token.startsWith('sedx_'))
+  assert.ok(currentDefaultDb.getDoc(`integrationApiKeys/${result.keyId}`))
+  assert.ok(currentDefaultDb.getDoc(`stores/store-a/integrationApiKeys/${result.keyId}`))
+  assert.ok(currentDefaultDb.getDoc(`storeSettings/store-a/integrationApiKeys/${result.keyId}`))
+}
+
+async function runTeamMemberFallbackTest() {
+  const { createIntegrationApiKey } = loadIntegrationApiKeysModule({
+    'teamMembers/owner-uid': { storeId: 'store-from-team' },
+  })
+
+  const result = await createIntegrationApiKey.run(
+    { name: 'Fallback key', purpose: 'website' },
+    authContext(),
+  )
+
+  assert.strictEqual(result.ok, true)
+  assert.strictEqual(result.storeId, 'store-from-team')
+  const record = currentDefaultDb.getDoc(`integrationApiKeys/${result.keyId}`)
+  assert.strictEqual(record.storeId, 'store-from-team')
+}
+
+async function runMissingStoreTest() {
+  const { createIntegrationApiKey } = loadIntegrationApiKeysModule({
+    'teamMembers/owner-uid': { role: 'owner' },
+  })
+
+  await assertHttpsError(
+    createIntegrationApiKey.run({ name: 'Missing store' }, authContext()),
+    'failed-precondition',
+    'No store is assigned to this account. Please refresh your workspace or contact support.',
+  )
+}
+
+async function runOtherStoreDeniedTest() {
+  const { createIntegrationApiKey } = loadIntegrationApiKeysModule({
+    'teamMembers/owner-uid': { storeId: 'store-a' },
+  })
+
+  await assertHttpsError(
+    createIntegrationApiKey.run({ storeId: 'store-b', name: 'Wrong store' }, authContext()),
+    'permission-denied',
+    'You cannot create keys for this store.',
+  )
+}
+
+async function runUnauthenticatedTest() {
+  const { createIntegrationApiKey } = loadIntegrationApiKeysModule({
+    'teamMembers/owner-uid': { storeId: 'store-a' },
+  })
+
+  await assertHttpsError(
+    createIntegrationApiKey.run({ storeId: 'store-a', name: 'No auth' }, {}),
+    'unauthenticated',
+    'Sign in required.',
+  )
+}
+
+async function run() {
+  await runExplicitStoreIdTest()
+  await runTeamMemberFallbackTest()
+  await runMissingStoreTest()
+  await runOtherStoreDeniedTest()
+  await runUnauthenticatedTest()
+}
+
+run()
+  .then(() => {
+    console.log('integrationApiKeys tests passed')
+  })
+  .catch(error => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/web/src/pages/AccountOverview.tsx
+++ b/web/src/pages/AccountOverview.tsx
@@ -1414,6 +1414,14 @@ export default function AccountOverview({
   }
 
   async function handleCreateIntegrationApiKey() {
+    if (storeLoading || !storeId) {
+      publish({
+        message: 'Workspace is still loading. Please wait before creating an integration key.',
+        tone: 'warning',
+      })
+      return
+    }
+
     if (!integrationKeyName.trim()) {
       publish({ message: 'Provide a key name first.', tone: 'error' })
       return
@@ -1422,7 +1430,11 @@ export default function AccountOverview({
     try {
       setIsCreatingIntegrationKey(true)
       const callable = httpsCallable(functions, 'createIntegrationApiKey')
-      const response = await callable({ name: integrationKeyName.trim(), storeId })
+      const response = await callable({
+        storeId,
+        name: integrationKeyName.trim(),
+        purpose: 'website',
+      })
       const data = (response.data ?? {}) as { token?: unknown }
       const token = typeof data.token === 'string' ? data.token : ''
 
@@ -2370,9 +2382,13 @@ export default function AccountOverview({
                   type="button"
                   className="button button--secondary"
                   onClick={handleCreateIntegrationApiKey}
-                  disabled={isCreatingIntegrationKey}
+                  disabled={isCreatingIntegrationKey || storeLoading || !storeId}
                 >
-                  {isCreatingIntegrationKey ? 'Creating…' : 'Create integration key'}
+                  {storeLoading || !storeId
+                    ? 'Workspace loading…'
+                    : isCreatingIntegrationKey
+                      ? 'Creating…'
+                      : 'Create integration key'}
                 </button>
               </div>
             )}


### PR DESCRIPTION
### Motivation
- The callable `createIntegrationApiKey` required `body.storeId` and failed when the frontend omitted it, even though the authenticated team member can have an assigned workspace in `teamMembers/{uid}.storeId`.
- The goal is to securely fall back to the authenticated user’s assigned storeId, preserve existing authorization and storage behavior, and ensure the frontend sends the active storeId and does not call the function while the workspace is still loading.

### Description
- Backend: updated `createIntegrationApiKey` to read `body.storeId` into `explicitStoreId`, load `teamMembers/{uid}`, and resolve `storeId` with `const storeId = explicitStoreId || clean(teamData.storeId, 180)`, and throw a `failed-precondition` error with a clear message when neither source exists while keeping `canManageStore(uid, storeId)` and all token hashing/storage/response fields intact.
- Frontend: updated `web/src/pages/AccountOverview.tsx` to avoid calling the callable while `storeLoading` or `storeId` is missing, to send `{ storeId, name, purpose }`, and to disable the create button (showing a `Workspace loading…` label) until the active store is available.
- Tests: added `functions/test/integrationApiKeys.test.js` to cover explicit `storeId`, team-member fallback, missing store, forbidden attempts to create for another store, and unauthenticated requests.
- Files changed: `functions/src/integrationApiKeys.ts`, `web/src/pages/AccountOverview.tsx`, `functions/test/integrationApiKeys.test.js`.

### Testing
- Built functions: ran `npm --prefix functions run build` and the TypeScript build succeeded (OK).
- Callable tests: ran `node functions/test/integrationApiKeys.test.js` and all new tests passed (OK).
- Web build: attempted `npm --prefix web run build` but it failed because `web/node_modules` were not installed and `npm install` failed with a registry `403 Forbidden` for `@azure/msal-browser` (blocked); TypeScript/vite build cannot be completed until frontend dependencies install (FAILED / blocked).
- Notes: no backend TypeScript errors were introduced; the Firebase function that must be redeployed is `createIntegrationApiKey`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32b7c8662483219b427a0f83aae708)