### PR TITLE
Show discount details in POS sales report

### DIFF
--- a/web/src/pages/reports/PosSalesReport.css
+++ b/web/src/pages/reports/PosSalesReport.css
@@ -7,6 +7,36 @@
   line-height: 1.5;
 }
 
+.pos-sales-report__discount-total {
+  display: inline-flex;
+  min-width: 150px;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+  white-space: nowrap;
+}
+
+.pos-sales-report__discount-total strong {
+  color: #0f172a;
+  font-size: 1.02em;
+}
+
+.pos-sales-report__original-total {
+  color: #64748b;
+  font-size: 12px;
+  text-decoration: line-through;
+}
+
+.pos-sales-report__discount-badge {
+  display: inline-flex;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #166534;
+  padding: 3px 7px;
+  font-size: 11px;
+  font-weight: 750;
+}
+
 @media (max-width: 720px) {
   .pos-sales-report {
     gap: 14px;
@@ -83,6 +113,12 @@
   .pos-sales-report .report-data-table .report-cell--total {
     font-size: 16px;
     font-weight: 800;
+  }
+
+  .pos-sales-report__discount-total {
+    min-width: 0;
+    align-items: flex-start;
+    white-space: normal;
   }
 
   .pos-sales-report .report-data-table .report-cell--items {

--- a/web/src/pages/reports/PosSalesReport.tsx
+++ b/web/src/pages/reports/PosSalesReport.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { collection, onSnapshot, query, where } from 'firebase/firestore'
 import { httpsCallable } from 'firebase/functions'
-import { db } from '../../firebase'
-import { functions } from '../../firebase'
+import { db, functions } from '../../firebase'
 import { useActiveStore } from '../../hooks/useActiveStore'
 import { useMemberships } from '../../hooks/useMemberships'
 import { useToast } from '../../components/ToastProvider'
@@ -14,6 +13,9 @@ type SaleRow = {
   id: string
   receiptNo: string
   customerName: string
+  originalTotal: number
+  discount: number
+  discountPercent: number
   total: number
   cashTotal: number
   cardTotal: number
@@ -26,18 +28,18 @@ type SaleRow = {
   voidReason: string
 }
 
-type SalesMetric = {
-  count: number
-  revenue: number
-}
+type SalesMetric = { count: number; revenue: number }
 
 export function mapSale(id: string, data: Record<string, unknown>): SaleRow {
   const tenders = getNestedObject(data, 'tenders')
+  const payment = getNestedObject(data, 'payment')
+  const paymentTenders = getNestedObject(payment, 'tenders')
+  const totals = getNestedObject(data, 'totals')
   const customer = getNestedObject(data, 'customer')
   const items = Array.isArray(data.items) ? data.items as Array<Record<string, unknown>> : []
-  const cashTotal = asNumber(tenders.cash, 0)
-  const cardTotal = asNumber(tenders.card, 0)
-  const momoTotal = asNumber(tenders.momo ?? tenders.mobileMoney ?? tenders.mobile_money, 0)
+  const cashTotal = asNumber(tenders.cash ?? paymentTenders.cash, 0)
+  const cardTotal = asNumber(tenders.card ?? paymentTenders.card, 0)
+  const momoTotal = asNumber(tenders.momo ?? tenders.mobileMoney ?? tenders.mobile_money ?? paymentTenders.momo, 0)
   const unitsSold = items.reduce((sum, item) => sum + asNumber(item.qty ?? item.quantity, 0), 0)
   const itemsSummary = items.map(item => {
     const name = asText(item.name ?? item.productName, 'Unnamed item')
@@ -50,17 +52,28 @@ export function mapSale(id: string, data: Record<string, unknown>): SaleRow {
     momoTotal > 0 ? `MoMo ${formatMoney(momoTotal)}` : '',
   ].filter(Boolean)
 
+  const total = asNumber(data.total ?? totals.total ?? data.grandTotal ?? data.amount, 0)
+  const subTotal = asNumber(data.subTotal ?? totals.subTotal ?? data.subtotal, 0)
+  const taxTotal = asNumber(data.taxTotal ?? totals.taxTotal ?? data.tax, 0)
+  const storedDiscount = Math.max(0, asNumber(data.discount ?? totals.discount ?? data.discountAmount, 0))
+  const originalTotal = Math.max(total, subTotal + taxTotal, total + storedDiscount)
+  const discount = Math.max(storedDiscount, originalTotal - total)
+  const discountPercent = originalTotal > 0 ? (discount / originalTotal) * 100 : 0
+
   return {
     id,
     receiptNo: asText(data.receiptNo ?? data.receiptNumber ?? data.reference, id),
     customerName: asText(customer.name ?? data.customerName, 'Walk-in customer'),
-    total: asNumber(data.total ?? data.grandTotal ?? data.amount, 0),
+    originalTotal,
+    discount,
+    discountPercent,
+    total,
     cashTotal,
     cardTotal,
     momoTotal,
     unitsSold,
     itemsSummary: itemsSummary || 'No item details',
-    paymentSummary: paymentParts.join(' · ') || 'Not specified',
+    paymentSummary: paymentParts.join(' · ') || asText(payment.method, 'Not specified'),
     createdAt: toDate(data.createdAt),
     status: asText(data.status, '').toLowerCase() === 'voided' ? 'voided' : 'completed',
     voidReason: asText(data.voidReason, ''),
@@ -82,11 +95,12 @@ function endOfDay(date: Date) {
 function metricForRange(sales: SaleRow[], start: Date, end: Date): SalesMetric {
   return sales.reduce<SalesMetric>((metric, sale) => {
     if (sale.status === 'voided' || !sale.createdAt || sale.createdAt < start || sale.createdAt > end) return metric
-    return {
-      count: metric.count + 1,
-      revenue: metric.revenue + sale.total,
-    }
+    return { count: metric.count + 1, revenue: metric.revenue + sale.total }
   }, { count: 0, revenue: 0 })
+}
+
+function formatDiscountPercent(value: number) {
+  return `${value.toFixed(value >= 10 ? 1 : 2).replace(/\.0$/, '')}%`
 }
 
 export default function PosSalesReport() {
@@ -106,9 +120,8 @@ export default function PosSalesReport() {
       setSales([])
       return undefined
     }
-
     setLoadError('')
-    const unsubscribe = onSnapshot(
+    return onSnapshot(
       query(collection(db, 'sales'), where('storeId', '==', storeId)),
       snapshot => {
         setLoadError('')
@@ -120,8 +133,6 @@ export default function PosSalesReport() {
         setLoadError('Sales could not be loaded. Check your connection and try again.')
       },
     )
-
-    return unsubscribe
   }, [storeId])
 
   const dashboardMetrics = useMemo(() => {
@@ -134,7 +145,6 @@ export default function PosSalesReport() {
     sevenDaysStart.setDate(sevenDaysStart.getDate() - 6)
     const thirtyDaysStart = startOfDay(new Date(now))
     thirtyDaysStart.setDate(thirtyDaysStart.getDate() - 29)
-
     return {
       today: metricForRange(sales, todayStart, todayEnd),
       yesterday: metricForRange(sales, startOfDay(yesterday), endOfDay(yesterday)),
@@ -145,11 +155,9 @@ export default function PosSalesReport() {
 
   const filtered = useMemo(() => {
     if (range === 'all') return sales
-
     const now = new Date()
     let start = startOfDay(now)
     let end = endOfDay(now)
-
     if (range === 'yesterday') {
       start.setDate(start.getDate() - 1)
       end.setDate(end.getDate() - 1)
@@ -162,13 +170,13 @@ export default function PosSalesReport() {
       start = customStart ? startOfDay(new Date(`${customStart}T00:00:00`)) : new Date(0)
       end = customEnd ? endOfDay(new Date(`${customEnd}T00:00:00`)) : endOfDay(now)
     }
-
     return sales.filter(sale => sale.createdAt && sale.createdAt >= start && sale.createdAt <= end)
   }, [customEnd, customStart, range, sales])
 
   const totals = useMemo(() => ({
     count: filtered.filter(sale => sale.status !== 'voided').length,
     revenue: filtered.reduce((sum, sale) => sum + (sale.status === 'voided' ? 0 : sale.total), 0),
+    discount: filtered.reduce((sum, sale) => sum + (sale.status === 'voided' ? 0 : sale.discount), 0),
     units: filtered.reduce((sum, sale) => sum + (sale.status === 'voided' ? 0 : sale.unitsSold), 0),
     cash: filtered.reduce((sum, sale) => sum + (sale.status === 'voided' ? 0 : sale.cashTotal), 0),
   }), [filtered])
@@ -177,11 +185,20 @@ export default function PosSalesReport() {
     { key: 'receiptNo', label: 'Receipt', sortable: true, value: row => row.receiptNo },
     { key: 'customer', label: 'Customer', sortable: true, value: row => row.customerName },
     { key: 'items', label: 'Items sold', value: row => row.itemsSummary, render: row => <span className="pos-sales-report__items">{row.itemsSummary}</span> },
-    { key: 'total', label: 'Total', sortable: true, align: 'right', value: row => row.total, render: row => formatMoney(row.total) },
+    {
+      key: 'total', label: 'Total', sortable: true, align: 'right', value: row => row.total,
+      render: row => row.discount > 0 ? (
+        <span className="pos-sales-report__discount-total">
+          <strong>{formatMoney(row.total)}</strong>
+          <span className="pos-sales-report__original-total">{formatMoney(row.originalTotal)}</span>
+          <span className="pos-sales-report__discount-badge">Discount {formatMoney(row.discount)} · {formatDiscountPercent(row.discountPercent)}</span>
+        </span>
+      ) : formatMoney(row.total),
+    },
     { key: 'payment', label: 'Payment', sortable: true, value: row => row.paymentSummary },
     { key: 'units', label: 'Units', sortable: true, align: 'right', value: row => row.unitsSold },
     { key: 'date', label: 'Date', sortable: true, value: row => row.createdAt ?? undefined, render: row => formatDate(row.createdAt) },
-    { key: 'status', label: 'Status', sortable: true, value: row => row.status, render: row => row.status === 'voided' ? `Voided${row.voidReason ? ` — ${row.voidReason}` : ''}` : 'Completed' },
+    { key: 'status', label: 'Status', sortable: true, value: row => row.status, render: row => row.status === 'voided' ? `Voided${row.voidReason ? ` — ${row.voidReason}` : ''}` : row.discount > 0 ? 'Completed · Discounted' : 'Completed' },
     { key: 'actions', label: 'Actions', render: row => row.status === 'voided' ? '—' : isOwner ? <button type="button" className="button button--secondary button--small" disabled={voidingId === row.id} onClick={() => void handleVoidSale(row)}>{voidingId === row.id ? 'Voiding…' : 'Void sale'}</button> : 'Owner approval required' },
   ]
 
@@ -194,11 +211,9 @@ export default function PosSalesReport() {
       return
     }
     if (!window.confirm(`Void ${sale.receiptNo} and restore ${sale.unitsSold} unit(s) to stock? This action cannot be undone.`)) return
-
     setVoidingId(sale.id)
     try {
-      const callable = httpsCallable(functions, 'voidSale')
-      await callable({ storeId, saleId: sale.id, reason })
+      await httpsCallable(functions, 'voidSale')({ storeId, saleId: sale.id, reason })
       publish({ tone: 'success', message: 'Sale voided and inventory restored. Record the corrected sale if needed.' })
     } catch (error) {
       const message = error instanceof Error ? error.message.replace(/^Firebase:\s*/i, '') : 'The sale could not be voided.'
@@ -213,7 +228,10 @@ export default function PosSalesReport() {
       receiptNo: sale.receiptNo,
       customer: sale.customerName,
       itemsSold: sale.itemsSummary,
-      total: sale.total,
+      originalTotal: sale.originalTotal,
+      discountAmount: sale.discount,
+      discountPercent: Number(sale.discountPercent.toFixed(2)),
+      finalTotal: sale.total,
       cash: sale.cashTotal,
       card: sale.cardTotal,
       momo: sale.momoTotal,
@@ -227,10 +245,11 @@ export default function PosSalesReport() {
   function exportPdf() {
     exportReportPdf({
       title: 'POS sales report',
-      subtitle: 'Detailed POS sales with receipts, payment split, units sold, and totals.',
+      subtitle: 'Detailed POS sales with original totals, discounts, final totals, payment split, and units sold.',
       summary: [
         { label: 'Sales', value: totals.count },
         { label: 'Sales value', value: formatMoney(totals.revenue) },
+        { label: 'Discounts given', value: formatMoney(totals.discount) },
         { label: 'Units sold', value: totals.units },
         { label: 'Cash collected', value: formatMoney(totals.cash) },
       ],
@@ -238,7 +257,10 @@ export default function PosSalesReport() {
         receiptNo: sale.receiptNo,
         customer: sale.customerName,
         itemsSold: sale.itemsSummary,
-        total: sale.total,
+        originalTotal: sale.originalTotal,
+        discountAmount: sale.discount,
+        discountPercent: Number(sale.discountPercent.toFixed(2)),
+        finalTotal: sale.total,
         cash: sale.cashTotal,
         card: sale.cardTotal,
         momo: sale.momoTotal,
@@ -276,8 +298,8 @@ export default function PosSalesReport() {
         <div className="workspace-grid workspace-grid--four">
           <article><strong>{totals.count}</strong><span>Filtered sales</span></article>
           <article><strong>{formatMoney(totals.revenue)}</strong><span>Filtered sales value</span></article>
+          <article><strong>{formatMoney(totals.discount)}</strong><span>Discounts given</span></article>
           <article><strong>{totals.units}</strong><span>Filtered units sold</span></article>
-          <article><strong>{formatMoney(totals.cash)}</strong><span>Filtered cash collected</span></article>
         </div>
         <div className="workspace-toolbar" style={{ alignItems: 'end', gap: 12, flexWrap: 'wrap' }}>
           <label>
@@ -294,14 +316,8 @@ export default function PosSalesReport() {
           </label>
           {range === 'custom' && (
             <>
-              <label>
-                <span className="workspace-muted">From</span>
-                <input type="date" value={customStart} max={customEnd || undefined} onChange={event => setCustomStart(event.target.value)} />
-              </label>
-              <label>
-                <span className="workspace-muted">To</span>
-                <input type="date" value={customEnd} min={customStart || undefined} onChange={event => setCustomEnd(event.target.value)} />
-              </label>
+              <label><span className="workspace-muted">From</span><input type="date" value={customStart} max={customEnd || undefined} onChange={event => setCustomStart(event.target.value)} /></label>
+              <label><span className="workspace-muted">To</span><input type="date" value={customEnd} min={customStart || undefined} onChange={event => setCustomEnd(event.target.value)} /></label>
             </>
           )}
         </div>


### PR DESCRIPTION
Updates the POS sales report to expose discount information already stored on each sale.

- shows final total prominently
- shows the original total with a strike-through
- shows discount amount and percentage
- labels completed discounted transactions
- adds total discounts given to the report summary
- includes original total, discount amount, discount percentage, and final total in PDF and CSV exports
- reads the canonical totals fields written by the POS commitSale function