### PR TITLE
Add WhatsApp and contact export actions

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="/shell-navigation.css" />
     <link rel="stylesheet" href="/website-template-enhancements.css" />
     <link rel="stylesheet" href="/sell-final-price-discount.css" />
+    <link rel="stylesheet" href="/customer-whatsapp-contact.css" />
 
     <!-- Paystack Inline (needed for card/mobile checkout) -->
     <script src="https://js.paystack.co/v1/inline.js"></script>
@@ -57,5 +58,6 @@
     <script src="/website-template-enhancements.js"></script>
     <script src="/website-template-apply-bridge.js"></script>
     <script src="/sell-final-price-discount.js"></script>
+    <script src="/customer-whatsapp-contact.js"></script>
   </body>
 </html>

--- a/web/public/customer-whatsapp-contact.css
+++ b/web/public/customer-whatsapp-contact.css
@@ -1,0 +1,29 @@
+.customer-contact-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-right: 6px;
+}
+
+.customer-contact-actions__whatsapp {
+  border-color: #16a34a;
+  color: #166534;
+}
+
+.customer-contact-actions__whatsapp:hover:not(:disabled) {
+  background: #f0fdf4;
+}
+
+@media (max-width: 720px) {
+  .customer-contact-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+    margin: 0 0 8px;
+  }
+
+  .customer-contact-actions .button {
+    width: 100%;
+    min-height: 40px;
+  }
+}

--- a/web/public/customer-whatsapp-contact.js
+++ b/web/public/customer-whatsapp-contact.js
@@ -1,0 +1,144 @@
+(() => {
+  const ENHANCED_ATTR = 'data-sedifex-contact-actions'
+
+  function normalizePhone(value) {
+    const text = String(value || '').trim()
+    if (!text) return ''
+    const hasPlus = text.startsWith('+')
+    let digits = text.replace(/\D/g, '')
+    if (!digits) return ''
+    if (text.startsWith('00')) digits = digits.replace(/^00/, '')
+    else if (!hasPlus && text.startsWith('0')) digits = `233${digits.replace(/^0/, '')}`
+    return digits
+  }
+
+  function parseContact(text) {
+    const parts = String(text || '').split('•').map(part => part.trim()).filter(Boolean)
+    const phone = parts.find(part => /\d/.test(part)) || ''
+    const email = parts.find(part => part.includes('@')) || ''
+    return { phone, email }
+  }
+
+  function escapeVCard(value) {
+    return String(value || '')
+      .replace(/\\/g, '\\\\')
+      .replace(/\n/g, '\\n')
+      .replace(/;/g, '\\;')
+      .replace(/,/g, '\\,')
+  }
+
+  function safeFilename(value) {
+    const normalized = String(value || 'customer')
+      .normalize('NFKD')
+      .replace(/[^a-zA-Z0-9 _-]/g, '')
+      .trim()
+      .replace(/\s+/g, '-')
+      .toLowerCase()
+    return normalized || 'customer'
+  }
+
+  function buildVCard({ name, phone, email }) {
+    const lines = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      `FN:${escapeVCard(name || 'Customer')}`,
+      `N:${escapeVCard(name || 'Customer')};;;;`,
+    ]
+    if (phone) lines.push(`TEL;TYPE=CELL:${escapeVCard(phone)}`)
+    if (email) lines.push(`EMAIL;TYPE=INTERNET:${escapeVCard(email)}`)
+    lines.push('NOTE:Saved from Sedifex', 'END:VCARD')
+    return `${lines.join('\r\n')}\r\n`
+  }
+
+  function downloadContact(contact) {
+    const blob = new Blob([buildVCard(contact)], { type: 'text/vcard;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `${safeFilename(contact.name)}.vcf`
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000)
+  }
+
+  function openWhatsApp(contact) {
+    const phone = normalizePhone(contact.phone)
+    if (!phone) return
+    const message = encodeURIComponent(`Hello ${contact.name || 'there'}, thank you for being our customer.`)
+    window.open(`https://wa.me/${phone}?text=${message}`, '_blank', 'noopener,noreferrer')
+  }
+
+  function makeButton(label, className, handler, disabled = false) {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = className
+    button.textContent = label
+    button.disabled = disabled
+    button.addEventListener('click', event => {
+      event.preventDefault()
+      event.stopPropagation()
+      handler()
+    })
+    return button
+  }
+
+  function enhanceRows() {
+    if (!location.pathname.startsWith('/customers')) return
+    const rows = document.querySelectorAll('.customers-page table tbody tr')
+    rows.forEach(row => {
+      if (row.hasAttribute(ENHANCED_ATTR)) return
+      const cells = row.querySelectorAll('td')
+      if (cells.length < 2) return
+      const actionsCell = row.querySelector('.customers-page__table-actions') || cells[cells.length - 1]
+      if (!actionsCell) return
+
+      const name = cells[0]?.textContent?.trim() || 'Customer'
+      const { phone, email } = parseContact(cells[1]?.textContent)
+      const contact = { name, phone, email }
+      const group = document.createElement('span')
+      group.className = 'customer-contact-actions'
+      group.append(
+        makeButton('WhatsApp', 'button button--outline button--small customer-contact-actions__whatsapp', () => openWhatsApp(contact), !normalizePhone(phone)),
+        makeButton('Save contact', 'button button--ghost button--small', () => downloadContact(contact), !phone && !email),
+      )
+      actionsCell.prepend(group)
+      row.setAttribute(ENHANCED_ATTR, 'true')
+    })
+  }
+
+  function selectedContact() {
+    const row = document.querySelector('.customers-page__row--selected')
+    if (!row) return null
+    const cells = row.querySelectorAll('td')
+    if (cells.length < 2) return null
+    const name = cells[0]?.textContent?.trim() || 'Customer'
+    const { phone, email } = parseContact(cells[1]?.textContent)
+    return { name, phone, email }
+  }
+
+  function enhanceDetails() {
+    if (!location.pathname.startsWith('/customers')) return
+    const detail = document.querySelector('.customers-page__details-content')
+    if (!detail || detail.querySelector('[data-sedifex-save-contact]')) return
+    const engageButtons = detail.querySelector('.customers-page__action-buttons')
+    if (!engageButtons) return
+
+    const button = makeButton('Save contact', 'button button--ghost button--small', () => {
+      const contact = selectedContact()
+      if (contact) downloadContact(contact)
+    })
+    button.setAttribute('data-sedifex-save-contact', 'true')
+    engageButtons.appendChild(button)
+  }
+
+  function enhance() {
+    enhanceRows()
+    enhanceDetails()
+  }
+
+  const observer = new MutationObserver(enhance)
+  observer.observe(document.documentElement, { childList: true, subtree: true })
+  window.addEventListener('popstate', enhance)
+  enhance()
+})()


### PR DESCRIPTION
Adds one-tap customer contact actions on the Customers page:

- open a WhatsApp chat with a prepared greeting
- download a .vcf contact card with customer name, phone, and email
- add Save contact in the selected customer profile
- include mobile-friendly action styling

Browsers and WhatsApp still require the user to confirm saving the contact.