### PR TITLE
Fix email-only customer phone detection

### DIFF
--- a/web/public/customer-whatsapp-contact.js
+++ b/web/public/customer-whatsapp-contact.js
@@ -14,8 +14,8 @@
 
   function parseContact(text) {
     const parts = String(text || '').split('•').map(part => part.trim()).filter(Boolean)
-    const phone = parts.find(part => /\d/.test(part)) || ''
     const email = parts.find(part => part.includes('@')) || ''
+    const phone = parts.find(part => part !== email && !part.includes('@') && /\d/.test(part)) || ''
     return { phone, email }
   }
 


### PR DESCRIPTION
Prevents email addresses containing digits from being treated as phone numbers in the customer WhatsApp/contact helper.

- identifies email parts first
- excludes email-like parts from phone detection
- disables WhatsApp correctly for email-only customers
- avoids invalid TEL entries in exported vCards