### PR TITLE
Polish collapsed navigation restore button

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,6 +25,7 @@
     <link rel="stylesheet" href="/customer-whatsapp-contact.css" />
     <link rel="stylesheet" href="/customer-new-tracking.css" />
     <link rel="stylesheet" href="/expand-workspace-prompt.css" />
+    <link rel="stylesheet" href="/show-navigation-button-fix.css" />
 
     <!-- Paystack Inline (needed for card/mobile checkout) -->
     <script src="https://js.paystack.co/v1/inline.js"></script>

--- a/web/public/expand-workspace-prompt.js
+++ b/web/public/expand-workspace-prompt.js
@@ -4,7 +4,7 @@
   let applying = false
 
   function isDesktop() {
-    return window.matchMedia('(min-width: 901px)').matches
+    return window.matchMedia('(min-width: 961px)').matches
   }
 
   function isCollapsed() {
@@ -47,9 +47,9 @@
 
     const showButton = document.querySelector('.shell__nav-rail-button')
     if (showButton && !showButton.hasAttribute(ENHANCED_ATTR)) {
-      const label = showButton.querySelector('span:last-child')
-      if (label) label.textContent = 'Show navigation'
+      showButton.innerHTML = '<span class="shell__nav-restore-icon" aria-hidden="true">☰</span><span class="shell__nav-restore-label">Show navigation</span>'
       showButton.setAttribute('title', 'Restore the navigation sidebar')
+      showButton.setAttribute('aria-label', 'Show navigation sidebar')
       showButton.setAttribute(ENHANCED_ATTR, 'true')
     }
   }

--- a/web/public/show-navigation-button-fix.css
+++ b/web/public/show-navigation-button-fix.css
@@ -1,0 +1,62 @@
+@media (min-width: 961px) {
+  .shell__nav-rail {
+    position: fixed !important;
+    top: auto !important;
+    right: auto !important;
+    bottom: 24px !important;
+    left: 24px !important;
+    z-index: 60 !important;
+    margin: 0 !important;
+  }
+
+  .shell__nav-rail-button {
+    width: auto !important;
+    min-width: 0 !important;
+    min-height: 46px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 9px !important;
+    padding: 11px 16px !important;
+    border: 1px solid rgba(67, 56, 202, 0.24) !important;
+    border-radius: 999px !important;
+    background: #ffffff !important;
+    color: #3730a3 !important;
+    font-size: 13px !important;
+    font-weight: 800 !important;
+    line-height: 1 !important;
+    writing-mode: horizontal-tb !important;
+    white-space: nowrap !important;
+    box-shadow: 0 16px 38px -16px rgba(15, 23, 42, 0.42) !important;
+  }
+
+  .shell__nav-rail-button:hover {
+    border-color: rgba(67, 56, 202, 0.42) !important;
+    background: #f8f7ff !important;
+    transform: translateY(-1px);
+  }
+
+  .shell__nav-restore-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 7px;
+    background: #eef2ff;
+    color: #4338ca;
+    font-size: 15px;
+    line-height: 1;
+  }
+
+  .shell__nav-restore-label {
+    display: inline-block;
+    line-height: 1;
+  }
+}
+
+@media (max-width: 960px) {
+  .shell__nav-rail {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Fixes the awkward duplicated Show nav / Show navigation control after expanding the workspace.

- rebuilds the restore button markup so the label appears only once
- uses the same 961px desktop breakpoint as the shell
- moves the control to a compact bottom-left floating pill
- prevents overlap with report headings and cards
- adds a clearer icon, hover state, tooltip, and accessible label

This supersedes the standalone breakpoint-only fix in PR #1562.