### PR TITLE
Fix /reports/sales route

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -114,6 +114,7 @@ const router = createBrowserRouter([
       { path: 'reports', element: <ReportsHome /> },
       { path: 'reports/sales-cash', element: <LazyPage><SalesCashReport /></LazyPage> },
       { path: 'reports/inventory', element: <InventoryReport /> },
+      { path: 'reports/sales', element: <Navigate to="/reports/pos-sales" replace /> },
       { path: 'reports/pos-sales', element: <PosSalesReport /> },
       { path: 'reports/website-sales', element: <WebsiteSalesReport /> },
       { path: 'reports/settlement', element: <SettlementReport /> },


### PR DESCRIPTION
Add a compatibility redirect from `/reports/sales` to `/reports/pos-sales` so staff opening the sales report no longer receive a React Router 404.