### PR TITLE
Show paid bookings by default

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -26,6 +26,7 @@
     <link rel="stylesheet" href="/customer-new-tracking.css" />
     <link rel="stylesheet" href="/expand-workspace-prompt.css" />
     <link rel="stylesheet" href="/show-navigation-button-fix.css" />
+    <link rel="stylesheet" href="/bookings-paid-default.css" />
 
     <!-- Paystack Inline (needed for card/mobile checkout) -->
     <script src="https://js.paystack.co/v1/inline.js"></script>
@@ -64,5 +65,6 @@
     <script src="/customer-whatsapp-contact.js"></script>
     <script src="/customer-new-tracking.js"></script>
     <script src="/expand-workspace-prompt.js"></script>
+    <script src="/bookings-paid-default.js"></script>
   </body>
 </html>

--- a/web/public/bookings-paid-default.css
+++ b/web/public/bookings-paid-default.css
@@ -1,0 +1,17 @@
+.bookings-paid-default-notice {
+  margin: -4px 0 2px;
+  padding: 10px 12px;
+  border: 1px solid #c7d2fe;
+  border-radius: 12px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+@media (max-width: 640px) {
+  .bookings-paid-default-notice {
+    margin-top: 0;
+    font-size: 13px;
+  }
+}

--- a/web/public/bookings-paid-default.js
+++ b/web/public/bookings-paid-default.js
@@ -1,0 +1,55 @@
+(() => {
+  const PAGE_SELECTOR = '.bookings-page'
+  const TABS_SELECTOR = '.bookings-page__tabs'
+  const INITIALIZED_ATTR = 'data-sedifex-paid-default-initialized'
+  let applying = false
+
+  function findPaidTab(tabs) {
+    return Array.from(tabs.querySelectorAll('button')).find(
+      button => button.textContent?.trim().toLowerCase() === 'paid',
+    )
+  }
+
+  function addNotice(page, tabs) {
+    if (page.querySelector('[data-sedifex-paid-bookings-notice]')) return
+
+    const notice = document.createElement('p')
+    notice.className = 'bookings-paid-default-notice'
+    notice.setAttribute('data-sedifex-paid-bookings-notice', 'true')
+    notice.innerHTML =
+      '<strong>Showing paid bookings.</strong> Pending or unsuccessful payment attempts are available under <strong>Awaiting payment</strong> or <strong>All</strong>.'
+    tabs.insertAdjacentElement('afterend', notice)
+  }
+
+  function apply() {
+    if (applying) return
+    applying = true
+
+    try {
+      const page = document.querySelector(PAGE_SELECTOR)
+      const tabs = page?.querySelector(TABS_SELECTOR)
+      if (!page || !tabs) return
+
+      addNotice(page, tabs)
+
+      if (page.hasAttribute(INITIALIZED_ATTR)) return
+
+      const paidTab = findPaidTab(tabs)
+      if (!paidTab) return
+
+      page.setAttribute(INITIALIZED_ATTR, 'true')
+      if (!paidTab.classList.contains('is-active')) paidTab.click()
+    } finally {
+      applying = false
+    }
+  }
+
+  const observer = new MutationObserver(() => window.requestAnimationFrame(apply))
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  })
+
+  window.addEventListener('popstate', apply)
+  apply()
+})()

--- a/web/public/bookings-paid-default.js
+++ b/web/public/bookings-paid-default.js
@@ -17,7 +17,7 @@
     notice.className = 'bookings-paid-default-notice'
     notice.setAttribute('data-sedifex-paid-bookings-notice', 'true')
     notice.innerHTML =
-      '<strong>Showing paid bookings.</strong> Pending or unsuccessful payment attempts are available under <strong>Awaiting payment</strong> or <strong>All</strong>.'
+      '<strong>Paid bookings are shown by default when this page opens.</strong> Use <strong>Awaiting payment</strong> to review pending or unsuccessful payment attempts, or <strong>All</strong> to see every booking.'
     tabs.insertAdjacentElement('afterend', notice)
   }
 


### PR DESCRIPTION
Makes the Bookings page open on the existing Paid filter so unsuccessful or pending checkout attempts do not fill the main booking view.

- automatically selects Paid on first load of the Bookings page
- keeps Awaiting payment and All available for follow-up and auditing
- adds a clear notice explaining where pending or unsuccessful attempts can be found
- preserves the user's ability to switch filters after the initial load
- includes responsive styling for the notice