### PR TITLE
Make newly saved customers easy to track

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="/website-template-enhancements.css" />
     <link rel="stylesheet" href="/sell-final-price-discount.css" />
     <link rel="stylesheet" href="/customer-whatsapp-contact.css" />
+    <link rel="stylesheet" href="/customer-new-tracking.css" />
 
     <!-- Paystack Inline (needed for card/mobile checkout) -->
     <script src="https://js.paystack.co/v1/inline.js"></script>
@@ -59,5 +60,6 @@
     <script src="/website-template-apply-bridge.js"></script>
     <script src="/sell-final-price-discount.js"></script>
     <script src="/customer-whatsapp-contact.js"></script>
+    <script src="/customer-new-tracking.js"></script>
   </body>
 </html>

--- a/web/public/customer-new-tracking.css
+++ b/web/public/customer-new-tracking.css
@@ -1,0 +1,39 @@
+.customer-new-tracking__badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.5rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #166534;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.2;
+  vertical-align: middle;
+}
+
+.customer-new-tracking__filter--active {
+  background: #dcfce7 !important;
+  border-color: #86efac !important;
+  color: #166534 !important;
+}
+
+[data-sedifex-date-added-cell] {
+  white-space: nowrap;
+  font-size: 0.88rem;
+}
+
+.customers-page__row[data-sedifex-added-at]:not([data-sedifex-added-at='0']) {
+  box-shadow: inset 3px 0 0 #22c55e;
+}
+
+@media (max-width: 760px) {
+  [data-sedifex-date-added-header],
+  [data-sedifex-date-added-cell] {
+    min-width: 8.5rem;
+  }
+
+  .customer-new-tracking__filter {
+    width: 100%;
+  }
+}

