### PR TITLE
Add POS sale voiding with inventory restore, ledger entry and UI/report support

### DIFF
--- a/docs/how-to-use-sedifex.md
+++ b/docs/how-to-use-sedifex.md
@@ -266,6 +266,18 @@ Use:
 5. Track **Marketplace Orders**, customers, receipts, expenses, settlement, and reports.
 6. Build a website with **Website Builder** and connect it from **Integrations**.
 
+#### Correcting a completed POS sale
+
+If a mistake is found before checkout, change the quantity or remove the item in **Sell** before selecting **Record sale**. After a sale has been recorded:
+
+1. A workspace owner opens **Reports → POS Sales Report**.
+2. Find the incorrect receipt and select **Void sale**.
+3. Enter a clear reason and confirm the action. Sedifex preserves the original sale for audit history and restores inventory with reversing ledger entries.
+4. Complete any customer refund separately through the original cash, card, or Mobile Money channel.
+5. Return to **Sell** and record the corrected sale when required.
+
+Only owners can void completed sales. A void cannot itself be undone, and attempting it again will not restore inventory twice.
+
 ### Travel workflow
 
 1. Select **Travel** in navigation settings.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -49,3 +49,4 @@ export { getPricingPlans } from './pricingPlans'
 
 export { commitSale } from './pos/commitSale'
 export { receiveStock } from './pos/receiveStock'
+export { voidSale } from './pos/voidSale'

--- a/functions/src/pos/voidSale.ts
+++ b/functions/src/pos/voidSale.ts
@@ -1,0 +1,125 @@
+import * as functions from 'firebase-functions/v1'
+import { admin, defaultDb } from '../firestore'
+
+type SaleLine = {
+  productId?: unknown
+  qty?: unknown
+  quantity?: unknown
+  type?: unknown
+  isService?: unknown
+}
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function positiveNumber(value: unknown) {
+  const number = Number(value)
+  return Number.isFinite(number) && number > 0 ? number : 0
+}
+
+async function assertOwner(uid: string, storeId: string) {
+  const direct = await defaultDb.collection('teamMembers').doc(uid).get()
+  if (direct.exists && text(direct.get('storeId')) === storeId && text(direct.get('role')).toLowerCase() === 'owner') {
+    return
+  }
+
+  const matches = await defaultDb.collection('teamMembers').where('uid', '==', uid).where('storeId', '==', storeId).limit(5).get()
+  if (matches.docs.some(member => text(member.get('role')).toLowerCase() === 'owner')) return
+
+  throw new functions.https.HttpsError('permission-denied', 'Only a workspace owner can void a sale')
+}
+
+/**
+ * Voids a completed POS sale without deleting its audit history. Inventory is
+ * restored and a reversing ledger entry is written in the same transaction.
+ */
+export const voidSale = functions.https.onCall(async (data, context) => {
+  if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Login required')
+
+  const storeId = text(data?.storeId)
+  const saleId = text(data?.saleId)
+  const reason = text(data?.reason)
+  if (!storeId || !saleId) throw new functions.https.HttpsError('invalid-argument', 'Workspace and sale are required')
+  if (reason.length < 5 || reason.length > 500) {
+    throw new functions.https.HttpsError('invalid-argument', 'Enter a correction reason between 5 and 500 characters')
+  }
+
+  await assertOwner(context.auth.uid, storeId)
+
+  const saleRef = defaultDb.collection('sales').doc(saleId)
+  const now = admin.firestore.FieldValue.serverTimestamp()
+
+  await defaultDb.runTransaction(async tx => {
+    const saleSnap = await tx.get(saleRef)
+    if (!saleSnap.exists) throw new functions.https.HttpsError('not-found', 'Sale not found')
+    if (text(saleSnap.get('storeId') ?? saleSnap.get('branchId')) !== storeId) {
+      throw new functions.https.HttpsError('permission-denied', 'Sale does not belong to this workspace')
+    }
+    if (text(saleSnap.get('status')).toLowerCase() === 'voided') {
+      throw new functions.https.HttpsError('already-exists', 'This sale has already been voided')
+    }
+
+    const items = Array.isArray(saleSnap.get('items')) ? saleSnap.get('items') as SaleLine[] : []
+    const restoreByProduct = new Map<string, number>()
+    for (const item of items) {
+      const productId = text(item.productId)
+      const itemType = text(item.type).toLowerCase()
+      if (!productId || item.isService === true || itemType === 'service') continue
+      const quantity = positiveNumber(item.qty ?? item.quantity)
+      if (quantity) restoreByProduct.set(productId, (restoreByProduct.get(productId) ?? 0) + quantity)
+    }
+
+    const productSnapshots = new Map<string, FirebaseFirestore.DocumentSnapshot>()
+    for (const productId of restoreByProduct.keys()) {
+      const productRef = defaultDb.collection('products').doc(productId)
+      productSnapshots.set(productId, await tx.get(productRef))
+    }
+
+    for (const [productId, quantity] of restoreByProduct) {
+      const productRef = defaultDb.collection('products').doc(productId)
+      const productSnap = productSnapshots.get(productId)
+      if (!productSnap?.exists) {
+        throw new functions.https.HttpsError('failed-precondition', `Cannot restore missing product ${productId}`)
+      }
+      const productStoreId = text(productSnap.get('storeId'))
+      if (productStoreId && productStoreId !== storeId) {
+        throw new functions.https.HttpsError('failed-precondition', `Product ${productId} belongs to another workspace`)
+      }
+
+      tx.update(productRef, {
+        stockCount: Number(productSnap.get('stockCount') ?? 0) + quantity,
+        updatedAt: now,
+      })
+      tx.set(defaultDb.collection('ledger').doc(), {
+        productId,
+        qtyChange: quantity,
+        type: 'sale_void',
+        refId: saleId,
+        storeId,
+        reason,
+        createdAt: now,
+        createdBy: context.auth?.uid ?? null,
+      })
+    }
+
+    tx.update(saleRef, {
+      status: 'voided',
+      voidReason: reason,
+      voidedAt: now,
+      voidedBy: context.auth?.uid ?? null,
+      updatedAt: now,
+    })
+    tx.set(defaultDb.collection('activity').doc(), {
+      storeId,
+      type: 'sale.voided',
+      summary: 'POS sale voided',
+      detail: `Sale ${saleId} was voided: ${reason}`,
+      actor: context.auth?.token.email ?? context.auth?.uid ?? 'Owner',
+      refId: saleId,
+      createdAt: now,
+    })
+  })
+
+  return { ok: true, saleId, status: 'voided' }
+})

