### PR TITLE
Preserve report table width in expanded view

### DIFF
--- a/web/public/expand-workspace-prompt.css
+++ b/web/public/expand-workspace-prompt.css
@@ -69,10 +69,14 @@
   }
 
   .shell--nav-collapsed .workspace-card,
-  .shell--nav-collapsed .report-table-wrap,
-  .shell--nav-collapsed .report-data-table {
+  .shell--nav-collapsed .report-table-wrap {
     max-width: 100%;
     min-width: 0;
+    box-sizing: border-box;
+  }
+
+  .shell--nav-collapsed .report-data-table {
+    max-width: 100%;
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
Fixes the expanded-workspace CSS so report tables retain their intentional minimum width.

- removes `min-width: 0` from `.report-data-table`
- keeps `min-width: 0` on the workspace card and scroll wrapper
- preserves horizontal scrolling for wide POS and cash reports near the desktop breakpoint
- avoids squeezing eight or nine columns into unreadable widths