### PR TITLE
Optimize public blog API usage

### DIFF
--- a/web/api/public-blog.ts
+++ b/web/api/public-blog.ts
@@ -1,57 +1,89 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { db } from './_firebase-admin.js'
 
+const LIST_CONTENT_PREVIEW_LENGTH = 600
+const BROWSER_CACHE_SECONDS = 60
+const VERCEL_CDN_CACHE_SECONDS = 300
+const STALE_WHILE_REVALIDATE_SECONDS = 86_400
+
+function setPublicCacheHeaders(res: VercelResponse) {
+  res.setHeader(
+    'Cache-Control',
+    `public, max-age=${BROWSER_CACHE_SECONDS}, stale-while-revalidate=${VERCEL_CDN_CACHE_SECONDS}`,
+  )
+  res.setHeader(
+    'Vercel-CDN-Cache-Control',
+    `public, max-age=${VERCEL_CDN_CACHE_SECONDS}, stale-while-revalidate=${STALE_WHILE_REVALIDATE_SECONDS}`,
+  )
+}
+
+function compactListContent(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const content = value.trim()
+  if (content.length <= LIST_CONTENT_PREVIEW_LENGTH) return content
+  return `${content.slice(0, LIST_CONTENT_PREVIEW_LENGTH).trimEnd()}…`
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
+    res.setHeader('Cache-Control', 'no-store')
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
   const storeId = typeof req.query.storeId === 'string' ? req.query.storeId.trim() : ''
   if (!storeId) {
+    res.setHeader('Cache-Control', 'no-store')
     return res.status(400).json({ error: 'storeId is required' })
   }
 
   const postSlug = typeof req.query.slug === 'string' ? req.query.slug.trim() : ''
   const tag = typeof req.query.tag === 'string' ? req.query.tag.trim() : ''
+  const isDetailRequest = Boolean(postSlug)
 
   const firestore = db()
   let query = firestore.collection('blogPosts').where('storeId', '==', storeId)
 
   const now = new Date()
 
-  if (postSlug) {
+  if (isDetailRequest) {
     query = query.where('slug', '==', postSlug).limit(1)
   } else {
     query = query.orderBy('updatedAt', 'desc').limit(50)
   }
 
   const snap = await query.get()
-  let items = snap.docs.map(doc => {
-    const data = doc.data()
-    const status = data.status ?? 'draft'
-    const publishAt = data.publishAt?.toDate ? data.publishAt.toDate() : null
-    const isVisible = status === 'published' || (status === 'scheduled' && publishAt && publishAt <= now)
-    if (!isVisible) return null
-    return {
-      id: doc.id,
-      title: data.title ?? '',
-      slug: data.slug ?? '',
-      excerpt: data.excerpt ?? null,
-      content: data.content ?? '',
-      linkUrl: data.linkUrl ?? null,
-      imageUrl: data.imageUrl ?? null,
-      metaTitle: data.metaTitle ?? null,
-      metaDescription: data.metaDescription ?? null,
-      canonicalUrl: data.canonicalUrl ?? null,
-      ogImage: data.ogImage ?? null,
-      tags: Array.isArray(data.tags) ? data.tags.filter((item: unknown) => typeof item === 'string') : [],
-      publishedAt: data.publishedAt?.toDate ? data.publishedAt.toDate().toISOString() : null,
-    }
-  }).filter(Boolean)
+  let items = snap.docs
+    .map(doc => {
+      const data = doc.data()
+      const status = data.status ?? 'draft'
+      const publishAt = data.publishAt?.toDate ? data.publishAt.toDate() : null
+      const isVisible = status === 'published' || (status === 'scheduled' && publishAt && publishAt <= now)
+      if (!isVisible) return null
+
+      const content = typeof data.content === 'string' ? data.content : ''
+
+      return {
+        id: doc.id,
+        title: data.title ?? '',
+        slug: data.slug ?? '',
+        excerpt: data.excerpt ?? null,
+        content: isDetailRequest ? content : compactListContent(content),
+        linkUrl: data.linkUrl ?? null,
+        imageUrl: data.imageUrl ?? null,
+        metaTitle: data.metaTitle ?? null,
+        metaDescription: data.metaDescription ?? null,
+        canonicalUrl: data.canonicalUrl ?? null,
+        ogImage: data.ogImage ?? null,
+        tags: Array.isArray(data.tags) ? data.tags.filter((item: unknown) => typeof item === 'string') : [],
+        publishedAt: data.publishedAt?.toDate ? data.publishedAt.toDate().toISOString() : null,
+      }
+    })
+    .filter(Boolean)
 
   if (tag) {
     items = items.filter(item => (item?.tags ?? []).includes(tag))
   }
 
+  setPublicCacheHeaders(res)
   return res.status(200).json({ items })
 }

--- a/web/src/pages/PublicBlogPage.tsx
+++ b/web/src/pages/PublicBlogPage.tsx
@@ -11,16 +11,22 @@ export default function PublicBlogPage() {
 
   useEffect(() => {
     if (!storeId) return
+
+    setSelectedTag('all')
     const params = new URLSearchParams({ storeId })
     if (slug) params.set('slug', slug)
-    if (selectedTag !== 'all') params.set('tag', selectedTag)
+
     fetch(`/api/public-blog?${params.toString()}`)
       .then(r => r.json())
       .then(data => setPosts(Array.isArray(data.items) ? data.items : []))
       .catch(() => setPosts([]))
-  }, [storeId, slug, selectedTag])
+  }, [storeId, slug])
 
   const allTags = useMemo(() => ['all', ...new Set(posts.flatMap(post => post.tags ?? []))], [posts])
+  const visiblePosts = useMemo(
+    () => selectedTag === 'all' ? posts : posts.filter(post => (post.tags ?? []).includes(selectedTag)),
+    [posts, selectedTag],
+  )
   const detailPost = slug ? posts[0] : null
 
   useEffect(() => {
@@ -34,7 +40,7 @@ export default function PublicBlogPage() {
     <main className="page" style={{ maxWidth: 900, margin: '0 auto', padding: 16 }}>
       <h1>Store Blog</h1>
       {!slug ? <p><label>Filter by tag: <select value={selectedTag} onChange={e => setSelectedTag(e.target.value)}>{allTags.map(tag => <option key={tag} value={tag}>{tag}</option>)}</select></label></p> : null}
-      {posts.map(post => (
+      {visiblePosts.map(post => (
         <article key={post.id} className="card" style={{ marginBottom: 16, padding: 16 }}>
           <h2>{post.title}</h2>
           {post.imageUrl ? <SafeFirebaseImage src={post.imageUrl} alt={post.title} style={{ maxWidth: 320 }} /> : null}


### PR DESCRIPTION
## What changed
- Cache successful `/api/public-blog` responses in browsers for 60 seconds and at Vercel's CDN for 5 minutes, with stale-while-revalidate support.
- Keep validation and unsupported-method responses uncached.
- Return compact content previews for blog-list requests while preserving full content for individual article requests.
- Filter blog tags in the browser instead of invoking the API again whenever a visitor changes the selected tag.

## Expected effect
- Repeated requests for the same public blog URL can be served from Vercel's CDN instead of running the function each time.
- Tag changes no longer create new function invocations.
- Smaller list responses reduce serialization and transfer work.

Please review the Vercel preview before merging.