### PR TITLE
Make full-width workspace option easier to notice

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="/sell-final-price-discount.css" />
     <link rel="stylesheet" href="/customer-whatsapp-contact.css" />
     <link rel="stylesheet" href="/customer-new-tracking.css" />
+    <link rel="stylesheet" href="/expand-workspace-prompt.css" />
 
     <!-- Paystack Inline (needed for card/mobile checkout) -->
     <script src="https://js.paystack.co/v1/inline.js"></script>
@@ -61,5 +62,6 @@
     <script src="/sell-final-price-discount.js"></script>
     <script src="/customer-whatsapp-contact.js"></script>
     <script src="/customer-new-tracking.js"></script>
+    <script src="/expand-workspace-prompt.js"></script>
   </body>
 </html>

--- a/web/public/expand-workspace-prompt.css
+++ b/web/public/expand-workspace-prompt.css
@@ -1,0 +1,51 @@
+.shell-expand-prompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 16px;
+  border: 1px solid #c7d2fe;
+  border-radius: 16px;
+  padding: 14px 16px;
+  background: linear-gradient(135deg, #eef2ff 0%, #ffffff 100%);
+  box-shadow: 0 8px 24px rgba(79, 70, 229, 0.08);
+}
+
+.shell-expand-prompt__copy {
+  display: grid;
+  gap: 3px;
+  color: #1e293b;
+}
+
+.shell-expand-prompt__copy strong {
+  color: #312e81;
+  font-size: 15px;
+}
+
+.shell-expand-prompt__copy span {
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.shell-expand-prompt__actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.shell__nav-collapse-button[data-sedifex-expand-enhanced] {
+  border-color: #a5b4fc;
+  background: #eef2ff;
+  color: #3730a3;
+  font-weight: 700;
+}
+
+.shell__nav-collapse-button[data-sedifex-expand-enhanced]:hover {
+  background: #e0e7ff;
+}
+
+@media (max-width: 900px) {
+  .shell-expand-prompt {
+    display: none;
+  }
+}

--- a/web/public/expand-workspace-prompt.js
+++ b/web/public/expand-workspace-prompt.js
@@ -1,0 +1,108 @@
+(() => {
+  const DISMISSED_KEY = 'sedifex.expandWorkspacePrompt.dismissed.v1'
+  const ENHANCED_ATTR = 'data-sedifex-expand-enhanced'
+  let applying = false
+
+  function isDesktop() {
+    return window.matchMedia('(min-width: 901px)').matches
+  }
+
+  function isCollapsed() {
+    return Boolean(document.querySelector('.shell--nav-collapsed'))
+  }
+
+  function dismissPrompt() {
+    try {
+      localStorage.setItem(DISMISSED_KEY, 'true')
+    } catch (error) {
+      console.warn('[shell] Unable to remember workspace prompt dismissal', error)
+    }
+    document.querySelector('[data-sedifex-expand-prompt]')?.remove()
+  }
+
+  function wasDismissed() {
+    try {
+      return localStorage.getItem(DISMISSED_KEY) === 'true'
+    } catch {
+      return false
+    }
+  }
+
+  function findCollapseButton() {
+    return Array.from(document.querySelectorAll('.shell__nav-collapse-button')).find(button =>
+      button.textContent?.toLowerCase().includes('hide navigation') ||
+      button.textContent?.toLowerCase().includes('expand workspace'),
+    )
+  }
+
+  function enhanceButtons() {
+    const collapseButton = findCollapseButton()
+    if (collapseButton && !collapseButton.hasAttribute(ENHANCED_ATTR)) {
+      collapseButton.innerHTML = '<span aria-hidden="true">⛶</span><span>Expand workspace</span>'
+      collapseButton.setAttribute('title', 'Hide the navigation and use the full page width')
+      collapseButton.setAttribute('aria-label', 'Expand workspace by hiding navigation')
+      collapseButton.setAttribute(ENHANCED_ATTR, 'true')
+      collapseButton.addEventListener('click', dismissPrompt)
+    }
+
+    const showButton = document.querySelector('.shell__nav-rail-button')
+    if (showButton && !showButton.hasAttribute(ENHANCED_ATTR)) {
+      const label = showButton.querySelector('span:last-child')
+      if (label) label.textContent = 'Show navigation'
+      showButton.setAttribute('title', 'Restore the navigation sidebar')
+      showButton.setAttribute(ENHANCED_ATTR, 'true')
+    }
+  }
+
+  function ensurePrompt() {
+    if (!isDesktop() || isCollapsed() || wasDismissed()) {
+      document.querySelector('[data-sedifex-expand-prompt]')?.remove()
+      return
+    }
+
+    const content = document.querySelector('.shell__content')
+    const collapseButton = findCollapseButton()
+    if (!content || !collapseButton || content.querySelector('[data-sedifex-expand-prompt]')) return
+
+    const prompt = document.createElement('div')
+    prompt.className = 'shell-expand-prompt'
+    prompt.setAttribute('data-sedifex-expand-prompt', 'true')
+    prompt.setAttribute('role', 'status')
+    prompt.innerHTML = `
+      <div class="shell-expand-prompt__copy">
+        <strong>Need a wider view?</strong>
+        <span>Expand the workspace to see more report columns and use the full screen.</span>
+      </div>
+      <div class="shell-expand-prompt__actions">
+        <button type="button" class="button button--primary button--small" data-sedifex-expand-now>Expand workspace</button>
+        <button type="button" class="button button--ghost button--small" data-sedifex-expand-dismiss>Not now</button>
+      </div>
+    `
+
+    prompt.querySelector('[data-sedifex-expand-now]')?.addEventListener('click', () => {
+      dismissPrompt()
+      collapseButton.click()
+    })
+    prompt.querySelector('[data-sedifex-expand-dismiss]')?.addEventListener('click', dismissPrompt)
+
+    const inner = content.querySelector('.shell__content-inner')
+    content.insertBefore(prompt, inner || content.firstChild)
+  }
+
+  function apply() {
+    if (applying) return
+    applying = true
+    try {
+      enhanceButtons()
+      ensurePrompt()
+    } finally {
+      applying = false
+    }
+  }
+
+  const observer = new MutationObserver(() => window.requestAnimationFrame(apply))
+  observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] })
+  window.addEventListener('resize', apply)
+  window.addEventListener('popstate', apply)
+  apply()
+})()


### PR DESCRIPTION
Improves the desktop navigation collapse experience so store users understand the benefit.

- renames Hide navigation to Expand workspace
- adds a full-width icon and explanatory tooltip
- shows a first-time desktop prompt above the workspace
- explains that expanding reveals more report columns and reduces scrolling
- provides Expand workspace and Not now actions
- remembers the user's choice in localStorage
- renames the collapsed control to Show navigation
- keeps the prompt hidden on mobile