--- a/web/public/customer-new-tracking.js
+++ b/web/public/customer-new-tracking.js
@@ -1,10 +1,11 @@
 (() => {
   const STORAGE_KEY = 'sedifex.customerAddedAt.v1'
   const NEW_DAYS = 7
-  const INITIALIZED_ATTR = 'data-sedifex-new-tracking-ready'
   let applying = false
   let initialized = false
   let recentOnly = false
+  let timer = null
+  const knownKeys = new Set()
 
   function loadAddedAt() {
     try {
@@ -53,6 +54,7 @@
     button.type = 'button'
     button.className = 'button button--ghost button--small customer-new-tracking__filter'
     button.setAttribute('data-sedifex-recently-added', 'true')
+    button.setAttribute('aria-pressed', 'false')
     button.textContent = 'Recently added'
     button.addEventListener('click', () => {
       recentOnly = !recentOnly
@@ -91,18 +93,14 @@
       const addedAt = loadAddedAt()
       const now = Date.now()
 
-      if (!initialized) {
-        initialized = document.documentElement.hasAttribute(INITIALIZED_ATTR)
-        document.documentElement.setAttribute(INITIALIZED_ATTR, 'true')
-      }
-
       rows.forEach(row => {
         const key = rowKey(row)
         if (!key || key === '|') return
 
-        if (initialized && !Object.prototype.hasOwnProperty.call(addedAt, key)) {
+        if (initialized && !knownKeys.has(key) && !Object.prototype.hasOwnProperty.call(addedAt, key)) {
           addedAt[key] = now
         }
+        knownKeys.add(key)
 
         const timestamp = addedAt[key]
         const cells = row.querySelectorAll('td')
@@ -140,7 +138,7 @@
 
       const trackedThisWeek = rows.filter(row => {
         const timestamp = Number(row.dataset.sedifexAddedAt || 0)
-        return timestamp && isNew(timestamp)
+        return Boolean(timestamp && isNew(timestamp))
       }).length
       const badge = document.querySelector('.customers-page__badge')
       if (badge && !badge.querySelector('[data-sedifex-new-count]')) {
@@ -160,8 +158,8 @@
   }
 
   const observer = new MutationObserver(() => {
-    window.clearTimeout(observer.timer)
-    observer.timer = window.setTimeout(applyTracking, 80)
+    window.clearTimeout(timer)
+    timer = window.setTimeout(applyTracking, 80)
   })
   observer.observe(document.documentElement, { childList: true, subtree: true })
   window.addEventListener('popstate', applyTracking)

--- a/web/public/customer-new-tracking.js
+++ b/web/public/customer-new-tracking.js
@@ -1,0 +1,169 @@
+(() => {
+  const STORAGE_KEY = 'sedifex.customerAddedAt.v1'
+  const NEW_DAYS = 7
+  const INITIALIZED_ATTR = 'data-sedifex-new-tracking-ready'
+  let applying = false
+  let initialized = false
+  let recentOnly = false
+
+  function loadAddedAt() {
+    try {
+      const value = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+      return value && typeof value === 'object' ? value : {}
+    } catch {
+      return {}
+    }
+  }
+
+  function saveAddedAt(value) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(value))
+    } catch (error) {
+      console.warn('[customers] Could not persist newly saved customer tracking', error)
+    }
+  }
+
+  function rowKey(row) {
+    const cells = row.querySelectorAll('td')
+    const name = cells[0]?.textContent?.replace(/\s*New\s*$/i, '').trim().toLowerCase() || ''
+    const contact = cells[1]?.textContent?.trim().toLowerCase() || ''
+    return `${name}|${contact}`
+  }
+
+  function formatAddedAt(timestamp) {
+    const date = new Date(timestamp)
+    if (Number.isNaN(date.getTime())) return '—'
+    const now = new Date()
+    if (date.toDateString() === now.toDateString()) {
+      return `Today, ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+    }
+    return date.toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' })
+  }
+
+  function isNew(timestamp) {
+    return Date.now() - Number(timestamp) <= NEW_DAYS * 24 * 60 * 60 * 1000
+  }
+
+  function ensureControls(table) {
+    const card = table.closest('.card')
+    const toolbar = card?.querySelector('.customers-page__toolbar')
+    if (!toolbar || toolbar.querySelector('[data-sedifex-recently-added]')) return
+
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'button button--ghost button--small customer-new-tracking__filter'
+    button.setAttribute('data-sedifex-recently-added', 'true')
+    button.textContent = 'Recently added'
+    button.addEventListener('click', () => {
+      recentOnly = !recentOnly
+      button.classList.toggle('customer-new-tracking__filter--active', recentOnly)
+      button.setAttribute('aria-pressed', String(recentOnly))
+      applyTracking()
+    })
+
+    const target = toolbar.querySelector('.customers-page__tool-buttons') || toolbar
+    target.prepend(button)
+  }
+
+  function ensureDateHeader(table) {
+    const headerRow = table.querySelector('thead tr')
+    if (!headerRow || headerRow.querySelector('[data-sedifex-date-added-header]')) return
+    const actionsHeader = Array.from(headerRow.children).find(cell => cell.textContent?.trim() === 'Actions')
+    const th = document.createElement('th')
+    th.scope = 'col'
+    th.textContent = 'Date added'
+    th.setAttribute('data-sedifex-date-added-header', 'true')
+    headerRow.insertBefore(th, actionsHeader || null)
+  }
+
+  function applyTracking() {
+    if (applying || !location.pathname.startsWith('/customers')) return
+    const table = document.querySelector('.customers-page table')
+    const tbody = table?.querySelector('tbody')
+    if (!table || !tbody) return
+
+    applying = true
+    try {
+      ensureControls(table)
+      ensureDateHeader(table)
+
+      const rows = Array.from(tbody.querySelectorAll('tr'))
+      const addedAt = loadAddedAt()
+      const now = Date.now()
+
+      if (!initialized) {
+        initialized = document.documentElement.hasAttribute(INITIALIZED_ATTR)
+        document.documentElement.setAttribute(INITIALIZED_ATTR, 'true')
+      }
+
+      rows.forEach(row => {
+        const key = rowKey(row)
+        if (!key || key === '|') return
+
+        if (initialized && !Object.prototype.hasOwnProperty.call(addedAt, key)) {
+          addedAt[key] = now
+        }
+
+        const timestamp = addedAt[key]
+        const cells = row.querySelectorAll('td')
+        const actionsCell = row.querySelector('.customers-page__table-actions') || cells[cells.length - 1]
+        let dateCell = row.querySelector('[data-sedifex-date-added-cell]')
+        if (!dateCell) {
+          dateCell = document.createElement('td')
+          dateCell.setAttribute('data-sedifex-date-added-cell', 'true')
+          row.insertBefore(dateCell, actionsCell || null)
+        }
+        dateCell.textContent = timestamp ? formatAddedAt(timestamp) : 'Earlier'
+
+        const nameCell = cells[0]
+        let badge = nameCell?.querySelector('.customer-new-tracking__badge')
+        if (timestamp && isNew(timestamp)) {
+          if (!badge && nameCell) {
+            badge = document.createElement('span')
+            badge.className = 'customer-new-tracking__badge'
+            badge.textContent = 'New'
+            nameCell.appendChild(badge)
+          }
+        } else {
+          badge?.remove()
+        }
+
+        row.hidden = recentOnly && !(timestamp && isNew(timestamp))
+        row.dataset.sedifexAddedAt = timestamp ? String(timestamp) : '0'
+      })
+
+      saveAddedAt(addedAt)
+
+      rows
+        .sort((a, b) => Number(b.dataset.sedifexAddedAt || 0) - Number(a.dataset.sedifexAddedAt || 0))
+        .forEach(row => tbody.appendChild(row))
+
+      const trackedThisWeek = rows.filter(row => {
+        const timestamp = Number(row.dataset.sedifexAddedAt || 0)
+        return timestamp && isNew(timestamp)
+      }).length
+      const badge = document.querySelector('.customers-page__badge')
+      if (badge && !badge.querySelector('[data-sedifex-new-count]')) {
+        const count = document.createElement('span')
+        count.setAttribute('data-sedifex-new-count', 'true')
+        count.textContent = ` • ${trackedThisWeek} new this week`
+        badge.appendChild(count)
+      } else {
+        const count = badge?.querySelector('[data-sedifex-new-count]')
+        if (count) count.textContent = ` • ${trackedThisWeek} new this week`
+      }
+
+      initialized = true
+    } finally {
+      applying = false
+    }
+  }
+
+  const observer = new MutationObserver(() => {
+    window.clearTimeout(observer.timer)
+    observer.timer = window.setTimeout(applyTracking, 80)
+  })
+  observer.observe(document.documentElement, { childList: true, subtree: true })
+  window.addEventListener('popstate', applyTracking)
+  applyTracking()
+})()


### PR DESCRIPTION
Adds lightweight tracking for newly appearing customer records on the Customers page:

- newest tracked customers appear first
- customers saved within the last 7 days receive a New badge
- adds a Recently added filter
- adds a Date added column
- shows the number of new customers this week
- persists tracking in localStorage so it survives refreshes

Existing customers that predate this feature are labelled Earlier rather than being incorrectly marked as new.