### PR TITLE
Bookings: add Paid/Confirm/Complete/Cancel actions and tabs; update travel label and docs

### DIFF
--- a/web/src/config/navigation.ts
+++ b/web/src/config/navigation.ts
@@ -51,7 +51,7 @@ export const NAV_ITEMS: NavItem[] = [
 
 const INDUSTRY_LABELS: Record<Industry, Partial<Record<string, string>>> = {
   shop: {},
-  travel: { '/customers': 'Customers', '/bookings': 'Booking', '/upcoming-events': 'Upcoming trips', '/marketplace-orders': 'Online Orders', '/website-builder': 'Website Builder', '/promo': 'Trip promos', '/gallery': 'Trip gallery', '/social-links': 'Contact links' },
+  travel: { '/customers': 'Customers', '/bookings': 'Booking', '/upcoming-events': 'Upcoming events', '/marketplace-orders': 'Online Orders', '/website-builder': 'Website Builder', '/promo': 'Trip promos', '/gallery': 'Trip gallery', '/social-links': 'Contact links' },
   ngo: { '/customers': 'Donors', '/bookings': 'Campaigns', '/upcoming-events': 'Upcoming campaigns', '/marketplace-orders': 'Online Orders', '/website-builder': 'Website Builder', '/promo': 'Campaign promo', '/gallery': 'Impact gallery', '/social-links': 'Contact links', '/expenses': 'Petty expenses' },
   school: { '/customers': 'Contacts', '/students': 'Students', '/bookings': 'Classes', '/upcoming-events': 'Upcoming classes', '/marketplace-orders': 'Registrations & Orders', '/website-builder': 'Website Builder', '/promo': 'Admissions promo', '/gallery': 'School gallery', '/social-links': 'Contact links' },
 }

--- a/web/src/pages/Bookings.tsx
+++ b/web/src/pages/Bookings.tsx
@@ -3,14 +3,23 @@ import {
   collection,
   deleteDoc,
   doc,
+  getDoc,
   getDocs,
   query,
+  setDoc,
   Timestamp,
   where,
 } from "firebase/firestore";
 import { Link } from "react-router-dom";
 import { db } from "../firebase";
 import { useActiveStore } from "../hooks/useActiveStore";
+import {
+  buildCancelBookingPayload,
+  buildCompleteBookingPayload,
+  buildConfirmBookingPayload,
+  hasAppScriptBookingSyncConfigured,
+  type BookingActionType,
+} from "../utils/bookingActions";
 import "./Bookings.css";
 
 type BookingRecord = {
@@ -121,8 +130,15 @@ export default function Bookings() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [deletingIds, setDeletingIds] = useState<string[]>([]);
+  const [updatingIds, setUpdatingIds] = useState<string[]>([]);
   const [activeTab, setActiveTab] = useState<
-    "needs_action" | "today" | "upcoming" | "all" | "cancelled"
+    | "needs_action"
+    | "paid"
+    | "awaiting_payment"
+    | "today"
+    | "upcoming"
+    | "all"
+    | "cancelled"
   >("needs_action");
 
   const hydrateBooking = useCallback(
@@ -427,6 +443,7 @@ export default function Bookings() {
     paymentPending: bookings.filter((b) =>
       ["pending", "payment_pending", "manual_review"].includes(b.paymentStatus),
     ).length,
+    paid: bookings.filter((b) => b.paymentStatus === "paid").length,
     confirmed: bookings.filter((b) => b.status === "confirmed").length,
     completed: bookings.filter((b) => b.status === "completed").length,
     cancelled: bookings.filter((b) =>
@@ -440,6 +457,14 @@ export default function Bookings() {
         if (activeTab === "all") return true;
         if (activeTab === "cancelled")
           return ["cancelled", "deleted"].includes(b.status);
+        if (activeTab === "paid") return b.paymentStatus === "paid";
+        if (activeTab === "awaiting_payment")
+          return (
+            !["cancelled", "deleted"].includes(b.status) &&
+            ["pending", "payment_pending", "manual_review"].includes(
+              b.paymentStatus,
+            )
+          );
         if (activeTab === "today") return dateKey(b.bookingDate) === todayStr;
         if (activeTab === "upcoming") {
           const d = b.bookingDate ? new Date(b.bookingDate) : null;
@@ -458,6 +483,81 @@ export default function Bookings() {
         );
       }),
     [activeTab, bookings, todayStr],
+  );
+
+  const applyBookingAction = useCallback(
+    async (booking: BookingRecord, action: BookingActionType) => {
+      if (!storeId) return;
+      const label =
+        action === "confirm"
+          ? "mark this booking as paid and confirmed"
+          : action === "complete"
+            ? "mark this booking as completed"
+            : "cancel this booking";
+      if (!window.confirm(`Are you sure you want to ${label}?`)) return;
+
+      setUpdatingIds((current) => [...new Set([...current, booking.id])]);
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      try {
+        const storeSnap = await getDoc(doc(db, "stores", storeId));
+        const shouldQueueSync = hasAppScriptBookingSyncConfigured(
+          storeSnap.exists()
+            ? (storeSnap.data() as Record<string, unknown>)
+            : null,
+        );
+        const payload =
+          action === "confirm"
+            ? buildConfirmBookingPayload(booking.payment, shouldQueueSync)
+            : action === "complete"
+              ? buildCompleteBookingPayload(shouldQueueSync)
+              : buildCancelBookingPayload(shouldQueueSync);
+        const nextPayment =
+          action === "confirm"
+            ? { ...booking.payment, status: "paid", confirmed: true }
+            : booking.payment;
+        const collectionName =
+          booking.sourcePath === "order"
+            ? "integrationOrders"
+            : "integrationBookings";
+        await Promise.all([
+          setDoc(
+            doc(db, "stores", storeId, collectionName, booking.id),
+            payload,
+            { merge: true },
+          ),
+          setDoc(doc(db, collectionName, booking.id), payload, { merge: true }),
+        ]);
+        setBookings((current) =>
+          current.map((item) =>
+            item.id === booking.id
+              ? {
+                  ...item,
+                  status: String(payload.status),
+                  bookingStatus: String(payload.bookingStatus),
+                  paymentStatus:
+                    action === "confirm" ? "paid" : item.paymentStatus,
+                  syncStatus: "pending",
+                  payment: nextPayment,
+                }
+              : item,
+          ),
+        );
+        setSuccessMessage(
+          action === "confirm"
+            ? "Booking marked as paid and confirmed."
+            : action === "complete"
+              ? "Booking marked as completed."
+              : "Booking cancelled successfully.",
+        );
+      } catch (error) {
+        console.error(error);
+        setErrorMessage("Unable to update booking right now. Please try again.");
+      } finally {
+        setUpdatingIds((current) => current.filter((id) => id !== booking.id));
+      }
+    },
+    [storeId],
   );
 
   const deleteBookingRecords = useCallback(
@@ -574,6 +674,7 @@ export default function Bookings() {
             ["New today", summary.newToday],
             ["Pending approval", summary.pending],
             ["Payment pending", summary.paymentPending],
+            ["Paid", summary.paid],
             ["Confirmed", summary.confirmed],
             ["Completed", summary.completed],
             ["Cancelled", summary.cancelled],
@@ -591,6 +692,8 @@ export default function Bookings() {
         <div className="bookings-page__tabs">
           {[
             ["needs_action", "Needs action"],
+            ["paid", "Paid"],
+            ["awaiting_payment", "Awaiting payment"],
             ["today", "Today"],
             ["upcoming", "Upcoming"],
             ["all", "All"],
@@ -776,6 +879,45 @@ export default function Bookings() {
                           >
                             Open
                           </Link>
+                          {b.paymentStatus !== "paid" &&
+                          !["cancelled", "deleted"].includes(b.status) ? (
+                            <button
+                              type="button"
+                              className="btn btn-secondary"
+                              onClick={() =>
+                                void applyBookingAction(b, "confirm")
+                              }
+                              disabled={updatingIds.includes(b.id)}
+                            >
+                              Paid + confirm
+                            </button>
+                          ) : null}
+                          {!["completed", "cancelled", "deleted"].includes(
+                            b.status,
+                          ) ? (
+                            <button
+                              type="button"
+                              className="btn btn-secondary"
+                              onClick={() =>
+                                void applyBookingAction(b, "complete")
+                              }
+                              disabled={updatingIds.includes(b.id)}
+                            >
+                              Complete
+                            </button>
+                          ) : null}
+                          {!["cancelled", "deleted"].includes(b.status) ? (
+                            <button
+                              type="button"
+                              className="btn btn-secondary"
+                              onClick={() =>
+                                void applyBookingAction(b, "cancel")
+                              }
+                              disabled={updatingIds.includes(b.id)}
+                            >
+                              Cancel
+                            </button>
+                          ) : null}
                           <button
                             type="button"
                             className="btn btn-danger"
@@ -825,6 +967,39 @@ export default function Bookings() {
                     >
                       Open
                     </Link>
+                    {b.paymentStatus !== "paid" &&
+                    !["cancelled", "deleted"].includes(b.status) ? (
+                      <button
+                        type="button"
+                        className="btn btn-secondary"
+                        onClick={() => void applyBookingAction(b, "confirm")}
+                        disabled={updatingIds.includes(b.id)}
+                      >
+                        Paid + confirm
+                      </button>
+                    ) : null}
+                    {!["completed", "cancelled", "deleted"].includes(
+                      b.status,
+                    ) ? (
+                      <button
+                        type="button"
+                        className="btn btn-secondary"
+                        onClick={() => void applyBookingAction(b, "complete")}
+                        disabled={updatingIds.includes(b.id)}
+                      >
+                        Complete
+                      </button>
+                    ) : null}
+                    {!["cancelled", "deleted"].includes(b.status) ? (
+                      <button
+                        type="button"
+                        className="btn btn-secondary"
+                        onClick={() => void applyBookingAction(b, "cancel")}
+                        disabled={updatingIds.includes(b.id)}
+                      >
+                        Cancel
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       className="btn btn-danger"

--- a/web/src/pages/docs/HowToUseSedifexPage.tsx
+++ b/web/src/pages/docs/HowToUseSedifexPage.tsx
@@ -25,7 +25,7 @@ export default function HowToUseSedifexPage() {
         <h2>Pick your workspace type</h2>
         <ul>
           <li><strong>Retail / Shop:</strong> Items, Sell, Marketplace Orders, Quick Pay, Customers, Bookings, Website Builder, and Reports.</li>
-          <li><strong>Travel:</strong> Booking, Customers, Upcoming trips, Online Orders, Trip promos, Trip gallery, and Contact links.</li>
+          <li><strong>Travel:</strong> Booking, Customers, Upcoming events, Online Orders, Trip promos, Trip gallery, and Contact links.</li>
           <li><strong>NGO:</strong> Donors, Campaigns, Upcoming campaigns, Volunteers, Support requests, Campaign promo, Impact gallery, and Petty expenses.</li>
           <li><strong>School:</strong> Students, Classes, Upcoming classes, Student registration, Registrations & Orders, Admissions promo, and School gallery.</li>
         </ul>


### PR DESCRIPTION
### Motivation
- Allow store users to mark bookings as paid, confirmed, completed or cancelled directly from the Bookings UI and surface paid/awaiting payment bookings as first-class filters. 
- Ensure bookings updates are queued/synced to integration collections (store + root) so downstream integrations can pick up status changes. 
- Align travel industry wording for upcoming events across navigation and documentation.

### Description
- Added imports for booking action helpers and Firestore `getDoc`/`setDoc`, introduced `applyBookingAction` to build payloads (`buildConfirmBookingPayload`, `buildCompleteBookingPayload`, `buildCancelBookingPayload`) and write to both store-scoped and root integration collections while updating local UI state and sync status. 
- Added `updatingIds` state to track in-flight updates and wired `Paid + confirm`, `Complete`, and `Cancel` buttons into both table rows and cards with appropriate enable/disable behavior. 
- Introduced new tabs/filters and summary metric for `paid` and `awaiting_payment`, and updated the visible booking filter logic accordingly. 
- Minor navigation label change for the travel industry from "Upcoming trips" to "Upcoming events" and corresponding documentation text updated in the HowToUseSedifex page. 

### Testing
- Ran TypeScript build with `yarn build` to verify compilation and type changes, which completed successfully. 
- Executed the test suite with `yarn test`, and all tests passed. 
- Ran linter with `yarn lint` and addressed issues; lint completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e37f79ab08321adc6a6b446bb743b)