### PR TITLE
Improve expanded workspace margins across devices

### DIFF
--- a/web/public/expand-workspace-prompt.css
+++ b/web/public/expand-workspace-prompt.css
@@ -44,8 +44,118 @@
   background: #e0e7ff;
 }
 
-@media (max-width: 900px) {
+/* Keep expanded pages comfortably inside the viewport on large screens. */
+@media (min-width: 961px) {
+  .shell--nav-collapsed .shell__main {
+    padding-inline: clamp(18px, 2.5vw, 40px);
+  }
+
+  .shell--nav-collapsed .shell__container,
+  .shell--nav-collapsed .shell__layout,
+  .shell--nav-collapsed .shell__content,
+  .shell--nav-collapsed .shell__content-inner {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+
+  .shell--nav-collapsed .workspace-page {
+    width: 100%;
+    max-width: 1540px;
+    margin-inline: auto;
+    padding-inline: 0;
+    box-sizing: border-box;
+  }
+
+  .shell--nav-collapsed .workspace-card,
+  .shell--nav-collapsed .report-table-wrap,
+  .shell--nav-collapsed .report-data-table {
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+
+  .shell--nav-collapsed .workspace-grid {
+    min-width: 0;
+  }
+
+  .shell--nav-collapsed .workspace-grid--four {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .shell--nav-collapsed .shell__nav-rail {
+    left: 20px;
+    bottom: 20px;
+    top: auto;
+  }
+}
+
+/* Reduce crowding before the layout reaches phone size. */
+@media (min-width: 961px) and (max-width: 1180px) {
+  .shell--nav-collapsed .workspace-grid--four {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* Balanced gutters and safe card widths on tablets and phones. */
+@media (max-width: 960px) {
   .shell-expand-prompt {
     display: none;
+  }
+
+  .shell__main {
+    padding-inline: 12px;
+  }
+
+  .shell__container,
+  .shell__layout,
+  .shell__content,
+  .shell__content-inner,
+  .workspace-page {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+
+  .workspace-page {
+    padding-inline: 0;
+  }
+
+  .workspace-card {
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+
+  .workspace-section-header {
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .workspace-section-header > * {
+    min-width: 0;
+  }
+
+  .report-table-wrap {
+    max-width: 100%;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+  }
+}
+
+@media (max-width: 520px) {
+  .shell__main {
+    padding-inline: 8px;
+  }
+
+  .workspace-card {
+    border-radius: 18px;
+    padding-inline: 14px;
+  }
+
+  .workspace-section-header .button {
+    min-height: 42px;
   }
 }


### PR DESCRIPTION
Improves spacing and overflow behavior when the navigation is collapsed and on smaller screens.

- adds balanced desktop gutters around expanded pages
- keeps workspace cards and report tables inside the viewport
- caps expanded content width and centers it on very large monitors
- switches four-column summary grids to two columns on narrower desktop widths
- moves the floating Show navigation pill clear of report content
- adds safe tablet and phone side padding
- preserves horizontal scrolling only inside wide report tables
- reduces card padding and corner size on small phones