--- a/functions/test/voidSale.test.js
+++ b/functions/test/voidSale.test.js
@@ -1,0 +1,78 @@
+const assert = require('assert')
+const Module = require('module')
+const { MockFirestore, MockTimestamp } = require('./helpers/mockFirestore')
+
+let currentDb
+const originalLoad = Module._load
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'firebase-admin') {
+    const apps = []
+    const firestore = () => currentDb
+    firestore.FieldValue = { serverTimestamp: () => ({ __mockServerTimestamp: true }) }
+    firestore.Timestamp = MockTimestamp
+    return {
+      initializeApp: () => { const app = { name: 'mock-app' }; apps[0] = app; return app },
+      app: () => apps[0] || null,
+      apps,
+      firestore,
+      auth: () => ({}),
+    }
+  }
+  if (request === 'firebase-admin/firestore') return { getFirestore: () => currentDb }
+  return originalLoad(request, parent, isMain)
+}
+
+async function run() {
+  currentDb = new MockFirestore({
+    'teamMembers/owner-1': { uid: 'owner-1', storeId: 'store-1', role: 'owner' },
+    'teamMembers/staff-1': { uid: 'staff-1', storeId: 'store-1', role: 'staff' },
+    'products/product-1': { storeId: 'store-1', stockCount: 7 },
+    'sales/sale-1': {
+      storeId: 'store-1',
+      status: 'completed',
+      total: 50,
+      items: [
+        { productId: 'product-1', qty: 2, type: 'product' },
+        { productId: null, qty: 1, type: 'service', isService: true },
+      ],
+    },
+  })
+
+  delete require.cache[require.resolve('../lib/index.js')]
+  const { voidSale } = require('../lib/index.js')
+  const ownerContext = { auth: { uid: 'owner-1', token: { email: 'owner@example.com' } } }
+
+  const result = await voidSale.run({ storeId: 'store-1', saleId: 'sale-1', reason: 'Wrong quantity entered' }, ownerContext)
+  assert.deepStrictEqual(result, { ok: true, saleId: 'sale-1', status: 'voided' })
+  assert.strictEqual(currentDb.getDoc('products/product-1').stockCount, 9)
+  assert.strictEqual(currentDb.getDoc('sales/sale-1').status, 'voided')
+  assert.strictEqual(currentDb.getDoc('sales/sale-1').voidReason, 'Wrong quantity entered')
+
+  const reversals = currentDb.listCollection('ledger')
+  assert.strictEqual(reversals.length, 1)
+  assert.strictEqual(reversals[0].data.type, 'sale_void')
+  assert.strictEqual(reversals[0].data.qtyChange, 2)
+  assert.strictEqual(currentDb.listCollection('activity').length, 1)
+
+  await assert.rejects(
+    () => voidSale.run({ storeId: 'store-1', saleId: 'sale-1', reason: 'Try twice' }, ownerContext),
+    error => error.code === 'already-exists',
+  )
+  assert.strictEqual(currentDb.getDoc('products/product-1').stockCount, 9, 'a repeated void must not restore stock twice')
+
+  currentDb.setRaw('sales/sale-2', { storeId: 'store-1', status: 'completed', items: [] })
+  await assert.rejects(
+    () => voidSale.run(
+      { storeId: 'store-1', saleId: 'sale-2', reason: 'Staff correction attempt' },
+      { auth: { uid: 'staff-1', token: { email: 'staff@example.com' } } },
+    ),
+    error => error.code === 'permission-denied',
+  )
+  assert.strictEqual(currentDb.getDoc('sales/sale-2').status, 'completed')
+
+  console.log('voidSale tests passed')
+}
+
+run()
+  .catch(error => { console.error(error); process.exitCode = 1 })
+  .finally(() => { Module._load = originalLoad })

