### PR TITLE
Add simple stocktake workflow

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,7 @@ import Dashboard from './pages/Dashboard'
 import MarketplaceOrders from './pages/MarketplaceOrdersV2'
 import DashboardHub from './pages/DashboardHub'
 import Products from './pages/ProductsWorkspace'
+import Stocktake from './pages/Stocktake'
 import Sell from './pages/Sell'
 import QuickPay from './pages/QuickPay'
 import QuickPayPrint from './pages/QuickPayPrint'
@@ -126,6 +127,7 @@ const router = createBrowserRouter([
       { path: 'reports/blog', element: <BlogReport /> },
       { path: 'products', element: <Products /> },
       { path: 'products/new', element: <Products /> },
+      { path: 'products/stocktake', element: <Stocktake /> },
       { path: 'sell', element: <Sell /> },
       { path: 'quick-pay', element: <QuickPay /> },
       { path: 'quick-pay/print', element: <QuickPayPrint /> },

--- a/web/src/pages/ProductsWorkspace.tsx
+++ b/web/src/pages/ProductsWorkspace.tsx
@@ -16,6 +16,11 @@ export default function ProductsWorkspace() {
         >
           All items
         </Link>
+        {!isAddPage ? (
+          <Link to="/products/stocktake" className="products-workspace__nav-link">
+            Stocktake
+          </Link>
+        ) : null}
         <Link
           to="/products/new"
           className={`products-workspace__nav-link products-workspace__nav-link--primary ${isAddPage ? 'is-active' : ''}`}

--- a/web/src/pages/Stocktake.css
+++ b/web/src/pages/Stocktake.css
@@ -1,0 +1,174 @@
+.stocktake-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.stocktake-page__header {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.stocktake-page__back {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  color: #4f46e5;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.stocktake-page__summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.stocktake-page__summary > div {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 16px;
+  background: var(--surface, #fff);
+}
+
+.stocktake-page__summary strong {
+  font-size: 1.35rem;
+}
+
+.stocktake-page__summary span {
+  color: #64748b;
+  font-size: 0.8rem;
+}
+
+.stocktake-page__message {
+  margin: 0;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-weight: 600;
+}
+
+.stocktake-page__card {
+  padding: 1rem;
+}
+
+.stocktake-page__tools {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.stocktake-page__tools input[type='search'] {
+  width: min(100%, 380px);
+}
+
+.stocktake-page__difference-toggle {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.stocktake-page__table-wrap {
+  overflow-x: auto;
+}
+
+.stocktake-page__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.stocktake-page__table th,
+.stocktake-page__table td {
+  padding: 0.8rem 0.7rem;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.stocktake-page__table th {
+  color: #64748b;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.stocktake-page__table td:first-child strong,
+.stocktake-page__table td:first-child span {
+  display: block;
+}
+
+.stocktake-page__table td:first-child span {
+  margin-top: 0.2rem;
+  color: #94a3b8;
+  font-size: 0.75rem;
+}
+
+.stocktake-page__table input[type='number'] {
+  width: 90px;
+  min-height: 40px;
+}
+
+.stocktake-page__table tr.has-difference {
+  background: #fff7ed;
+}
+
+.stocktake-status {
+  display: inline-flex;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #64748b;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.stocktake-status--ok {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.stocktake-status--check {
+  background: #ffedd5;
+  color: #c2410c;
+}
+
+.stocktake-page__empty {
+  margin: 0;
+  padding: 2rem;
+  text-align: center;
+  color: #64748b;
+}
+
+@media (max-width: 700px) {
+  .stocktake-page__header,
+  .stocktake-page__tools {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .stocktake-page__header .button,
+  .stocktake-page__tools input[type='search'] {
+    width: 100%;
+  }
+
+  .stocktake-page__summary {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .stocktake-page__summary > div {
+    padding: 0.75rem;
+  }
+
+  .stocktake-page__table th:nth-child(5),
+  .stocktake-page__table td:nth-child(5) {
+    display: none;
+  }
+}

--- a/web/src/pages/Stocktake.tsx
+++ b/web/src/pages/Stocktake.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { collection, doc, onSnapshot, query, serverTimestamp, updateDoc, where, writeBatch } from 'firebase/firestore'
+import { collection, doc, onSnapshot, query, serverTimestamp, where, writeBatch } from 'firebase/firestore'
 import { db } from '../firebase'
 import { useActiveStore } from '../hooks/useActiveStore'
 import './Stocktake.css'
@@ -115,15 +115,17 @@ export default function Stocktake() {
     setSaving(true)
     setMessage('')
     try {
-      const batch = writeBatch(db)
-      reviewed.forEach(item => {
-        batch.update(doc(db, 'products', item.id), {
-          stockCount: Number(counts[item.id]),
-          stocktakeUpdatedAt: serverTimestamp(),
-          updatedAt: serverTimestamp(),
+      for (let index = 0; index < reviewed.length; index += 450) {
+        const batch = writeBatch(db)
+        reviewed.slice(index, index + 450).forEach(item => {
+          batch.update(doc(db, 'products', item.id), {
+            stockCount: Number(counts[item.id]),
+            stocktakeUpdatedAt: serverTimestamp(),
+            updatedAt: serverTimestamp(),
+          })
         })
-      })
-      await batch.commit()
+        await batch.commit()
+      }
       setCounts({})
       setShowDifferencesOnly(false)
       setMessage(`Stock updated for ${reviewed.length} product${reviewed.length === 1 ? '' : 's'}.`)

--- a/web/src/pages/Stocktake.tsx
+++ b/web/src/pages/Stocktake.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { collection, doc, onSnapshot, query, serverTimestamp, updateDoc, where, writeBatch } from 'firebase/firestore'
+import { db } from '../firebase'
+import { useActiveStore } from '../hooks/useActiveStore'
+import './Stocktake.css'
+
+type StockItem = {
+  id: string
+  name: string
+  sku: string
+  stockCount: number
+}
+
+type CountMap = Record<string, string>
+
+function numberOrZero(value: unknown) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
+}
+
+export default function Stocktake() {
+  const { storeId, isLoading: storeLoading } = useActiveStore()
+  const [items, setItems] = useState<StockItem[]>([])
+  const [counts, setCounts] = useState<CountMap>({})
+  const [search, setSearch] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState('')
+  const [showDifferencesOnly, setShowDifferencesOnly] = useState(false)
+
+  useEffect(() => {
+    if (!storeId) {
+      setItems([])
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    const productsQuery = query(collection(db, 'products'), where('storeId', '==', storeId))
+    return onSnapshot(
+      productsQuery,
+      snapshot => {
+        const rows = snapshot.docs
+          .map(productDoc => {
+            const data = productDoc.data() as Record<string, unknown>
+            const itemType = typeof data.itemType === 'string' ? data.itemType : 'product'
+            if (itemType !== 'product') return null
+            return {
+              id: productDoc.id,
+              name: typeof data.name === 'string' && data.name.trim() ? data.name.trim() : 'Unnamed product',
+              sku: typeof data.sku === 'string' && data.sku.trim() ? data.sku.trim() : typeof data.barcode === 'string' ? data.barcode : '',
+              stockCount: numberOrZero(data.stockCount),
+            } satisfies StockItem
+          })
+          .filter((item): item is StockItem => Boolean(item))
+          .sort((a, b) => a.name.localeCompare(b.name))
+        setItems(rows)
+        setLoading(false)
+      },
+      () => {
+        setItems([])
+        setLoading(false)
+        setMessage('We could not load the inventory list. Please try again.')
+      },
+    )
+  }, [storeId])
+
+  const reviewedCount = useMemo(
+    () => items.filter(item => counts[item.id]?.trim() !== '').length,
+    [counts, items],
+  )
+
+  const differenceCount = useMemo(
+    () => items.filter(item => {
+      const input = counts[item.id]
+      if (input == null || input.trim() === '') return false
+      const counted = Number(input)
+      return Number.isFinite(counted) && counted !== item.stockCount
+    }).length,
+    [counts, items],
+  )
+
+  const visibleItems = useMemo(() => {
+    const term = search.trim().toLowerCase()
+    return items.filter(item => {
+      const input = counts[item.id]
+      const counted = input == null || input.trim() === '' ? null : Number(input)
+      const hasDifference = counted !== null && Number.isFinite(counted) && counted !== item.stockCount
+      if (showDifferencesOnly && !hasDifference) return false
+      if (!term) return true
+      return `${item.name} ${item.sku}`.toLowerCase().includes(term)
+    })
+  }, [counts, items, search, showDifferencesOnly])
+
+  const saveReviewedCounts = async () => {
+    if (!storeId || saving) return
+    const reviewed = items.filter(item => counts[item.id]?.trim() !== '')
+    if (!reviewed.length) {
+      setMessage('Enter at least one counted quantity first.')
+      return
+    }
+
+    const invalid = reviewed.find(item => {
+      const value = Number(counts[item.id])
+      return !Number.isFinite(value) || value < 0 || !Number.isInteger(value)
+    })
+    if (invalid) {
+      setMessage(`Enter a whole number of 0 or more for ${invalid.name}.`)
+      return
+    }
+
+    if (!window.confirm(`Update the stock for ${reviewed.length} reviewed product${reviewed.length === 1 ? '' : 's'}?`)) return
+
+    setSaving(true)
+    setMessage('')
+    try {
+      const batch = writeBatch(db)
+      reviewed.forEach(item => {
+        batch.update(doc(db, 'products', item.id), {
+          stockCount: Number(counts[item.id]),
+          stocktakeUpdatedAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+        })
+      })
+      await batch.commit()
+      setCounts({})
+      setShowDifferencesOnly(false)
+      setMessage(`Stock updated for ${reviewed.length} product${reviewed.length === 1 ? '' : 's'}.`)
+    } catch (error) {
+      console.error('[stocktake] Failed to update stock', error)
+      setMessage('We could not update the stock. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <main className="page stocktake-page">
+      <header className="stocktake-page__header">
+        <div>
+          <Link to="/products" className="stocktake-page__back">← Back to items</Link>
+          <h2 className="page__title">Stocktake</h2>
+          <p className="page__subtitle">Count what is physically in the shop, then update only the products you reviewed.</p>
+        </div>
+        <button type="button" className="button button--primary" onClick={saveReviewedCounts} disabled={saving || reviewedCount === 0}>
+          {saving ? 'Saving…' : `Save reviewed (${reviewedCount})`}
+        </button>
+      </header>
+
+      <section className="stocktake-page__summary" aria-label="Stocktake progress">
+        <div><strong>{items.length}</strong><span>Products</span></div>
+        <div><strong>{reviewedCount}</strong><span>Reviewed</span></div>
+        <div><strong>{differenceCount}</strong><span>Differences</span></div>
+      </section>
+
+      {message ? <p className="stocktake-page__message">{message}</p> : null}
+
+      <section className="card stocktake-page__card">
+        <div className="stocktake-page__tools">
+          <input
+            type="search"
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            placeholder="Search product or SKU"
+            aria-label="Search inventory"
+          />
+          <label className="stocktake-page__difference-toggle">
+            <input type="checkbox" checked={showDifferencesOnly} onChange={event => setShowDifferencesOnly(event.target.checked)} />
+            <span>Show differences only</span>
+          </label>
+        </div>
+
+        {storeLoading || loading ? <p className="stocktake-page__empty">Loading inventory…</p> : null}
+        {!loading && !storeId ? <p className="stocktake-page__empty">Select a store to start a stocktake.</p> : null}
+        {!loading && storeId && items.length === 0 ? <p className="stocktake-page__empty">No physical products found.</p> : null}
+
+        {!loading && visibleItems.length > 0 ? (
+          <div className="stocktake-page__table-wrap">
+            <table className="stocktake-page__table">
+              <thead>
+                <tr>
+                  <th>Product</th>
+                  <th>System</th>
+                  <th>Counted</th>
+                  <th>Difference</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleItems.map(item => {
+                  const input = counts[item.id] ?? ''
+                  const counted = input.trim() === '' ? null : Number(input)
+                  const validCount = counted !== null && Number.isFinite(counted) && counted >= 0
+                  const difference = validCount ? counted - item.stockCount : null
+                  const matches = difference === 0
+                  return (
+                    <tr key={item.id} className={difference !== null && !matches ? 'has-difference' : ''}>
+                      <td>
+                        <strong>{item.name}</strong>
+                        {item.sku ? <span>{item.sku}</span> : null}
+                      </td>
+                      <td>{item.stockCount}</td>
+                      <td>
+                        <input
+                          type="number"
+                          min="0"
+                          step="1"
+                          inputMode="numeric"
+                          value={input}
+                          onChange={event => setCounts(current => ({ ...current, [item.id]: event.target.value }))}
+                          aria-label={`Counted stock for ${item.name}`}
+                        />
+                      </td>
+                      <td>{difference === null ? '—' : difference > 0 ? `+${difference}` : difference}</td>
+                      <td>
+                        {difference === null ? <span className="stocktake-status">Not checked</span> : matches ? <span className="stocktake-status stocktake-status--ok">OK</span> : <span className="stocktake-status stocktake-status--check">Check</span>}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple `/products/stocktake` page for checking physical inventory
- show product, system stock, counted stock, difference, and a clear status
- show only three small progress numbers: products, reviewed, differences
- add search and an optional differences-only filter
- update only products that were actually reviewed
- add a single `Stocktake` entry point from the products page
- keep the page mobile-friendly and intentionally simple

This gives shops a fast way to compare physical stock with Sedifex without making the normal products page complicated.