### PR TITLE
Hide Ask Sedifex launcher

### DIFF
--- a/web/src/layout/ShellLayout.tsx
+++ b/web/src/layout/ShellLayout.tsx
@@ -3,11 +3,14 @@ import { Outlet } from 'react-router-dom'
 import AskSedifexAgent from '../components/AskSedifexAgent'
 import Shell from './Shell'
 
+const SHOW_ASK_SEDIFEX = false
+
 export function ShellLayout() {
   return (
     <Shell>
       <Outlet />
-      <AskSedifexAgent enabled />
+      {/* Temporarily hide Ask Sedifex until it is ready to return. */}
+      {SHOW_ASK_SEDIFEX ? <AskSedifexAgent enabled /> : null}
     </Shell>
   )
 }


### PR DESCRIPTION
### Motivation
- Temporarily hide the bottom "Ask Sedifex" launcher while the owner is testing it so it can be brought back later without deleting the component.

### Description
- Added a `SHOW_ASK_SEDIFEX = false` flag in `web/src/layout/ShellLayout.tsx` and replaced the direct `<AskSedifexAgent enabled />` render with a conditional `{SHOW_ASK_SEDIFEX ? <AskSedifexAgent enabled /> : null}` plus a brief comment.

### Testing
- Ran `git diff --check` (no issues), `npm run lint` (failed due to missing `@eslint/js` in the environment), `npm run build` (failed due to missing type definitions for `vite/client` and `vitest/globals`), and `npm ci` (failed due to `package-lock.json` being out of sync with `package.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44e37e78fc83219d61f72cc1582a65)