### PR TITLE
Match workspace prompt to desktop breakpoint

### DIFF
--- a/web/public/expand-workspace-prompt.js
+++ b/web/public/expand-workspace-prompt.js
@@ -4,7 +4,7 @@
   let applying = false
 
   function isDesktop() {
-    return window.matchMedia('(min-width: 901px)').matches
+    return window.matchMedia('(min-width: 961px)').matches
   }
 
   function isCollapsed() {


### PR DESCRIPTION
Aligns the expand-workspace prompt with the shell's actual desktop breakpoint.

- changes the media query from 901px to 961px
- prevents the prompt from appearing where sidebar collapse controls are unavailable
- avoids persisting a collapsed preference that only takes effect after the window is widened