### PR TITLE
Split products list and add item pages

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,7 +6,7 @@ import ShellLayout from './layout/ShellLayout'
 import Dashboard from './pages/Dashboard'
 import MarketplaceOrders from './pages/MarketplaceOrdersV2'
 import DashboardHub from './pages/DashboardHub'
-import Products from './pages/ProductsServiceFirst'
+import Products from './pages/ProductsWorkspace'
 import Sell from './pages/Sell'
 import QuickPay from './pages/QuickPay'
 import QuickPayPrint from './pages/QuickPayPrint'
@@ -125,6 +125,7 @@ const router = createBrowserRouter([
       { path: 'reports/funds', element: <FundsReport /> },
       { path: 'reports/blog', element: <BlogReport /> },
       { path: 'products', element: <Products /> },
+      { path: 'products/new', element: <Products /> },
       { path: 'sell', element: <Sell /> },
       { path: 'quick-pay', element: <QuickPay /> },
       { path: 'quick-pay/print', element: <QuickPayPrint /> },

--- a/web/src/pages/ProductsWorkspace.css
+++ b/web/src/pages/ProductsWorkspace.css
@@ -1,0 +1,80 @@
+.products-workspace {
+  display: grid;
+  gap: 1rem;
+}
+
+.products-workspace__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.products-workspace__nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.65rem 1rem;
+  border: 1px solid var(--border, #dbe2ea);
+  border-radius: 999px;
+  background: var(--surface, #fff);
+  color: var(--text, #172033);
+  font-weight: 700;
+  text-decoration: none;
+  transition: border-color 160ms ease, background 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.products-workspace__nav-link:hover {
+  transform: translateY(-1px);
+  border-color: #a5b4fc;
+}
+
+.products-workspace__nav-link.is-active {
+  border-color: #6366f1;
+  background: #eef2ff;
+  color: #3730a3;
+}
+
+.products-workspace__nav-link--primary {
+  background: #111827;
+  border-color: #111827;
+  color: #fff;
+}
+
+.products-workspace__nav-link--primary:hover,
+.products-workspace__nav-link--primary.is-active {
+  background: #111827;
+  border-color: #111827;
+  color: #fff;
+}
+
+/* Keep the existing product logic in one component, but present it as two focused pages. */
+.products-workspace--list .products-page > .products-page__grid > .products-page__add-card {
+  display: none;
+}
+
+.products-workspace--add .products-page > .products-page__grid > .products-page__list-card {
+  display: none;
+}
+
+/* Editing still works from the list. When the existing component enters edit mode,
+   temporarily show the form and hide the list until the user saves or cancels. */
+.products-workspace--list .products-page > .products-page__grid > .products-page__add-card:has(.products-page__list-actions button:nth-child(2)) {
+  display: block;
+}
+
+.products-workspace--list .products-page > .products-page__grid:has(> .products-page__add-card .products-page__list-actions button:nth-child(2)) > .products-page__list-card {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  .products-workspace__nav {
+    justify-content: stretch;
+  }
+
+  .products-workspace__nav-link {
+    flex: 1 1 0;
+  }
+}

--- a/web/src/pages/ProductsWorkspace.tsx
+++ b/web/src/pages/ProductsWorkspace.tsx
@@ -1,0 +1,31 @@
+import { Link, useLocation } from 'react-router-dom'
+import ProductsServiceFirst from './ProductsServiceFirst'
+import './ProductsWorkspace.css'
+
+export default function ProductsWorkspace() {
+  const location = useLocation()
+  const isAddPage = location.pathname === '/products/new'
+
+  return (
+    <div className={`products-workspace ${isAddPage ? 'products-workspace--add' : 'products-workspace--list'}`}>
+      <nav className="products-workspace__nav" aria-label="Products navigation">
+        <Link
+          to="/products"
+          className={`products-workspace__nav-link ${!isAddPage ? 'is-active' : ''}`}
+          aria-current={!isAddPage ? 'page' : undefined}
+        >
+          All items
+        </Link>
+        <Link
+          to="/products/new"
+          className={`products-workspace__nav-link products-workspace__nav-link--primary ${isAddPage ? 'is-active' : ''}`}
+          aria-current={isAddPage ? 'page' : undefined}
+        >
+          + Add item
+        </Link>
+      </nav>
+
+      <ProductsServiceFirst />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- make `/products` a focused catalogue/list view
- add `/products/new` as a dedicated add-item page
- add clear navigation between **All items** and **+ Add item**
- keep the existing ProductsServiceFirst business logic in one place instead of duplicating product saving/loading logic
- preserve editing from the list by temporarily showing the existing edit form when an item enters edit mode
- keep mobile navigation responsive

This simplifies the products workspace so staff no longer see the long add form and full catalogue at the same time.