--- a/web/src/pages/CloseDay.tsx
+++ b/web/src/pages/CloseDay.tsx
@@ -126,6 +126,7 @@ export default function CloseDay() {
 
       snap.forEach(d => {
         const data = d.data() as any
+        if (String(data.status ?? '').toLowerCase() === 'voided') return
 
         // Total
         const saleTotal =

--- a/web/src/pages/Customers.tsx
+++ b/web/src/pages/Customers.tsx
@@ -537,6 +537,7 @@ export default function Customers() {
 
     records.forEach(record => {
       if (!record) return
+      if (String(record.status ?? '').toLowerCase() === 'voided') return
       const customer =
         record.customer && typeof record.customer === 'object'
           ? (record.customer as { id?: string | null; name?: string | null; phone?: string | null })

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -194,7 +194,7 @@ export default function Dashboard() {
     return () => unsubscribers.forEach(unsubscribe => unsubscribe())
   }, [storeId])
 
-  const todaySales = sales.filter(item => isToday(item.createdAt))
+  const todaySales = sales.filter(item => item.status !== 'voided' && isToday(item.createdAt))
   const todayOrders = orders.filter(item => isToday(item.createdAtServer ?? item.createdAt))
   const todayBookings = bookings.filter(item => isToday(item.createdAtServer ?? item.createdAt))
   const todayVolunteers = volunteers.filter(item => isToday(item.createdAtServer ?? item.createdAt))

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -821,7 +821,7 @@ export default function Products() {
     const unsubscribe = onSnapshot(
       q,
       snapshot => {
-        const rows: SaleRecord[] = snapshot.docs.map(docSnap => {
+        const rows: SaleRecord[] = snapshot.docs.filter(docSnap => docSnap.data().status !== 'voided').map(docSnap => {
           const data = docSnap.data() as Record<string, unknown>
           return {
             id: docSnap.id,

--- a/web/src/pages/Sell.tsx
+++ b/web/src/pages/Sell.tsx
@@ -1495,7 +1495,7 @@ export default function Sell() {
     const unsubscribe = onSnapshot(
       q,
       snapshot => {
-        setDailySalesCount(snapshot.docs.length)
+        setDailySalesCount(snapshot.docs.filter(sale => sale.data().status !== 'voided').length)
       },
       () => {
         setDailySalesCount(0)

--- a/web/src/pages/reports/PosSalesReport.tsx
+++ b/web/src/pages/reports/PosSalesReport.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
 import { collection, onSnapshot, query, where } from 'firebase/firestore'
+import { httpsCallable } from 'firebase/functions'
 import { db } from '../../firebase'
+import { functions } from '../../firebase'
 import { useActiveStore } from '../../hooks/useActiveStore'
+import { useMemberships } from '../../hooks/useMemberships'
+import { useToast } from '../../components/ToastProvider'
 import ReportDataTable, { type ReportColumn } from './ReportDataTable'
 import { asNumber, asText, downloadCsv, exportReportPdf, formatDate, formatMoney, getNestedObject, toDate } from './reportUtils'
 
@@ -16,6 +20,8 @@ type SaleRow = {
   unitsSold: number
   paymentSummary: string
   createdAt: Date | null
+  status: 'completed' | 'voided'
+  voidReason: string
 }
 
 function mapSale(id: string, data: Record<string, unknown>): SaleRow {
@@ -43,13 +49,19 @@ function mapSale(id: string, data: Record<string, unknown>): SaleRow {
     unitsSold,
     paymentSummary: paymentParts.join(' · ') || 'Not specified',
     createdAt: toDate(data.createdAt),
+    status: asText(data.status, '').toLowerCase() === 'voided' ? 'voided' : 'completed',
+    voidReason: asText(data.voidReason, ''),
   }
 }
 
 export default function PosSalesReport() {
   const { storeId } = useActiveStore()
+  const { memberships } = useMemberships()
+  const { publish } = useToast()
   const [sales, setSales] = useState<SaleRow[]>([])
   const [range, setRange] = useState('all')
+  const [voidingId, setVoidingId] = useState<string | null>(null)
+  const isOwner = memberships.some(membership => membership.storeId === storeId && membership.role === 'owner')
 
   useEffect(() => {
     if (!storeId) {
@@ -75,10 +87,10 @@ export default function PosSalesReport() {
   }, [range, sales])
 
   const totals = useMemo(() => ({
-    count: filtered.length,
-    revenue: filtered.reduce((sum, sale) => sum + sale.total, 0),
-    units: filtered.reduce((sum, sale) => sum + sale.unitsSold, 0),
-    cash: filtered.reduce((sum, sale) => sum + sale.cashTotal, 0),
+    count: filtered.filter(sale => sale.status !== 'voided').length,
+    revenue: filtered.reduce((sum, sale) => sum + (sale.status === 'voided' ? 0 : sale.total), 0),
+    units: filtered.reduce((sum, sale) => sum + (sale.status === 'voided' ? 0 : sale.unitsSold), 0),
+    cash: filtered.reduce((sum, sale) => sum + (sale.status === 'voided' ? 0 : sale.cashTotal), 0),
   }), [filtered])
 
 
@@ -89,7 +101,32 @@ export default function PosSalesReport() {
     { key: 'payment', label: 'Payment', sortable: true, value: row => row.paymentSummary },
     { key: 'units', label: 'Units', sortable: true, align: 'right', value: row => row.unitsSold },
     { key: 'date', label: 'Date', sortable: true, value: row => row.createdAt ?? undefined, render: row => formatDate(row.createdAt) },
+    { key: 'status', label: 'Status', sortable: true, value: row => row.status, render: row => row.status === 'voided' ? `Voided${row.voidReason ? ` — ${row.voidReason}` : ''}` : 'Completed' },
+    { key: 'actions', label: 'Actions', render: row => row.status === 'voided' ? '—' : isOwner ? <button type="button" className="button button--secondary button--small" disabled={voidingId === row.id} onClick={() => void handleVoidSale(row)}>{voidingId === row.id ? 'Voiding…' : 'Void sale'}</button> : 'Owner approval required' },
   ]
+
+  async function handleVoidSale(sale: SaleRow) {
+    if (!storeId || !isOwner || voidingId) return
+    const reason = window.prompt(`Why are you voiding receipt ${sale.receiptNo}?\n\nInventory will be restored. Refunds must still be completed through the original payment provider.`)?.trim()
+    if (!reason) return
+    if (reason.length < 5) {
+      publish({ tone: 'error', message: 'Enter a correction reason of at least 5 characters.' })
+      return
+    }
+    if (!window.confirm(`Void ${sale.receiptNo} and restore ${sale.unitsSold} unit(s) to stock? This action cannot be undone.`)) return
+
+    setVoidingId(sale.id)
+    try {
+      const callable = httpsCallable(functions, 'voidSale')
+      await callable({ storeId, saleId: sale.id, reason })
+      publish({ tone: 'success', message: 'Sale voided and inventory restored. Record the corrected sale if needed.' })
+    } catch (error) {
+      const message = error instanceof Error ? error.message.replace(/^Firebase:\s*/i, '') : 'The sale could not be voided.'
+      publish({ tone: 'error', message })
+    } finally {
+      setVoidingId(null)
+    }
+  }
 
   function exportRows() {
     downloadCsv('sedifex-pos-sales-report.csv', filtered.map(sale => ({
@@ -101,6 +138,8 @@ export default function PosSalesReport() {
       momo: sale.momoTotal,
       unitsSold: sale.unitsSold,
       createdAt: formatDate(sale.createdAt),
+      status: sale.status,
+      voidReason: sale.voidReason,
     })))
   }
 
@@ -124,6 +163,8 @@ export default function PosSalesReport() {
         unitsSold: sale.unitsSold,
         paymentSummary: sale.paymentSummary,
         createdAt: formatDate(sale.createdAt),
+        status: sale.status,
+        voidReason: sale.voidReason,
       })),
     })
   }
@@ -133,7 +174,7 @@ export default function PosSalesReport() {
       <section className="workspace-card">
         <p className="workspace-eyebrow">Reports / POS sales</p>
         <h1>Internal sales report</h1>
-        <p className="workspace-muted">Detailed POS sales recorded through Sell, including receipt totals, payment split, units sold, and CSV export.</p>
+        <p className="workspace-muted">Review completed sales, void mistakes with owner approval, restore inventory, and export an audit-friendly history.</p>
       </section>
       <section className="workspace-grid workspace-grid--four">
         <article className="workspace-card"><strong>{totals.count}</strong><span>Sales</span></article>
@@ -143,7 +184,7 @@ export default function PosSalesReport() {
       </section>
       <section className="workspace-card">
         <div className="workspace-section-header">
-          <div><h2>Sale details</h2><p className="workspace-muted">Filter by period and export sales.</p></div>
+          <div><h2>Sale details</h2><p className="workspace-muted">Owners can void an incorrect sale, then record the corrected sale in Sell. Payment refunds must be completed separately with the payment provider.</p></div>
           <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
             <button type="button" className="button button--secondary" onClick={exportPdf} disabled={!filtered.length}>Export PDF</button>
             <button type="button" className="button button--primary" onClick={exportRows} disabled={!filtered.length}>Export CSV</button>

--- a/web/src/pages/reports/SalesCashReport.tsx
+++ b/web/src/pages/reports/SalesCashReport.tsx
@@ -85,7 +85,8 @@ function inRange(date: Date | null, range: string) {
 function mapPosSale(id: string, data: Record<string, unknown>): BusinessSaleRow {
   const customer = getNestedObject(data, 'customer')
   const first = firstItem(data)
-  const amount = asNumber(data.total ?? data.grandTotal ?? data.amount, readAmount(data))
+  const isVoided = asText(data.status).toLowerCase() === 'voided'
+  const amount = isVoided ? 0 : asNumber(data.total ?? data.grandTotal ?? data.amount, readAmount(data))
   return {
     id: `pos-${id}`,
     type: 'pos',


### PR DESCRIPTION
### Motivation

- Provide an owner-only way to void a completed POS sale, restore inventory, and keep an audit trail without deleting the original sale.
- Ensure reports and UI metrics exclude voided sales from counts and totals so dashboards and analyses remain accurate.
- Surface the void action in the POS sales report with owner confirmation and reason capture.

### Description

- Added a callable cloud function `voidSale` in `functions/src/pos/voidSale.ts` that validates owner permissions, requires a 5–500 character reason, restores product stock, writes reversing `ledger` entries, marks the sale as `voided` with metadata, and records an `activity` entry in a single transaction.
- Exported the new function from `functions/src/index.ts` and added unit tests in `functions/test/voidSale.test.js` that exercise stock restore, ledger entry creation, duplicate-void rejection, and permission checks.
- Updated several frontend pages to ignore voided sales in metrics and counts: `CloseDay.tsx`, `Customers.tsx`, `Dashboard.tsx`, `Products.tsx`, and `Sell.tsx`.
- Enhanced `web/src/pages/reports/PosSalesReport.tsx` to show sale `status` and `voidReason`, add an owner-only `Void sale` action which prompts for a reason and calls the `voidSale` callable (`httpsCallable(functions, 'voidSale')`), and added toast notifications for success/error states; also added membership check via `useMemberships`.
- Adjusted `web/src/pages/reports/SalesCashReport.tsx` mapping to treat voided sales as amount `0` for cash/reporting purposes.
- Added documentation guidance `docs/how-to-use-sedifex.md` with a new "Correcting a completed POS sale" section describing the workflow and owner-only constraint.

### Testing

- Ran the new unit test `functions/test/voidSale.test.js` which covers normal void flow, stock restoration, ledger and activity writes, idempotent/duplicate void rejection, and permission denial for non-owners; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a707054c24c8321b30f0cba6ff297c7)